### PR TITLE
[2.11.x] DDF-3383 temporarily modified clean directory() not to delete directories

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddf.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddf.bat
@@ -4,6 +4,6 @@ setlocal
 set ARGS=%*
 set DIRNAME=%~dp0%
 
-# Actually invoke ddf to gain restart support
+rem Actually invoke ddf to gain restart support
 call "%DIRNAME%/karaf.bat" %ARGS%
 

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ImportMigrationContextImplTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ImportMigrationContextImplTest.java
@@ -330,7 +330,9 @@ public class ImportMigrationContextImplTest extends AbstractMigrationTest {
 
     Assert.assertThat(dir2.toFile().exists(), Matchers.equalTo(true));
     Assert.assertThat(path2.toFile().exists(), Matchers.equalTo(false));
-    Assert.assertThat(dir.toFile().exists(), Matchers.equalTo(false));
+    // because we are temporarly not deleting sub-sirectories when cleaning, it should still exist
+    // Assert.assertThat(dir.toFile().exists(), Matchers.equalTo(false));
+    Assert.assertThat(dir.toFile().exists(), Matchers.equalTo(true));
     Assert.assertThat(path.toFile().exists(), Matchers.equalTo(false));
   }
 


### PR DESCRIPTION
#### What does this PR do?
It temporarily modifies import's clean directory feature to only delete files and not directories in order to workaround a delete handle still opened issue on Windows which renders us incapable of re-creating a directory we just deleted at import time.

A change in the migration API will be coming up with the same ticket that replace the need for this workaround.
#### Who is reviewing it? 
@tbatie @emanns95 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@figliold
@lessarderic
#### How should this be tested? (List steps with links to updated documentation)
Perform an export followed by an import on a Windows 2000 server machine.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3383](https://codice.atlassian.net/browse/DDF-3383)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
