### PR TITLE
DDF-3394 Revoked Certificate now returns 403 instead of 500

### DIFF
--- a/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
+++ b/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
@@ -104,8 +104,7 @@ public abstract class AbstractPKIHandler implements AuthenticationHandler {
       String errorMsg = "The certificate used to complete the request has been revoked.";
       LOGGER.info(errorMsg);
       try {
-        httpResponse.sendError(
-            HttpServletResponse.SC_FORBIDDEN, "Your certificate is revoked.");
+        httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Your certificate is revoked.");
         httpResponse.flushBuffer();
       } catch (Exception e) {
         LOGGER.error("Error returning revoked certificate request.");

--- a/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
+++ b/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
@@ -101,13 +101,18 @@ public abstract class AbstractPKIHandler implements AuthenticationHandler {
       handlerResult.setToken(token);
       handlerResult.setStatus(HandlerResult.Status.COMPLETED);
     } else {
-      String errorMsg = "The certificate used to complete the request has been revoked.";
-      LOGGER.info(errorMsg);
-      try {
-        httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Your certificate is revoked.");
-        httpResponse.flushBuffer();
-      } catch (Exception e) {
-        LOGGER.error("Error returning revoked certificate request.");
+
+      if (httpResponse == null) {
+        LOGGER.error(
+            "Error returning revoked certificate request because the HTTP response object is invalid.");
+      } else {
+
+        try {
+          httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Your certificate is revoked.");
+          httpResponse.flushBuffer();
+        } catch (Exception e) {
+          LOGGER.error("Error returning revoked certificate request.");
+        }
       }
       handlerResult.setStatus(HandlerResult.Status.REDIRECTED);
     }

--- a/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
+++ b/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
@@ -103,7 +103,14 @@ public abstract class AbstractPKIHandler implements AuthenticationHandler {
     } else {
       String errorMsg = "The certificate used to complete the request has been revoked.";
       LOGGER.info(errorMsg);
-      throw new ServletException(errorMsg);
+      try {
+        httpResponse.sendError(
+            HttpServletResponse.SC_FORBIDDEN, "Your certificate has been revoked.");
+        httpResponse.flushBuffer();
+      } catch (Exception e) {
+        LOGGER.error("Error returning 403 to revoked certificate request.");
+      }
+      handlerResult.setStatus(HandlerResult.Status.REDIRECTED);
     }
 
     return handlerResult;

--- a/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
+++ b/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
@@ -110,6 +110,7 @@ public abstract class AbstractPKIHandler implements AuthenticationHandler {
         try {
           httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Your certificate is revoked.");
           httpResponse.flushBuffer();
+          LOGGER.info("The certificate used to complete the request has been revoked.");
         } catch (Exception e) {
           LOGGER.error("Error returning revoked certificate request.");
         }

--- a/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
+++ b/platform/security/handler/security-handler-pki/src/main/java/org/codice/ddf/security/handler/pki/AbstractPKIHandler.java
@@ -105,10 +105,10 @@ public abstract class AbstractPKIHandler implements AuthenticationHandler {
       LOGGER.info(errorMsg);
       try {
         httpResponse.sendError(
-            HttpServletResponse.SC_FORBIDDEN, "Your certificate has been revoked.");
+            HttpServletResponse.SC_FORBIDDEN, "Your certificate is revoked.");
         httpResponse.flushBuffer();
       } catch (Exception e) {
-        LOGGER.error("Error returning 403 to revoked certificate request.");
+        LOGGER.error("Error returning revoked certificate request.");
       }
       handlerResult.setStatus(HandlerResult.Status.REDIRECTED);
     }

--- a/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/PKIHandlerTest.java
+++ b/platform/security/handler/security-handler-pki/src/test/java/org/codice/ddf/security/handler/pki/PKIHandlerTest.java
@@ -113,10 +113,8 @@ public class PKIHandlerTest {
     verify(handler.crlChecker, never()).passesCrlCheck(getTestCerts());
   }
 
-  /**
-   * Tests that the PKIHandler trows a ServletException when the cert fails to pass the CRL check
-   */
-  @Test(expected = ServletException.class)
+  /** Tests that the PKIHandler returns REDIRECTED when the cert fails to pass the CRL check */
+  @Test
   public void testGetNormalizedTokenFailsWhenCrlFails()
       throws ServletException, CertificateException {
     PKIHandler handler = getPKIHandlerWithMockedCrl("signature.properties", false);
@@ -128,8 +126,9 @@ public class PKIHandlerTest {
     when(request.getAttribute(("javax.servlet.request.X509Certificate")))
         .thenReturn(getTestCerts());
 
-    // should throw ServletException from the CrlChecker failing
-    handler.getNormalizedToken(request, response, chain, true);
+    // should return REDIRECTED
+    HandlerResult handlerResult = handler.getNormalizedToken(request, response, chain, true);
+    assertThat(handlerResult.getStatus(), equalTo(HandlerResult.Status.REDIRECTED));
   }
 
   /**

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -56,6 +56,7 @@
                 <value>${org.codice.ddf.system.rootContext}/logout</value>
                 <value>${org.codice.ddf.system.rootContext}/internal/session</value>
                 <value>/logout</value>
+                <value>/error</value>
             </array>
         </property>
         <property name="traversalDepth">

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -42,7 +42,7 @@
         <AD description="List of contexts that will not use security. Note that sub-contexts to ones listed here will also skip security, unless authentication types are provided for it. For example: if /foo is listed here, then /foo/bar will also not require any sort of authentication. However, if /foo is listed and /foo/bar has authentication types provided in the 'Authentication Types' field, then that more specific policy will be used."
             name="White Listed Contexts" id="whiteListContexts" required="true" cardinality="100"
             type="String"
-            default="${org.codice.ddf.system.rootContext}/SecurityTokenService,${org.codice.ddf.system.rootContext}/internal/metrics,/proxy,${org.codice.ddf.system.rootContext}/saml,${org.codice.ddf.system.rootContext}/idp,/idp,${org.codice.ddf.system.rootContext}/platform/config/ui,/login,/logout,${org.codice.ddf.system.rootContext}/internal/session"/>
+            default="${org.codice.ddf.system.rootContext}/SecurityTokenService,${org.codice.ddf.system.rootContext}/internal/metrics,/proxy,${org.codice.ddf.system.rootContext}/saml,${org.codice.ddf.system.rootContext}/idp,/idp,${org.codice.ddf.system.rootContext}/platform/config/ui,/login,/logout,${org.codice.ddf.system.rootContext}/internal/session,/error"/>
 
     </OCD>
 


### PR DESCRIPTION
#### What does this PR do?
Error Messages reporting a revoked certificate used to return 500, now returns 403.

#### Who is reviewing it? 
@rzwiefel @vinamartin @garrettfreibott
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@shaundmorris
@stustison
#### How should this be tested?
1. Build DDF
2. Talk to @josephthweatt or @garrettfreibott 

#### What are the relevant tickets?
[DDF-3394](https://codice.atlassian.net/browse/DDF-3394)
#### Screenshots
![image](https://user-images.githubusercontent.com/11358088/31972234-7ef43a2c-b8d4-11e7-9747-567b3a315e2c.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
