### PR TITLE
DDF-3362 Update AbstractCswSource.alignStream to close resource for IOException

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -109,6 +109,7 @@ import net.opengis.ows.v_1_0_0.DomainType;
 import net.opengis.ows.v_1_0_0.Operation;
 import net.opengis.ows.v_1_0_0.OperationsMetadata;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.common.util.CollectionUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
@@ -1018,6 +1019,9 @@ public abstract class AbstractCswSource extends MaskableImpl
         throw new IOException("Server skipped more bytes than requested in the range header.");
       }
     } catch (IOException e) {
+      /*In the event an IOException is thrown, the InputStream should be closed to prevent resource
+      leakage. Otherwise the stream should be kept open to pass into the ResourceImpl constructor.*/
+      IOUtils.closeQuietly(in);
       throw new IOException(
           String.format(
               "Unable to align input stream with the requested byteOffset of %d",


### PR DESCRIPTION
#### What does this PR do?
In the event that alignStream throws an IOException,  the InputStream passed in will be orphaned and become a resource leak. This change closes the stream when the IOException is caught, before it is re-thrown. 

#### Who is reviewing it? 
@rzwiefel @idperez @stustison @garrettfreibott @shaundmorris 

#### How should this be tested? (List steps with links to updated documentation)
Review changes

#### Any background context you want to provide?
This was identified by a coverity scan.

#### What are the relevant tickets?
[DDF-3362](https://codice.atlassian.net/browse/DDF-3362)
