### PR TITLE
[2.11.x] DDF-3386 Upgrades yarn and frontend-maven-plugin

### DIFF
--- a/libs/libs-pomfix-run/yarn.lock
+++ b/libs/libs-pomfix-run/yarn.lock
@@ -29,7 +29,7 @@ buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-chalk@^1.1.1:
+chalk@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -39,7 +39,7 @@ chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-cheerio@^0.19.0:
+cheerio@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.19.0.tgz#772e7015f2ee29965096d71ea4175b75ab354925"
   dependencies:
@@ -49,7 +49,7 @@ cheerio@^0.19.0:
     htmlparser2 "~3.8.1"
     lodash "^3.2.0"
 
-commander@^2.9.0:
+commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -122,7 +122,7 @@ escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-event-stream@^3.3.2:
+event-stream@3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   dependencies:
@@ -203,13 +203,13 @@ pause-stream@0.0.11:
 "pom-fix@file:target/npm/pom-fix":
   version "2.9.0"
   dependencies:
-    chalk "^1.1.1"
-    cheerio "^0.19.0"
-    commander "^2.9.0"
-    event-stream "^3.3.2"
-    readdirp "^2.0.0"
-    stream-combiner "^0.2.2"
-    vkbeautify "^0.99.1"
+    chalk "1.1.3"
+    cheerio "0.19.0"
+    commander "2.9.0"
+    event-stream "3.3.4"
+    readdirp "2.1.0"
+    stream-combiner "0.2.2"
+    vkbeautify "0.99.1"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -236,7 +236,7 @@ readable-stream@^2.0.2:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdirp@^2.0.0:
+readdirp@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
   dependencies:
@@ -255,7 +255,7 @@ split@0.3:
   dependencies:
     through "2"
 
-stream-combiner@^0.2.2:
+stream-combiner@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.2.2.tgz#aec8cbac177b56b6f4fa479ced8c1912cee52858"
   dependencies:
@@ -290,6 +290,6 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-vkbeautify@^0.99.1:
+vkbeautify@0.99.1:
   version "0.99.1"
   resolved "https://registry.yarnpkg.com/vkbeautify/-/vkbeautify-0.99.1.tgz#203f69e07facc04f3cfdafaa0525f865aa7d3fe1"

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <project.report.output.directory>project-info</project.report.output.directory>
         <!-- Properties for the frontend-maven-plugin -->
         <node.version>v7.1.0</node.version>
-        <yarn.version>v0.21.2</yarn.version>
+        <yarn.version>v1.2.1</yarn.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-collections4.version>4.1</commons-collections4.version>
         <commons-io.version>2.5</commons-io.version>
@@ -475,7 +475,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.4.CODICE_1</version>
+                    <version>1.6.CODICE</version>
                     <executions>
                         <execution>
                             <id>install node and yarn</id>


### PR DESCRIPTION
- Upgrades frontend-maven-plugin to https://github.com/codice/frontend-maven-plugin/tree/frontend-plugins-1.6
 - Upgrade necessary to upgrade yarn.

#### What does this PR do?
backports #2513 
#### Who is reviewing it? 
@clockard @shaundmorris 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
