### PR TITLE
[2.11.x] DDF-3380 Fixed needing to save a workspace twice after saving a search in Intrigue

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/QueryMetacardTypeImpl.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/QueryMetacardTypeImpl.java
@@ -136,7 +136,7 @@ public class QueryMetacardTypeImpl extends MetacardTypeImpl {
             true /* stored */,
             false /* tokenized */,
             false /* multivalued */,
-            BasicTypes.STRING_TYPE));
+            BasicTypes.BOOLEAN_TYPE));
   }
 
   public QueryMetacardTypeImpl() {


### PR DESCRIPTION
#### What does this PR do?
It's no longer required to save a workspace twice after saving a search in Intrigue.
#### Who is reviewing it? 
@emanns95 @AzGoalie 
#### Select relevant component teams: 
@codice/ui 
#### Choose 2 committers to review/merge the PR.
@andrewkfiedler
@jlcsmith
#### How should this be tested?
1. Save a search in Intrigue.
    ![image](https://user-images.githubusercontent.com/8041246/31680060-fa13f8a8-b327-11e7-9743-6cbb1b06ea72.png)
2. Save the workspace.
    <img height="55" alt="save" src="https://user-images.githubusercontent.com/8041246/31680101-234f00a0-b328-11e7-9e87-2aaea46c3894.png">

3. Notice that the workspace appears saved the first time.
    <img height="55" alt="saving" src="https://user-images.githubusercontent.com/8041246/31680272-b16edb94-b328-11e7-95a3-a40231b3480f.png">
    <img height="55" alt="saved" src="https://user-images.githubusercontent.com/8041246/31680328-db38c5fc-b328-11e7-9321-28f3e8103910.png">
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3380](https://codice.atlassian.net/browse/DDF-3380)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
