### PR TITLE
[2.11.x] DDF-3335 Added delayed start to Platform Command Scheduler jobs

### DIFF
--- a/distribution/docs/src/main/resources/content/_running/command-scheduler.adoc
+++ b/distribution/docs/src/main/resources/content/_running/command-scheduler.adoc
@@ -16,24 +16,30 @@ Writing these types of scripts are specific to the administrator's operating sys
 The administrator can also create a Command Schedule, which currently requires only two fields.
 The Command Scheduler only runs when the container is running, so there is no need to verify if the container is up.
 In addition, when the container is restarted, the commands are rescheduled and executed again.
+A command will be repeatedly executed indefinitely according to the configured interval until the container is shutdown or the Scheduled Command is deleted.
+
+[NOTE]
+====
+There will be further attempts to execute the command according to the configured interval even if an attempt fails.
+See the log for details about failures.
+====
 
 ====== Schedule a Command
 
 Configure the Command Scheduler to execute a command at specific intervals.
 
-. Navigate to the ${admin-console} (${secure_url}/admin).
+. Navigate to the *${admin-console}* (${secure_url}/admin).
 . Select the *${ddf-platform}* application.
+. Click on the *Configuration* tab.
 . Select *Platform Command Scheduler*.
 . Enter the command or commands to be executed in the *Command* text field. Commands can be separated by a semicolon and will execute in order from left to right.
-. Enter an interval in the *Interval* field.  This can either be a Quartz Cron expression or a positive integer (seconds) (e.x. '0 0 0 1/1 * ? *' or '12').
+. Enter an interval in the *Interval* field. This can either be a Quartz Cron expression or a positive integer (seconds) (e.x. `0 0 0 1/1 * ? *` or `12`).
 . Select the interval type in the *Interval Type* drop-down.
-. Select the *Save* button.
+. Click the *Save changes* button.
 
 [NOTE]
 ====
-Scheduled Commands can be updated and deleted.
-To delete, clear the fields and click *Save*.
-To update, modify the fields and click *Save*.
+Scheduling commands will be delayed by 1 minute to allow time for bundles to load when ${branding} is starting up.
 ====
 
 ===== Updating a Scheduled Command
@@ -43,17 +49,15 @@ Change the timing, order, or execution of scheduled commands.
 . Navigate to the *${admin-console}*.
 . Click on the *${ddf-platform}* application.
 . Click on the *Configuration* tab.
-. Under the *Platform Command Scheduler* configuration are all the scheduled commands.
-Scheduled commands have the following syntax `${ddf-branding-lowercase}.platform.scheduler.Command.{GUID}` such as `${ddf-branding-lowercase}.platform.scheduler.Command.4d60c917-003a-42e8-9367-1da0f822ca6e`.
-. Find the desired configuration to modify and update either the *Command* text field, the *Interval* field, or the *Interval Type*.
-. Click *Save changes*.
-Once the Save button has been clicked, the command will be executed immediately.
-Its next scheduled execution happens after the time specified in Interval In Seconds and repeats indefinitely until the container is shutdown or the Scheduled Command is deleted.
+. Under the *Platform Command Scheduler* configuration are all of the scheduled commands.
+Scheduled commands have the following syntax: `${ddf-branding-lowercase}.platform.scheduler.Command.{GUID}` such as `${ddf-branding-lowercase}.platform.scheduler.Command.4d60c917-003a-42e8-9367-1da0f822ca6e`.
+. Find the desired configuration to modify, and update fields.
+. Click the *Save changes* button.
 
 ====== Command Output
 
-Commands that normally write out to the console will write out to the distribution's log.
-For example, if an `echo "Hello World"` command is set to run every five seconds, the log displays the following:
+Commands that normally write out to the console will write out to the log.
+For example, if an `echo "Hello World"` command is set to run every five seconds, the log contains the following:
 
 .Sample Command Output in the Log
 ----

