### PR TITLE
[2.11.x] DDF-3354 Remove javafx.util.Pair and replace with internal class

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -41,8 +41,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>net.jodah</groupId>
@@ -326,7 +327,8 @@
                             hazelcast,
                             sardine,
                             httpclient,
-                            httpcore
+                            httpcore,
+                            commons-lang3
                         </Embed-Dependency>
                         <Import-Package>
                             !org.eclipse.jetty.server.bio,

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileAlterationListener.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileAlterationListener.java
@@ -24,9 +24,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import javafx.util.Pair;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.codice.ddf.platform.util.StandardThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,13 +98,13 @@ public class DurableFileAlterationListener extends FileAlterationListenerAdaptor
   @Override
   public void onFileChange(File file) {
     if (!fileMap.containsKey(file)) {
-      fileMap.put(file, new Pair<>(-1L, StandardWatchEventKinds.ENTRY_MODIFY));
+      fileMap.put(file, new ImmutablePair<>(-1L, StandardWatchEventKinds.ENTRY_MODIFY));
     }
   }
 
   @Override
   public void onFileCreate(File file) {
-    fileMap.put(file, new Pair<>(-1L, StandardWatchEventKinds.ENTRY_CREATE));
+    fileMap.put(file, new ImmutablePair<>(-1L, StandardWatchEventKinds.ENTRY_CREATE));
   }
 
   @Override
@@ -118,7 +119,7 @@ public class DurableFileAlterationListener extends FileAlterationListenerAdaptor
         completedFiles.add(entry.getKey());
         consumer.createExchangeHelper(entry.getKey(), entry.getValue().getValue());
       } else {
-        entry.setValue(new Pair<>(entry.getKey().length(), entry.getValue().getValue()));
+        entry.setValue(new ImmutablePair<>(entry.getKey().length(), entry.getValue().getValue()));
       }
     }
     completedFiles.stream().forEach(file -> fileMap.remove(file));


### PR DESCRIPTION
#### What does this PR do?
 OpenJDK installs don't have the javafx class so replacing with an internal implementation.
#### Who is reviewing it? 
@peterhuffer @emmberk 

#### Choose 2 committers to review/merge the PR. 

@bdeining 
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
CI build should be enough. If you want to get crazy you could try installing using OpenJDK and make sure the directory monitor works.

#### What are the relevant tickets?
[DDF-3354](https://codice.atlassian.net/browse/DDF-3354)
