### PR TITLE
[2.11.x] DDF-3436 Removes the ability to delete non factory configurations

### DIFF
--- a/platform/admin/ui/src/main/webapp/js/views/configuration/Service.view.js
+++ b/platform/admin/ui/src/main/webapp/js/views/configuration/Service.view.js
@@ -64,7 +64,7 @@ define([
             }
         },
         serializeData: function () {
-            return _.extend(this.model.toJSON(), {displayName: this.model.getConfigurationDisplayName()});
+            return _.extend(this.model.toJSON(), {displayName: this.model.getConfigurationDisplayName()}, {hasFactory: this.model.get('fpid')});
         }
     });
 

--- a/platform/admin/ui/src/main/webapp/templates/configuration/configurationRow.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/configuration/configurationRow.handlebars
@@ -25,5 +25,7 @@
     {{bundle_name}}
 </td>
 <td class="column3">
+    {{#if hasFactory}}
     <a href='#' class='removeLink glyphicon glyphicon-remove'></a>
+    {{/if}}
 </td>


### PR DESCRIPTION
#### What does this PR do?
Removes the ability to delete non factory configurations as these configurations can't really be deleted so even when removing the configuration the configuration will persist. 

#### Who is reviewing it? 
@andrewkfiedler 
@tbatie @djblue @Lambeaux @lessarderic 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@pklinef
@rzwiefel

#### How should this be tested? 
Navigate to the Platform app in the UI and click the Configuration tab.
Configure "Platform UI Configuration".
Verify it can't be deleted. 

Verify the Custom Mime Types _can_ be deleted

#### What are the relevant tickets?
[DDF-3436](https://codice.atlassian.net/browse/DDF-3436)
#### Screenshots 
![screen shot 2017-11-06 at 11 03 29](https://user-images.githubusercontent.com/9013407/32456249-260c4a86-c2e2-11e7-9c38-bb910281349f.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
