### PR TITLE
DDF-3138 Fix for WhoAmI groovy test failure

### DIFF
--- a/platform/security/servlet/security-servlet-whoami/src/test/groovy/org/codice/ddf/security/servlet/whoami/SubjectSpecification.groovy
+++ b/platform/security/servlet/security-servlet-whoami/src/test/groovy/org/codice/ddf/security/servlet/whoami/SubjectSpecification.groovy
@@ -30,7 +30,10 @@ import java.util.stream.Collectors
 class SubjectSpecification extends Specification {
 
     protected Date notOnOrAfter = Date.from(LocalDateTime.now()
-            .plusDays(7)
+            .plusDays(6)
+            .plusHours(18)
+            .plusMinutes(20)
+            .plusSeconds(35)
             .atZone(ZoneId.systemDefault()).toInstant())
 
     protected def mockSubject() {


### PR DESCRIPTION
#### What does this PR do?
Fixes failing tests in WhoAmI unit tests. Ensure that there will be days, hours, minutes, and seconds differences in time while testing.

#### Who is reviewing it? 
@oconnormi 
@adimka 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Full build.

#### Any background context you want to provide?
Corrects the error that occurred in WhoAmI tests:
[ERROR] formats expiration duration of assertion(org.codice.ddf.security.servlet.whoami.WhoAmISpec)  Time elapsed: 0.16 s  <<< FAILURE!
org.spockframework.runtime.ConditionNotSatisfiedError:
Condition not satisfied:

duration.contains('days')
|        |
|        false
59 minutes 59 seconds

    at org.codice.ddf.security.servlet.whoami.WhoAmISpec.formats expiration duration of assertion(WhoAmISpec.groovy:104)

#### What are the relevant tickets?
[DDF-3138](https://codice.atlassian.net/browse/DDF-3138)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
