### PR TITLE
DDF-2824 fixed appendix docs template

### DIFF
--- a/distribution/docs/src/main/resources/content/_appendixIntros/dependency-list-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_appendixIntros/dependency-list-intro.adoc
@@ -1,8 +1,9 @@
-:title: Dependency List
+:title: ${branding} Dependency List
 :type: appendixIntro
 :status: published
-:children: ${branding} Dependency List
 :order: 02
 :summary: Introduction to dependency list appendix.
+
+== {title}
 
 This list of ${branding} dependencies is automatically generated:

--- a/distribution/docs/src/main/resources/content/_appendixIntros/metadata-attributes-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_appendixIntros/metadata-attributes-intro.adoc
@@ -5,6 +5,8 @@
 :order: 01
 :summary: Introduction to metadata attributes.
 
+== {title}
+
 ${branding} extracts basic metadata from the resources ingested. Many file types and contain additional <<_format_specific_attribute_mappings,format-specific metadata attributes>>.
 A neutral <<_catalog_taxonomy,Catalog Taxonomy>> enables transformation of metadata to other formats.
 See also a <<supported_file_types,list of all formats supported>> for ingest.

--- a/distribution/docs/src/main/resources/content/_appendixIntros/whitelist-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_appendixIntros/whitelist-intro.adoc
@@ -5,4 +5,6 @@
 :order: 00
 :summary: Introduction to application whitelists.
 
+== {title}
+
 Within each ${branding} application, certain packages are exported for use by third parties.

--- a/distribution/docs/src/main/resources/content/_dependencyList/ddf-dependency-list.adoc
+++ b/distribution/docs/src/main/resources/content/_dependencyList/ddf-dependency-list.adoc
@@ -2,10 +2,10 @@
 :type: appendix
 :status: published
 :parent: ${ddf-branding} Dependency List
-:children: none
 :order: 00
 :summary: ${ddf-branding} ${project.version} Dependency List.
 
+.{summary} {status}
 * antlr:antlr:jar:2.7.7
 * c3p0:c3p0:jar:0.9.1.1
 * ca.juliusdavies:not-yet-commons-ssl:jar:0.3.11

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/associations-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/associations-attributes-table.adoc
@@ -1,10 +1,13 @@
-﻿:title: Associations
+﻿:title: Associations Attributes Table
 :type: subAppendix
+:order: 01
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group represent associations between products.
 
