### PR TITLE
[2.11.x] DDF-3297: Added the content directory to security manager policy

### DIFF
--- a/catalog/spatial/geocoding/spatial-geocoding-admin-module/src/main/java/org/codice/ddf/spatial/admin/module/service/Geocoding.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-admin-module/src/main/java/org/codice/ddf/spatial/admin/module/service/Geocoding.java
@@ -32,7 +32,7 @@ public class Geocoding implements GeocodingMBean {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Geocoding.class);
 
-  private static final String BASE_DIR = System.getProperty("user.dir") + "/content/store/";
+  private static final String BASE_DIR = System.getProperty("ddf.home") + "/content/store/";
 
   private GeoEntryExtractor geoEntryExtractor;
 

--- a/catalog/spatial/geocoding/spatial-geocoding-admin-module/src/test/java/org/codice/ddf/spatial/admin/module/TestGeocodingMbean.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-admin-module/src/test/java/org/codice/ddf/spatial/admin/module/TestGeocodingMbean.java
@@ -37,7 +37,7 @@ public class TestGeocodingMbean {
 
   private GeoEntryIndexer geoEntryIndexer;
 
-  private static final String PATH = System.getProperty("user.dir") + "/src/test/resources/";
+  private static final String PATH = "/src/test/resources/";
 
   private static final String CONTENT_FILE = "0000-0000-0000-0000";
 
@@ -54,6 +54,7 @@ public class TestGeocodingMbean {
     geoEntryIndexer = Mockito.mock(GeoEntryIndexer.class);
     geocoding.setGeoEntryIndexer(geoEntryIndexer);
     geocoding.setGeoEntryExtractor(geoEntryExtractor);
+    System.setProperty("ddf.home", System.getProperty("user.dir"));
   }
 
   @Test

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -197,10 +197,12 @@ grant {
     permission java.io.FilePermission "${ddf.home}${/}solr", "read, write";
     permission java.io.FilePermission "${ddf.home}${/}system", "read, write";
     permission java.io.FilePermission "${ddf.home}${/}workspace", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}content", "read, write";
 
     permission java.io.FilePermission "${ddf.home}${/}data${/}-", "read, write";
     permission java.io.FilePermission "${ddf.home}${/}instances${/}-", "read, write";
     permission java.io.FilePermission "${ddf.home}${/}solr${/}-", "read, write";
     permission java.io.FilePermission "${ddf.home}${/}system${/}-", "read, write";
     permission java.io.FilePermission "${ddf.home}${/}workspace${/}-", "read, write";
+    permission java.io.FilePermission "${ddf.home}${/}content${/}-", "read, write";
 };


### PR DESCRIPTION
#### What does this PR do?
Changed Geooding class to use the "ddf.home" system property instead of "user.dir"
Updated security manager policy to account for ${ddf.home}/content/*

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@coyotesqrl @paouelle @emanns95 

#### Select relevant component teams: 
@codice/security 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@figliold
@lessarderic
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full successful build

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
