### PR TITLE
DDF-3273 Disable Java Security Manager & update hardening guide re: SSH

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -78,9 +78,11 @@ export EXTRA_JAVA_OPTS
 # for more information.
 #
 # export KARAF_SYSTEM_OPTS="-Dprograde.generated.policy=$DDF_HOME/generated.policy -Dprograde.use.own.policy=true -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.PolicyFileGeneratorJSM -Djava.security.policy==$DDF_HOME/security/default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity"
+
 #
-# Production Security Permissions
-export KARAF_SYSTEM_OPTS="-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM -Djava.security.policy==$DDF_HOME/security/default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity"
+# The Security Manager is turned off by default in DDF.
+#
+# export KARAF_SYSTEM_OPTS="-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM -Djava.security.policy==$DDF_HOME/security/default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity"
 
 # The following defines an environment variable referencing our script to be executed by the JVM
 # when errors are detected. The environment variable will be expanded by the JVM.

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -77,8 +77,10 @@ rem See http://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFil
 rem for more information.
 rem
 rem set KARAF_SYSTEM_OPTS=-Dprograde.generated.policy="%DDF_HOME%/generated.policy" -Dprograde.use.own.policy=true -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.PolicyFileGeneratorJSM -Djava.security.policy==%DDF_HOME%\security\default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
+
 rem
-rem Production Security Permissions
-set KARAF_SYSTEM_OPTS=-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM -Djava.security.policy==%DDF_HOME%\security\default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
+rem The Security Manager is turned off by default in DDF.
+rem
+rem set KARAF_SYSTEM_OPTS=-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM -Djava.security.policy==%DDF_HOME%\security\default.policy -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
 
 set JAVA_OPTS=-Xms2g -Xmx4g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.policy=%DDF_HOME_POLICY% -XX:+DisableAttachMechanism

--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -58,8 +58,8 @@
 
                 <!--
                 Skipping customized libraries.
-                -->
                 <exclude>**/org/apache/aries/blueprint/org.apache.aries.blueprint.core/1.8.2/org.apache.aries.blueprint.core-1.8.2.jar</exclude>
+                -->
 
                 <!-- excluding jars we don't need that have OWASP vulnerabilities -->
                 <!--
@@ -245,6 +245,7 @@
         </fileSet>
 
         <!-- Custom library overrides -->
+        <!--
         <fileSet>
             <directory>${setup.folder}/libraryOverrides</directory>
             <outputDirectory>
@@ -254,7 +255,7 @@
                 <include>org.apache.aries.blueprint.core-1.8.2.jar</include>
             </includes>
         </fileSet>
-
+        -->
     </fileSets>
 
     <!-- We need this because the feature service is not up when we want to provision our

--- a/distribution/docs/src/main/resources/content/_configuring/environment-hardening.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/environment-hardening.adoc
@@ -65,8 +65,10 @@ By definition, all connections over SSH will be authenticated and authorized and
 [WARNING]
 ====
 Enabling SSH will expose your file system such that any user with access to your ${branding} shell will
-have read/write access to all directories and files accessible to your installation user. It is not
-recommended in a secure environment.
+have read/write/execute access to all directories and files accessible to your installation user.
+
+*Because of this, SSH is not recommended in a secure environment and should be turned off
+in a fully hardened system.*
 ====
 
 Set `karaf.shutdown.port=-1` in `<${branding}_HOME>/etc/custom.properties` or `<${branding}_HOME>/etc/config.properties`.

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -65,7 +65,6 @@ import javax.ws.rs.core.MediaType;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
@@ -596,13 +595,6 @@ public abstract class AbstractIntegrationTest {
   }
 
   protected Option[] configureVmOptions() {
-    String ddfHomePolicyPath;
-    if (SystemUtils.IS_OS_WINDOWS) {
-      ddfHomePolicyPath = "-Dddf.home.policy=/{karaf.home}/";
-    } else {
-      ddfHomePolicyPath = "-Dddf.home.policy={karaf.home}/";
-    }
-
     return options(
         vmOption("-Xmx2048M"),
         // avoid integration tests stealing focus on OS X

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -608,26 +608,7 @@ public abstract class AbstractIntegrationTest {
         // avoid integration tests stealing focus on OS X
         vmOption("-Djava.awt.headless=true"),
         vmOption("-Dfile.encoding=UTF8"),
-        vmOption("-Djava.security.policy==security/default.policy"),
-        vmOption(
-            "-DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity"),
-        vmOption("-Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy"),
-        HomeAwareVmOption.homeAwareVmOption("-Dddf.home={karaf.home}"),
-        HomeAwareVmOption.homeAwareVmOption(ddfHomePolicyPath),
-        when(Boolean.getBoolean("generatePolicyFile")).useOptions(generatorSecurityManager()),
-        when(!Boolean.getBoolean("generatePolicyFile")).useOptions(standardSecurityManager()));
-  }
-
-  private Option[] generatorSecurityManager() {
-    return options(
-        HomeAwareVmOption.homeAwareVmOption(
-            "-Dprograde.generated.policy={karaf.home}/generated.policy"),
-        vmOption("-Dprograde.use.own.policy=true"),
-        vmOption("-Djava.security.manager=net.sourceforge.prograde.sm.PolicyFileGeneratorJSM"));
-  }
-
-  private Option[] standardSecurityManager() {
-    return options(vmOption("-Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM"));
+        HomeAwareVmOption.homeAwareVmOption("-Dddf.home={karaf.home}"));
   }
 
   protected Option[] configureStartScript() {


### PR DESCRIPTION
#### What does this PR do?
Turns off security manager.

(cherry picked from commit bbe5f30)
#### Who is reviewing it? 
@tbatie @paouelle 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic
@ricklarsen - Documentation
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full CI build. Full regression pass.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3273](https://codice.atlassian.net/browse/DDF-3273)
[DDF-3297](https://codice.atlassian.net/browse/DDF-3297)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
