### PR TITLE
[2.11.x] DDF-3210 Update tika data types that were missed in the original PR

### DIFF
--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -90,44 +90,54 @@ public class TikaInputTransformer implements InputTransformer {
   private static final Map<com.google.common.net.MediaType, String>
       FALLBACK_MIME_TYPE_DATA_TYPE_MAP;
 
-  private static final String OVERALL_FALLBACK_DATA_TYPE = "Dataset";
+  private static final String OVERALL_FALLBACK_DATA_TYPE = DataType.DATASET.toString();
 
   static {
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP = new HashMap<>();
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.MICROSOFT_EXCEL, "Document");
+        com.google.common.net.MediaType.MICROSOFT_EXCEL, DataType.TEXT.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.MICROSOFT_POWERPOINT, "Document");
+        com.google.common.net.MediaType.MICROSOFT_POWERPOINT, DataType.TEXT.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.MICROSOFT_WORD, "Document");
+        com.google.common.net.MediaType.MICROSOFT_WORD, DataType.TEXT.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.OPENDOCUMENT_GRAPHICS, "Document");
+        com.google.common.net.MediaType.OPENDOCUMENT_GRAPHICS, DataType.TEXT.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.OPENDOCUMENT_PRESENTATION, "Document");
+        com.google.common.net.MediaType.OPENDOCUMENT_PRESENTATION, DataType.TEXT.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.OPENDOCUMENT_SPREADSHEET, "Document");
+        com.google.common.net.MediaType.OPENDOCUMENT_SPREADSHEET, DataType.TEXT.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.OPENDOCUMENT_TEXT, "Document");
+        com.google.common.net.MediaType.OPENDOCUMENT_TEXT, DataType.TEXT.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.APPLICATION_BINARY, "Document");
-    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.PDF, "Document");
+        com.google.common.net.MediaType.APPLICATION_BINARY, DataType.TEXT.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.APPLICATION_XML_UTF_8, "Text");
-    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.JSON_UTF_8, "Text");
-    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.KML, "Text");
-    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.ZIP, "Collection");
-    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.TAR, "Collection");
-    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.GZIP, "Collection");
-    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.BZIP2, "Collection");
+        com.google.common.net.MediaType.PDF, DataType.TEXT.toString());
+    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.APPLICATION_XML_UTF_8, DataType.TEXT.toString());
+    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.JSON_UTF_8, DataType.TEXT.toString());
+    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.KML, DataType.TEXT.toString());
+    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.ZIP, DataType.COLLECTION.toString());
+    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.TAR, DataType.COLLECTION.toString());
+    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.GZIP, DataType.COLLECTION.toString());
+    SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.BZIP2, DataType.COLLECTION.toString());
     SPECIFIC_MIME_TYPE_DATA_TYPE_MAP.put(
         com.google.common.net.MediaType.OCTET_STREAM, OVERALL_FALLBACK_DATA_TYPE);
 
     FALLBACK_MIME_TYPE_DATA_TYPE_MAP = new HashMap<>();
     FALLBACK_MIME_TYPE_DATA_TYPE_MAP.put(
-        com.google.common.net.MediaType.ANY_APPLICATION_TYPE, "Document");
-    FALLBACK_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.ANY_IMAGE_TYPE, "Image");
-    FALLBACK_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.ANY_TEXT_TYPE, "Text");
-    FALLBACK_MIME_TYPE_DATA_TYPE_MAP.put(com.google.common.net.MediaType.ANY_AUDIO_TYPE, "Sound");
+        com.google.common.net.MediaType.ANY_APPLICATION_TYPE, DataType.TEXT.toString());
+    FALLBACK_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.ANY_IMAGE_TYPE, DataType.IMAGE.toString());
+    FALLBACK_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.ANY_TEXT_TYPE, DataType.TEXT.toString());
+    FALLBACK_MIME_TYPE_DATA_TYPE_MAP.put(
+        com.google.common.net.MediaType.ANY_AUDIO_TYPE, DataType.SOUND.toString());
   }
 
   private Templates templates = null;

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -51,6 +51,7 @@ import ddf.catalog.data.impl.types.MediaAttributes;
 import ddf.catalog.data.impl.types.ValidationAttributes;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Validation;