-.[[_associations_attributes_table]]Associations: Attributes in this group represent associations between products.
+== {title}
+
+.Associations: Attributes in this group represent associations between products.
 [cols="1,2,1,1,1" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/catalog-taxonomy-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/catalog-taxonomy-intro.adoc
@@ -2,9 +2,10 @@
 :type: appendix
 :status: published
 :parent: Metadata Attributes
-:children: Catalog Taxonomy
 :order: 02
 :summary: Introduction to catalog taxonomy appendix.
+
+== {title}
 
 To facilitate data sharing while maximizing the usefulness of metadata, the attributes on resources are normalized into a common taxonomy that maps to attributes in the desired output format.
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/complete-list-file-types.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/complete-list-file-types.adoc
@@ -6,6 +6,8 @@
 :order: 03
 :summary: Complete list of supported file types.
 
+== {title}
+
 Using the various input transformers, ${branding} supports ingest of the following MIME types.
 
 .[[supported_file_types]]Supported File Types

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/contact-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/contact-attributes-table.adoc
@@ -1,10 +1,13 @@
-:title: Contact
+:title: Contact Attributes Table
 :type: subAppendix
+:order: 02
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group reflect metadata about different kinds of people/groups/units/organizations that can be associated with a metacard.
 
-.[[_contact_attributes_table]]Contact: Attributes in this group reflect metadata about different kinds of people/groups/units/organizations that can be associated with a metacard.
+== {title}
+
+.Contact: Attributes in this group reflect metadata about different kinds of people/groups/units/organizations that can be associated with a metacard.
 [cols="1,2,1,1,1" options="header"]
 |===
 |Term

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/core-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/core-attributes-table.adoc
@@ -1,10 +1,13 @@
-:title: Core Attributes
+:title: Core Attributes Table
 :type: subAppendix
+:order: 00
 :parent: Catalog Taxonomy
 :status: published
 :summary: Core Attributes.
 
-.[[_core_attributes_table]]Core Attributes
+== {title}
+
+.Core Attributes
 [cols="1,2,1,1,1" options="header"]
 |===
 |Term

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/datetime-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/datetime-attributes-table.adoc
@@ -1,10 +1,13 @@
-:title: DateTime
+:title: DateTime Attributes Table
 :type: subAppendix
+:order: 03
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group reflect temporal aspects about the resource.  
 
-.[[_datetime_attributes_table]]DateTime: Attributes in this group reflect temporal aspects about the resource.  
+== {title}
+
+.DateTime: Attributes in this group reflect temporal aspects about the resource.  
 [cols="5" options="header"]
 |===
 |Term

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/format-specific-attributes.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/format-specific-attributes.adoc
@@ -2,9 +2,10 @@
 :type: appendix
 :status: published
 :parent: Metadata Attributes
-:children: Metadata Attributes
 :order: 01
 :summary: Format-specific attribute mappings by data/file format.
+
+== {title}
 
 Many file formats support additional metadata attributes that ${branding} is able to extract and make discoverable.
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/history-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/history-attributes-table.adoc
@@ -1,10 +1,13 @@
-:title: History
+:title: History Attributes Table
 :type: subAppendix
+:order: 04
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group describe the history/versioning of the metacard.
 
-.[[_history_attributes_table]]History: Attributes in this group describe the history/versioning of the metacard.
+== {title}
+
+.History: Attributes in this group describe the history/versioning of the metacard.
 [cols="1,2,1,1,1" options="header"]
 |===
 |Term

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/location-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/location-attributes-table.adoc
@@ -1,10 +1,13 @@
-:title: Location
+:title: Location Attributes Table
 :type: subAppendix
+:order: 05
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group reflect location aspects about the resource.
 
-.[[_location_attributes_table]]Location: Attributes in this group reflect location aspects about the resource.
+== {title}
+
+.Location: Attributes in this group reflect location aspects about the resource.
 [cols="1,2,1,1,1" options="header"]
 |===
 |Term

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/media-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/media-attributes-table.adoc
@@ -1,10 +1,13 @@
-:title: Media
+:title: Media Attributes Table
 :type: subAppendix
+:order: 06
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group reflect metadata about media in general.
 
-.[[_media_attributes_table]]Media: Attributes in this group reflect metadata about media in general.
+== {title}
+
+.Media: Attributes in this group reflect metadata about media in general.
 [cols="1,2,1,1,1" options="header"]
 |===
 |Term

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/metacard-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/metacard-attributes-table.adoc
@@ -1,10 +1,13 @@
-:title: Metacard
+:title: Metacard Attributes Table
 :type: subAppendix
+:order: 07
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group describe the metacard itself.
 
-.[[_metacard_attributes_table]]Metacard: Attributes in this group describe the metacard itself.
+== {title}
+
+.Metacard: Attributes in this group describe the metacard itself.
 [cols="5" options="header"]
 |===
 |Term

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/mp4-attributes.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/mp4-attributes.adoc
@@ -1,8 +1,11 @@
 :title: Mp4 Additional Attribute
 :type: subAppendix
-:parent: Metadata Attributes
+:order: 10
+:parent: Format-specific Attribute Mappings
 :status: published
 :summary: Additional attribute for Mp4 files.
+
+== {title}
 
 Mp4 files have an additional attribute:
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/security-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/security-attributes-table.adoc
@@ -1,10 +1,13 @@
-﻿:title: Security
+﻿:title: Security Attributes Table
 :type: subAppendix
+:order: 08
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group relate to security of the resource and metadata.
 
-.[[_security_attributes_table]]Security: Attributes in this group relate to security of the resource and metadata.
+== {title}
+
+.Security: Attributes in this group relate to security of the resource and metadata.
 [cols="1,2,1,1,1" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/topic-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/topic-attributes-table.adoc
@@ -1,10 +1,13 @@
-﻿:title: Topic
+﻿:title: Topic Attributes Table
 :type: subAppendix
+:order: 09
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group describe the topic of the resource.
 
-.[[_topic_attributes_table]]Topic: Attributes in this group describe the topic of the resource.
+== {title}
+
+.Topic: Attributes in this group describe the topic of the resource.
 [cols="1,2,1,1,1" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/validation-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/validation-attributes-table.adoc
@@ -1,10 +1,13 @@
-﻿:title: Validation
+﻿:title: Validation Attributes Table
 :type: subAppendix
+:order: 10
 :parent: Catalog Taxonomy
 :status: published
 :summary: Attributes in this group identify validation issues with the metacard and/or resource.
 
-.[[_validation_attributes_table]]Validation: Attributes in this group identify validation issues with the metacard and/or resource.
+== {title}
+
+.Validation: Attributes in this group identify validation issues with the metacard and/or resource.
 [cols="1,2,1,1,1" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_whitelists/admin-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/admin-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 00
 :summary: ${ddf-admin} whitelist.
 
+== {title}
+
 The following classes have been exported by the ${ddf-admin} application and are approved for use by third parties:
 
 In package `org.codice.ddf.ui.admin.api.module`

--- a/distribution/docs/src/main/resources/content/_whitelists/catalog-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/catalog-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 01
 :summary: ${ddf-catalog} whitelist.
 
+== {title}
+
 The following classes have been exported by the ${ddf-catalog} application and are approved for use by third parties:
 
 In package `ddf.catalog`

--- a/distribution/docs/src/main/resources/content/_whitelists/platform-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/platform-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 02
 :summary: ${ddf-platform} whitelist.
 
+== {title}
+
 The following classes have been exported by the ${ddf-platform} application and are approved for use by third parties:
 
 In package `ddf.action`

--- a/distribution/docs/src/main/resources/content/_whitelists/registry-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/registry-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 03
 :summary: ${ddf-registry} whitelist.
 
+== {title}
+
 The following classes have been exported by the ${ddf-registry} Application and are approved for use by third parties:
 
 None.

--- a/distribution/docs/src/main/resources/content/_whitelists/removed-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/removed-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 09
 :summary: List of packages removed from the whitelist
 
+== {title}
+
 In the transition of the whitelist from the ambiguous package listing to the new class listing several errors were found. The packages originally listed that were removed either did not exist, contained experimental interfaces, or contained only internal implementations and should have never been included in the whitelist. The following is a list of packages that were listed in error and have been removed from the whitelist.
 
 [NOTE]

--- a/distribution/docs/src/main/resources/content/_whitelists/security-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/security-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 04
 :summary: ${ddf-security} whitelist.
 
+== {title}
+
 The following classes have been exported by the ${ddf-security} application and are approved for use by third parties:
 
 In package `ddf.security`

--- a/distribution/docs/src/main/resources/content/_whitelists/solr-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/solr-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 05
 :summary: ${ddf-solr} whitelist.
 
+== {title}
+
 The following classes have been exported by the ${ddf-solr} application and are approved for use by third parties:
 
 None.

--- a/distribution/docs/src/main/resources/content/_whitelists/spatial-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/spatial-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 06
 :summary: ${ddf-spatial} whitelist.
 
+== {title}
+
 The following classes have been exported by the ${ddf-spatial} application and are approved for use by third parties:
 
 In package `org.codice.ddf.spatial.kml.transformer`

--- a/distribution/docs/src/main/resources/content/_whitelists/ui-whitelist.adoc
+++ b/distribution/docs/src/main/resources/content/_whitelists/ui-whitelist.adoc
@@ -6,6 +6,8 @@
 :order: 07
 :summary: ${ddf-ui} whitelist.
 
+== {title}
+
 The following classes have been exported by the ${ddf-ui} application and are approved for use by third parties:
 
 None.

--- a/distribution/docs/src/main/resources/templates/appendices.ftl
+++ b/distribution/docs/src/main/resources/templates/appendices.ftl
@@ -2,19 +2,15 @@
 <#if (ai.status == "published")>
 
 [appendix]
-== ${ai.title}
-
 include::${ai.file}[]
 <#list appendixs?sort_by("order") as appendix>
-<#if (ai.children?contains (appendix.parent))>
+<#if (appendix.parent == ai.title && appendix.status == "published")>
 
-=== ${appendix.title}
-include::${appendix.file}[]
-<#list subAppendixs as subAppendix>
-<#if (subAppendix.parent == appendix.children)>
+include::${appendix.file}[leveloffset=+1]
+<#list subAppendixs?sort_by("order") as subAppendix>
+<#if (subAppendix.parent == appendix.title && subAppendix.status == "published")>
 
-==== ${subAppendix.title}
-include::${subAppendix.file}[]
+include::${subAppendix.file}[leveloffset=+2]
 </#if>
 </#list>
 </#if>


### PR DESCRIPTION
#### What does this PR do?

Fixes appendix template in docs to allow specifying defined order to sections.

#### Who is reviewing it? 

@emmberk @mcalcote @vinamartin @ahoffer @garrettfreibott 
#### Choose 2 committers to review/merge the PR. 

@clockard
@coyotesqrl
@lessarderic
@pklinef
@ricklarsen - Documentation
@rzwiefel
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

-appendix builds successfully. No content changes made.

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
