### PR TITLE
[2.11.x] DDF-3425 Fix UpdateOperations page size

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
@@ -638,7 +638,7 @@ public class UpdateOperations {
         new QueryImpl(
             queryOperations.getFilterWithAdditionalFilters(idFilters, updateRequest),
             1, /* start index */
-            0, /* page size */
+            updateRequest.getUpdates().size(), /* page size */
             null,
             false, /* total result count */
             0 /* timeout */);


### PR DESCRIPTION
#### What does this PR do?
Updates the page size in UpdateOperations that was missed in the ResultsIterator updates
#### Who is reviewing it? 
@emmberk @peterhuffer @AzGoalie 
#### Choose 2 committers to review/merge the PR. 
@coyotesqrl
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Easiest way to test is to setup to DDFs with registries. 
Publish/Subscribe ddf1 to ddf2. 
Update ddf1 identity node by adding a description and save.
Verify that ddf2 has the updated description in its remote nodes.

#### What are the relevant tickets?
[DDF-3425](https://codice.atlassian.net/browse/DDF-3425)
