### PR TITLE
[2.11.x] DDF-3417 Fix remote registry modal closing issue when deleting

### DIFF
--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/Registry.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/Registry.js
@@ -126,7 +126,7 @@ function (Q, Service, Backbone, _) {
         createDeletePromise: function(registry, config) {
             var deferred = Q.defer();
             var serviceModels = this.model.get('value');
-            config.destroy().success(function() {
+            config.destroy().done(function() {
                 //sync up the service model so that the refresh updates properly
                 serviceModels.remove(config.getService());
                 deferred.resolve({


### PR DESCRIPTION
#### What does this PR do?
Fix remote registry modal closing issue when deleting
#### Who is reviewing it? 
@vinamartin @mcalcote @peterhuffer 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and install the registry
Navigate to the Remote Registries tab 
Add some remote registry
Click the trash can icon to see the "Delete Registry Configuration" window
Select some remote registry to delete and click delete
See that the modal does disappears 
#### What are the relevant tickets?
[DDF-3417](https://codice.atlassian.net/browse/DDF-3417)
