### PR TITLE
[2.11.x] DDF-3419 Add timeout parameters to CSW federation source metatype

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/csw/spatial-csw-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -134,6 +134,14 @@
             required="false" type="String"/>
         <AD description="Password for CSW Service (optional)" name="Password" id="password"
             required="false" type="Password" default=""/>
+
+        <AD description="Amount of time to attempt to establish a connection before timing out, in milliseconds."
+            name="Connection Timeout" id="connectionTimeout"
+            required="true" type="Integer" default="30000"/>
+
+        <AD description="Amount of time to wait for a response before timing out, in milliseconds."
+            name="Receive Timeout" id="receiveTimeout"
+            required="true" type="Integer" default="60000"/>
     </OCD>
 
     <OCD name="GMD CSW ISO Federated Source" id="Gmd_Csw_Federated_Source"

--- a/distribution/docs/src/main/resources/content/_tables/Csw_Federation_Profile_Source.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/Csw_Federation_Profile_Source.adoc
@@ -58,4 +58,18 @@
 |null
 |false
 
+|Connection Timeout
+|connectionTimeout
+|Integer
+|Amount of time to attempt to establish a connection before timing out,in milliseconds.
+|30000
+|true
+
+|Receive Timeout
+|receiveTimeout
+|Integer
+|Amount of time to wait for a response before timing out,in milliseconds.
+|60000
+|true
+
 |===


### PR DESCRIPTION
#### What does this PR do?
 Add timeout parameters to CSW federation source metatype
#### Who is reviewing it? 
@peterhuffer @emmberk @AzGoalie 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Install DDF
Go to Catalog->Sources and add CSW Federation Profile Source
Verify that you can set the two timeout parameters

#### What are the relevant tickets?
[DDF-3419](https://codice.atlassian.net/browse/DDF-3419)

