### PR TITLE
DDF-3379 Add support for adding imagery providers as trusted servers

### DIFF
--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
@@ -164,9 +164,9 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
     </div>
     <div style={{ padding: '0 16px' }}>
       <Flexbox flex='1'>
-        <Flexbox width='250px'>
+        <Flexbox width='290px'>
           <Checkbox
-            label='Use Stored Credentials'
+            label='Allow Credential Forwarding'
             checked={bool(provider.get('withCredentials'))}
             onCheck={(e, value) => {
               onUpdate(value, 'withCredentials')
@@ -174,7 +174,7 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
         </Flexbox>
         <Flexbox flex='1'>
           {bool(provider.get('withCredentials'))
-            ? <Warning>Requests will fail if the server is not configured to use CORS</Warning>
+            ? <Warning>Requests will fail if the server does not prompt for credentials</Warning>
             : null}
         </Flexbox>
       </Flexbox>

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import CircularProgress from 'material-ui/CircularProgress'
 import ContentAdd from 'material-ui/svg-icons/content/add'
 import DeleteIcon from 'material-ui/svg-icons/action/delete'
+import WarningIcon from 'material-ui/svg-icons/alert/warning'
 import Checkbox from 'material-ui/Checkbox'
 import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
@@ -18,7 +19,6 @@ import RaisedButton from 'material-ui/RaisedButton'
 import SelectField from 'material-ui/SelectField'
 import Snackbar from 'material-ui/Snackbar'
 import TextField from 'material-ui/TextField'
-import Toggle from 'material-ui/Toggle'
 import muiThemeable from 'material-ui/styles/muiThemeable'
 import { List, ListItem } from 'material-ui/List'
 import SortUp from 'material-ui/svg-icons/navigation/arrow-upward'
@@ -82,6 +82,16 @@ const Title = muiThemeable()(({ children, muiTheme }) => (
 
 const DeleteIconThemed = muiThemeable()(({ muiTheme }) => (
   <DeleteIcon style={{ color: muiTheme.palette.errorColor }} />
+
+const Warning = muiThemeable()(({ children, muiTheme }) => (
+  <Flexbox style={{ color: muiTheme.palette.warningColor }} alignItems='center'>
+    <div style={{ paddingRight: 10 }}>
+      <WarningIcon color={muiTheme.palette.warningColor} />
+    </div>
+    <div>
+      {children}
+    </div>
+  </Flexbox>
 ))
 
 const implementationSupport = (implementors) => {
@@ -119,6 +129,8 @@ let Link = ({ muiTheme: { palette }, children, ...props }) => (
 
 Link = muiThemeable()(Link)
 
+const bool = (value) => typeof value === 'boolean' ? value : false
+
 const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) => (
   <div style={{ padding: 16 }}>
     <div style={{ padding: '0 16px' }}>
@@ -142,11 +154,28 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
     <div style={{ padding: '0 16px' }}>
       <Flexbox flex='1'>
         <Checkbox
-          checked={typeof provider.get('proxyEnabled') === 'boolean' ? provider.get('proxyEnabled') : ''}
           label='Proxy Imagery Provider URL'
+          checked={bool(provider.get('proxyEnabled'))}
           onCheck={(e, value) => {
             onUpdate(value, 'proxyEnabled')
           }} />
+      </Flexbox>
+    </div>
+    <div style={{ padding: '0 16px' }}>
+      <Flexbox flex='1'>
+        <Flexbox width='200px'>
+          <Checkbox
+            label='Allow Redirects'
+            checked={bool(provider.get('allowRedirects'))}
+            onCheck={(e, value) => {
+              onUpdate(value, 'allowRedirects')
+            }} />
+        </Flexbox>
+        <Flexbox flex='1'>
+          {bool(provider.get('allowRedirects'))
+            ? <Warning>STOP</Warning>
+            : null}
+        </Flexbox>
       </Flexbox>
     </div>
     <Flexbox flex='1' style={{ padding: '0 16px' }}>
@@ -193,27 +222,24 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
       </Flexbox>
     </Flexbox>
     <div style={{ padding: '0 16px' }}>
-      <Toggle
+      <Checkbox
         label='Show'
         id='show'
-        toggled={provider.get('show')}
-        labelStyle={{
-          width: '100px'
-        }}
-        onToggle={(e, value) => {
+        checked={bool(provider.get('show'))}
+        onCheck={(e, value) => {
           onUpdate(value, 'show')
         }}
       />
     </div>
     <div style={{ padding: '0 16px' }}>
-      <Toggle
+      <Checkbox
         label='Transparent'
         id='transparent'
-        toggled={provider.getIn(['parameters', 'transparent'], false)}
+        checked={bool(provider.getIn(['parameters', 'transparent']))}
         labelStyle={{
-          width: '100px'
+          width: '200px'
         }}
-        onToggle={(e, value) => {
+        onCheck={(e, value) => {
           onUpdate(value, ['parameters', 'transparent'])
           if (value) {
             onUpdate('image/png', ['parameters', 'format'])
@@ -251,7 +277,11 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
                 href={options[provider.get('type')].help.cesium} />
             </div> : null,
           <div key='ace' style={{ margin: '0 15px' }}>
-            <Error errorText={error.get('buffer')}>
+            <Error errorText={
+              ['buffer', 'proxyEnabled', 'order', 'show', 'allowRedirects']
+              .map((key) => error.get(key))
+              .filter((msg) => msg !== undefined)[0]
+            }>
               <AceEditor
                 mode='json'
                 theme='github'

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
@@ -82,6 +82,7 @@ const Title = muiThemeable()(({ children, muiTheme }) => (
 
 const DeleteIconThemed = muiThemeable()(({ muiTheme }) => (
   <DeleteIcon style={{ color: muiTheme.palette.errorColor }} />
+))
 
 const Warning = muiThemeable()(({ children, muiTheme }) => (
   <Flexbox style={{ color: muiTheme.palette.warningColor }} alignItems='center'>
@@ -163,17 +164,17 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
     </div>
     <div style={{ padding: '0 16px' }}>
       <Flexbox flex='1'>
-        <Flexbox width='200px'>
+        <Flexbox width='250px'>
           <Checkbox
-            label='Allow Redirects'
-            checked={bool(provider.get('allowRedirects'))}
+            label='Use Stored Credentials'
+            checked={bool(provider.get('withCredentials'))}
             onCheck={(e, value) => {
-              onUpdate(value, 'allowRedirects')
+              onUpdate(value, 'withCredentials')
             }} />
         </Flexbox>
         <Flexbox flex='1'>
-          {bool(provider.get('allowRedirects'))
-            ? <Warning>STOP</Warning>
+          {bool(provider.get('withCredentials'))
+            ? <Warning>Requests will fail if the server is not configured to use CORS</Warning>
             : null}
         </Flexbox>
       </Flexbox>

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
@@ -279,7 +279,7 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
             </div> : null,
           <div key='ace' style={{ margin: '0 15px' }}>
             <Error errorText={
-              ['buffer', 'proxyEnabled', 'order', 'show', 'allowRedirects']
+              ['buffer', 'proxyEnabled', 'order', 'show', 'withCredentials']
               .map((key) => error.get(key))
               .filter((msg) => msg !== undefined)[0]
             }>

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
@@ -234,10 +234,10 @@ export const validate = (providers) => {
       }
     }
 
-    const redirects = layer.get('allowRedirects')
+    const redirects = layer.get('withCredentials')
 
     if (typeof redirects !== 'boolean') {
-      errors = errors.setIn([i, 'allowRedirects'], 'Allow redirects must be true or false')
+      errors = errors.setIn([i, 'withCredentials'], 'With credentials must be true or false')
     }
   })
 
@@ -251,7 +251,7 @@ const emptyProvider = (index) => {
     type: '',
     alpha: '',
     proxyEnabled: true,
-    allowRedirects: false,
+    withCredentials: false,
     show: true,
     parameters: {
       transparent: false,

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
@@ -179,15 +179,13 @@ export const validate = (providers) => {
     const proxyEnabled = layer.get('proxyEnabled')
 
     if (typeof proxyEnabled !== 'boolean') {
-      errors = errors.setIn([i, 'proxyEnabled'], 'Proxy enabled settings needs to be true or false')
+      errors = errors.setIn([i, 'proxyEnabled'], 'Proxy enabled must be true or false')
     }
 
     const show = layer.get('show')
 
-    if (show === undefined) {
-      errors = errors.setIn([i, 'buffer'], 'Show must be true or false')
-    } else if (typeof show !== 'boolean') {
-      errors = errors.setIn([i, 'buffer'], `Show must be set to true or false`)
+    if (typeof show !== 'boolean') {
+      errors = errors.setIn([i, 'show'], 'Show must be true or false')
     }
 
     const type = layer.get('type')
@@ -222,18 +220,24 @@ export const validate = (providers) => {
     const order = layer.get('order')
 
     if (order === '' || order === undefined) {
-      errors = errors.setIn([i, 'buffer'], 'Order cannot be empty')
+      errors = errors.setIn([i, 'order'], 'Order cannot be empty')
     } else if (typeof order !== 'number') {
-      errors = errors.setIn([i, 'buffer'], 'Order must be a number')
+      errors = errors.setIn([i, 'order'], 'Order must be a number')
     } else if (order < 0 || order > providers.size - 1) {
-      errors = errors.setIn([i, 'buffer'], `Order should be between 0 and ${providers.size - 1}`)
+      errors = errors.setIn([i, 'order'], `Order should be between 0 and ${providers.size - 1}`)
     } else {
       const previous = providers.slice(0, i)
         .find((provider) => order === provider.getIn(['layer', 'order']))
       if (previous !== undefined) {
-        errors = errors.setIn([i, 'buffer'],
+        errors = errors.setIn([i, 'order'],
           `Order ${order} previously used for ${previous.getIn(['layer', 'name'])}`)
       }
+    }
+
+    const redirects = layer.get('allowRedirects')
+
+    if (typeof redirects !== 'boolean') {
+      errors = errors.setIn([i, 'allowRedirects'], 'Allow redirects must be true or false')
     }
   })
 
@@ -247,6 +251,7 @@ const emptyProvider = (index) => {
     type: '',
     alpha: '',
     proxyEnabled: true,
+    allowRedirects: false,
     show: true,
     parameters: {
       transparent: false,

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/validate.spec.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/validate.spec.js
@@ -148,24 +148,40 @@ describe('validate providers', () => {
   describe('order', () => {
     it('should be a valid order', () => {
       const values = [0, 1, 2, 3, 4]
-      const providers = fromJS(values.map((order) => ({ layer: { order, show: true }, buffer: '[]' })))
+      const providers = fromJS(values.map((order) => ({ layer: { order } })))
       values.forEach((order) => {
-        expect(validate(providers).getIn([0, 'buffer'])).to.equal(undefined)
+        expect(validate(providers).getIn([order, 'order'])).to.equal(undefined)
       })
     })
     it('should be out of bounds order', () => {
       const values = [0, 1, 2, 4]
-      const providers = fromJS(values.map((order) => ({ layer: { order, show: true }, buffer: '[]' })))
+      const providers = fromJS(values.map((order) => ({ layer: { order } })))
       values.slice(0, values.length - 2).forEach((order) => {
-        expect(validate(providers).getIn([0, 'buffer'])).to.equal(undefined)
+        expect(validate(providers).getIn([0, 'order'])).to.equal(undefined)
       })
-      expect(validate(providers).getIn([values.length - 1, 'buffer'])).to.not.equal(undefined)
+      expect(validate(providers).getIn([values.length - 1, 'order'])).to.not.equal(undefined)
     })
     it('should not be a valid order', () => {
       const values = [-1, {}, [], 1.1, true, false, 2]
       values.forEach((order) => {
-        const providers = fromJS([ { layer: { order }, buffer: '[]' } ])
-        expect(validate(providers).getIn([0, 'buffer'])).to.not.equal(undefined)
+        const providers = fromJS([ { layer: { order } } ])
+        expect(validate(providers).getIn([0, 'order'])).to.not.equal(undefined)
+      })
+    })
+  })
+  describe('allowRedirects', () => {
+    it('should be a valid trusted value', () => {
+      const values = [true, false]
+      values.forEach((allowRedirects) => {
+        const providers = fromJS([{ layer: { allowRedirects } }])
+        expect(validate(providers).getIn([0, 'allowRedirects'])).to.equal(undefined)
+      })
+    })
+    it('should not be a valid trusted value', () => {
+      const values = ['hello', undefined, null]
+      values.forEach((allowRedirects) => {
+        const providers = fromJS([{ layer: { allowRedirects } }])
+        expect(validate(providers).getIn([0, 'allowRedirects'])).to.not.equal(undefined)
       })
     })
   })

--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/validate.spec.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/validate.spec.js
@@ -169,19 +169,19 @@ describe('validate providers', () => {
       })
     })
   })
-  describe('allowRedirects', () => {
+  describe('withCredentials', () => {
     it('should be a valid trusted value', () => {
       const values = [true, false]
-      values.forEach((allowRedirects) => {
-        const providers = fromJS([{ layer: { allowRedirects } }])
-        expect(validate(providers).getIn([0, 'allowRedirects'])).to.equal(undefined)
+      values.forEach((withCredentials) => {
+        const providers = fromJS([{ layer: { withCredentials } }])
+        expect(validate(providers).getIn([0, 'withCredentials'])).to.equal(undefined)
       })
     })
     it('should not be a valid trusted value', () => {
       const values = ['hello', undefined, null]
-      values.forEach((allowRedirects) => {
-        const providers = fromJS([{ layer: { allowRedirects } }])
-        expect(validate(providers).getIn([0, 'allowRedirects'])).to.not.equal(undefined)
+      values.forEach((withCredentials) => {
+        const providers = fromJS([{ layer: { withCredentials } }])
+        expect(validate(providers).getIn([0, 'withCredentials'])).to.not.equal(undefined)
       })
     })
   })

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -61,8 +61,11 @@ define(['underscore',
 
                 var provider = new type(initObj);
 
-                /* Optionally add this provider as a TrustedServer to allow redirects */
-                if (model.get('allowRedirects')) {
+                /*
+                  Optionally add this provider as a TrustedServer. This sets withCredentials = true
+                  on the XmlHttpRequests for CORS.
+                 */
+                if (model.get('withCredentials')) {
                   var parsedUrl = new URL(provider.url);
                   var port = parsedUrl.port;
                   if (!port) {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -20,6 +20,9 @@ define(['underscore',
 ], function (_, Marionette, Cesium, CommonLayerController, properties) {
     "use strict";
 
+    const DEFAULT_HTTPS_PORT = 443;
+    const DEFAULT_HTTP_PORT = 80;
+
     var imageryProviderTypes = {
         OSM: Cesium.createOpenStreetMapImageryProvider,
         AGM: Cesium.ArcGisMapServerImageryProvider,
@@ -70,7 +73,7 @@ define(['underscore',
                   var parsedUrl = url.parse(provider.url);
                   var port = parsedUrl.port;
                   if (!port) {
-                    port = (parsedUrl.protocol === "https:") ? 443 : 80;
+                    port = (parsedUrl.protocol === "https:") ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
                   }
                   Cesium.TrustedServers.add(parsedUrl.hostname, port);
                 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -66,10 +66,11 @@ define(['underscore',
                   on the XmlHttpRequests for CORS.
                  */
                 if (model.get('withCredentials')) {
-                  var parsedUrl = new URL(provider.url);
+                  const url = require('url');
+                  var parsedUrl = url.parse(provider.url);
                   var port = parsedUrl.port;
                   if (!port) {
-                    port = (parsedUrl.protocol === "https") ? 443 : 80;
+                    port = (parsedUrl.protocol === "https:") ? 443 : 80;
                   }
                   Cesium.TrustedServers.add(parsedUrl.hostname, port);
                 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -60,6 +60,17 @@ define(['underscore',
                 }
 
                 var provider = new type(initObj);
+
+                /* Optionally add this provider as a TrustedServer to allow redirects */
+                if (model.get('allowRedirects')) {
+                  var parsedUrl = new URL(provider.url);
+                  var port = parsedUrl.port;
+                  if (!port) {
+                    port = (parsedUrl.protocol === "https") ? 443 : 80;
+                  }
+                  Cesium.TrustedServers.add(parsedUrl.hostname, port);
+                }
+
                 var layer = this.map.imageryLayers.addImageryProvider(provider, 0);  // the collection is sorted by order, so later things should go at bottom of stack
                 this.layerForCid[model.id] = layer;
                 layer.alpha = model.get('alpha');


### PR DESCRIPTION
#### What does this PR do?
Adds a `withCredentials` field to the imagery providers json so each provider can optionally be added as a trusted server in Cesium. Also adds a new option in the Map Layers Configuration UI and changes the Show and Transparent toggle to checkboxes for consistency.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@djblue @bdeining
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Add a new imagery provider using the Map Layers Configuration UI. Give it a name, set the url to `http://c.tile.openstreetmap.org`, set alpha to 1, set provider type to "Open Street Map", and only check "show" (leave all the other boxes unchecked). Go to `/search/catalog/` and you should see the globe with the map like normal. Now go back into the Map Layers Configuration UI and check "Use Stored Credentials" and save. Refresh the search page and you should see an empty globe without any map (because that URL isn't configured to handle CORS).

#### Any background context you want to provide?
Adding a provider as a trusted server sets `withCredentials=true` on the XHRs for the tiles for CORS requests.
#### What are the relevant tickets?
[DDF-3379](https://codice.atlassian.net/browse/DDF-3379)
#### Screenshots (if appropriate)
<img width="1384" alt="screen shot 2017-10-12 at 6 40 43 pm" src="https://user-images.githubusercontent.com/8922441/31526698-5118ae54-af7d-11e7-8f2a-e167c48f388a.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