--- a/platform/platform-scheduler/pom.xml
+++ b/platform/platform-scheduler/pom.xml
@@ -137,17 +137,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.71</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.56</minimum>
+                                            <minimum>0.57</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/CommandJob.java
+++ b/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/CommandJob.java
@@ -20,9 +20,11 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import org.apache.felix.gogo.runtime.CommandNotFoundException;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.shell.api.console.Session;
 import org.apache.karaf.shell.api.console.SessionFactory;
+import org.apache.shiro.subject.ExecutionException;
 import org.codice.ddf.security.common.Security;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -30,7 +32,6 @@ import org.osgi.framework.FrameworkUtil;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +43,9 @@ import org.slf4j.LoggerFactory;
  */
 public class CommandJob implements Job {
 
-  public static final String COMMAND_KEY = "command";
-
   private static final Logger LOGGER = LoggerFactory.getLogger(CommandJob.class);
+
+  public static final String COMMAND_KEY = "command";
 
   private static final Security SECURITY = Security.getInstance();
 
@@ -53,143 +54,133 @@ public class CommandJob implements Job {
   }
 
   @Override
-  public void execute(final JobExecutionContext context) throws JobExecutionException {
-    // TODO extract the command name and use that in the log messages
+  public void execute(final JobExecutionContext context) {
+    final String commandString = getCommandString(context);
+    if (StringUtils.isNotBlank(commandString)) {
+      try {
+        SECURITY.runAsAdmin(
+            () -> {
+              final Subject subject = getSystemSubject();
 
-    try {
-      SECURITY.runAsAdmin(
-          () -> {
-            Subject subject = getSystemSubject();
+              if (subject != null) {
+                try {
+                  subject.execute(
+                      () -> {
+                        doExecute(commandString);
+                        return null;
+                      });
+                } catch (ExecutionException e) {
+                  logWarningMessage(commandString);
+                  LOGGER.debug("Unable to execute as subject.", e);
+                }
+              } else {
+                // This might happen when the system is very slow to start up where not all of the
+                // required security bundles are started yet.
+                logWarningMessage(commandString);
+                LOGGER.debug("Unable to get system subject.");
+              }
 
-            if (subject != null) {
-              subject.execute(
-                  () -> {
-                    doExecute(context);
-                    return null;
-                  });
-            } else {
-              // This might happen when the system is very slow to start up where not all of the
-              // required security bundles are started yet.
-              LOGGER.debug("Could not execute command. Could not get subject to run command.");
-            }
-
-            return null;
-          });
-    } catch (RuntimeException e) {
-      // This might happen when the system is very slow to start up where not all of the required
-      // security bundles are started yet.
-      LOGGER.info("Could not execute command as admin. See debug log for more details.");
-      LOGGER.debug("Could not execute command as admin.", e);
+              return null;
+            });
+      } catch (RuntimeException e) {
+        // This might happen when the system is very slow to start up where not all of the required
+        // security bundles are started yet.
+        logWarningMessage(commandString);
+        LOGGER.debug("Could not execute command as admin.", e);
+      }
+    } else {
+      LOGGER.warn(
+          "Could not execute command. Unable to get non-blank command string from job execution context.");
     }
   }
 
+  @Nullable
   private Bundle getBundle() {
     return FrameworkUtil.getBundle(getClass());
   }
 
+  @Nullable
   protected SessionFactory getSessionFactory() {
-    BundleContext bundleContext = getBundle().getBundleContext();
-    if (bundleContext == null) {
-      return null;
+    final Bundle bundle = getBundle();
+    if (bundle != null) {
+      final BundleContext bundleContext = bundle.getBundleContext();
+      if (bundleContext != null) {
+        return bundleContext.getService(bundleContext.getServiceReference(SessionFactory.class));
+      }
     }
-    return bundleContext.getService(bundleContext.getServiceReference(SessionFactory.class));
+
+    return null;
   }
 
-  private void doExecute(JobExecutionContext context) {
-    String commandInput;
-    try {
-      commandInput = checkInput(context);
-    } catch (CommandException e) {
-      LOGGER.debug("unable to get command from job execution context", e);
-      return;
-    }
+  private void doExecute(final String commandString) {
+    final SessionFactory sessionFactory = getSessionFactory();
+    if (sessionFactory != null) {
+      try (final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+          final PrintStream output = createPrintStream(byteArrayOutputStream);
+          // TODO DDF-3280 remove work-around for NPE when creating session with a null "in"
+          // parameter from a SessionFactory
+          final InputStream emptyInputStream =
+              new InputStream() {
+                @Override
+                public int read() throws IOException {
+                  LOGGER.error(
+                      "This method implementation of an InputStream is just a work-around for a Karaf bug and should never be called. There is an issue with the Platform Command Scheduler implementation.");
+                  return -1;
+                }
+              };
+          final Session session = sessionFactory.create(emptyInputStream, output, output)) {
+        if (session != null) {
+          LOGGER.trace("Executing command \"{}\"", commandString);
+          try {
+            session.execute(commandString);
 
-    SessionFactory sessionFactory = getSessionFactory();
+            try {
+              final String commandOutput =
+                  byteArrayOutputStream.toString(StandardCharsets.UTF_8.name());
 
-    if (sessionFactory == null) {
-      LOGGER.debug("unable to create session factory: command=[{}]", commandInput);
-      return;
-    }
-
-    Session session = null;
-
-    try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        PrintStream output = getPrintStream(byteArrayOutputStream);
-        // TODO DDF-3280 remove work-around for NPE when creating session with a null "in" parameter
-        // from a SessionFactory
-        InputStream emptyInputStream =
-            new InputStream() {
-              @Override
-              public int read() throws IOException {
-                LOGGER.error(
-                    "This method implementation of an InputStream is just a work-around for a Karaf bug and should never be called. There is an issue with the Platform Command Scheduler implementation.");
-                return -1;
-              }
-            }) {
-
-      session = sessionFactory.create(emptyInputStream, output, output);
-
-      if (session == null) {
-        LOGGER.debug("unable to create session: command=[{}]", commandInput);
-        return;
-      }
-
-      if (commandInput != null) {
-        try {
-          LOGGER.trace("Executing command [{}]", commandInput);
-          session.execute(commandInput);
-          LOGGER.info(
-              "Execution Output: {}",
-              byteArrayOutputStream.toString(StandardCharsets.UTF_8.name()));
-        } catch (CommandNotFoundException e) {
-          LOGGER.info(
-              "Command could not be found. Make sure the command's library has been loaded and try again: {}",
-              e.getLocalizedMessage());
-          LOGGER.debug("Command not found.", e);
-        } catch (Exception e) {
-          LOGGER.info("Error with execution. ", e);
+              LOGGER.info("Execution output for command \"{}\": {}", commandString, commandOutput);
+            } catch (UnsupportedEncodingException e) {
+              LOGGER.debug("Unable to get command output.", e);
+            }
+          } catch (Exception e) {
+            logWarningMessage(commandString);
+            LOGGER.debug("Unable to execute command.", e);
+          }
+        } else {
+          logWarningMessage(commandString);
+          LOGGER.debug("Unable to create session.");
         }
+      } catch (IOException e) {
+        logWarningMessage(commandString);
+        LOGGER.debug("Unable to create session.", e);
       }
-    } catch (UnsupportedEncodingException e) {
-      LOGGER.info("Unable to produce output", e);
-    } catch (IOException e) {
-      LOGGER.warn(
-          "Error with the emptyInputStream used as a work-around for a Karaf bug. This should never happen. There is an issue with the Platform Command Scheduler implementation.",
-          e);
-    } finally {
-      if (session != null) {
-        session.close();
-      }
+    } else {
+      logWarningMessage(commandString);
+      LOGGER.debug("Unable to create session factory.");
     }
   }
 
-  private PrintStream getPrintStream(ByteArrayOutputStream byteArrayOutputStream)
+  private PrintStream createPrintStream(ByteArrayOutputStream byteArrayOutputStream)
       throws UnsupportedEncodingException {
     return new PrintStream(byteArrayOutputStream, false, StandardCharsets.UTF_8.name());
   }
 
-  private String checkInput(JobExecutionContext context) throws CommandException {
-    String command = null;
+  @Nullable
+  private static String getCommandString(JobExecutionContext context) {
+    if (context != null) {
+      final JobDataMap mergedJobDataMap = context.getMergedJobDataMap();
 
-    if (context == null) {
-      LOGGER.debug(
-          "No JobExecutionContext found. Could not fire {}", CommandJob.class.getSimpleName());
-      throw new CommandException();
+      if (mergedJobDataMap != null) {
+        return mergedJobDataMap.getString(COMMAND_KEY);
+      }
     }
 
-    JobDataMap mergedJobDataMap = context.getMergedJobDataMap();
-
-    if (mergedJobDataMap == null) {
-      LOGGER.debug("No input found. Could not fire {}", CommandJob.class.getSimpleName());
-      throw new CommandException();
-    }
-
-    if (mergedJobDataMap.getString(COMMAND_KEY) != null) {
-      command = mergedJobDataMap.getString(COMMAND_KEY);
-    }
-
-    return command;
+    return null;
   }
 
-  private static class CommandException extends Exception {}
+  private void logWarningMessage(String commandString) {
+    LOGGER.warn(
+        "Unable to execute command \"{}\". See debug log for more details. The command is still scheduled for execution according to the configured interval.",
+        commandString);
+  }
 }

--- a/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/CommandJob.java
+++ b/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/CommandJob.java
@@ -127,7 +127,7 @@ public class CommandJob implements Job {
         try {
           LOGGER.trace("Executing command [{}]", commandInput);
           session.execute(commandInput);
-          LOGGER.trace(
+          LOGGER.info(
               "Execution Output: {}",
               byteArrayOutputStream.toString(StandardCharsets.UTF_8.name()));
         } catch (CommandNotFoundException e) {

--- a/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/ScheduledCommandTask.java
+++ b/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/ScheduledCommandTask.java
@@ -155,16 +155,16 @@ public class ScheduledCommandTask implements ScheduledTask {
       this.command = commandValue.toString();
     }
 
-    Object intervalString = properties.get(INTERVAL_STRING);
-    if (intervalString != null) {
-      LOGGER.debug("Updating intervalString : {}", intervalString);
-      this.intervalString = (String) intervalString;
+    Object intervalStringPropertyValue = properties.get(INTERVAL_STRING);
+    if (intervalStringPropertyValue != null) {
+      LOGGER.debug("Updating intervalString : {}", intervalStringPropertyValue);
+      this.intervalString = (String) intervalStringPropertyValue;
     }
 
-    Object intervalType = properties.get(INTERVAL_TYPE);
-    if (intervalType != null) {
-      LOGGER.debug("Updating intervalType : {}", intervalType);
-      this.intervalType = (String) intervalType;
+    Object intervalTypePropertyValue = properties.get(INTERVAL_TYPE);
+    if (intervalTypePropertyValue != null) {
+      LOGGER.debug("Updating intervalType : {}", intervalTypePropertyValue);
+      this.intervalType = (String) intervalTypePropertyValue;
     }
 
     JobDetail newJob = createJob();
@@ -229,12 +229,13 @@ public class ScheduledCommandTask implements ScheduledTask {
   }
 
   private Date getTriggerStartTime() {
+    final String timeUnitString = TRIGGER_DELAY_TIME_UNIT.name().toLowerCase();
     LOGGER.debug(
         "Creating trigger with {} {}. Delaying start by {} {}.",
         intervalString,
         intervalType,
         TRIGGER_DELAY_DURATION,
-        TRIGGER_DELAY_TIME_UNIT.name().toLowerCase());
+        timeUnitString);
 
     return new Date(
         System.currentTimeMillis() + TRIGGER_DELAY_TIME_UNIT.toMillis(TRIGGER_DELAY_DURATION));

--- a/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/ScheduledTask.java
+++ b/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/ScheduledTask.java
@@ -31,7 +31,7 @@ public interface ScheduledTask {
    * Removes a task completely so that it does not run or exist.
    *
    * @param code - not used
-   * @see https://issues.apache.org/jira/browse/ARIES-1436
+   * @see <a href="ARIES-1436">https://issues.apache.org/jira/browse/ARIES-1436</a>
    */
   void deleteTask(int code);
 

--- a/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/ServiceStore.java
+++ b/platform/platform-scheduler/src/main/java/ddf/platform/scheduler/ServiceStore.java
@@ -27,7 +27,7 @@ public class ServiceStore {
 
   private static ServiceStore uniqueInstance;
 
-  private Map<String, Object> map = new HashMap<>();
+  private final Map<String, Object> map = new HashMap<>();
 
   private ServiceStore() {}
 

--- a/platform/platform-scheduler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/platform-scheduler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -14,27 +14,28 @@
 -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
-  <OCD description="" name="Platform Command Scheduler" id="ddf.platform.scheduler.Command">
-  
-    <AD name="Command" id="command" required="true" type="String" default=""
-        description="Shell command to be used within the container. For example, log:set DEBUG">
-    </AD>
-    
-    <AD name="Interval" id="intervalString"
-        description="The Interval String for each execution. Based on the Interval Type, this will either be a Cron String or a Second Interval.  (e.x. '0 0 0 1/1 * ? *' or '12')"
-        required="true" type="String"/>
+    <OCD name="Platform Command Scheduler"
+         description="The Platform Command Scheduler allows administrators to schedule Command Line Commands to be run at specified intervals."
+         id="ddf.platform.scheduler.Command">
 
-    <AD name="Interval Type" id="intervalType"
-        description="Interval Type"
-        required="true" type="String" default="cronString">
-        <Option label="Cron Expression" value="cronString"/>
-        <Option label="Second Interval" value="secondInterval"/>
-    </AD>
+        <AD name="Command"
+            description="Shell command to be used within the container. For example, log:set DEBUG"
+            id="command" type="String"/>
 
-  </OCD>
+        <AD name="Interval"
+            description="The Interval String for each execution. Based on the Interval Type, this will either be a Cron Expression (e.g. '0 0 0 1/1 * ? *') or a Second Interval (e.g. '12'). NOTE: Scheduling commands will be delayed by 1 minute. See the Documentation for more details."
+            id="intervalString" type="String"/>
 
-  <Designate pid="ddf.platform.scheduler.Command" factoryPid="ddf.platform.scheduler.Command">
-    <Object ocdref="ddf.platform.scheduler.Command"/>
-  </Designate>
-  
+        <AD name="Interval Type" description="Interval Type" id="intervalType" type="String"
+            default="cronString">
+            <Option label="Cron Expression" value="cronString"/>
+            <Option label="Second Interval" value="secondInterval"/>
+        </AD>
+
+    </OCD>
+
+    <Designate pid="ddf.platform.scheduler.Command" factoryPid="ddf.platform.scheduler.Command">
+        <Object ocdref="ddf.platform.scheduler.Command"/>
+    </Designate>
+
 </metatype:MetaData>

--- a/platform/platform-scheduler/src/main/resources/quartz.properties
+++ b/platform/platform-scheduler/src/main/resources/quartz.properties
@@ -4,18 +4,18 @@
 # Only difference from main file is the 
 # org.quartz.scheduler.skipUpdateCheck is set to true
 
-org.quartz.scheduler.instanceName: DefaultQuartzScheduler
-org.quartz.scheduler.rmi.export: false
-org.quartz.scheduler.rmi.proxy: false
-org.quartz.scheduler.wrapJobExecutionInUserTransaction: false
+org.quartz.scheduler.instanceName = DefaultQuartzScheduler
+org.quartz.scheduler.rmi.export = false
+org.quartz.scheduler.rmi.proxy = false
+org.quartz.scheduler.wrapJobExecutionInUserTransaction = false
 
-org.quartz.threadPool.class: org.quartz.simpl.SimpleThreadPool
-org.quartz.threadPool.threadCount: 10
-org.quartz.threadPool.threadPriority: 5
-org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread: true
+org.quartz.threadPool.class = org.quartz.simpl.SimpleThreadPool
+org.quartz.threadPool.threadCount = 10
+org.quartz.threadPool.threadPriority = 5
+org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread = true
 
-org.quartz.jobStore.misfireThreshold: 60000
+org.quartz.jobStore.misfireThreshold = 60000
 
-org.quartz.jobStore.class: org.quartz.simpl.RAMJobStore
+org.quartz.jobStore.class = org.quartz.simpl.RAMJobStore
 
 org.quartz.scheduler.skipUpdateCheck = true

--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/Security.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/Security.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.shiro.UnavailableSecurityManagerException;
@@ -176,8 +177,9 @@ public class Security {
    * Gets the {@link Subject} associated with this system. Uses a cached subject since the subject
    * will not change between calls.
    *
-   * @return system's {@link Subject}
+   * @return system's {@link Subject} or {@code null} if unable to get the system's {@link Subject}
    */
+  @Nullable
   public synchronized Subject getSystemSubject() {
 
     if (!javaSubjectHasAdminRole()) {
@@ -285,13 +287,17 @@ public class Security {
   /**
    * Gets a reference to the {@link SecurityManager}.
    *
-   * @return reference to the {@link SecurityManager}
+   * @return reference to the {@link SecurityManager} or {@code null} if unable to get the {@link
+   *     SecurityManager}
    */
+  @Nullable
   public SecurityManager getSecurityManager() {
     BundleContext context = getBundleContext();
     if (context != null) {
       ServiceReference securityManagerRef = context.getServiceReference(SecurityManager.class);
-      return (SecurityManager) context.getService(securityManagerRef);
+      if (securityManagerRef != null) {
+        return (SecurityManager) context.getService(securityManagerRef);
+      }
     }
     LOGGER.warn(
         "Unable to get Security Manager. Authentication and Authorization mechanisms will not work correctly. A restart of the system may be necessary.");


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue where platform-scheduler fails on the first attempt(s) to run command jobs after a restart. There is now a 1 minute delay before `Platform Command Scheduler` jobs are started.
#### Who is reviewing it? 
@peterhuffer @AzGoalie @oconnormi 
#### Choose 2 committers to review/merge the PR. 
@clockard
@lessarderic
#### How should this be tested?

1. Before starting up for the first time, add a `ddf.platform.scheduler.Command` configuration file to `/etc`. When I tested, I used

    _`ddf.platform.scheduler.Command-removeExpiredRecords.config`_
    ```
    command="removeall\ -f\ --expired"
    intervalString="10"
    intervalType="secondInterval"
    
    ```

    I made the interval small so I could see it execute multiple times. I also used a command that will only work after installation to make sure that everything works as expected.

2. Start up DDF.
3. Search for `platform-scheduler` in the ddf log, and confirm that there are no `Platform Command Scheduler` warnings.
4. Complete the installer.
5. Follow the Documentation to schedule a new job, and confirm that the new job starts and works as expected.
6. Restart DDF.
7. Check the logs during start-up, search for `platform-scheduler` in the ddf log, and again confirm that there are `Platform Command Scheduler` warnings.
8. Confirm that the previously-configured jobs are working.

#### Any background context you want to provide?
During start-up, the `Platform Command Scheduler` would attempt to execute commands before required bundles has been started, causing nasty error messages to be logged.
#### What are the relevant tickets?
[DDF-3335](https://codice.atlassian.net/browse/DDF-3335)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
