### PR TITLE
DDF-3364 Fix the security-sts-server to successfully start up after restarting DDF when the broker-app is installed

### DIFF
--- a/platform/security/sts/security-sts-server/pom.xml
+++ b/platform/security/sts/security-sts-server/pom.xml
@@ -105,6 +105,11 @@
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs</artifactId>
+            <version>${findbugs.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -127,8 +132,8 @@
                         </Embed-Dependency>
                         <Import-Package>
                             javax.net.ssl,
-                            net.sf.ehcache;resolution:=optional;version="[2.5,3.0.0)",
-                            net.sf.ehcache.config;resolution:=optional;version="[2.5,3.0.0)",
+                            net.sf.ehcache;version="[2.5,3.0.0)",
+                            net.sf.ehcache.config;version="[2.5,3.0.0)",
                             ch.qos.logback.classic;resolution:=optional;version="[1.0,2)",
                             com.hazelcast.core;resolution:=optional,
                             org.springframework.ldap*;resolution:=optional,

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/DefaultInMemoryTokenStore.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/DefaultInMemoryTokenStore.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ddf.security.sts;
+
+import static org.apache.cxf.common.classloader.ClassLoaderUtils.getResource;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+
+public class DefaultInMemoryTokenStore extends EHCacheTokenStore {
+
+  public DefaultInMemoryTokenStore(Bus b) {
+    super("STS", b, getResource("cxf-ehcache.xml", DefaultInMemoryTokenStore.class));
+  }
+
+  public DefaultInMemoryTokenStore() {
+    super(
+        "STS",
+        BusFactory.getDefaultBus(),
+        getResource("cxf-ehcache.xml", DefaultInMemoryTokenStore.class));
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheManagerHolder.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheManagerHolder.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ddf.security.sts;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.sf.ehcache.CacheException;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.config.Configuration;
+import net.sf.ehcache.config.ConfigurationFactory;
+import org.apache.wss4j.common.util.Loader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class EHCacheManagerHolder {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(org.apache.wss4j.common.cache.EHCacheManagerHolder.class);
+
+  private static final ConcurrentHashMap<String, AtomicInteger> COUNTS =
+      new ConcurrentHashMap(8, 0.75F, 2);
+
+  private static Method cacheManagerCreateMethodNoArg;
+
+  private static Method createMethodURLArg;
+
+  private static Method cacheManagerCreateMethodConfigurationArg;
+
+  private EHCacheManagerHolder() {}
+
+  public static CacheConfiguration getCacheConfiguration(String key, CacheManager cacheManager) {
+    CacheConfiguration cc =
+        (CacheConfiguration) cacheManager.getConfiguration().getCacheConfigurations().get(key);
+    if (cc == null && key.contains("-")) {
+      cc =
+          (CacheConfiguration)
+              cacheManager
+                  .getConfiguration()
+                  .getCacheConfigurations()
+                  .get(key.substring(0, key.lastIndexOf(45)));
+    }
+
+    if (cc == null) {
+      cc = cacheManager.getConfiguration().getDefaultCacheConfiguration();
+    }
+
+    if (cc == null) {
+      cc = new CacheConfiguration();
+    } else {
+      cc = cc.clone();
+    }
+
+    cc.setName(key);
+    return cc;
+  }
+
+  public static synchronized CacheManager getCacheManager(String confName, URL configFileURL) {
+    CacheManager cacheManager = null;
+    if (configFileURL == null) {
+      cacheManager = findDefaultCacheManager(confName);
+    }
+
+    if (cacheManager == null) {
+      if (configFileURL == null) {
+        cacheManager = createCacheManager();
+      } else {
+        cacheManager = findDefaultCacheManager(confName, configFileURL);
+      }
+    }
+
+    AtomicInteger a = (AtomicInteger) COUNTS.get(cacheManager.getName());
+    if (a == null) {
+      COUNTS.putIfAbsent(cacheManager.getName(), new AtomicInteger());
+      a = (AtomicInteger) COUNTS.get(cacheManager.getName());
+    }
+
+    a.incrementAndGet();
+    return cacheManager;
+  }
+
+  private static CacheManager findDefaultCacheManager(String confName) {
+    String defaultConfigFile = "/wss4j-ehcache.xml";
+    URL configFileURL = null;
+
+    try {
+      configFileURL = Loader.getResource(defaultConfigFile);
+      if (configFileURL == null) {
+        configFileURL = new URL(defaultConfigFile);
+      }
+    } catch (IOException var4) {
+      LOG.debug(var4.getMessage());
+    }
+
+    return findDefaultCacheManager(confName, configFileURL);
+  }
+
+  private static CacheManager findDefaultCacheManager(String confName, URL configFileURL) {
+    try {
+      Configuration t = ConfigurationFactory.parseConfiguration(configFileURL);
+      t.setName(confName);
+      if ("java.io.tmpdir".equals(t.getDiskStoreConfiguration().getOriginalPath())) {
+        String path = t.getDiskStoreConfiguration().getPath() + File.separator + confName;
+        t.getDiskStoreConfiguration().setPath(path);
+      }
+
+      return createCacheManager(t);
+    } catch (Throwable var4) {
+      return null;
+    }
+  }
+
+  public static synchronized void releaseCacheManger(CacheManager cacheManager) {
+    AtomicInteger a = (AtomicInteger) COUNTS.get(cacheManager.getName());
+    if (a != null) {
+      if (a.decrementAndGet() == 0) {
+        cacheManager.shutdown();
+      }
+    }
+  }
+
+  static CacheManager createCacheManager() throws CacheException {
+    try {
+      return (CacheManager) cacheManagerCreateMethodNoArg.invoke((Object) null, (Object[]) null);
+    } catch (Exception var1) {
+      throw new CacheException(var1);
+    }
+  }
+
+  static CacheManager createCacheManager(URL url) throws CacheException {
+    try {
+      return (CacheManager) createMethodURLArg.invoke((Object) null, new Object[] {url});
+    } catch (Exception var2) {
+      throw new CacheException(var2);
+    }
+  }
+
+  static CacheManager createCacheManager(Configuration conf) throws CacheException {
+    try {
+      return (CacheManager)
+          cacheManagerCreateMethodConfigurationArg.invoke((Object) null, new Object[] {conf});
+    } catch (Exception var2) {
+      throw new CacheException(var2);
+    }
+  }
+
+  static {
+    try {
+      cacheManagerCreateMethodNoArg = CacheManager.class.getMethod("newInstance", (Class[]) null);
+      createMethodURLArg = CacheManager.class.getMethod("newInstance", new Class[] {URL.class});
+      cacheManagerCreateMethodConfigurationArg =
+          CacheManager.class.getMethod("newInstance", new Class[] {Configuration.class});
+    } catch (NoSuchMethodException var3) {
+      try {
+        cacheManagerCreateMethodNoArg = CacheManager.class.getMethod("create", (Class[]) null);
+        createMethodURLArg = CacheManager.class.getMethod("create", new Class[] {URL.class});
+        cacheManagerCreateMethodConfigurationArg =
+            CacheManager.class.getMethod("create", new Class[] {Configuration.class});
+      } catch (Throwable var2) {
+        LOG.warn(var2.getMessage());
+      }
+    }
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheUtils.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheUtils.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ddf.security.sts;
+
+import java.net.URL;
+import net.sf.ehcache.CacheManager;
+import org.apache.cxf.Bus;
+
+public final class EHCacheUtils {
+  public static final String GLOBAL_EHCACHE_MANAGER_NAME = "ws-security.global.ehcachemanager";
+
+  private EHCacheUtils() {}
+
+  public static CacheManager getCacheManager(Bus bus, URL configFileURL) {
+    CacheManager cacheManager = null;
+    String globalCacheManagerName = getGlobalCacheManagerName(bus);
+    if (globalCacheManagerName != null) {
+      cacheManager = CacheManager.getCacheManager(globalCacheManagerName);
+    }
+
+    if (cacheManager == null) {
+      String confName = "";
+      if (bus != null) {
+        confName = bus.getId();
+      }
+
+      cacheManager = EHCacheManagerHolder.getCacheManager(confName, configFileURL);
+    }
+
+    return cacheManager;
+  }
+
+  private static String getGlobalCacheManagerName(Bus bus) {
+    return bus != null ? (String) bus.getProperty("ws-security.global.ehcachemanager") : null;
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EhCacheTokenStore.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EhCacheTokenStore.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ddf.security.sts;
+
+import java.io.Closeable;
+import java.net.URL;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import net.sf.ehcache.Status;
+import net.sf.ehcache.config.CacheConfiguration;
+import org.apache.cxf.Bus;
+import org.apache.cxf.buslifecycle.BusLifeCycleListener;
+import org.apache.cxf.buslifecycle.BusLifeCycleManager;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.apache.cxf.ws.security.tokenstore.TokenStore;
+
+@edu.umd.cs.findbugs.annotations.SuppressWarnings(
+  value = "ML_SYNC_ON_FIELD_TO_GUARD_CHANGING_THAT_FIELD"
+)
+public class EHCacheTokenStore implements TokenStore, Closeable, BusLifeCycleListener {
+
+  public static final long DEFAULT_TTL = 3600L;
+
+  public static final long MAX_TTL = 43200L;
+
+  private Ehcache cache;
+
+  private Bus bus;
+
+  private CacheManager cacheManager;
+
+  private long ttl = 3600L;
+
+  public EHCacheTokenStore(String key, Bus b, URL configFileURL) {
+    this.bus = b;
+    if (this.bus != null) {
+      ((BusLifeCycleManager) b.getExtension(BusLifeCycleManager.class))
+          .registerLifeCycleListener(this);
+    }
+
+    this.cacheManager = EHCacheUtils.getCacheManager(this.bus, configFileURL);
+    CacheConfiguration cc =
+        EHCacheManagerHolder.getCacheConfiguration(key, this.cacheManager).overflowToDisk(false);
+    EHCacheTokenStore.RefCountCache newCache = new EHCacheTokenStore.RefCountCache(cc);
+    this.cache = this.cacheManager.addCacheIfAbsent(newCache);
+    Ehcache var6 = this.cache;
+    synchronized (this.cache) {
+      if (this.cache.getStatus() != Status.STATUS_ALIVE) {
+        this.cache = this.cacheManager.addCacheIfAbsent(newCache);
+      }
+
+      if (this.cache instanceof EHCacheTokenStore.RefCountCache) {
+        ((EHCacheTokenStore.RefCountCache) this.cache).incrementAndGet();
+      }
+    }
+
+    this.ttl = cc.getTimeToLiveSeconds();
+  }
+
+  public void setTTL(long newTtl) {
+    this.ttl = newTtl;
+  }
+
+  public void add(SecurityToken token) {
+    if (token != null && !StringUtils.isEmpty(token.getId())) {
+      Element element = new Element(token.getId(), token, this.getTTL(), this.getTTL());
+      element.resetAccessStatistics();
+      this.cache.put(element);
+    }
+  }
+
+  public void add(String identifier, SecurityToken token) {
+    if (token != null && !StringUtils.isEmpty(identifier)) {
+      Element element = new Element(identifier, token, this.getTTL(), this.getTTL());
+      element.resetAccessStatistics();
+      this.cache.put(element);
+    }
+  }
+
+  public void remove(String identifier) {
+    if (this.cache != null
+        && !StringUtils.isEmpty(identifier)
+        && this.cache.isKeyInCache(identifier)) {
+      this.cache.remove(identifier);
+    }
+  }
+
+  public Collection<String> getTokenIdentifiers() {
+    return this.cache == null ? null : this.cache.getKeysWithExpiryCheck();
+  }
+
+  public SecurityToken getToken(String identifier) {
+    if (this.cache == null) {
+      return null;
+    } else {
+      Element element = this.cache.get(identifier);
+      return element != null && !this.cache.isExpired(element)
+          ? (SecurityToken) element.getObjectValue()
+          : null;
+    }
+  }
+
+  private int getTTL() {
+    int parsedTTL = (int) this.ttl;
+    if (this.ttl != (long) parsedTTL) {
+      parsedTTL = 3600;
+    }
+
+    return parsedTTL;
+  }
+
+  public void close() {
+    if (this.cacheManager != null) {
+      if (this.cache != null) {
+        Ehcache var1 = this.cache;
+        synchronized (this.cache) {
+          if (this.cache instanceof EHCacheTokenStore.RefCountCache
+              && ((EHCacheTokenStore.RefCountCache) this.cache).decrementAndGet() == 0) {
+            this.cacheManager.removeCache(this.cache.getName());
+          }
+        }
+      }
+
+      EHCacheManagerHolder.releaseCacheManger(this.cacheManager);
+      this.cacheManager = null;
+      this.cache = null;
+      if (this.bus != null) {
+        ((BusLifeCycleManager) this.bus.getExtension(BusLifeCycleManager.class))
+            .unregisterLifeCycleListener(this);
+      }
+    }
+  }
+
+  public void initComplete() {}
+
+  public void preShutdown() {
+    this.close();
+  }
+
+  public void postShutdown() {
+    this.close();
+  }
+
+  private static class RefCountCache extends Cache {
+    AtomicInteger count = new AtomicInteger();
+
+    RefCountCache(CacheConfiguration cc) {
+      super(cc);
+    }
+
+    public int incrementAndGet() {
+      return this.count.incrementAndGet();
+    }
+
+    public int decrementAndGet() {
+      return this.count.decrementAndGet();
+    }
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/tokenstore.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/tokenstore.xml
@@ -16,7 +16,7 @@
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
         http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
         
-    <bean id="defaultTokenStore" class="org.apache.cxf.sts.cache.DefaultInMemoryTokenStore"
+    <bean id="defaultTokenStore" class="ddf.security.sts.DefaultInMemoryTokenStore"
           scope="singleton"/>
     
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
-Copies classes directly from the `cxf-rt-ws-security`and `wss4j` bundles that depend on classes from the `net.sf.ehcache` package into DDF's `security-sts-server` bundle. There seemed to be a timing issue where the ehcache dependency brought in by `cxf-rt-ws-security` and `wss4j` wasn’t available at the time `security-sts-server` needed it, causing NoClassDefFoundError exceptions to occur. This fix will prevent the need for `cxf-rt-ws-security` and `wss4j` to bring in the ehcache dependency as the classes that depend on ehcache are contained in `security-sts-server` instead.
#### Who is reviewing it? 
@ryeats 
@harrison-tarr 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@jaymcnallie
@stustison
#### How should this be tested? (List steps with links to updated documentation)
1. Run a full build. 
2. Install DDF, install the broker-app. Restart DDF. Make sure the `security-sts-server` bundle has successfully started.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3364](https://codice.atlassian.net/browse/DDF-3364)
#### Screenshots (if appropriate)
#### Checklist:
- [N/A] Documentation Updated
- [N/A] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
