### PR TITLE
[2.11.x] DDF-2644 Silence warnings about attribute definition discrepancies

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.collection.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.collection.view.js
@@ -220,19 +220,8 @@ define([
                         if (!metacardDefinitions.metacardTypes[property.id].multivalued){
                             if (value.sort === undefined){
                                 value = [value];
-                            } else {
-                                announcement.announce({
-                                    title: 'Conflicting Attribute Definition',
-                                    message: property.id+' claims to be singlevalued by definition, but the value on the result is not.  If this problem persists, contact your Administrator.',
-                                    type: 'warn'
-                                });
                             }
                         } else if (value.sort === undefined){
-                            announcement.announce({
-                                title: 'Conflicting Attribute Definition',
-                                message: property.id+' claims to be multivalued by definition, but the value on the result is not.  If this problem persists, contact your Administrator.',
-                                type: 'warn'
-                            });
                             value = [value];
                         }
                     } else {


### PR DESCRIPTION
#### What does this PR do?
Silence warnings about attribute definition discrepancies. Users can't do anything about these warnings and it doesn't affect the functionality so remove the warning from the user interface. 

#### Who is reviewing it? 
@mcalcote @djblue 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@lessarderic
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Install and ingest a product that has known issues with attribute definitions and verify no warning message is shown.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-2644](https://codice.atlassian.net/browse/DDF-2644)
