### PR TITLE
DDF-3402 Added cache control headers to LogoutService

### DIFF
--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutService.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutService.java
@@ -86,6 +86,8 @@ public class LogoutService {
 
     return Response.ok(
             new ByteArrayInputStream(toJson(realmToPropMaps).getBytes(StandardCharsets.UTF_8)))
+        .header("Cache-Control", "no-cache, no-store")
+        .header("Pragma", "no-cache")
         .build();
   }
 


### PR DESCRIPTION
#### What does this PR do?
Adds `no-cache` and `no-store` to the responses from LogoutService.
#### Who is reviewing it? 
@peterhuffer @emmberk @emanns95 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@clockard
#### How should this be tested? (List steps with links to updated documentation)
1. Install DDF normally
2. Clear browser cache, cookies, sessions or use an incognito/private window.
3. Login as Guest
4. Visit https://localhost:8993/logout and verify that you are logged in as Guest
5. Logout of Guest
6. Login as Admin
7. Visit https://localhost:8993/logout and verify that you are logged in as Admin

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3402](https://codice.atlassian.net/browse/3402)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
