### PR TITLE
DDF-3382 Usage Header and Footer Configurations are Sanitized

### DIFF
--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -62,6 +62,8 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
 
   private static final String GUEST_CLAIMS_CONFIG_PID = "ddf.security.sts.guestclaims";
 
+  private static final String UI_CONFIG_PID = "ddf.platform.ui.config";
+
   private static final String PROFILE_KEY = "profile";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AdminConsoleService.class);
@@ -419,7 +421,7 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
   }
 
   private Object sanitizeUIConfiguration(String pid, String configEntryKey, Object configEntryValue) {
-    if (pid.equals("ddf.platform.ui.config")) {
+    if (pid.equals(UI_CONFIG_PID)) {
       if (configEntryKey.equals("color") || configEntryKey.equals("background")) {
         return String.valueOf(configEntryValue).split(";")[0];
       }

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -26,9 +26,11 @@ import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Vector;
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanServer;
@@ -37,6 +39,7 @@ import javax.management.ObjectName;
 import javax.management.StandardMBean;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Transformer;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.SecurityUtils;
 import org.codice.ddf.admin.core.api.ConfigurationAdmin;
@@ -69,7 +72,8 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AdminConsoleService.class);
 
-  private static final String[] ILLEGAL_CHARACTERS = {";", "<", ">", "{", "}"};
+  private static final Set<Character> ILLEGAL_CHARACTER_SET =
+      new HashSet<>(Arrays.asList(';', '<', '>', '{', '}'));
 
   private final org.osgi.service.cm.ConfigurationAdmin configurationAdmin;
 
@@ -426,9 +430,9 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
       String pid, String configEntryKey, Object configEntryValue) {
     if (UI_CONFIG_PID.equals(pid)
         && ("color".equals(configEntryKey) || "background".equals(configEntryKey))
-        && (Arrays.stream(ILLEGAL_CHARACTERS)
+        && (Arrays.stream(ArrayUtils.toObject(String.valueOf(configEntryValue).toCharArray()))
             .parallel()
-            .anyMatch(String.valueOf(configEntryValue)::contains))) {
+            .anyMatch(ILLEGAL_CHARACTER_SET::contains))) {
       throw loggedException("Invalid UI Configuration");
     }
     return configEntryValue;

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -402,7 +402,7 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
       for (Map.Entry<String, Object> configEntry : configEntries) {
         String configEntryKey = configEntry.getKey();
         Object configEntryValue =
-            sanitizeUIConfiguration(pid, configEntryKey, configEntry.getValue());
+            sanitizeUIConfiguration(pid, configEntryKey.toLowerCase(), configEntry.getValue());
         if (configEntryValue.equals("password")) {
           for (Map<String, Object> metatypeProperties : metatype.getAttributeDefinitions()) {
             if (metatypeProperties.get("id").equals(configEntry.getKey())

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -398,9 +398,7 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
       // "password", do not update the password.
       for (Map.Entry<String, Object> configEntry : configEntries) {
         String configEntryKey = configEntry.getKey();
-        Object configEntryValue = configEntry.getValue();
-        configEntryValue = sanitizeUIConfiguration(pid, configEntryKey, configEntryValue);
-
+        Object configEntryValue = sanitizeUIConfiguration(pid, configEntryKey, configEntry.getValue());
         if (configEntryValue.equals("password")) {
           for (Map<String, Object> metatypeProperties : metatype.getAttributeDefinitions()) {
             if (metatypeProperties.get("id").equals(configEntry.getKey())

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -425,12 +425,11 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
   private Object sanitizeUIConfiguration(
       String pid, String configEntryKey, Object configEntryValue) {
     if (UI_CONFIG_PID.equals(pid)
-        && ("color".equals(configEntryKey) || "background".equals(configEntryKey))) {
-      if (Arrays.stream(ILLEGAL_CHARACTERS)
-          .parallel()
-          .anyMatch(String.valueOf(configEntryValue)::contains)) {
-        throw loggedException("Invalid UI Configuration");
-      }
+        && ("color".equals(configEntryKey) || "background".equals(configEntryKey))
+        && (Arrays.stream(ILLEGAL_CHARACTERS)
+            .parallel()
+            .anyMatch(String.valueOf(configEntryValue)::contains))) {
+      throw loggedException("Invalid UI Configuration");
     }
     return configEntryValue;
   }

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -397,6 +397,8 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
       for (Map.Entry<String, Object> configEntry : configEntries) {
         String configEntryKey = configEntry.getKey();
         Object configEntryValue = configEntry.getValue();
+        configEntryValue = sanitizeConfig(pid, configEntryKey, configEntryValue);
+
         if (configEntryValue.equals("password")) {
           for (Map<String, Object> metatypeProperties : metatype.getAttributeDefinitions()) {
             if (metatypeProperties.get("id").equals(configEntry.getKey())
@@ -414,6 +416,15 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
 
       config.update(newConfigProperties);
     }
+  }
+
+  private Object sanitizeConfig(String pid, String configEntryKey, Object configEntryValue) {
+    if (pid.equals("ddf.platform.ui.config")) {
+      if (configEntryKey.equals("color") || configEntryKey.equals("background")) {
+        return String.valueOf(configEntryValue).split(";")[0];
+      }
+    }
+    return configEntryValue;
   }
 
   public ConfigurationStatus disableConfiguration(String servicePid) throws IOException {

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -397,7 +397,7 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
       for (Map.Entry<String, Object> configEntry : configEntries) {
         String configEntryKey = configEntry.getKey();
         Object configEntryValue = configEntry.getValue();
-        configEntryValue = sanitizeConfig(pid, configEntryKey, configEntryValue);
+        configEntryValue = sanitizeUIConfiguration(pid, configEntryKey, configEntryValue);
 
         if (configEntryValue.equals("password")) {
           for (Map<String, Object> metatypeProperties : metatype.getAttributeDefinitions()) {
@@ -418,7 +418,7 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
     }
   }
 
-  private Object sanitizeConfig(String pid, String configEntryKey, Object configEntryValue) {
+  private Object sanitizeUIConfiguration(String pid, String configEntryKey, Object configEntryValue) {
     if (pid.equals("ddf.platform.ui.config")) {
       if (configEntryKey.equals("color") || configEntryKey.equals("background")) {
         return String.valueOf(configEntryValue).split(";")[0];

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -433,7 +433,8 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
         && (Arrays.stream(ArrayUtils.toObject(String.valueOf(configEntryValue).toCharArray()))
             .parallel()
             .anyMatch(ILLEGAL_CHARACTER_SET::contains))) {
-      throw loggedException("Invalid UI Configuration");
+      throw loggedException(
+          "Invalid UI Configuration: The color and background properties must only contain a color value");
     }
     return configEntryValue;
   }

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -421,8 +421,8 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
   }
 
   private Object sanitizeUIConfiguration(String pid, String configEntryKey, Object configEntryValue) {
-    if (pid.equals(UI_CONFIG_PID)) {
-      if (configEntryKey.equals("color") || configEntryKey.equals("background")) {
+    if (UI_CONFIG_PID.equals(pid)) {
+      if ("color".equals(configEntryKey) || "background".equals(configEntryKey)) {
         return String.valueOf(configEntryValue).split(";")[0];
       }
     }

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminConsoleServiceTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminConsoleServiceTest.java
@@ -821,9 +821,7 @@ public class AdminConsoleServiceTest {
         "background",
         "black; float: left; text-align: center; width: 120px; border: 1px solid gray; margin: 4px; padding: 6px;");
 
-    ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
     configAdmin.update(UI_CONFIG_PID, currentProps);
-    verify(testConfig, times(1)).update(captor.capture());
   }
 
   @Test

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminConsoleServiceTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminConsoleServiceTest.java
@@ -810,15 +810,13 @@ public class AdminConsoleServiceTest {
     assertThat(((Integer[]) captor.getValue().get(arrayInteger)).length, equalTo(0));
   }
 
-  @Test
+  @Test(expected = IllegalArgumentException.class)
   public void testSanitizeUIConfiguration() throws Exception {
     AdminConsoleService configAdmin = getConfigAdmin();
 
-    // Initialize sanitized values.
+    // Initialize illegal values.
     Map<String, Object> currentProps = new Hashtable<>();
-    currentProps.put(
-        "color",
-        "white; height: 210px; z-index: 999999; background-image: url(https://gifimage.net/wp-content/uploads/2017/06/troll-face-gif-8.gif); background-repeat: no-repeat; background-attachment: fixed; background-position-x: center");
+    currentProps.put("color", "yellow;");
     currentProps.put(
         "background",
         "black; float: left; text-align: center; width: 120px; border: 1px solid gray; margin: 4px; padding: 6px;");
@@ -826,10 +824,6 @@ public class AdminConsoleServiceTest {
     ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
     configAdmin.update(UI_CONFIG_PID, currentProps);
     verify(testConfig, times(1)).update(captor.capture());
-
-    // Assert the Text Color and Background Color fields have been sanitized.
-    assertThat(captor.getValue().get("color"), equalTo("white"));
-    assertThat(captor.getValue().get("background"), equalTo("black"));
   }
 
   @Test

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminConsoleServiceTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminConsoleServiceTest.java
@@ -811,6 +811,28 @@ public class AdminConsoleServiceTest {
   }
 
   @Test
+  public void testSanitizeUIConfiguration() throws Exception {
+    AdminConsoleService configAdmin = getConfigAdmin();
+
+    // Initialize sanitized values.
+    Map<String, Object> currentProps = new Hashtable<>();
+    currentProps.put(
+        "color",
+        "white; height: 210px; z-index: 999999; background-image: url(https://gifimage.net/wp-content/uploads/2017/06/troll-face-gif-8.gif); background-repeat: no-repeat; background-attachment: fixed; background-position-x: center");
+    currentProps.put(
+        "background",
+        "black; float: left; text-align: center; width: 120px; border: 1px solid gray; margin: 4px; padding: 6px;");
+
+    ArgumentCaptor<Dictionary> captor = ArgumentCaptor.forClass(Dictionary.class);
+    configAdmin.update(UI_CONFIG_PID, currentProps);
+    verify(testConfig, times(1)).update(captor.capture());
+
+    // Assert the Text Color and Background Color fields have been sanitized.
+    assertThat(captor.getValue().get("color"), equalTo("white"));
+    assertThat(captor.getValue().get("background"), equalTo("black"));
+  }
+
+  @Test
   public void testUpdateGuestClaimsProfile() throws Exception {
     Map<String, Object> guestClaims = new HashMap<>();
     Map<String, Object> systemClaims = new HashMap<>();


### PR DESCRIPTION
#### What does this PR do?
The color values for the header and footer configurations in the Admin UI are escaped to limit only the color being affected.

#### Who is reviewing it? 
@Lambeaux 
@garrettfreibott 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl  
@brjeter 

#### How should this be tested? (List steps with links to updated documentation)
Start Admin UI
In Admin Console click Platform
Click Configuration
Click Platform UI Configuration
Edit Text Color and Background Color fields with any form of extraneous CSS
Check if only the color is affected

#### Any background context you want to provide?
Before this change if you change the text color to:
white; height: 210px; z-index: 999999; background-image: url(https://gifimage.net/wp-content/uploads/2017/06/troll-face-gif-8.gif); background-repeat: no-repeat; background-attachment: fixed; background-position-x: center

And changed the background color to: 
white

You would affect more than the color of those fields

#### What are the relevant tickets?
[DDF-3382](https://codice.atlassian.net/browse/DDF-3382)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
