### PR TITLE
[2.11.x] DDF-3422 Add SessionIndex to SAML LogoutRequest

### DIFF
--- a/platform/security/common/pom.xml
+++ b/platform/security/common/pom.xml
@@ -176,17 +176,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.27</minimum>
+                                            <minimum>0.40</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.24</minimum>
+                                            <minimum>0.34</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.21</minimum>
+                                            <minimum>0.32</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/security/common/src/main/java/ddf/security/assertion/impl/SecurityAssertionImpl.java
+++ b/platform/security/common/src/main/java/ddf/security/assertion/impl/SecurityAssertionImpl.java
@@ -204,6 +204,9 @@ public class SecurityAssertionImpl implements SecurityAssertion {
                     if (AuthnStatement.AUTHN_INSTANT_ATTRIB_NAME.equals(name)) {
                       authenticationStatement.setAuthnInstant(DateTime.parse(value));
                     }
+                    if (AuthnStatement.SESSION_INDEX_ATTRIB_NAME.equals(name)) {
+                      authenticationStatement.setSessionIndex(value);
+                    }
                   }
                   break;
                 case AuthnContextClassRef.DEFAULT_ELEMENT_LOCAL_NAME:
@@ -868,6 +871,8 @@ public class SecurityAssertionImpl implements SecurityAssertion {
 
     AuthnContext authnContext;
 
+    String sessionIndex;
+
     boolean isNil;
 
     @Override
@@ -882,11 +887,13 @@ public class SecurityAssertionImpl implements SecurityAssertion {
 
     @Override
     public String getSessionIndex() {
-      return null;
+      return sessionIndex;
     }
 
     @Override
-    public void setSessionIndex(String s) {}
+    public void setSessionIndex(String sessionIndex) {
+      this.sessionIndex = sessionIndex;
+    }
 
     @Override
     public DateTime getSessionNotOnOrAfter() {

--- a/platform/security/common/src/test/java/ddf/security/assertion/impl/SecurityAssertionImplTest.java
+++ b/platform/security/common/src/test/java/ddf/security/assertion/impl/SecurityAssertionImplTest.java
@@ -25,6 +25,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import java.util.TimeZone;
 import javax.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilder;
@@ -33,6 +35,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.junit.Test;
+import org.opensaml.saml.saml2.core.AuthnStatement;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -55,6 +58,8 @@ public class SecurityAssertionImplTest {
   private static final int NUM_NAUTH = 1;
 
   private static final int NUM_AUTHZ = 0;
+
+  private static final String SESSION_INDEX = "42";
 
   public static Document readXml(InputStream is)
       throws SAXException, IOException, ParserConfigurationException {
@@ -100,7 +105,14 @@ public class SecurityAssertionImplTest {
     assertEquals(PRINCIPAL, assertion.getPrincipal().getName());
     assertEquals(PRINCIPAL, assertion.getPrincipal().toString());
     assertEquals(NUM_ATTRIBUTES, assertion.getAttributeStatements().size());
-    assertEquals(NUM_NAUTH, assertion.getAuthnStatements().size());
+    List<AuthnStatement> authnStatements = assertion.getAuthnStatements();
+    assertEquals(NUM_NAUTH, authnStatements.size());
+    assertEquals(
+        (long) NUM_NAUTH, authnStatements.stream().map(AuthnStatement::getSessionIndex).count());
+    Optional<String> sessionIndex =
+        authnStatements.stream().map(AuthnStatement::getSessionIndex).findFirst();
+    assertTrue(sessionIndex.isPresent());
+    assertEquals(SESSION_INDEX, sessionIndex.get());
     assertEquals(
         DatatypeConverter.parseDateTime(BEFORE).getTimeInMillis(),
         assertion.getNotBefore().getTime());

--- a/platform/security/common/src/test/resources/saml.xml
+++ b/platform/security/common/src/test/resources/saml.xml
@@ -87,7 +87,7 @@
             <saml2:Audience>https://localhost:8993/services</saml2:Audience>
         </saml2:AudienceRestriction>
     </saml2:Conditions>
-    <saml2:AuthnStatement AuthnInstant="2013-04-23T23:39:54.777Z">
+    <saml2:AuthnStatement AuthnInstant="2013-04-23T23:39:54.777Z" SessionIndex="42">
         <saml2:AuthnContext>
             <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified
             </saml2:AuthnContextClassRef>

--- a/platform/security/core/security-core-impl/pom.xml
+++ b/platform/security/core/security-core-impl/pom.xml
@@ -178,6 +178,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>ddf.platform.util</groupId>
+          <artifactId>util-uuidgenerator-api</artifactId>
+          <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.UriBuilder;
 import javax.xml.stream.XMLStreamException;
 import org.apache.cxf.helpers.DOMUtils;
@@ -38,6 +38,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
 import org.apache.wss4j.common.util.DOM2Writer;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.common.SAMLObject;
@@ -55,13 +56,18 @@ public class LogoutMessageImpl implements LogoutMessage {
 
   public static final String SAML_SOAP_ACTION = "http://www.oasis-open.org/committees/security";
 
-  private SystemCrypto systemCrypto;
-
   static {
     OpenSAMLUtil.initSamlEngine();
   }
 
-  public String getIdpSingleLogoutLocation(@NotNull IDPSSODescriptor descriptor) {
+  private SystemCrypto systemCrypto;
+  private UuidGenerator uuidGenerator;
+
+  public LogoutMessageImpl(UuidGenerator generator) {
+    uuidGenerator = generator;
+  }
+
+  public String getIdpSingleLogoutLocation(IDPSSODescriptor descriptor) {
     return descriptor
         .getSingleLogoutServices()
         .stream()
@@ -71,7 +77,7 @@ public class LogoutMessageImpl implements LogoutMessage {
         .orElse("");
   }
 
-  public SignableSAMLObject extractXmlObject(@NotNull String samlLogoutResponse)
+  public SignableSAMLObject extractXmlObject(String samlLogoutResponse)
       throws WSSecurityException, XMLStreamException {
     Document responseDoc =
         StaxUtils.read(
@@ -83,7 +89,7 @@ public class LogoutMessageImpl implements LogoutMessage {
     return null;
   }
 
-  private <T extends SAMLObject> T extract(@NotNull String samlObject, @NotNull Class<T> clazz)
+  private <T extends SAMLObject> T extract(String samlObject, Class<T> clazz)
       throws WSSecurityException, XMLStreamException {
     Document responseDoc =
         StaxUtils.read(new ByteArrayInputStream(samlObject.getBytes(StandardCharsets.UTF_8)));
@@ -95,13 +101,13 @@ public class LogoutMessageImpl implements LogoutMessage {
   }
 
   @Override
-  public LogoutResponse extractSamlLogoutResponse(@NotNull String samlLogoutResponse)
+  public LogoutResponse extractSamlLogoutResponse(String samlLogoutResponse)
       throws XMLStreamException, WSSecurityException {
     return extract(samlLogoutResponse, LogoutResponse.class);
   }
 
   @Override
-  public LogoutRequest extractSamlLogoutRequest(@NotNull String samlLogoutResponse)
+  public LogoutRequest extractSamlLogoutRequest(String samlLogoutResponse)
       throws XMLStreamException, WSSecurityException {
     return extract(samlLogoutResponse, LogoutRequest.class);
   }
@@ -112,16 +118,18 @@ public class LogoutMessageImpl implements LogoutMessage {
    *
    * @param nameIdString NameId of user to log out
    * @param issuerOrEntityId The Issuer of the LogoutRequest
+   * @param sessionIndexes The list of session indexes selected for log out
    * @return the built <code>LogoutRequest</code>
    */
   @Override
   public LogoutRequest buildLogoutRequest(
-      @NotNull String nameIdString, @NotNull String issuerOrEntityId) {
-    return buildLogoutRequest(nameIdString, issuerOrEntityId, UUID.randomUUID().toString());
+      String nameIdString, String issuerOrEntityId, List<String> sessionIndexes) {
+    return buildLogoutRequest(
+        nameIdString, issuerOrEntityId, getUuidGenerator().generateUuid(), sessionIndexes);
   }
 
   public LogoutRequest buildLogoutRequest(
-      @NotNull String nameIdString, @NotNull String issuerOrEntityId, @NotNull String id) {
+      String nameIdString, String issuerOrEntityId, String id, List<String> sessionIndexes) {
     if (nameIdString == null) {
       throw new IllegalArgumentException("Name ID cannot be null");
     }
@@ -131,9 +139,15 @@ public class LogoutMessageImpl implements LogoutMessage {
     if (id == null) {
       throw new IllegalArgumentException("ID cannot be null");
     }
+    if (sessionIndexes == null) {
+      throw new IllegalArgumentException("Session Index collection can be empty, but not null.");
+    }
 
     return SamlProtocol.createLogoutRequest(
-        SamlProtocol.createIssuer(issuerOrEntityId), SamlProtocol.createNameID(nameIdString), id);
+        SamlProtocol.createIssuer(issuerOrEntityId),
+        SamlProtocol.createNameID(nameIdString),
+        id,
+        sessionIndexes);
   }
 
   /**
@@ -144,8 +158,7 @@ public class LogoutMessageImpl implements LogoutMessage {
    * @return LogoutResponse
    */
   @Override
-  public LogoutResponse buildLogoutResponse(
-      @NotNull String issuerOrEntityId, @NotNull String statusCodeValue) {
+  public LogoutResponse buildLogoutResponse(String issuerOrEntityId, String statusCodeValue) {
     return buildLogoutResponse(issuerOrEntityId, statusCodeValue, null);
   }
 
@@ -157,10 +170,7 @@ public class LogoutMessageImpl implements LogoutMessage {
   }
 
   public LogoutResponse buildLogoutResponse(
-      @NotNull String issuerOrEntityId,
-      @NotNull String statusCodeValue,
-      String inResponseTo,
-      @NotNull String id) {
+      String issuerOrEntityId, String statusCodeValue, String inResponseTo, String id) {
     if (issuerOrEntityId == null) {
       throw new IllegalArgumentException("Issuer cannot be null");
     }
@@ -179,14 +189,14 @@ public class LogoutMessageImpl implements LogoutMessage {
   }
 
   @Override
-  public Element getElementFromSaml(@NotNull XMLObject xmlObject) throws WSSecurityException {
+  public Element getElementFromSaml(XMLObject xmlObject) throws WSSecurityException {
     Document doc = DOMUtils.createDocument();
     doc.appendChild(doc.createElement("root"));
     return OpenSAMLUtil.toDom(xmlObject, doc);
   }
 
   @Override
-  public String sendSamlLogoutRequest(@NotNull LogoutRequest request, @NotNull String targetUri)
+  public String sendSamlLogoutRequest(LogoutRequest request, String targetUri)
       throws IOException, WSSecurityException {
     Element requestElement = getElementFromSaml(request);
     String requestMessage = DOM2Writer.nodeToString(requestElement);
@@ -202,26 +212,20 @@ public class LogoutMessageImpl implements LogoutMessage {
   }
 
   @Override
-  public URI signSamlGetResponse(
-      @NotNull SAMLObject samlObject, @NotNull URI target, String relayState)
+  public URI signSamlGetResponse(SAMLObject samlObject, URI target, String relayState)
       throws WSSecurityException, SimpleSign.SignatureException, IOException {
 
     return signSamlGet(samlObject, target, relayState, SSOConstants.SAML_RESPONSE);
   }
 
   @Override
-  public URI signSamlGetRequest(
-      @NotNull SAMLObject samlObject, @NotNull URI target, String relayState)
+  public URI signSamlGetRequest(SAMLObject samlObject, URI target, String relayState)
       throws WSSecurityException, SimpleSign.SignatureException, IOException {
 
     return signSamlGet(samlObject, target, relayState, SSOConstants.SAML_REQUEST);
   }
 
-  private URI signSamlGet(
-      @NotNull SAMLObject samlObject,
-      @NotNull URI target,
-      String relayState,
-      @NotNull String requestType)
+  private URI signSamlGet(SAMLObject samlObject, URI target, String relayState, String requestType)
       throws WSSecurityException, SimpleSign.SignatureException, IOException {
     Document doc = DOMUtils.createDocument();
     doc.appendChild(doc.createElement("root"));
@@ -242,5 +246,9 @@ public class LogoutMessageImpl implements LogoutMessage {
 
   public void setSystemCrypto(SystemCrypto systemCrypto) {
     this.systemCrypto = systemCrypto;
+  }
+
+  public UuidGenerator getUuidGenerator() {
+    return uuidGenerator;
   }
 }

--- a/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,7 +18,11 @@
                                http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <ext:property-placeholder/>
-    
+
+    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
+
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+
     <reference-list id="realmList" interface="org.apache.shiro.realm.Realm"
                     ext:proxy-method="greedy"/>
 
@@ -45,6 +49,7 @@
     </bean>
 
     <bean id="logoutMessageImpl" class="ddf.security.samlp.impl.LogoutMessageImpl">
+        <argument ref="uuidGenerator"/>
         <cm:managed-properties persistent-id="ddf.security.samlp.LogoutMessage"
                                update-strategy="container-managed"/>
         <property name="systemCrypto" ref="crypto"/>

--- a/platform/security/core/security-core-impl/src/test/groovy/ddf/security/samlp/impl/LogoutMessageSpecTest.groovy
+++ b/platform/security/core/security-core-impl/src/test/groovy/ddf/security/samlp/impl/LogoutMessageSpecTest.groovy
@@ -9,7 +9,6 @@ import org.opensaml.saml.common.SAMLVersion
 import org.opensaml.saml.saml2.core.LogoutRequest
 import org.opensaml.saml.saml2.core.LogoutResponse
 import org.opensaml.saml.saml2.core.StatusCode
-
 import spock.lang.Specification
 
 import java.time.Instant
@@ -30,6 +29,7 @@ class LogoutMessageSpecTest extends Specification {
     final String ISSUER_ID = "MyIssuerId"
 
     final String IN_RESPONSE_TO = "InResponseToID"
+    final String SESSION_INDEX = "MySessionIndex";
 
     void setup() {
         System.setProperty("org.codice.ddf.system.hostname", "localhost")
@@ -44,8 +44,8 @@ class LogoutMessageSpecTest extends Specification {
         copyResourceToFile(encryptionFile, "/encryption.properties")
 
         EncryptionService encryptionService = Mock(EncryptionService.class) {
-            decrypt(_ as String) >> {String data -> data.substring(ENCRYPT_PREFIX.length())}
-            encrypt(_ as String) >> {String data -> "$ENCRYPT_PREFIX$data"}
+            decrypt(_ as String) >> { String data -> data.substring(ENCRYPT_PREFIX.length()) }
+            encrypt(_ as String) >> { String data -> "$ENCRYPT_PREFIX$data" }
         }
 
         System.setProperty("javax.net.ssl.keyStore", jksFile.getAbsolutePath());
@@ -53,12 +53,15 @@ class LogoutMessageSpecTest extends Specification {
         logoutMessage.systemCrypto = new SystemCrypto(encryptionFile.absolutePath,
                 signatureFile.absolutePath,
                 encryptionService)
+        logoutMessage.uuidGenerator = Mock(org.codice.ddf.platform.util.uuidgenerator.UuidGenerator.class) {
+            generateUuid() >> { UUID.randomUUID().toString() }
+        }
     }
 
     void copyResourceToFile(File file, String resource) throws IOException {
-        file.withOutputStream {fileOutputStream ->
+        file.withOutputStream { fileOutputStream ->
             LogoutMessageSpecTest.class.getResourceAsStream(resource).
-                    withStream {resourceStream -> fileOutputStream << resourceStream
+                    withStream { resourceStream -> fileOutputStream << resourceStream
                     };
         };
     }
@@ -69,34 +72,37 @@ class LogoutMessageSpecTest extends Specification {
 
     def "build valid logout request"() {
         when:
-        LogoutRequest logoutRequest = logoutMessage.buildLogoutRequest(NAME_ID, ISSUER_ID)
-
+        LogoutRequest logoutRequest = logoutMessage.buildLogoutRequest(NAME_ID, ISSUER_ID, Collections.singletonList(SESSION_INDEX))
 
         then:
         isNotBlank(logoutRequest.ID)
         NAME_ID.equals(logoutRequest.nameID.value)
         ISSUER_ID.equals(logoutRequest.issuer.value)
         SAMLVersion.VERSION_20.equals(logoutRequest.version)
-        now().
-                isAfter(Instant.ofEpochMilli(logoutRequest.issueInstant.millis))
+        logoutRequest.sessionIndexes.size() == 1
+        SESSION_INDEX.equals(logoutRequest.sessionIndexes.get(0).getSessionIndex());
+        now().isAfter(Instant.ofEpochMilli(logoutRequest.issueInstant.millis))
     }
 
     def "build logout request with invalid info"() {
+
         when:
-        LogoutRequest logoutRequest = logoutMessage.buildLogoutRequest(nameId, issuerId, id)
+        LogoutRequest logoutRequest = logoutMessage.buildLogoutRequest(nameId, issuerId, id,
+                sessionIndex == null ? null : Collections.singletonList(sessionIndex))
 
         then:
         thrown(IllegalArgumentException)
 
         where: "any param is null"
-        nameId | issuerId | id
-        null   | null     | "xxx"
-        "xxx"  | null     | "xxx"
-        null   | "xxx"    | "xxx"
-        null   | null     | null
-        "xxx"  | null     | null
-        null   | "xxx"    | null
-        "xxx"  | "xxx"    | null
+        nameId | issuerId | id    | sessionIndex
+        null   | null     | "xxx" | "xxx"
+        "xxx"  | null     | "xxx" | "xxx"
+        null   | "xxx"    | "xxx" | "xxx"
+        null   | null     | null  | null
+        "xxx"  | null     | null  | "xxx"
+        null   | "xxx"    | null  | null
+        "xxx"  | "xxx"    | null  | null
+        "xxx"  | "xxx"    | "xxx" | null
     }
 
     def "build logout response with valid info and inResponseTo"() {
@@ -118,7 +124,7 @@ class LogoutMessageSpecTest extends Specification {
     def "build logout response with no inResponseTo"() {
         when:
         LogoutResponse logoutResponse = logoutMessage.buildLogoutResponse("issuer",
-                StatusCode.SUCCESS )
+                StatusCode.SUCCESS)
 
         then:
         logoutResponse.inResponseTo == null
@@ -126,7 +132,7 @@ class LogoutMessageSpecTest extends Specification {
 
     def "verify signed saml request"() {
         setup:
-        LogoutRequest logoutRequest = logoutMessage.buildLogoutRequest(NAME_ID, ISSUER_ID)
+        LogoutRequest logoutRequest = logoutMessage.buildLogoutRequest(NAME_ID, ISSUER_ID, Collections.singletonList(SESSION_INDEX))
 
         def target = new URI("https://mytarget.com")
         def relayState = "MyRelayStateGuid"

--- a/platform/security/handler/security-handler-api/pom.xml
+++ b/platform/security/handler/security-handler-api/pom.xml
@@ -109,17 +109,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.39</minimum>
+                                            <minimum>0.40</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.31</minimum>
+                                            <minimum>0.29</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.34</minimum>
+                                            <minimum>0.35</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/security/handler/security-handler-api/src/main/java/org/codice/ddf/security/handler/api/HandlerResult.java
+++ b/platform/security/handler/security-handler-api/src/main/java/org/codice/ddf/security/handler/api/HandlerResult.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.security.handler.api;
 
+import java.util.Objects;
+
 /**
  * Encapsulates the return status for each handler. Consists of the status of any action taken by
  * the handler (successfully retrieved desired tokens, responded to a client in order to obtain
@@ -67,7 +69,7 @@ public class HandlerResult {
     sb.append("; Source: ");
     sb.append(source);
     sb.append("; Token: ");
-    sb.append(token.toString());
+    sb.append(Objects.isNull(token) ? "null" : token.toString());
     return sb.toString();
   }
 

--- a/platform/security/idp/security-idp-client/pom.xml
+++ b/platform/security/idp/security-idp-client/pom.xml
@@ -137,6 +137,12 @@
             <version>${org.slf4j.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -206,17 +212,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.47</minimum>
+                                            <minimum>0.51</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.48</minimum>
+                                            <minimum>0.52</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/LogoutRequestServiceTest.java
+++ b/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/LogoutRequestServiceTest.java
@@ -13,11 +13,15 @@
  */
 package org.codice.ddf.security.idp.client;
 
+import static org.codice.ddf.security.idp.client.LogoutRequestService.UNABLE_TO_PARSE_LOGOUT_REQUEST;
+import static org.codice.ddf.security.idp.client.LogoutRequestService.UNABLE_TO_VALIDATE_LOGOUT_REQUEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,13 +29,13 @@ import ddf.security.SecurityConstants;
 import ddf.security.common.SecurityTokenHolder;
 import ddf.security.encryption.EncryptionService;
 import ddf.security.http.SessionFactory;
-import ddf.security.samlp.LogoutMessage;
 import ddf.security.samlp.SamlProtocol;
 import ddf.security.samlp.SimpleSign;
-import ddf.security.samlp.ValidationException;
+import ddf.security.samlp.impl.LogoutMessageImpl;
 import ddf.security.samlp.impl.RelayStates;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletRequest;
@@ -40,76 +44,68 @@ import javax.ws.rs.core.Response;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 import org.opensaml.saml.saml2.core.LogoutResponse;
+import org.opensaml.saml.saml2.core.SessionIndex;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.core.impl.LogoutRequestBuilder;
 import org.opensaml.saml.saml2.core.impl.LogoutResponseBuilder;
-import org.opensaml.xmlsec.signature.SignableXMLObject;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 public class LogoutRequestServiceTest {
 
+  public static final String UNENCODED_SAML_RESPONSE = "TEST-SAML-RESPONSE";
+  public static final String UNENCODED_SAML_REQUEST = "TEST-SAML-REQUEST";
+  public static final String SIGNATURE = "signature";
+  public static final String SIGNATURE_ALGORITHM = "sha1";
   private static final long LOGOUT_PAGE_TIMEOUT = TimeUnit.HOURS.toMillis(1);
-
+  private static final String SESSION_INDEX = "123";
+  private static final String ID = "TEST-ID";
   private LogoutRequestService logoutRequestService;
-
   private String nameId = "nameId";
-
   private Long time = System.currentTimeMillis();
-
   private String logoutUrl = "https://www.logout.url/logout";
-
   private String redirectLogoutUrl = "https://www.redirectlogout.location.com/logout";
-
   private String postLogoutUrl = "https://www.postlogout.location.com/logout";
-
   private RelayStates<String> relayStates;
-
   private SessionFactory sessionFactory;
-
   private HttpServletRequest request;
-
-  private LogoutMessage logoutMessage;
-
+  private LogoutMessageImpl logoutMessage;
   private EncryptionService encryptionService;
-
   private IdpMetadata idpMetadata;
-
   private SimpleSign simpleSign;
-
   private HttpSession session;
-
   private SecurityTokenHolder securityTokenHolder;
+  private String relayState = UUID.randomUUID().toString();
 
-  private class MockLogoutRequestService extends LogoutRequestService {
+  public static Document readSamlAssertion()
+      throws SAXException, IOException, ParserConfigurationException {
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
-    public MockLogoutRequestService(
-        SimpleSign simpleSign, IdpMetadata idpMetadata, RelayStates<String> relayStates) {
-      super(simpleSign, idpMetadata, relayStates);
-    }
+    dbf.setValidating(false);
+    dbf.setIgnoringComments(false);
+    dbf.setIgnoringElementContentWhitespace(true);
+    dbf.setNamespaceAware(true);
 
-    @Override
-    protected void buildAndValidateSaml(
-        String samlRequest,
-        String relayState,
-        String signatureAlgorithm,
-        String signature,
-        SignableXMLObject xmlObject)
-        throws ValidationException {
-      return;
-    }
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    db.setEntityResolver(new DOMUtils.NullResolver());
+
+    return db.parse(LogoutRequestServiceTest.class.getResourceAsStream("/SAMLAssertion.xml"));
   }
 
   @Before
@@ -119,7 +115,10 @@ public class LogoutRequestServiceTest {
     relayStates = mock(RelayStates.class);
     sessionFactory = mock(SessionFactory.class);
     request = mock(HttpServletRequest.class);
-    logoutMessage = mock(LogoutMessage.class);
+    logoutMessage = mock(LogoutMessageImpl.class);
+    UuidGenerator uuidGenerator = mock(UuidGenerator.class);
+    doReturn(UUID.randomUUID().toString()).when(uuidGenerator).generateUuid();
+    doReturn(uuidGenerator).when(logoutMessage).getUuidGenerator();
     encryptionService = mock(EncryptionService.class);
     session = mock(HttpSession.class);
     securityTokenHolder = mock(SecurityTokenHolder.class);
@@ -127,16 +126,7 @@ public class LogoutRequestServiceTest {
     String assertionId = issuedAssertion.getAttributeNodeNS(null, "ID").getNodeValue();
     SecurityToken token = new SecurityToken(assertionId, issuedAssertion, null);
     when(securityTokenHolder.getSecurityToken("idp")).thenReturn(token);
-
-    logoutRequestService = new MockLogoutRequestService(simpleSign, idpMetadata, relayStates);
-    logoutRequestService.setEncryptionService(encryptionService);
-    logoutRequestService.setLogOutPageTimeOut(LOGOUT_PAGE_TIMEOUT);
-    logoutRequestService.setLogoutMessage(logoutMessage);
-    logoutRequestService.setRequest(request);
-    logoutRequestService.setSessionFactory(sessionFactory);
-
-    logoutRequestService.init();
-
+    initializeLogutRequestService();
     when(sessionFactory.getOrCreateSession(request)).thenReturn(session);
     when(session.getAttribute(eq(SecurityConstants.SAML_ASSERTION)))
         .thenReturn(securityTokenHolder);
@@ -145,6 +135,16 @@ public class LogoutRequestServiceTest {
     when(idpMetadata.getSingleLogoutBinding()).thenReturn(SamlProtocol.REDIRECT_BINDING);
     when(idpMetadata.getSingleLogoutLocation()).thenReturn(redirectLogoutUrl);
     System.setProperty("security.audit.roles", "none");
+  }
+
+  private void initializeLogutRequestService() {
+    logoutRequestService = new LogoutRequestService(simpleSign, idpMetadata, relayStates);
+    logoutRequestService.setEncryptionService(encryptionService);
+    logoutRequestService.setLogOutPageTimeOut(LOGOUT_PAGE_TIMEOUT);
+    logoutRequestService.setLogoutMessage(logoutMessage);
+    logoutRequestService.setRequest(request);
+    logoutRequestService.setSessionFactory(sessionFactory);
+    logoutRequestService.init();
   }
 
   @Test
@@ -166,7 +166,8 @@ public class LogoutRequestServiceTest {
     when(idpMetadata.getSingleLogoutBinding()).thenReturn(SamlProtocol.POST_BINDING);
     when(idpMetadata.getSingleLogoutLocation()).thenReturn(postLogoutUrl);
     LogoutRequest logoutRequest = new LogoutRequestBuilder().buildObject();
-    when(logoutMessage.buildLogoutRequest(eq(nameId), anyString())).thenReturn(logoutRequest);
+    when(logoutMessage.buildLogoutRequest(eq(nameId), anyString(), anyListOf(String.class)))
+        .thenReturn(logoutRequest);
     Response response = logoutRequestService.sendLogoutRequest(encryptedNameIdWithTime);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertTrue(
@@ -194,10 +195,15 @@ public class LogoutRequestServiceTest {
   public void testSendLogoutRequestInvalidNumberOfParams() throws Exception {
     String encryptedNameIdWithTime = nameId + "\n" + time;
     when(encryptionService.decrypt(any(String.class))).thenReturn(nameId);
+    LogoutRequest logoutRequest = mock(LogoutRequest.class);
+    when(logoutRequest.getIssueInstant()).thenReturn(DateTime.now());
+    SessionIndex sessionIndex = mock(SessionIndex.class);
+    when(sessionIndex.getSessionIndex()).thenReturn(SESSION_INDEX);
+    when(logoutRequest.getSessionIndexes()).thenReturn(Collections.singletonList(sessionIndex));
     Response response = logoutRequestService.sendLogoutRequest(encryptedNameIdWithTime);
     assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus());
-    String msg =
-        "Failed to decrypt logout request params. Invalid number of params.".replaceAll(" ", "+");
+    insertLogoutRequest();
+    String msg = LogoutRequestService.UNABLE_TO_DECRYPT_LOGOUT_REQUEST.replaceAll(" ", "+");
     assertTrue(
         "Expected message containing " + msg, response.getLocation().getQuery().contains(msg));
   }
@@ -219,14 +225,17 @@ public class LogoutRequestServiceTest {
 
   @Test
   public void getPostLogoutRequest() throws Exception {
-    String relayState = UUID.randomUUID().toString();
     String encodedSamlRequest = "encodedSamlRequest";
     String issuerStr = "issuer";
     LogoutRequest logoutRequest = mock(LogoutRequest.class);
+    when(logoutRequest.getIssueInstant()).thenReturn(DateTime.now());
+    SessionIndex sessionIndex = mock(SessionIndex.class);
+    when(sessionIndex.getSessionIndex()).thenReturn(SESSION_INDEX);
+    when(logoutRequest.getSessionIndexes()).thenReturn(Collections.singletonList(sessionIndex));
+    when(logoutMessage.extractSamlLogoutRequest(any(String.class))).thenReturn(logoutRequest);
     Issuer issuer = mock(Issuer.class);
     OpenSAMLUtil.initSamlEngine();
     LogoutResponse logoutResponse = new LogoutResponseBuilder().buildObject();
-    when(logoutMessage.extractSamlLogoutRequest(any(String.class))).thenReturn(logoutRequest);
     when(logoutRequest.getIssuer()).thenReturn(issuer);
     when(logoutRequest.getIssueInstant()).thenReturn(new DateTime());
     when(logoutRequest.getVersion()).thenReturn(SAMLVersion.VERSION_20);
@@ -246,19 +255,23 @@ public class LogoutRequestServiceTest {
 
   @Test
   public void getPostLogoutRequestNotParsable() throws Exception {
-    String relayState = UUID.randomUUID().toString();
     String encodedSamlRequest = "encodedSamlRequest";
+    LogoutRequest logoutRequest = mock(LogoutRequest.class);
+    when(logoutRequest.getIssueInstant()).thenReturn(DateTime.now());
+    SessionIndex sessionIndex = mock(SessionIndex.class);
+    when(sessionIndex.getSessionIndex()).thenReturn(SESSION_INDEX);
+    when(logoutRequest.getSessionIndexes()).thenReturn(Collections.singletonList(sessionIndex));
+    insertLogoutRequest();
     Response response =
         logoutRequestService.postLogoutRequest(encodedSamlRequest, null, relayState);
     assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus());
-    String msg = "Unable to parse logout request.".replaceAll(" ", "+");
+    String msg = UNABLE_TO_PARSE_LOGOUT_REQUEST.replaceAll(" ", "+");
     assertTrue(
         "Expected message containing " + msg, response.getLocation().getQuery().contains(msg));
   }
 
   @Test
   public void testPostLogoutRequestResponse() throws Exception {
-    String relayState = UUID.randomUUID().toString();
     String encodedSamlResponse = "encodedSamlRequest";
     String issuerStr = "issuer";
     Issuer issuer = mock(Issuer.class);
@@ -283,61 +296,70 @@ public class LogoutRequestServiceTest {
 
   @Test
   public void testPostLogoutRequestResponseNotParsable() throws Exception {
-    String relayState = UUID.randomUUID().toString();
+    LogoutRequest logoutRequest = mock(LogoutRequest.class);
+    when(logoutRequest.getIssueInstant()).thenReturn(DateTime.now());
+    SessionIndex sessionIndex = mock(SessionIndex.class);
+    when(sessionIndex.getSessionIndex()).thenReturn(SESSION_INDEX);
+    when(logoutRequest.getSessionIndexes()).thenReturn(Collections.singletonList(sessionIndex));
     String encodedSamlResponse = "encodedSamlRequest";
     when(logoutMessage.extractSamlLogoutResponse(any(String.class))).thenReturn(null);
+    insertLogoutRequest();
     Response response =
         logoutRequestService.postLogoutRequest(null, encodedSamlResponse, relayState);
     assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus());
-    String msg = "Unable to parse logout response.".replaceAll(" ", "+");
+    String msg = LogoutRequestService.UNABLE_TO_PARSE_LOGOUT_RESPONSE.replaceAll(" ", "+");
     assertTrue(
         "Expected message containing " + msg, response.getLocation().getQuery().contains(msg));
   }
 
   @Test
   public void testGetLogoutRequest() throws Exception {
-    String signature = "signature";
-    String signatureAlgorithm = "sha1";
-    String relayState = UUID.randomUUID().toString();
-    String deflatedSamlRequest = RestSecurity.deflateAndBase64Encode("deflatedSamlRequest");
-    LogoutRequest logoutRequest = mock(LogoutRequest.class);
-    when(logoutMessage.extractSamlLogoutRequest(eq("deflatedSamlRequest")))
-        .thenReturn(logoutRequest);
+    String deflatedSamlRequest = RestSecurity.deflateAndBase64Encode(UNENCODED_SAML_REQUEST);
+    doReturn(true).when(simpleSign).validateSignature(anyString(), anyString(), any());
+    initializeLogutRequestService();
+    insertLogoutRequest();
     when(logoutMessage.signSamlGetResponse(any(LogoutRequest.class), any(URI.class), anyString()))
         .thenReturn(new URI(redirectLogoutUrl));
     Response response =
         logoutRequestService.getLogoutRequest(
-            deflatedSamlRequest, null, relayState, signatureAlgorithm, signature);
+            deflatedSamlRequest, null, relayState, SIGNATURE_ALGORITHM, SIGNATURE);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     assertTrue(
         "Expected logout url of " + redirectLogoutUrl,
         response.getEntity().toString().contains(redirectLogoutUrl));
   }
 
+  private void insertLogoutRequest() throws XMLStreamException, WSSecurityException {
+    LogoutRequest logoutRequest = mock(LogoutRequest.class);
+    SessionIndex sessionIndex = mock(SessionIndex.class);
+    doReturn(SESSION_INDEX).when(sessionIndex).getSessionIndex();
+    doReturn((Collections.singletonList(sessionIndex))).when(logoutRequest).getSessionIndexes();
+    doReturn(DateTime.now()).when(logoutRequest).getIssueInstant();
+    doReturn(SAMLVersion.VERSION_20).when(logoutRequest).getVersion();
+    doReturn(ID).when(logoutRequest).getID();
+    doReturn(logoutRequest)
+        .when(logoutMessage)
+        .extractSamlLogoutRequest(eq(UNENCODED_SAML_REQUEST));
+  }
+
   @Test
   public void testGetLogoutRequestNotParsable() throws Exception {
-    String signature = "signature";
-    String signatureAlgorithm = "sha1";
-    String relayState = UUID.randomUUID().toString();
-    String deflatedSamlRequest = RestSecurity.deflateAndBase64Encode("deflatedSamlRequest");
-    when(logoutMessage.extractSamlLogoutRequest(eq("deflatedSamlRequest"))).thenReturn(null);
+    String deflatedSamlRequest = RestSecurity.deflateAndBase64Encode(UNENCODED_SAML_REQUEST);
+    when(logoutMessage.extractSamlLogoutRequest(eq(UNENCODED_SAML_REQUEST))).thenReturn(null);
     Response response =
         logoutRequestService.getLogoutRequest(
-            deflatedSamlRequest, null, relayState, signatureAlgorithm, signature);
+            deflatedSamlRequest, null, relayState, SIGNATURE_ALGORITHM, SIGNATURE);
     assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus());
-    String msg = "Unable to parse logout request.".replaceAll(" ", "+");
+    String msg = LogoutRequestService.UNABLE_TO_PARSE_LOGOUT_REQUEST.replaceAll(" ", "+");
     assertTrue(
         "Expected message containing " + msg, response.getLocation().getQuery().contains(msg));
   }
 
   @Test
   public void testGetLogoutRequestInvalidSignature() throws Exception {
-    String signature = "signature";
-    String signatureAlgorithm = "sha1";
-    String relayState = UUID.randomUUID().toString();
-    String deflatedSamlRequest = RestSecurity.deflateAndBase64Encode("deflatedSamlRequest");
+    String deflatedSamlRequest = RestSecurity.deflateAndBase64Encode(UNENCODED_SAML_REQUEST);
     LogoutRequest logoutRequest = mock(LogoutRequest.class);
-    when(logoutMessage.extractSamlLogoutRequest(eq("deflatedSamlRequest")))
+    when(logoutMessage.extractSamlLogoutRequest(eq(UNENCODED_SAML_REQUEST)))
         .thenReturn(logoutRequest);
 
     LogoutRequestService lrs = new LogoutRequestService(simpleSign, idpMetadata, relayStates);
@@ -348,29 +370,34 @@ public class LogoutRequestServiceTest {
     lrs.setRequest(request);
     lrs.setSessionFactory(sessionFactory);
     lrs.init();
+    doReturn(new URI(redirectLogoutUrl))
+        .when(logoutMessage)
+        .signSamlGetResponse(any(SAMLObject.class), any(URI.class), anyString());
+    insertLogoutRequest();
     Response response =
-        lrs.getLogoutRequest(deflatedSamlRequest, null, relayState, signatureAlgorithm, signature);
+        lrs.getLogoutRequest(deflatedSamlRequest, null, relayState, SIGNATURE_ALGORITHM, SIGNATURE);
     assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus());
-    String msg = "Unable to validate".replaceAll(" ", "+");
+    String msg = UNABLE_TO_VALIDATE_LOGOUT_REQUEST.replaceAll(" ", "+");
+
     assertTrue(
         "Expected message containing " + msg, response.getLocation().getQuery().contains(msg));
   }
 
   @Test
   public void testGetLogoutRequestResponse() throws Exception {
-    String signature = "signature";
-    String signatureAlgorithm = "sha1";
-    String relayState = UUID.randomUUID().toString();
-    String deflatedSamlResponse = RestSecurity.deflateAndBase64Encode("deflatedSamlResponse");
+    String deflatedSamlResponse = RestSecurity.deflateAndBase64Encode(UNENCODED_SAML_RESPONSE);
     LogoutResponse logoutResponse = mock(LogoutResponse.class);
     when(logoutResponse.getIssueInstant()).thenReturn(new DateTime());
     when(logoutResponse.getVersion()).thenReturn(SAMLVersion.VERSION_20);
     when(logoutResponse.getID()).thenReturn("id");
-    when(logoutMessage.extractSamlLogoutResponse(eq("deflatedSamlResponse")))
+    when(logoutMessage.extractSamlLogoutResponse(eq(UNENCODED_SAML_RESPONSE)))
         .thenReturn(logoutResponse);
+
+    doReturn(true).when(simpleSign).validateSignature(anyString(), anyString(), anyString());
     Response response =
         logoutRequestService.getLogoutRequest(
-            null, deflatedSamlResponse, relayState, signatureAlgorithm, signature);
+            null, deflatedSamlResponse, relayState, SIGNATURE_ALGORITHM, SIGNATURE);
+    initializeLogutRequestService();
     assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus());
     assertTrue(
         "Expected a successful logout message",
@@ -379,29 +406,53 @@ public class LogoutRequestServiceTest {
 
   @Test
   public void testGetLogoutRequestResponseNotParsable() throws Exception {
-    String signature = "signature";
-    String signatureAlgorithm = "sha1";
-    String relayState = UUID.randomUUID().toString();
-    String deflatedSamlResponse = RestSecurity.deflateAndBase64Encode("deflatedSamlResponse");
-    when(logoutMessage.extractSamlLogoutResponse(eq("deflatedSamlResponse"))).thenReturn(null);
+    insertLogoutRequest();
+    String deflatedSamlResponse = RestSecurity.deflateAndBase64Encode(UNENCODED_SAML_RESPONSE);
+    when(logoutMessage.extractSamlLogoutResponse(eq(UNENCODED_SAML_RESPONSE))).thenReturn(null);
+    insertLogoutRequest();
     Response response =
         logoutRequestService.getLogoutRequest(
-            null, deflatedSamlResponse, relayState, signatureAlgorithm, signature);
+            null, deflatedSamlResponse, relayState, SIGNATURE_ALGORITHM, SIGNATURE);
     assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus());
-    String msg = "Unable to parse logout response.".replaceAll(" ", "+");
+    String msg = LogoutRequestService.UNABLE_TO_PARSE_LOGOUT_RESPONSE.replaceAll(" ", "+");
     assertTrue(
         "Expected message containing " + msg, response.getLocation().getQuery().contains(msg));
   }
 
   @Test
+  public void testGetLogoutRequestNoSessionIndex() throws Exception {
+    String deflatedSamlRequest = RestSecurity.deflateAndBase64Encode(UNENCODED_SAML_REQUEST);
+    doReturn(true).when(simpleSign).validateSignature(anyString(), anyString(), any());
+    initializeLogutRequestService();
+    LogoutRequest logoutRequest = mock(LogoutRequest.class);
+
+    // No session index
+    doReturn(Collections.EMPTY_LIST).when(logoutRequest).getSessionIndexes();
+
+    doReturn(DateTime.now()).when(logoutRequest).getIssueInstant();
+    doReturn(SAMLVersion.VERSION_20).when(logoutRequest).getVersion();
+    doReturn(ID).when(logoutRequest).getID();
+    doReturn(logoutRequest)
+        .when(logoutMessage)
+        .extractSamlLogoutRequest(eq(UNENCODED_SAML_REQUEST));
+    when(logoutMessage.signSamlGetResponse(any(LogoutRequest.class), any(URI.class), anyString()))
+        .thenReturn(new URI(redirectLogoutUrl));
+    Response response =
+        logoutRequestService.getLogoutRequest(
+            deflatedSamlRequest, null, relayState, SIGNATURE_ALGORITHM, SIGNATURE);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertTrue(
+        "Expected logout url of " + redirectLogoutUrl,
+        response.getEntity().toString().contains(redirectLogoutUrl));
+  }
+
+  @Test
   public void testGetLogoutRequestResponseInvalidSignature() throws Exception {
-    String signature = "signature";
-    String signatureAlgorithm = "sha1";
-    String relayState = UUID.randomUUID().toString();
-    String deflatedSamlResponse = RestSecurity.deflateAndBase64Encode("deflatedSamlResponse");
+    String deflatedSamlResponse = RestSecurity.deflateAndBase64Encode(UNENCODED_SAML_RESPONSE);
     LogoutResponse logoutResponse = mock(LogoutResponse.class);
-    when(logoutMessage.extractSamlLogoutResponse(eq("deflatedSamlResponse")))
+    when(logoutMessage.extractSamlLogoutResponse(eq(UNENCODED_SAML_RESPONSE)))
         .thenReturn(logoutResponse);
+
     LogoutRequestService lrs = new LogoutRequestService(simpleSign, idpMetadata, relayStates);
 
     lrs.setEncryptionService(encryptionService);
@@ -411,25 +462,11 @@ public class LogoutRequestServiceTest {
     lrs.setSessionFactory(sessionFactory);
     lrs.init();
     Response response =
-        lrs.getLogoutRequest(null, deflatedSamlResponse, relayState, signatureAlgorithm, signature);
+        lrs.getLogoutRequest(
+            null, deflatedSamlResponse, relayState, SIGNATURE_ALGORITHM, SIGNATURE);
     assertEquals(Response.Status.SEE_OTHER.getStatusCode(), response.getStatus());
     String msg = "Unable to validate".replaceAll(" ", "+");
     assertTrue(
         "Expected message containing " + msg, response.getLocation().getQuery().contains(msg));
-  }
-
-  public static Document readSamlAssertion()
-      throws SAXException, IOException, ParserConfigurationException {
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-    dbf.setValidating(false);
-    dbf.setIgnoringComments(false);
-    dbf.setIgnoringElementContentWhitespace(true);
-    dbf.setNamespaceAware(true);
-
-    DocumentBuilder db = dbf.newDocumentBuilder();
-    db.setEntityResolver(new DOMUtils.NullResolver());
-
-    return db.parse(LogoutRequestServiceTest.class.getResourceAsStream("/SAMLAssertion.xml"));
   }
 }

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -149,9 +149,7 @@ import org.w3c.dom.Node;
 public class IdpEndpoint implements Idp {
 
   public static final String SERVICES_IDP_PATH = SystemBaseUrl.getRootContext() + "/idp";
-
   private static final Logger LOGGER = LoggerFactory.getLogger(IdpEndpoint.class);
-
   private static final String CERTIFICATES_ATTR = "javax.servlet.request.X509Certificate";
   private static final String IDP_LOGIN = "/idp/login";
   private static final String IDP_LOGOUT = "/idp/logout";
@@ -171,32 +169,19 @@ public class IdpEndpoint implements Idp {
   }
 
   protected CookieCache cookieCache = new CookieCache();
-
   private PKIAuthenticationTokenFactory tokenFactory;
-
   private SecurityManager securityManager;
-
   private AtomicReference<Map<String, EntityInformation>> serviceProviders =
       new AtomicReference<>();
-
   private List<String> spMetadata;
-
   private String indexHtml;
-
   private String submitForm;
-
   private String redirectPage;
-
   private String soapMessage;
-
   private Boolean strictSignature = true;
-
   private SystemCrypto systemCrypto;
-
   private LogoutMessage logoutMessage;
-
   private RelayStates<LogoutState> logoutStates;
-
   private boolean guestAccess = true;
 
   private Map<ServiceReference<SamlPresignPlugin>, SamlPresignPlugin> presignPlugins =
@@ -1223,6 +1208,8 @@ public class IdpEndpoint implements Idp {
     localLogoutState.setNameId(logoutRequest.getNameID().getValue());
     localLogoutState.setOriginalRequestId(logoutRequest.getID());
     localLogoutState.setInitialRelayState(relayState);
+    localLogoutState.setSessionIndexObjects(logoutRequest.getSessionIndexes());
+
     logoutStates.encode(cookie.getValue(), localLogoutState);
 
     cookieCache.removeSamlAssertion(cookie.getValue());
@@ -1251,7 +1238,9 @@ public class IdpEndpoint implements Idp {
         }
         LogoutRequest logoutRequest =
             logoutMessage.buildLogoutRequest(
-                logoutState.getNameId(), SystemBaseUrl.constructUrl(IDP_LOGOUT, true));
+                logoutState.getNameId(),
+                SystemBaseUrl.constructUrl(IDP_LOGOUT, true),
+                logoutState.getSessionIndexes());
         logoutState.setCurrentRequestId(logoutRequest.getID());
         logoutObject = logoutRequest;
         samlType = SamlProtocol.Type.REQUEST;

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/LogoutState.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/LogoutState.java
@@ -14,15 +14,18 @@
 package org.codice.ddf.security.idp.server;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.opensaml.saml.saml2.core.SessionIndex;
 
 /** LogoutState represents the current state of an in progress logout */
 public class LogoutState {
-  private String initialRelayState;
-
   private final Set<String> spDescriptors;
-
+  private String initialRelayState;
   private String originalIssuer;
 
   private String nameId;
@@ -33,10 +36,13 @@ public class LogoutState {
 
   private boolean partialLogout = false;
 
+  private List<String> sessionIndexes = Collections.emptyList();
+
   public LogoutState(Set<String> spDescriptors) {
-    this.spDescriptors = Collections.synchronizedSet(spDescriptors);
+    this.spDescriptors = new HashSet(spDescriptors);
   }
 
+  @SuppressWarnings("unused")
   public synchronized void removeSpDescriptor(String descriptor) {
     spDescriptors.remove(descriptor);
   }
@@ -74,12 +80,12 @@ public class LogoutState {
     this.nameId = nameId;
   }
 
-  public void setOriginalRequestId(String originalRequestId) {
-    this.originalRequestId = originalRequestId;
-  }
-
   public String getOriginalRequestId() {
     return originalRequestId;
+  }
+
+  public void setOriginalRequestId(String originalRequestId) {
+    this.originalRequestId = originalRequestId;
   }
 
   public boolean isPartialLogout() {
@@ -96,5 +102,23 @@ public class LogoutState {
 
   public void setCurrentRequestId(String currentRequestId) {
     this.currentRequestId = currentRequestId;
+  }
+
+  public List<String> getSessionIndexes() {
+    return sessionIndexes;
+  }
+
+  @SuppressWarnings("unused")
+  public void setSessionIndexes(List<String> sessionIndexes) {
+    if (Objects.nonNull(sessionIndexes)) {
+      this.sessionIndexes = sessionIndexes;
+    }
+  }
+
+  public void setSessionIndexObjects(List<SessionIndex> sessionIndexes) {
+    if (Objects.nonNull(sessionIndexes)) {
+      setSessionIndexes(
+          sessionIndexes.stream().map(SessionIndex::getSessionIndex).collect(Collectors.toList()));
+    }
   }
 }

--- a/platform/security/idp/security-idp-server/src/test/java/org/codice/ddf/security/idp/server/IdpEndpointTest.java
+++ b/platform/security/idp/security-idp-server/src/test/java/org/codice/ddf/security/idp/server/IdpEndpointTest.java
@@ -261,6 +261,8 @@ public class IdpEndpointTest {
     assertThat(response.getEntity().toString(), containsString("soapenv:Body"));
     assertThat(response.getEntity().toString(), containsString("saml2p:Response"));
     assertThat(response.getEntity().toString(), containsString("saml2:Assertion"));
+    assertThat(response.getEntity().toString(), containsString("saml2:AuthnStatement"));
+    assertThat(response.getEntity().toString(), containsString("SessionIndex="));
     assertThat(
         response.getHeaders().get("SOAPAction").get(0),
         is("http://www.oasis-open.org/committees/security"));
@@ -281,6 +283,7 @@ public class IdpEndpointTest {
     assertThat(response.getEntity().toString(), containsString("soapenv:Body"));
     assertThat(response.getEntity().toString(), containsString("saml2p:Response"));
     assertThat(response.getEntity().toString(), containsString("saml2:Assertion"));
+    assertThat(response.getEntity().toString(), containsString("SessionIndex="));
     assertThat(
         response.getHeaders().get("SOAPAction").get(0),
         is("http://www.oasis-open.org/committees/security"));
@@ -301,6 +304,8 @@ public class IdpEndpointTest {
     assertThat(response.getEntity().toString(), containsString("soapenv:Body"));
     assertThat(response.getEntity().toString(), containsString("saml2p:Response"));
     assertThat(response.getEntity().toString(), containsString("saml2:Assertion"));
+    assertThat(response.getEntity().toString(), containsString("SessionIndex="));
+
     assertThat(
         response.getHeaders().get("SOAPAction").get(0),
         is("http://www.oasis-open.org/committees/security"));

--- a/platform/security/idp/security-idp-server/src/test/resources/saml.xml
+++ b/platform/security/idp/security-idp-server/src/test/resources/saml.xml
@@ -93,7 +93,7 @@
             <saml2:Audience>https://localhost:8993/services</saml2:Audience>
         </saml2:AudienceRestriction>
     </saml2:Conditions>
-    <saml2:AuthnStatement AuthnInstant="2013-04-23T23:39:54.777Z">
+    <saml2:AuthnStatement AuthnInstant="2013-04-23T23:39:54.777Z" SessionIndex="1">
         <saml2:AuthnContext>
             <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified
             </saml2:AuthnContextClassRef>

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/LogoutMessage.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/LogoutMessage.java
@@ -15,7 +15,8 @@ package ddf.security.samlp;
 
 import java.io.IOException;
 import java.net.URI;
-import javax.validation.constraints.NotNull;
+import java.util.List;
+import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.opensaml.core.xml.XMLObject;
@@ -27,35 +28,33 @@ import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.w3c.dom.Element;
 
 public interface LogoutMessage {
-  String getIdpSingleLogoutLocation(@NotNull IDPSSODescriptor descriptor);
+  String getIdpSingleLogoutLocation(IDPSSODescriptor descriptor);
 
-  SignableSAMLObject extractXmlObject(@NotNull String samlLogoutResponse)
+  SignableSAMLObject extractXmlObject(String samlLogoutResponse)
       throws WSSecurityException, XMLStreamException;
 
-  LogoutResponse extractSamlLogoutResponse(@NotNull String samlLogoutResponse)
+  LogoutResponse extractSamlLogoutResponse(String samlLogoutResponse)
       throws XMLStreamException, WSSecurityException;
 
-  LogoutRequest extractSamlLogoutRequest(@NotNull String samlLogoutRequest)
+  LogoutRequest extractSamlLogoutRequest(String samlLogoutRequest)
       throws XMLStreamException, WSSecurityException;
 
-  LogoutRequest buildLogoutRequest(@NotNull String nameIdString, @NotNull String issuerOrEntityId);
+  LogoutRequest buildLogoutRequest(
+      String nameIdString, String issuerOrEntityId, List<String> sessionIndexes);
+
+  LogoutResponse buildLogoutResponse(String issuerOrEntityId, String statusCodeValue);
 
   LogoutResponse buildLogoutResponse(
-      @NotNull String issuerOrEntityId, @NotNull String statusCodeValue);
+      String issuerOrEntityId, String statusCodeValue, String inResponseTo);
 
-  LogoutResponse buildLogoutResponse(
-      @NotNull String issuerOrEntityId, @NotNull String statusCodeValue, String inResponseTo);
+  Element getElementFromSaml(XMLObject xmlObject) throws WSSecurityException;
 
-  Element getElementFromSaml(@NotNull XMLObject xmlObject) throws WSSecurityException;
-
-  String sendSamlLogoutRequest(@NotNull LogoutRequest request, @NotNull String targetUri)
+  String sendSamlLogoutRequest(LogoutRequest request, String targetUri)
       throws IOException, WSSecurityException;
 
-  URI signSamlGetResponse(
-      @NotNull SAMLObject samlObject, @NotNull URI uriNameMeLater, String relayState)
+  URI signSamlGetResponse(SAMLObject samlObject, URI uriNameMeLater, @Nullable String relayState)
       throws WSSecurityException, SimpleSign.SignatureException, IOException;
 
-  URI signSamlGetRequest(
-      @NotNull SAMLObject samlObject, @NotNull URI uriNameMeLater, String relayState)
+  URI signSamlGetRequest(SAMLObject samlObject, URI uriNameMeLater, @Nullable String relayState)
       throws WSSecurityException, SimpleSign.SignatureException, IOException;
 }

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
@@ -51,9 +51,11 @@ import org.opensaml.saml.saml2.core.LogoutRequest;
 import org.opensaml.saml.saml2.core.LogoutResponse;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.SessionIndex;
 import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.impl.SessionIndexBuilder;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
@@ -520,13 +522,21 @@ public class SamlProtocol {
     return createAttributeQuery(issuer, subject, null);
   }
 
-  public static LogoutRequest createLogoutRequest(Issuer issuer, NameID nameId, String id) {
+  public static LogoutRequest createLogoutRequest(
+      Issuer issuer, NameID nameId, String id, List<String> sessionIndexes) {
     LogoutRequest logoutRequest = logoutRequestBuilder.buildObject();
     logoutRequest.setID(id);
     logoutRequest.setIssuer(issuer);
     logoutRequest.setNameID(nameId);
     logoutRequest.setIssueInstant(DateTime.now());
     logoutRequest.setVersion(SAMLVersion.VERSION_20);
+    SessionIndexBuilder builder = new SessionIndexBuilder();
+    for (String index : sessionIndexes) {
+      SessionIndex sessionIndexObject = builder.buildObject();
+      sessionIndexObject.setSessionIndex(index);
+      logoutRequest.getSessionIndexes().add(sessionIndexObject);
+    }
+
     return logoutRequest;
   }
 

--- a/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/SamlProtocolTest.java
+++ b/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/SamlProtocolTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.junit.Test;
@@ -93,7 +94,6 @@ public class SamlProtocolTest {
             .getNameIDFormats()
             .get(0)
             .getFormat());
-
     assertEquals(
         "logoutlocation",
         entityDescriptor
@@ -101,12 +101,10 @@ public class SamlProtocolTest {
             .getSingleLogoutServices()
             .get(0)
             .getLocation());
-
     List<SingleSignOnService> ssoServices =
         entityDescriptor
             .getIDPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
             .getSingleSignOnServices();
-
     assertTrue(
         ssoServices
             .stream()
@@ -176,7 +174,6 @@ public class SamlProtocolTest {
             .getX509Certificates()
             .get(0)
             .getValue());
-
     assertEquals(
         "logoutlocation",
         entityDescriptor
@@ -184,12 +181,10 @@ public class SamlProtocolTest {
             .getSingleLogoutServices()
             .get(0)
             .getLocation());
-
     List<AssertionConsumerService> acServices =
         entityDescriptor
             .getSPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
             .getAssertionConsumerServices();
-
     assertTrue(
         acServices
             .stream()
@@ -250,7 +245,10 @@ public class SamlProtocolTest {
   public void testCreateLogoutRequest() {
     LogoutRequest logoutRequest =
         SamlProtocol.createLogoutRequest(
-            SamlProtocol.createIssuer("myissuer"), SamlProtocol.createNameID("mynameid"), "myid");
+            SamlProtocol.createIssuer("myissuer"),
+            SamlProtocol.createNameID("mynameid"),
+            "myid",
+            Collections.emptyList());
     assertEquals("myissuer", logoutRequest.getIssuer().getValue());
     assertEquals("mynameid", logoutRequest.getNameID().getValue());
     assertEquals("myid", logoutRequest.getID());

--- a/platform/security/security-services-app/pom.xml
+++ b/platform/security/security-services-app/pom.xml
@@ -125,6 +125,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.security.handler</groupId>
             <artifactId>security-handler-api</artifactId>
             <version>${project.version}</version>

--- a/platform/security/security-services-app/src/main/resources/features.xml
+++ b/platform/security/security-services-app/src/main/resources/features.xml
@@ -34,6 +34,7 @@
         <feature>security-handler-api</feature>
         <bundle>mvn:ddf.security.expansion/security-expansion-api/${project.version}</bundle>
         <bundle dependency="true">mvn:ddf.security.encryption/security-encryption-api/${project.version}</bundle>
+        <bundle dependency="true">mvn:ddf.platform.util/util-uuidgenerator-api/${project.version}</bundle>
         <bundle>mvn:ddf.security.core/security-core-impl/${project.version}</bundle>
     </feature>
 

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/AuthNStatementProvider.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/AuthNStatementProvider.java
@@ -46,7 +46,13 @@ public class AuthNStatementProvider implements AuthenticationStatementProvider {
   @Override
   public AuthenticationStatementBean getStatement(TokenProviderParameters providerParameters) {
     AuthenticationStatementBean authBean = new AuthenticationStatementBean();
-    authBean.setSessionIndex(Integer.toString(secureRandom.nextInt()));
+    // "Use small positive integers (or reoccurring constants in a list) for the SessionIndex"
+    // Ref: sstc-saml-core-errata-2.0-wd-07, line 1140
+    int smallPositiveInteger = 0;
+    while (smallPositiveInteger == 0) {
+      smallPositiveInteger = secureRandom.nextInt(Short.MAX_VALUE);
+    }
+    authBean.setSessionIndex(Integer.toString(smallPositiveInteger));
 
     TokenRequirements tokenRequirements = providerParameters.getTokenRequirements();
     ReceivedToken receivedToken = null;


### PR DESCRIPTION
What does this PR do?
Implements SessionIndex for SAML. Specifically:
- SecurityAssertionImpl parses a SecurityToken, it copies the SessionIndex from the Security token into its own copy of the AuthnStatement
- The SessionIndex is extracted from an incoming SAML logout request by the LogoutMessage
- The SamlProtocol class copies the SessionIndex from the LogoutRequest it creates
- The SamlValidator checks for the presence of a SessionIndex when it validates a SAML request.
- Added SessionIndex attribute to XML file used in testing
- Changed how SessionIndex is generated in AuthnStatementProvider. SessionIndex can be any string, but standard recommends small-ish integer. It now generate only positive session indexes and reduces the upper size of a session index
- Added unit test to SessionAssertionTest to check for presence of session index
- Updated LogoutMessageSpecTest.groovy to account for session indexes
- Updated LogoutRequestServiceTest to account for session indexes.  Also added 
  
Other
- Fixes a bug in the toString() method of HandlerResult that caused a null pointer exception (only inside of the IDE)
- Fixed some Sonar Lint findings in LogoutRequestService and LogoutReqestServiceTest

Who is reviewing it?
@mcalcote @vinamartin @lessarderic

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@rzwiefel 
@stustison 
@figliold 

How should this be tested? (List steps with links to updated documentation)
Login, logout. There should be no errors. 

What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3422

Checklist:
[N/A] Documentation Updated
[X] Update / Add Unit Tests
[N/A Update / Add Integration Tests

Review Comment Legend:

✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.