### PR TITLE
DDF-3410 Updates conflicting definition warning tactic

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/add-attribute/add-attribute.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/add-attribute/add-attribute.view.js
@@ -29,7 +29,7 @@ function determineMissingAttributes(selectionInterface) {
     var types = _.union.apply(this, selectionInterface.getSelectedResults().map((result) => {
         return [result.get('metacardType')];
     }));
-    var possibleAttributes = _.union.apply(this, types.map((type) => {
+    var possibleAttributes = _.intersection.apply(this, types.map((type) => {
         return Object.keys(metacardDefinitions.metacardDefinitions[type]);
     }));
     var missingAttributes = _.difference(possibleAttributes, attributes);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/attributes-rearrange/attributes-rearrange.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/attributes-rearrange/attributes-rearrange.view.js
@@ -25,10 +25,16 @@ var Sortable = require('sortablejs');
 var metacardDefinitions = require('component/singletons/metacard-definitions');
 
 function calculateAvailableAttributesFromSelection(selectionInterface) {
+    var types = _.union.apply(this, selectionInterface.getSelectedResults().map((result) => {
+        return [result.get('metacardType')];
+    }));
+    var possibleAttributes = _.intersection.apply(this, types.map((type) => {
+        return Object.keys(metacardDefinitions.metacardDefinitions[type]);
+    }));
     return selectionInterface.getSelectedResults().reduce(function (currentAvailable, result) {
         currentAvailable = _.union(currentAvailable, Object.keys(result.get('metacard').get('properties').toJSON()));
         return currentAvailable;
-    }, []).filter(function (property) {
+    }, []).filter((attribute) => possibleAttributes.indexOf(attribute) >= 0).filter(function (property) {
         if (metacardDefinitions.metacardTypes[property]) {
             return !metacardDefinitions.metacardTypes[property].hidden;
         } else {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/hide-attribute/hide-attribute.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/hide-attribute/hide-attribute.view.js
@@ -39,10 +39,16 @@ function filterAndSort(attributes){
 }
 
 function calculateAvailableAttributesFromSelection(selectionInterface) {
+    var types = _.union.apply(this, selectionInterface.getSelectedResults().map((result) => {
+        return [result.get('metacardType')];
+    }));
+    var possibleAttributes = _.intersection.apply(this, types.map((type) => {
+        return Object.keys(metacardDefinitions.metacardDefinitions[type]);
+    }));
     return selectionInterface.getSelectedResults().reduce(function (currentAvailable, result) {
         currentAvailable = _.union(currentAvailable, Object.keys(result.get('metacard').get('properties').toJSON()));
         return currentAvailable;
-    }, []);
+    }, []).filter((attribute) => possibleAttributes.indexOf(attribute) >= 0);
 }
 
 function calculateDetailsAttributes() {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.hbs
@@ -14,6 +14,10 @@
 <div class="property-readOnly" data-help="This attribute has been made read only by your Administrator.">
     <span>Read Only</span>
 </div>
+<div class="property-conflictingDefinitions" data-help="This attribute has been made read only to protect against conflicting definitions.  If you need to edit this field
+    please contact your Administrator and let them know that this attribute has conflicting definitions (claims to be single valued but isn't and vice versa).">
+    <span>Conflicting Definitions</span>
+</div>
 <div class="property-label">
     <div class="if-inline">
         <span class="if-editing fa fa-undo property-revert is-button"></span>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.js
@@ -133,6 +133,9 @@ define([
         isReadOnly: function(){
             return this.get('readOnly');
         },
+        hasConflictingDefinitions: function() {
+            return this.get('hasConflictingDefinition') === true;
+        },
         isEditing: function(){
             return this.get('isEditing');  
         },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.less
@@ -58,13 +58,9 @@
     padding: 0px @minimumSpacing;
   }
 
-  .property-readOnly {
+  .property-readOnly,
+  .property-conflictingDefinitions {
     display: none;
-  }
-}
-
-@{customElementNamespace}property.is-readOnly.is-editing {
-  .property-readOnly {
     left: 0px;
     top: 0px;
     width: 100%;
@@ -75,11 +71,22 @@
     height: 100%;
     padding-right: @largeSpacing;
     padding-top: @minimumSpacing;
-    display: inline-block;
     color: @heavily-lighten-inherited-background-color;
     opacity: @minimumOpacity;
     .background-gradient(@lighten-inherited-background-color, @darken-inherited-background-color);
     z-index: 0;
+  }
+}
+
+@{customElementNamespace}property.is-editing.has-conflicting-definitions:not(.is-readOnly) {
+  .property-conflictingDefinitions {
+    display: inline-block;
+  }
+}
+
+@{customElementNamespace}property.is-readOnly.is-editing {
+  .property-readOnly {
+    display: inline-block;
   }
 }
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/property/property.view.js
@@ -54,6 +54,7 @@ define([
         onRender: function () {
             this.handleEdit();
             this.handleReadOnly();
+            this.handleConflictingAttributeDefinition();
             this.handleValue();
             this.handleRevert();
             this.handleValidation();
@@ -77,6 +78,9 @@ define([
         handleLabel: function(){
             this.$el.toggleClass('hide-label', !this.model.showLabel());
         },
+        handleConflictingAttributeDefinition: function() {
+            this.$el.toggleClass('has-conflicting-definitions', this.model.hasConflictingDefinitions());
+        },
         handleReadOnly: function () {
             this.$el.toggleClass('is-readOnly', this.model.isReadOnly());
         },
@@ -87,7 +91,7 @@ define([
             this.$el.find('input').val(this.model.getValue());
         },
         turnOnEditing: function(){
-            if (!this.model.get('readOnly')) {
+            if (!this.model.get('readOnly') && !this.model.hasConflictingDefinitions()) {
                 this.model.set('isEditing', true);
             }
             this.$el.addClass('is-editing');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/remove-attribute/remove-attribute.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/remove-attribute/remove-attribute.view.js
@@ -26,7 +26,7 @@ function determineAttributes(selectionInterface) {
     var types = _.union.apply(this, selectionInterface.getSelectedResults().map((result) => {
         return [result.get('metacardType')];
     }));
-    var possibleAttributes = _.union.apply(this, types.map((type) => {
+    var possibleAttributes = _.intersection.apply(this, types.map((type) => {
         return Object.keys(metacardDefinitions.metacardDefinitions[type]);
     }));
     var attributes = _.union.apply(this, selectionInterface.getSelectedResults().map((result) => {


### PR DESCRIPTION
Follow on to: https://github.com/codice/ddf/pull/2542

#### What does this PR do?
 - Conflicting definitions are no longer warned about in announcements, they are now warned only when the user is in edit mode.  It's similar to read only attributes, except it shows 'Conflicting Definition'.  The help prompts them to contact the admin.  We do have to disallow editing, since it will appear to succeed but not actually change the attribute correctly.
 - Fixes a few places where we weren't intersecting metacard types.

Who is reviewing it?

@mcalcote @djblue

Choose 2 committers to review/merge the PR.

(please choose ONLY two committers from below, delete the rest)
@rzwiefel
@shaundmorris
@clockard 

How should this be tested?
Install and ingest a product that has known issues with attribute definitions and verify no warning message is shown.  Go to the details view and verify that in edit mode the attribute with conflicting definitions is read only (it will say conflicting definitions).  Note that read only will take precedence over conflicting definitions if both are present (although the end result is the same, read only).

![screen shot 2017-10-27 at 4 40 57 pm](https://user-images.githubusercontent.com/11984853/32132021-72f49fde-bb70-11e7-99ec-5a9e4c851cbd.png)


What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3410