### PR TITLE
DDF-3432 Only fetch imagery tiles if alpha > 0

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -81,7 +81,7 @@ define(['underscore',
                 var layer = this.map.imageryLayers.addImageryProvider(provider, 0);  // the collection is sorted by order, so later things should go at bottom of stack
                 this.layerForCid[model.id] = layer;
                 layer.alpha = model.get('alpha');
-                layer.show = model.get('show');
+                layer.show = this.showLayer(model);
             }, this);
 
             this.isMapCreated = true;
@@ -96,10 +96,14 @@ define(['underscore',
         setAlpha: function (model) {
             var layer = this.layerForCid[model.id];
             layer.alpha = model.get('alpha');
+            layer.show = this.showLayer(model);
         },
         setShow: function (model) {
             var layer = this.layerForCid[model.id];
-            layer.show = model.get('show');
+            layer.show = this.showLayer(model);
+        },
+        showLayer: function(model) {
+            return model.get('show') && model.get('alpha') > 0;
         },
         /*
             removing/re-adding the layers causes visible "re-render" of entire map;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -81,7 +81,7 @@ define(['underscore',
                 var layer = this.map.imageryLayers.addImageryProvider(provider, 0);  // the collection is sorted by order, so later things should go at bottom of stack
                 this.layerForCid[model.id] = layer;
                 layer.alpha = model.get('alpha');
-                layer.show = this.showLayer(model);
+                layer.show = model.shouldShowLayer();
             }, this);
 
             this.isMapCreated = true;
@@ -96,14 +96,10 @@ define(['underscore',
         setAlpha: function (model) {
             var layer = this.layerForCid[model.id];
             layer.alpha = model.get('alpha');
-            layer.show = this.showLayer(model);
         },
         setShow: function (model) {
             var layer = this.layerForCid[model.id];
-            layer.show = this.showLayer(model);
-        },
-        showLayer: function(model) {
-            return model.get('show') && model.get('alpha') > 0;
+            layer.show = model.shouldShowLayer();
         },
         /*
             removing/re-adding the layers causes visible "re-render" of entire map;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/common.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/common.layerCollection.controller.js
@@ -23,7 +23,7 @@ define([
             this.layerForCid = {};
 
             this.listenTo(this.collection, 'change:alpha', this.setAlpha);
-            this.listenTo(this.collection, 'change:show', this.setShow);
+            this.listenTo(this.collection, 'change:show change:alpha', this.setShow);
 
             // subclasses must implement reIndexLayers()
             this.listenTo(this.collection, 'sort', this.reIndexLayers);

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
@@ -115,16 +115,20 @@ define(['underscore',
         setAlpha: function (model) {
             var layer = this.layerForCid[model.id];
             layer.setOpacity(model.get('alpha'));
+            layer.setVisible(this.showLayer(model));
         },
         setShow: function (model) {
             var layer = this.layerForCid[model.id];
-            layer.setVisible(model.get('show'));
+            layer.setVisible(this.showLayer(model));
         },
         reIndexLayers: function () {
             this.collection.forEach(function (model, index) {
                 var widgetLayer = this.layerForCid[model.id];
                 widgetLayer.setZIndex(-(index + 1));
             }, this);
+        },
+        showLayer: function(model) {
+          return model.get('show') && model.get('alpha') > 0;
         },
         makeWidgetLayer: function (model) {
             var typeStr = model.get('type');
@@ -178,7 +182,7 @@ define(['underscore',
                       options.urls = [initObj.url];
                       initObj = options;
                       var layer = new layerType({
-                            visible: model.get('show'),
+                            visible: this.showLayer(model),
                             preload: Infinity,
                             opacity: model.get('alpha'),
                             source: new type(initObj)
@@ -195,7 +199,7 @@ define(['underscore',
             }
 
             return new layerType({
-                visible: model.get('show'),
+                visible: this.showLayer(model),
                 preload: Infinity,
                 opacity: model.get('alpha'),
                 source: new type(initObj)

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
@@ -115,20 +115,16 @@ define(['underscore',
         setAlpha: function (model) {
             var layer = this.layerForCid[model.id];
             layer.setOpacity(model.get('alpha'));
-            layer.setVisible(this.showLayer(model));
         },
         setShow: function (model) {
             var layer = this.layerForCid[model.id];
-            layer.setVisible(this.showLayer(model));
+            layer.setVisible(model.shouldShowLayer());
         },
         reIndexLayers: function () {
             this.collection.forEach(function (model, index) {
                 var widgetLayer = this.layerForCid[model.id];
                 widgetLayer.setZIndex(-(index + 1));
             }, this);
-        },
-        showLayer: function(model) {
-            return model.get('show') && model.get('alpha') > 0;
         },
         makeWidgetLayer: function (model) {
             var typeStr = model.get('type');
@@ -182,7 +178,7 @@ define(['underscore',
                       options.urls = [initObj.url];
                       initObj = options;
                       var layer = new layerType({
-                            visible: this.showLayer(model),
+                            visible: model.shouldShowLayer(),
                             preload: Infinity,
                             opacity: model.get('alpha'),
                             source: new type(initObj)
@@ -199,7 +195,7 @@ define(['underscore',
             }
 
             return new layerType({
-                visible: this.showLayer(model),
+                visible: model.shouldShowLayer(),
                 preload: Infinity,
                 opacity: model.get('alpha'),
                 source: new type(initObj)

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
@@ -128,7 +128,7 @@ define(['underscore',
             }, this);
         },
         showLayer: function(model) {
-          return model.get('show') && model.get('alpha') > 0;
+            return model.get('show') && model.get('alpha') > 0;
         },
         makeWidgetLayer: function (model) {
             var typeStr = model.get('type');

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -87,6 +87,9 @@ define([
                 id: Common.generateUUID()
             };
         },
+        shouldShowLayer: function() {
+            return this.get('show') && this.get('alpha') > 0;
+        },
         parse: function(resp) {
             var layer = _.clone(resp);
             layer.label = 'Type: ' + layer.type;


### PR DESCRIPTION
#### What does this PR do?
Configures Cesium and Open Layers to only fetch tiles if `show=true` and `alpha > 0`.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@adimka @mackncheesiest @Variadicism @glenhein @brianfelix 
#### Select relevant component teams: 
@codice/ui
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)
Configure a map layer in the Admin UI under `Applications` -> `Catalog` -> `Map Layers Configuration`.  Enter a name, set URL to `http://c.tile.openstreetmap.org`, set alpha to 1, and ensure only show is checked. Open a workspace in Intrigue (3D map) and open the dev tools. Verify image tiles are being fetched. Open the map layers configuration in the top right and set transparency to 0 (drag to the right). Repeat the procedure for a 2D map.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3432](https://codice.atlassian.net/browse/DDF-3432)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
