### PR TITLE
[2.11.x] DDF-3385 Updated platform-filter-delegate to auto install

### DIFF
--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -1046,7 +1046,7 @@
         <bundle>mvn:ddf.platform/platform-parser-xml/${project.version}</bundle>
     </feature>
 
-    <feature name="platform-filter-delegate" install="manual" version="${project.version}">
+    <feature name="platform-filter-delegate" install="auto" version="${project.version}">
         <feature prerequisite="true">commons</feature>
         <feature prerequisite="true" version="${project.version}">kernel</feature>
         <feature dependency="true" version="${spring.version}_1">spring</feature>


### PR DESCRIPTION
#### What does this PR do?
Changes the `platform-filter-delegate` feature to auto install. This helps alleviate an issue where it is not available for its dependencies during startup, which could cause ingest and actions to fail. This was observed most often in Windows Server 2012.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@vinamartin 
@mackncheesiest 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic
@figliold 

#### How should this be tested? (List steps with links to updated documentation)
Verify that installing DDF on Windows Server 2012 will have ingest and actions be available without requiring a restart.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3385](https://codice.atlassian.net/browse/DDF-3385)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
