### PR TITLE
DDF-3345 Update node security vulnerabilities for plotly.js

### DIFF
--- a/catalog/ui/catalog-ui-search/.nsprc
+++ b/catalog/ui/catalog-ui-search/.nsprc
@@ -1,18 +1,17 @@
 {
   "exceptions": [
+    "https://nodesecurity.io/advisories/57",
     "https://nodesecurity.io/advisories/106",
     "https://nodesecurity.io/advisories/120",
-    "https://nodesecurity.io/advisories/57",
-    "https://nodesecurity.io/advisories/309",
-    "https://nodesecurity.io/advisories/165",
-    "https://nodesecurity.io/advisories/328",
     "https://nodesecurity.io/advisories/127",
-    "https://nodesecurity.io/advisories/531",
-    "https://nodesecurity.io/advisories/535",
+    "https://nodesecurity.io/advisories/165",
+    "https://nodesecurity.io/advisories/309",
+    "https://nodesecurity.io/advisories/328",
     "https://nodesecurity.io/advisories/526",
     "https://nodesecurity.io/advisories/528",
+    "https://nodesecurity.io/advisories/531",
     "https://nodesecurity.io/advisories/534",
-    "https://nodesecurity.io/advisories/534",
-    "https://nodesecurity.io/advisories/534"
+    "https://nodesecurity.io/advisories/535",
+    "https://nodesecurity.io/advisories/548"
   ]
 }


### PR DESCRIPTION
#### What does this PR do?
Adds an exception for a dependency of plotly.js to the catalog-ui-search bundle.

#### Who is reviewing it? 
@oconnormi @vinamartin @djblue 

#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler @rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Observe the changes, run nsp check script to confirm the exception.

#### Any background context you want to provide?
This was causing the Node Js Security phase of the build to fail.
2.11.x PR - https://github.com/codice/ddf/pull/2547

#### What are the relevant tickets?
[DDF-3345](https://codice.atlassian.net/browse/DDF-3345)