+import ddf.catalog.data.types.constants.core.DataType;
 import ddf.catalog.data.types.experimental.Extracted;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
@@ -83,17 +84,15 @@ public class TikaInputTransformerTest {
 
   private static final String COMMON_METACARDTYPE_NAME = "fallback.common";
 
-  private static final String SOUND = "Sound";
+  private static final String SOUND = DataType.SOUND.toString();
 
-  private static final String IMAGE = "Image";
+  private static final String IMAGE = DataType.IMAGE.toString();
 
-  private static final String TEXT = "Text";
+  private static final String TEXT = DataType.TEXT.toString();
 
-  private static final String DOCUMENT = "Document";
+  private static final String DATASET = DataType.DATASET.toString();
 
-  private static final String DATASET = "Dataset";
-
-  private static final String COLLECTION = "Collection";
+  private static final String COLLECTION = DataType.COLLECTION.toString();
 
   private static final String EXCEL_METACARDTYPE_NAME = "fallback.excel";
 
@@ -251,7 +250,7 @@ public class TikaInputTransformerTest {
         metacard.getAttribute(Extracted.EXTRACTED_TEXT).getValue().toString(),
         containsString("DEFAULT_RESOURCE_NOT_FOUND_MESSAGE"));
     assertThat(metacard.getContentTypeName(), is("application/java-vm"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -510,7 +509,7 @@ public class TikaInputTransformerTest {
     assertThat(
         metacard.getMetadata(), containsString("<meta name=\"xmpTPg:NPages\" content=\"1\" />"));
     assertThat(metacard.getContentTypeName(), is("application/pdf"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -526,7 +525,7 @@ public class TikaInputTransformerTest {
         metacard.getAttribute(Extracted.EXTRACTED_TEXT).getValue().toString(),
         containsString("John Smith"));
     assertThat(metacard.getContentTypeName(), is("application/xml"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -558,7 +557,7 @@ public class TikaInputTransformerTest {
     assertThat(
         metacard.getContentTypeName(),
         is("application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -575,7 +574,7 @@ public class TikaInputTransformerTest {
         metacard.getAttribute(Extracted.EXTRACTED_TEXT).getValue().toString(),
         containsString("Created with Microsoft"));
     assertThat(metacard.getContentTypeName(), is("application/vnd.ms-powerpoint"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -594,7 +593,7 @@ public class TikaInputTransformerTest {
     assertThat(
         metacard.getContentTypeName(),
         is("application/vnd.openxmlformats-officedocument.presentationml.presentation"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -621,7 +620,7 @@ public class TikaInputTransformerTest {
         metacard.getAttribute(Extracted.EXTRACTED_TEXT).getValue().toString(),
         containsString("Written and saved in Microsoft Excel X for Mac Service Release 1."));
     assertThat(metacard.getContentTypeName(), is("application/vnd.ms-excel"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -640,7 +639,7 @@ public class TikaInputTransformerTest {
     assertThat(
         metacard.getContentTypeName(),
         is("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -699,7 +698,7 @@ public class TikaInputTransformerTest {
 
     // Reset timezone back to local time zone.
     TimeZone.setDefault(defaultTimeZone);
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test
@@ -714,7 +713,7 @@ public class TikaInputTransformerTest {
         metacard.getMetadata(),
         containsString(
             "<meta name=\"Content-Type\" content=\"application/vnd.ms-visio.drawing\" />"));
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(DOCUMENT));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(TEXT));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Updates the tika data types to use the correct types defined in the DataType enum
#### Who is reviewing it? 
@emmberk 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@coyotesqrl
@figliold
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and ingest some office documents. Verify that you can search for and find them.
#### What are the relevant tickets?
[DDF-3210](https://codice.atlassian.net/browse/DDF-3210)
#### Screenshots (if appropriate)
