### PR TITLE
DDF-3216 Makes notes view for queries visible

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.hbs
@@ -53,6 +53,13 @@
         Search Historical
     </div>
 </div>
+<div class="query-interaction interaction-annotations" title="View Notes" data-help="View notes on the search.">
+    <div class="interaction-icon fa fa-sticky-note-o">
+    </div>
+    <div class="interaction-text">
+        View Notes
+    </div>
+</div>
 <div class="query-interaction interaction-feedback" title="Submit Feedback" data-help="Brings up a form to submit comments about your current search and it's results">
     <div class="interaction-icon fa fa-comment">
     </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.less
@@ -53,3 +53,9 @@
     display: none !important;
   }
 }
+
+@{customElementNamespace}query-interactions.is-local {
+  .interaction-annotations {
+    display: none !important;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
@@ -26,10 +26,11 @@ define([
     'component/lightbox/lightbox.view.instance',
     'component/query-feedback/query-feedback.view',
     'component/confirmation/query/confirmation.query.view',
-    'component/loading/loading.view'
+    'component/loading/loading.view',
+    'component/query-annotations/query-annotations.view'
 ], function (wreqr, Marionette, _, $, template, CustomElements, 
     store, MenuNavigationDecorator, Decorators, lightboxInstance, 
-    QueryFeedbackView, QueryConfirmationView, LoadingView) {
+    QueryFeedbackView, QueryConfirmationView, LoadingView, QueryAnnotationsView) {
 
     return Marionette.ItemView.extend(Decorators.decorate({
         template: template,
@@ -44,6 +45,7 @@ define([
             'click .interaction-deleted': 'handleDeleted',
             'click .interaction-historic': 'handleHistoric',
             'click .interaction-feedback': 'handleFeedback',
+            'click .interaction-annotations': 'handleAnnotations',
             'click': 'handleClick'
         },
         ui: {
@@ -56,6 +58,10 @@ define([
             QueryConfirmationView = require('component/confirmation/query/confirmation.query.view');
         },
         onRender: function(){
+            this.handleLocal();
+        },
+        handleLocal: function() {
+            this.$el.toggleClass('is-local', this.model.isLocal());
         },
         startListeningToSearch: function(){
             this.listenToOnce(this.model, 'change:result', this.startListeningForResult);
@@ -122,6 +128,13 @@ define([
                 model: this.model
             }));
         },  
+        handleAnnotations: function() {
+            lightboxInstance.model.updateTitle('Search Notes');
+            lightboxInstance.model.open();
+            lightboxInstance.lightboxContent.show(new QueryAnnotationsView({
+                model: this.model
+            }));
+        },
         handleResult: function(){
             this.$el.toggleClass('has-results', this.model.get('result') !== undefined);
         },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-schedule/query-schedule.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-schedule/query-schedule.view.js
@@ -110,9 +110,14 @@ define([
             this.$el.trigger('closeDropdown.'+CustomElements.getNamespace());
         },
         save: function() {
-            this.model.set({
-                polling: this.propertyInterval.currentView.model.getValue()[0]
-            });
+            var value =  this.propertyInterval.currentView.model.getValue()[0];
+            if (value === false) {
+                this.model.unset('polling');
+            } else {
+                this.model.set({
+                    polling: value
+                });
+            }
             this.cancel();
         }
     });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.hbs
@@ -19,5 +19,12 @@
     {{bind selector="> .choice-date" event="change:modified" key=(path "niceDate")}}
 </div>
 <div class="choice-owner" title="{{bindAttr attr="title" selector="> .choice-owner" event="change:metacard.owner" key=(path "owner")}}" data-help="The owner of the workspace.">
-    {{bind selector="> .choice-owner" event="change:metacard.owner" key=(path "owner")}}
+    {{#if localStorage}} 
+        <span class="fa fa-home"></span>
+    {{else}}
+        <span class="fa fa-cloud"></span>
+    {{/if}}
+    <span class='owner-id'>
+        {{bind selector="> .choice-owner > .owner-id" event="change:metacard.owner" key=(path "owner")}}
+    </span>
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.less
@@ -45,3 +45,12 @@
     display: none;
   }
 }
+
+@{customElementNamespace}workspace-interactions.is-local {
+  .interaction-subscribe,
+  .interaction-unsubscribe,
+  .interaction-details,
+  .interaction-share {
+    display: none !important;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.view.js
@@ -55,6 +55,10 @@ define([
         initialize: function() {},
         onRender: function() {
             this.checkIfSubscribed();
+            this.handleLocal();
+        },
+        handleLocal: function() {
+            this.$el.toggleClass('is-local', this.model.isLocal());
         },
         checkIfSubscribed: function() {
             this.$el.toggleClass('is-subscribed', Boolean(this.model.get('subscribed')));

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -81,8 +81,12 @@ define([
                     sortOrder: 'descending',
                     result: undefined,
                     serverPageIndex: 0,
-                    isAdvanced: false
+                    isAdvanced: false,
+                    isLocal: false
                 };
+            },
+            isLocal: function() {
+                return this.get('isLocal');
             },
             initialize: function () {
                 this.currentIndexForSource = {};

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.collection.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.collection.js
@@ -144,7 +144,9 @@ module.exports = Backbone.Collection.extend({
         }).get('queries').first().startSearch();
     },
     duplicateWorkspace: function (workspace) {
-        this.create(_.omit(workspace.toJSON(), 'id', 'owner', 'metacard.sharing'));
+        let duplicateWorkspace = _.pick(workspace.toJSON(), 'title', 'queries');
+        duplicateWorkspace.queries = duplicateWorkspace.queries.map((query) => _.omit(query, 'isLocal', 'id'));
+        this.create(duplicateWorkspace);
     },
     saveAll: function () {
         this.forEach(function (workspace) {

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -65,8 +65,9 @@ module.exports = Backbone.AssociatedModel.extend({
         return query.get('id');
     },
     initialize: function () {
-        this.get('queries').on('add', function () {
-            this.trigger('change');
+        this.get('queries').on('add', (model, collection) => {
+            model.set('isLocal', this.isLocal());
+            collection.trigger('change');
         });
         this.listenTo(this.get('queries'), 'update add remove', this.handleQueryChange);
         this.listenTo(this.get('queries'), 'change', this.handleChange);
@@ -108,6 +109,9 @@ module.exports = Backbone.AssociatedModel.extend({
     },
     handleError: function () {
         this.set('saved', false);
+    },
+    isLocal: function() {
+        return Boolean(this.get('localStorage'));
     },
     isSaved: function () {
         return this.get('saved');


### PR DESCRIPTION
#### What does this PR do?
 - Makes the notes view for queries visible (under query interactions)
 - Adds distinguishment between guest workspaces and all others (cloud)
 - Uses distinguishment to hide / show certain actions, like notes and sharing
 - Fixes issues with duplicating workspaces, where things like owners and sharing were carried over.  Also fixes the issue of queries having the same id, which meant the notes on the query could be shared across workspaces when duplicating.

#### Who is reviewing it? 
@bdeining
@glenhein 
@adimka 
@mojogitoverhere 

#### What are the relevant tickets?
[DDF-3216](https://codice.atlassian.net/browse/DDF-3216)
