### PR TITLE
[2.11.x] DDF-3364 Fix the security-sts-server to successfully start up after restarting DDF when the broker-app is installed

### DIFF
--- a/platform/security/sts/security-sts-server/README.md
+++ b/platform/security/sts/security-sts-server/README.md
@@ -1,0 +1,10 @@
+There was a timing issue where the Ecache dependency brought in by a few classes from the `cxf-ws-security` and `wss4j` features were not available at the time the `security-sts-server` bundle required it, causing NoClassDefFoundError exceptions to occur.
+This issue caused `security-sts-server` to fail when restarting DDF while the broker-app was installed. For more information on this issue see: DDF-3364.
+
+The issue has been fixed by directly copying those classes from `cxf-ws-security` and `wss4j` that depend on Ecache into `security-sts-server`, allowing Ecache to become immediately available.
+
+The following classes have been copied directly into `security-sts-server`:
+DefaultInMemoryTokenStore.java
+EHCacheManagerHolder.java
+EHCacheTokenStore.java
+EHCacheUtils.java

--- a/platform/security/sts/security-sts-server/pom.xml
+++ b/platform/security/sts/security-sts-server/pom.xml
@@ -105,6 +105,11 @@
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs</artifactId>
+            <version>${findbugs.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -127,8 +132,8 @@
                         </Embed-Dependency>
                         <Import-Package>
                             javax.net.ssl,
-                            net.sf.ehcache;resolution:=optional;version="[2.5,3.0.0)",
-                            net.sf.ehcache.config;resolution:=optional;version="[2.5,3.0.0)",
+                            net.sf.ehcache;version="[2.5,3.0.0)",
+                            net.sf.ehcache.config;version="[2.5,3.0.0)",
                             ch.qos.logback.classic;resolution:=optional;version="[1.0,2)",
                             com.hazelcast.core;resolution:=optional,
                             org.springframework.ldap*;resolution:=optional,

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/DefaultInMemoryTokenStore.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/DefaultInMemoryTokenStore.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ddf.security.sts;
+
+import static org.apache.cxf.common.classloader.ClassLoaderUtils.getResource;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+
+public class DefaultInMemoryTokenStore extends EHCacheTokenStore {
+
+  public DefaultInMemoryTokenStore(Bus b) {
+    super("STS", b, getResource("cxf-ehcache.xml", DefaultInMemoryTokenStore.class));
+  }
+
+  public DefaultInMemoryTokenStore() {
+    super(
+        "STS",
+        BusFactory.getDefaultBus(),
+        getResource("cxf-ehcache.xml", DefaultInMemoryTokenStore.class));
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheManagerHolder.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheManagerHolder.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ddf.security.sts;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.sf.ehcache.CacheException;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.config.Configuration;
+import net.sf.ehcache.config.ConfigurationFactory;
+import org.apache.wss4j.common.util.Loader;
+
+public final class EHCacheManagerHolder {
+  private static final org.slf4j.Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(EHCacheManagerHolder.class);
+  private static final String NEW_INSTANCE = "newInstance";
+  private static final String CREATE = "create";
+  private static final ConcurrentHashMap<String, AtomicInteger> COUNTS =
+      new ConcurrentHashMap<>(8, 0.75f, 2);
+  private static Method cacheManagerCreateMethodNoArg;
+  private static Method createMethodURLArg;
+  private static Method cacheManagerCreateMethodConfigurationArg;
+
+  static {
+    // these methods are either completely available or absent (valid assumption from ehcache 2.5.0
+    // to 2.7.2 so far)
+    try {
+      // from 2.5.2
+      cacheManagerCreateMethodNoArg = CacheManager.class.getMethod(NEW_INSTANCE, (Class<?>[]) null);
+      createMethodURLArg = CacheManager.class.getMethod(NEW_INSTANCE, URL.class);
+      cacheManagerCreateMethodConfigurationArg =
+          CacheManager.class.getMethod(NEW_INSTANCE, Configuration.class);
+    } catch (NoSuchMethodException e) {
+      try {
+        // before 2.5.2
+        cacheManagerCreateMethodNoArg = CacheManager.class.getMethod(CREATE, (Class<?>[]) null);
+        createMethodURLArg = CacheManager.class.getMethod(CREATE, URL.class);
+        cacheManagerCreateMethodConfigurationArg =
+            CacheManager.class.getMethod(CREATE, Configuration.class);
+      } catch (Exception ex) {
+        // ignore
+        LOG.warn(ex.getMessage());
+      }
+    }
+  }
+
+  private EHCacheManagerHolder() {
+    // utility
+  }
+
+  public static CacheConfiguration getCacheConfiguration(String key, CacheManager cacheManager) {
+    CacheConfiguration cc = cacheManager.getConfiguration().getCacheConfigurations().get(key);
+    if (cc == null && key.contains("-")) {
+      cc =
+          cacheManager
+              .getConfiguration()
+              .getCacheConfigurations()
+              .get(key.substring(0, key.lastIndexOf('-')));
+    }
+    if (cc == null) {
+      cc = cacheManager.getConfiguration().getDefaultCacheConfiguration();
+    }
+    if (cc == null) {
+      cc = new CacheConfiguration();
+    } else {
+      cc = cc.clone();
+    }
+    cc.setName(key);
+    return cc;
+  }
+
+  public static synchronized CacheManager getCacheManager(String confName, URL configFileURL) {
+    CacheManager cacheManager = null;
+    if (configFileURL == null) {
+      // using the default
+      cacheManager = findDefaultCacheManager(confName);
+    }
+    if (cacheManager == null) {
+      if (configFileURL == null) {
+        cacheManager = createCacheManager();
+      } else {
+        cacheManager = findDefaultCacheManager(confName, configFileURL);
+      }
+    }
+    if (cacheManager == null) {
+      throw new IllegalStateException("Cache manager could not be found.");
+    }
+    AtomicInteger a = COUNTS.get(cacheManager.getName());
+    if (a == null) {
+      COUNTS.putIfAbsent(cacheManager.getName(), new AtomicInteger());
+      a = COUNTS.get(cacheManager.getName());
+    }
+    a.incrementAndGet();
+    return cacheManager;
+  }
+
+  private static CacheManager findDefaultCacheManager(String confName) {
+
+    String defaultConfigFile = "/wss4j-ehcache.xml";
+    URL configFileURL = null;
+    try {
+      configFileURL = Loader.getResource(defaultConfigFile);
+      if (configFileURL == null) {
+        configFileURL = new URL(defaultConfigFile);
+      }
+    } catch (IOException e) {
+      // Do nothing
+      LOG.debug(e.getMessage());
+    }
+    return findDefaultCacheManager(confName, configFileURL);
+  }
+
+  private static CacheManager findDefaultCacheManager(String confName, URL configFileURL) {
+    try {
+      Configuration conf = ConfigurationFactory.parseConfiguration(configFileURL);
+      conf.setName(confName);
+      if ("java.io.tmpdir".equals(conf.getDiskStoreConfiguration().getOriginalPath())) {
+        String path = conf.getDiskStoreConfiguration().getPath() + File.separator + confName;
+        conf.getDiskStoreConfiguration().setPath(path);
+      }
+      return createCacheManager(conf);
+    } catch (Exception ex) {
+      return null;
+    }
+  }
+
+  public static synchronized void releaseCacheManger(CacheManager cacheManager) {
+    AtomicInteger a = COUNTS.get(cacheManager.getName());
+    if (a == null) {
+      return;
+    }
+    if (a.decrementAndGet() == 0) {
+      cacheManager.shutdown();
+    }
+  }
+
+  static CacheManager createCacheManager() throws CacheException {
+    try {
+      return (CacheManager) cacheManagerCreateMethodNoArg.invoke(null, (Object[]) null);
+    } catch (Exception e) {
+      throw new CacheException(e);
+    }
+  }
+
+  static CacheManager createCacheManager(URL url) throws CacheException {
+    try {
+      return (CacheManager) createMethodURLArg.invoke(null, new Object[] {url});
+    } catch (Exception e) {
+      throw new CacheException(e);
+    }
+  }
+
+  static CacheManager createCacheManager(Configuration conf) throws CacheException {
+    try {
+      return (CacheManager)
+          cacheManagerCreateMethodConfigurationArg.invoke(null, new Object[] {conf});
+    } catch (Exception e) {
+      throw new CacheException(e);
+    }
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheTokenStore.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheTokenStore.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ddf.security.sts;
+
+import java.io.Closeable;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import net.sf.ehcache.Status;
+import net.sf.ehcache.config.CacheConfiguration;
+import org.apache.cxf.Bus;
+import org.apache.cxf.buslifecycle.BusLifeCycleListener;
+import org.apache.cxf.buslifecycle.BusLifeCycleManager;
+import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.apache.cxf.ws.security.tokenstore.TokenStore;
+
+@edu.umd.cs.findbugs.annotations.SuppressWarnings(
+  value = "ML_SYNC_ON_FIELD_TO_GUARD_CHANGING_THAT_FIELD"
+)
+public class EHCacheTokenStore implements TokenStore, Closeable, BusLifeCycleListener {
+
+  public static final long DEFAULT_TTL = 3600L;
+  public static final long MAX_TTL = DEFAULT_TTL * 12L;
+
+  private Ehcache cache;
+  private Bus bus;
+  private CacheManager cacheManager;
+  private long ttl = DEFAULT_TTL;
+
+  public EHCacheTokenStore(String key, Bus b, URL configFileURL) {
+    bus = b;
+    if (bus != null) {
+      b.getExtension(BusLifeCycleManager.class).registerLifeCycleListener(this);
+    }
+    cacheManager = EHCacheUtils.getCacheManager(bus, configFileURL);
+    // Cannot overflow to disk as SecurityToken Elements can't be serialized
+    @SuppressWarnings("deprecation")
+    CacheConfiguration cc =
+        EHCacheManagerHolder.getCacheConfiguration(key, cacheManager); // tokens not writable
+
+    Cache newCache = new RefCountCache(cc);
+    cache = cacheManager.addCacheIfAbsent(newCache);
+    synchronized (cache) {
+      if (cache.getStatus() != Status.STATUS_ALIVE) {
+        cache = cacheManager.addCacheIfAbsent(newCache);
+      }
+      if (cache instanceof RefCountCache) {
+        ((RefCountCache) cache).incrementAndGet();
+      }
+    }
+
+    // Set the TimeToLive value from the CacheConfiguration
+    ttl = cc.getTimeToLiveSeconds();
+  }
+
+  private static class RefCountCache extends Cache {
+    AtomicInteger count = new AtomicInteger();
+
+    RefCountCache(CacheConfiguration cc) {
+      super(cc);
+    }
+
+    public int incrementAndGet() {
+      return count.incrementAndGet();
+    }
+
+    public int decrementAndGet() {
+      return count.decrementAndGet();
+    }
+  }
+
+  /**
+   * Set a new (default) TTL value in seconds
+   *
+   * @param newTtl a new (default) TTL value in seconds
+   */
+  public void setTTL(long newTtl) {
+    ttl = newTtl;
+  }
+
+  public void add(SecurityToken token) {
+    if (token != null && !StringUtils.isEmpty(token.getId())) {
+      Element element = new Element(token.getId(), token, getTTL(), getTTL());
+      element.resetAccessStatistics();
+      cache.put(element);
+    }
+  }
+
+  public void add(String identifier, SecurityToken token) {
+    if (token != null && !StringUtils.isEmpty(identifier)) {
+      Element element = new Element(identifier, token, getTTL(), getTTL());
+      element.resetAccessStatistics();
+      cache.put(element);
+    }
+  }
+
+  public void remove(String identifier) {
+    if (cache != null && !StringUtils.isEmpty(identifier) && cache.isKeyInCache(identifier)) {
+      cache.remove(identifier);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public Collection<String> getTokenIdentifiers() {
+    if (cache == null) {
+      return Collections.emptyList();
+    }
+    return cache.getKeysWithExpiryCheck();
+  }
+
+  public SecurityToken getToken(String identifier) {
+    if (cache == null) {
+      return null;
+    }
+    Element element = cache.get(identifier);
+    if (element != null && !cache.isExpired(element)) {
+      return (SecurityToken) element.getObjectValue();
+    }
+    return null;
+  }
+
+  private int getTTL() {
+    int parsedTTL = (int) ttl;
+    if (ttl != (long) parsedTTL) {
+      // Fall back to 60 minutes if the default TTL is set incorrectly
+      parsedTTL = 3600;
+    }
+    return parsedTTL;
+  }
+
+  public void close() {
+    if (cacheManager != null) {
+      // this step is especially important for global shared cache manager
+      if (cache != null) {
+        synchronized (cache) {
+          if (cache instanceof RefCountCache && ((RefCountCache) cache).decrementAndGet() == 0) {
+            cacheManager.removeCache(cache.getName());
+          }
+        }
+      }
+
+      EHCacheManagerHolder.releaseCacheManger(cacheManager);
+      cacheManager = null;
+      cache = null;
+      if (bus != null) {
+        bus.getExtension(BusLifeCycleManager.class).unregisterLifeCycleListener(this);
+      }
+    }
+  }
+
+  public void initComplete() {}
+
+  public void preShutdown() {
+    close();
+  }
+
+  public void postShutdown() {
+    close();
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheUtils.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/EHCacheUtils.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ddf.security.sts;
+
+import java.net.URL;
+import net.sf.ehcache.CacheManager;
+import org.apache.cxf.Bus;
+
+public final class EHCacheUtils {
+  public static final String GLOBAL_EHCACHE_MANAGER_NAME = "ws-security.global.ehcachemanager";
+
+  private EHCacheUtils() {}
+
+  public static CacheManager getCacheManager(Bus bus, URL configFileURL) {
+    CacheManager cacheManager = null;
+
+    String globalCacheManagerName = getGlobalCacheManagerName(bus);
+    if (globalCacheManagerName != null) {
+      cacheManager = CacheManager.getCacheManager(globalCacheManagerName);
+    }
+
+    if (cacheManager == null) {
+      String confName = "";
+      if (bus != null) {
+        confName = bus.getId();
+      }
+      cacheManager = EHCacheManagerHolder.getCacheManager(confName, configFileURL);
+    }
+    return cacheManager;
+  }
+
+  private static String getGlobalCacheManagerName(Bus bus) {
+    if (bus != null) {
+      return (String) bus.getProperty(GLOBAL_EHCACHE_MANAGER_NAME);
+    } else {
+      return null;
+    }
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/tokenstore.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/tokenstore.xml
@@ -16,7 +16,7 @@
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
         http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
         
-    <bean id="defaultTokenStore" class="org.apache.cxf.sts.cache.DefaultInMemoryTokenStore"
+    <bean id="defaultTokenStore" class="ddf.security.sts.DefaultInMemoryTokenStore"
           scope="singleton"/>
     
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
Backport of https://github.com/codice/ddf/pull/2490
#### Who is reviewing it? 
@ryeats 
@harrison-tarr 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@jaymcnallie
@stustison
#### How should this be tested? (List steps with links to updated documentation)
1. Run a full build. 
2. Install DDF, install the broker-app. Restart DDF. Make sure the `security-sts-server` bundle has successfully started.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3364](https://codice.atlassian.net/browse/DDF-3364)
#### Screenshots (if appropriate)
#### Checklist:
- [N/A] Documentation Updated
- [N/A] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.

