### PR TITLE
DDF-3007 Ensure tika metacards have the extracted text attribute defined.

### DIFF
--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -24,6 +24,7 @@ import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.experimental.ExtractedAttributes;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Validation;
 import ddf.catalog.data.types.constants.core.DataType;
@@ -497,7 +498,6 @@ public class TikaInputTransformer implements InputTransformer {
   }
 
   protected MetacardType mergeAttributes(MetacardType metacardType) {
-    MetacardType returnObject = metacardType;
     Set<AttributeDescriptor> additionalAttributes =
         contentExtractors
             .values()
@@ -506,14 +506,11 @@ public class TikaInputTransformer implements InputTransformer {
             .flatMap(Collection::stream)
             .collect(Collectors.toSet());
 
-    // Guard against empty collection. If the collection is empty,
-    // the MetacardTypeImpl constructor throws an exception.
-    if (!additionalAttributes.isEmpty()) {
-      returnObject =
-          new MetacardTypeImpl(metacardType.getName(), metacardType, additionalAttributes);
-    }
+    // Always add extracted attribute descriptors since the given type might not have them
+    // defined. If they are not defined the attributes like extracted text will not be saved.
+    additionalAttributes.addAll(new ExtractedAttributes().getAttributeDescriptors());
 
-    return returnObject;
+    return new MetacardTypeImpl(metacardType.getName(), metacardType, additionalAttributes);
   }
 
   protected void enrichMetacard(

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -785,7 +785,7 @@ public class TikaInputTransformerTest {
   }
 
   @Test
-  public void testMetadataExtractorMetacardType() throws Exception {
+  public void testMetadataExtractorExtractedText() throws Exception {
     MetacardType metacardType = mock(MetacardType.class);
     MetadataExtractor metacardExtractor = mock(MetadataExtractor.class);
     when(metacardExtractor.canProcess(any())).thenReturn(true);
@@ -793,7 +793,10 @@ public class TikaInputTransformerTest {
     addMetadataExtractor(metacardExtractor);
 
     Metacard metacard = transform(new ByteArrayInputStream("something".getBytes()));
-    assertThat(metacard.getMetacardType(), equalTo(metacardType));
+    assertThat(
+        metacard.getMetacardType().getAttributeDescriptor(Extracted.EXTRACTED_TEXT),
+        notNullValue());
+    assertThat(metacard.getAttribute(Extracted.EXTRACTED_TEXT).getValue(), is("something\n"));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
 Ensure tika metacards have the extracted text attribute defined.
#### Who is reviewing it? 
@mcalcote @ahoffer @gordocanchola 

#### Choose 2 committers to review/merge the PR. 
@lessarderic
@rzwiefel
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Ingest office documents and ensure that they have the ext.extracted.txt attribute defined.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3007](https://codice.atlassian.net/browse/DDF-3007)
