### PR TITLE
DDF-3297 disable security manager when running using the service wrapper

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv-windows-wrapper.conf
+++ b/distribution/ddf-common/src/main/resources/bin/setenv-windows-wrapper.conf
@@ -11,7 +11,7 @@ wrapper.commandfile = %KARAF_HOME%/bin/restart.jvm
 
 # Additional JVM parameters
 # note that n is the parameter number starting from 11 (1-10 is defined in ddf-wrapper.conf).
-# make sure there is no gap
+# ### make sure there is no gap renumber remaining parameters if you add, remove or uncomment lines
 wrapper.java.additional.11 = -Dddf.home=%KARAF_HOME%
 wrapper.java.additional.12 = -Dddf.home.policy=%KARAF_HOME%/
 wrapper.java.additional.13 = -server
@@ -29,9 +29,9 @@ wrapper.java.additional.22 = -Djava.awt.headless=true
 wrapper.java.additional.23 = -Dorg.tanukisoftware.wrapper.WrapperManager.mbean=TRUE
 
 # Error handling scripts
-# uncomment when on-error scripts are supported on Windows and re-number remaining parameters
-#wrapper.java.additional.24 = -XX:OnOutOfMemoryError=%KARAF_HOME%/bin/ddf_on_error.bat wrapper %p
-#wrapper.java.additional.25 = -XX:OnError=%KARAF_HOME%/bin/ddf_on_error.bat wrapper %p
+# uncomment when on-error scripts are supported on Windows
+# wrapper.java.additional.24 = -XX:OnOutOfMemoryError=%KARAF_HOME%/bin/ddf_on_error.bat wrapper %p
+# wrapper.java.additional.25 = -XX:OnError=%KARAF_HOME%/bin/ddf_on_error.bat wrapper %p
 
 # The Security Manager is turned off by default in DDF.
 # N.B. The use of the double equals on the 'java.security.policy' property is intentional.

--- a/distribution/ddf-common/src/main/resources/bin/setenv-windows-wrapper.conf
+++ b/distribution/ddf-common/src/main/resources/bin/setenv-windows-wrapper.conf
@@ -33,12 +33,13 @@ wrapper.java.additional.23 = -Dorg.tanukisoftware.wrapper.WrapperManager.mbean=T
 #wrapper.java.additional.24 = -XX:OnOutOfMemoryError=%KARAF_HOME%/bin/ddf_on_error.bat wrapper %p
 #wrapper.java.additional.25 = -XX:OnError=%KARAF_HOME%/bin/ddf_on_error.bat wrapper %p
 
+# The Security Manager is turned off by default in DDF.
 # N.B. The use of the double equals on the 'java.security.policy' property is intentional.
 # See http://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html#DefaultLocs
 # for more information.
-wrapper.java.additional.24 = -Djava.security.policy==%KARAF_HOME%/security/default.policy
-wrapper.java.additional.25 = -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy
-wrapper.java.additional.26 = -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
+# wrapper.java.additional.24 = -Djava.security.policy==%KARAF_HOME%/security/default.policy
+# wrapper.java.additional.25 = -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy
+# wrapper.java.additional.26 = -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
 
 #
 # Admins can uncomment the following 3 lines and comment out the other definition of
@@ -54,7 +55,7 @@ wrapper.java.additional.26 = -DproGrade.getPermissions.override=sun.rmi.server.L
 # wrapper.java.additional.29 = -Dprograde.use.own.policy=true
 #
 # Production Security Permissions
-wrapper.java.additional.27 = -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM
+# wrapper.java.additional.27 = -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM
 
 # Uncomment to enable cxf logging interceptors
 # wrapper.java.additional.28 = -Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true

--- a/distribution/ddf-common/src/main/resources/bin/setenv-wrapper.conf
+++ b/distribution/ddf-common/src/main/resources/bin/setenv-wrapper.conf
@@ -35,13 +35,13 @@ wrapper.java.additional.24 = -Djava.security.egd=file:/dev/./urandom
 wrapper.java.additional.25 = -XX:OnOutOfMemoryError=%KARAF_HOME%/bin/ddf_on_error.sh wrapper %p
 wrapper.java.additional.26 = -XX:OnError=%KARAF_HOME%/bin/ddf_on_error.sh wrapper %p
 
+# The Security Manager is turned off by default in DDF.
 # N.B. The use of the double equals on the 'java.security.policy' property is intentional.
 # See http://docs.oracle.com/javase/7/docs/technotes/guides/security/PolicyFiles.html#DefaultLocs
 # for more information.
-wrapper.java.additional.27 = -Djava.security.policy==%KARAF_HOME%/security/default.policy
-wrapper.java.additional.28 = -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy
-wrapper.java.additional.29 = -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
-
+# wrapper.java.additional.27 = -Djava.security.policy==%KARAF_HOME%/security/default.policy
+# wrapper.java.additional.28 = -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy
+# wrapper.java.additional.29 = -DproGrade.getPermissions.override=sun.rmi.server.LoaderHandler:loadClass,org.apache.jasper.compiler.JspRuntimeContext:initSecurity
 #
 # Admins can uncomment the following 3 lines and comment out the other definition of
 # the java.security.manager property in order to determine any missing security permissions
@@ -56,7 +56,7 @@ wrapper.java.additional.29 = -DproGrade.getPermissions.override=sun.rmi.server.L
 # wrapper.java.additional.32 = -Dprograde.use.own.policy=true
 #
 # Production Security Permissions
-wrapper.java.additional.30 = -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM
+# wrapper.java.additional.30 = -Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM
 
 # Uncomment to enable cxf logging interceptors
 # wrapper.java.additional.31 = -Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true

--- a/distribution/ddf-common/src/main/resources/bin/setenv-wrapper.conf
+++ b/distribution/ddf-common/src/main/resources/bin/setenv-wrapper.conf
@@ -11,7 +11,7 @@ wrapper.commandfile = %KARAF_HOME%/bin/restart.jvm
 
 # Additional JVM parameters
 # note that n is the parameter number starting from 11 (1-10 is defined in ddf-wrapper.conf).
-# make sure there is no gap
+# ### make sure there is no gap renumber remaining parameters if you add, remove or uncomment lines
 wrapper.java.additional.11 = -Dddf.home=%KARAF_HOME%
 wrapper.java.additional.12 = -Dddf.home.policy=%KARAF_HOME%/
 wrapper.java.additional.13 = -server


### PR DESCRIPTION
#### What does this PR do?
Disables the security manager when running using the service wrapper.
#### Who is reviewing it? 
@figliold @tbatie  
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic
@stustison
@coyotesqrl
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3297](https://codice.atlassian.net/browse/DDF-3297)
[DDF-3273](https://codice.atlassian.net/browse/DDF-3273)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
