### PR TITLE
DDF-3401 Fixed catalog:ingest command from printing duplicate error messages

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -626,8 +626,6 @@ public class IngestCommand extends CatalogCommands {
       if (failedIngestDirectory != null) {
         moveToFailedIngestDirectory(file);
       }
-      printErrorMessage(String.format("Failed to ingest file [%s].", file.getAbsolutePath()));
-      INGEST_LOGGER.warn("Failed to ingest file [{}].", file.getAbsolutePath());
     }
 
     if (result != null) {


### PR DESCRIPTION
#### What does this PR do?
This PR updates the `catalog:ingest` command so that it no longers logs duplicate warnings to the ingest log and also stops warnings from being printed on the console that interrupt the progress bar.

_Before:_
console
```
admin@root()> catalog:ingest -t xml path/to/some/records
  0% [>                                                                       ]     0 records/secFailed to ingest file [path/to/some/records/someImage.png].
 80% [=========================================================>              ]    21 records/sec

 4 file(s) ingested in 0 seconds

1 file(s) failed to be ingested.  See the ingest log for more details.
```

ingest log:
```
10:09:07,522 | WARN  | tCommandThread 0 | ingestLogger                     | f.commands.catalog.IngestCommand  447 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | Failed to ingest file [path/to/some/records/someImage.png]:  
Invalid UTF-8 start byte 0x89 (at char #1, byte #-1)
Invalid UTF-8 start byte 0x89 (at char #1, byte #-1)
null
Error unmarshalling
Error unmarshalling
Failed Transformation.  Could not create Metacard from XML.
Transformation Failed for transformer: xml
java.lang.IllegalArgumentException: Transformation Failed for transformer: xml
10:09:07,524 | WARN  | tCommandThread 0 | ingestLogger                     | f.commands.catalog.IngestCommand  630 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | Failed to ingest file [path/to/some/records/someImage.png].
10:09:07,658 | INFO  | tCommandThread 0 | ingestLogger                     | ion.MetacardValidityMarkerPlugin   92 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | Validation results: 0 had warnings and 0 had errors.
10:09:07,712 | INFO  | oneNotXmlRecord  | ingestLogger                     | f.commands.catalog.IngestCommand  319 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | 4 file(s) ingested in 0 seconds [21 records/sec]
10:09:07,712 | WARN  | oneNotXmlRecord  | ingestLogger                     | f.commands.catalog.IngestCommand  332 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | 1 files(s) failed to be ingested.
```

_Fixed:_
console
```
admin@root()> catalog:ingest -t xml path/to/some/records
 80% [=========================================================>              ]    13 records/sec

 4 file(s) ingested in 0 seconds

1 file(s) failed to be ingested.  See the ingest log for more details.
```

ingest log:
```
10:06:38,230 | WARN  | tCommandThread 0 | ingestLogger                     | f.commands.catalog.IngestCommand  447 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | Failed to ingest file [path/to/some/records/someImage.png]:  
Invalid UTF-8 start byte 0x89 (at char #1, byte #-1)
Invalid UTF-8 start byte 0x89 (at char #1, byte #-1)
null
Error unmarshalling
Error unmarshalling
Failed Transformation.  Could not create Metacard from XML.
Transformation Failed for transformer: xml
java.lang.IllegalArgumentException: Transformation Failed for transformer: xml
10:06:38,333 | INFO  | tCommandThread 0 | ingestLogger                     | ion.MetacardValidityMarkerPlugin   92 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | Validation results: 0 had warnings and 0 had errors.
10:06:38,356 | INFO  | oneNotXmlRecord  | ingestLogger                     | f.commands.catalog.IngestCommand  319 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | 4 file(s) ingested in 0 seconds [13 records/sec]
10:06:38,357 | WARN  | oneNotXmlRecord  | ingestLogger                     | f.commands.catalog.IngestCommand  332 | 359 - catalog-plugin-metacard-validation - 2.11.1.SNAPSHOT | 1 files(s) failed to be ingested.
```

#### Who is reviewing it? 
@AzGoalie @peterhuffer
#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel
#### How should this be tested?
Ingest a batch of records with with the `catalog:ingest` command. Confirm that, when records are unable to be ingested, the output on the console and in the ingest log don't repeat warnings and that the progress bar looks correct.
#### What are the relevant tickets?
[DDF-3401](https://codice.atlassian.net/browse/DDF-3401)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
