### PR TITLE
DDF-3249 Turning bundle cache encryption back on

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/startup.properties
+++ b/distribution/ddf-common/src/main/resources/etc/startup.properties
@@ -7,8 +7,8 @@ mvn\:org.ops4j.pax.logging/pax-logging-api/1.10.1 = 8
 mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.10.1 = 8
 # Using a boot feature won't be good enough. We need to actually replace Felix with our own impl.
 # The following ddf.platform.osgi line (for the currently used karaf version) used to be:
-# mvn\:ddf.platform.osgi/platform-osgi-configadmin/${project.version} = 10
+mvn\:ddf.platform.osgi/platform-osgi-configadmin/${project.version} = 10
 
-mvn\:org.apache.felix/org.apache.felix.configadmin/1.8.14 = 10
+# mvn\:org.apache.felix/org.apache.felix.configadmin/1.8.14 = 10
 mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.0 = 11
 mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.1.2 = 15

--- a/platform/osgi/platform-osgi-configadmin/pom.xml
+++ b/platform/osgi/platform-osgi-configadmin/pom.xml
@@ -144,10 +144,6 @@
                             won't even start if we allow this import to be included (since it's not
                             installed in the container anymore). -->
                             !org.apache.felix.cm.*,
-                            !org.apache.log4j;resolution:=optional,
-                            !org.slf4j;resolution:=optional,
-                            !javax.crypto;resolution:=optional,
-                            !javax.crypto.spec;resolution:=optional,
                             org.osgi.service.cm;version="[1.5,1.6)",
                             org.osgi.framework;version="[1.4,2)",
                             org.osgi.service.log;resolution:=optional;version="1.3",

--- a/platform/osgi/platform-osgi-configadmin/src/main/resources/OSGI-INF/permissions.perm
+++ b/platform/osgi/platform-osgi-configadmin/src/main/resources/OSGI-INF/permissions.perm
@@ -1,2 +1,0 @@
-(java.util.PropertyPermission "*" "read")
-(java.lang.RuntimePermission "createClassLoader")


### PR DESCRIPTION
# Forward-port from 2.11.x: https://github.com/codice/ddf/pull/2526

#### What does this PR do?
Turns bundle cache encryption back on. It was turned off for Security Manager work.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@Lambeaux @blen-desta 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl 
@lessarderic 
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3249](https://codice.atlassian.net/browse/DDF-3249)
#### Screenshots (if appropriate)
#### Checklist:
- [] Documentation Updated
- [] Update / Add Unit Tests
- [] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
