### PR TITLE
[2.11.x] DDF-3372 Update WebDav to not get file when deleting

### DIFF
--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/content/ContentProducer.java
@@ -30,13 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ContentProducer extends DefaultProducer {
-  public static final int KB = 1024;
 
-  public static final int MB = 1024 * KB;
-
-  private static final transient Logger LOGGER = LoggerFactory.getLogger(ContentProducer.class);
-
-  private static final int DEFAULT_FILE_BACKED_OUTPUT_STREAM_THRESHOLD = 1 * MB;
+  private static final Logger LOGGER = LoggerFactory.getLogger(ContentProducer.class);
 
   private final FileSystemPersistenceProvider fileIdMap =
       new FileSystemPersistenceProvider("processed");
@@ -79,16 +74,11 @@ public class ContentProducer extends DefaultProducer {
 
     boolean storeRefKey = headers.containsKey(Constants.STORE_REFERENCE_KEY);
 
-    File ingestedFile = contentProducerDataAccessObject.getFileUsingRefKey(storeRefKey, in);
-
     WatchEvent.Kind<Path> eventType = contentProducerDataAccessObject.getEventType(storeRefKey, in);
 
-    if (ingestedFile == null) {
-      LOGGER.trace("EXITING: process - ingestedFile is NULL");
-      return;
-    }
+    File exchangeFile = contentProducerDataAccessObject.getFileUsingRefKey(storeRefKey, in);
 
-    String mimeType = contentProducerDataAccessObject.getMimeType(endpoint, ingestedFile);
+    String mimeType = contentProducerDataAccessObject.getMimeType(endpoint, exchangeFile);
 
     LOGGER.trace("Preparing content item for mimeType = {}", mimeType);
 
@@ -97,7 +87,7 @@ public class ContentProducer extends DefaultProducer {
     }
 
     contentProducerDataAccessObject.createContentItem(
-        fileIdMap, endpoint, ingestedFile, eventType, mimeType, headers);
+        fileIdMap, endpoint, exchangeFile, eventType, mimeType, headers);
 
     LOGGER.trace("EXITING: process");
   }

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
@@ -14,6 +14,7 @@
 package ddf.camel.component.catalog.content;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -85,6 +86,19 @@ public class ContentProducerDataAccessObjectTest {
     assertThat(
         contentProducerDataAccessObject.getFileUsingRefKey(true, mockMessage).equals(testFile),
         is(true));
+  }
+
+  @Test
+  public void testGetFileUsingRefKeyWithNullFile() throws Exception {
+    GenericFileMessage<File> mockMessage = getMockMessage(null);
+
+    // test with storeRefKey == false
+    assertThat(
+        contentProducerDataAccessObject.getFileUsingRefKey(false, mockMessage), is(nullValue()));
+
+    // test with storeRefKey == true
+    assertThat(
+        contentProducerDataAccessObject.getFileUsingRefKey(true, mockMessage), is(nullValue()));
   }
 
   @Test
@@ -160,6 +174,13 @@ public class ContentProducerDataAccessObjectTest {
     assertThat(
         contentProducerDataAccessObject.getMimeType(mockEndpoint, testFile2).equals("extension"),
         is(true));
+  }
+
+  @Test
+  public void testGetMimeTypeWithNullFile() throws Exception {
+    assertThat(
+        contentProducerDataAccessObject.getMimeType(mock(ContentEndpoint.class), null),
+        is(nullValue()));
   }
 
   @Test

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/content/ContentProducerDataAccessObjectTest.java
@@ -13,6 +13,9 @@
  */
 package ddf.camel.component.catalog.content;
 
+import static ddf.camel.component.catalog.content.ContentProducerDataAccessObject.ENTRY_CREATE;
+import static ddf.camel.component.catalog.content.ContentProducerDataAccessObject.ENTRY_DELETE;
+import static ddf.camel.component.catalog.content.ContentProducerDataAccessObject.ENTRY_MODIFY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,7 +24,9 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -63,7 +68,7 @@ import org.junit.rules.TemporaryFolder;
 public class ContentProducerDataAccessObjectTest {
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  ContentProducerDataAccessObject contentProducerDataAccessObject;
+  private ContentProducerDataAccessObject contentProducerDataAccessObject;
 
   @Before
   public void setUp() {
@@ -91,14 +96,72 @@ public class ContentProducerDataAccessObjectTest {
   @Test
   public void testGetFileUsingRefKeyWithNullFile() throws Exception {
     GenericFileMessage<File> mockMessage = getMockMessage(null);
-
-    // test with storeRefKey == false
-    assertThat(
-        contentProducerDataAccessObject.getFileUsingRefKey(false, mockMessage), is(nullValue()));
-
-    // test with storeRefKey == true
     assertThat(
         contentProducerDataAccessObject.getFileUsingRefKey(true, mockMessage), is(nullValue()));
+  }
+
+  @Test
+  public void testGetFileWithoutRefKeyWithNullFile() throws Exception {
+    GenericFileMessage<File> mockMessage = getMockMessage(null);
+    assertThat(
+        contentProducerDataAccessObject.getFileUsingRefKey(false, mockMessage), is(nullValue()));
+  }
+
+  @Test
+  public void testProcessNullFileOnEntryCreate() throws Exception {
+    Map<String, Object> headers = mock(Map.class);
+    CatalogFramework mockCatalogFramework = mock(CatalogFramework.class);
+    FileSystemPersistenceProvider mockFileSystemPersistenceProvider =
+        mock(FileSystemPersistenceProvider.class);
+
+    ContentComponent mockComponent = mock(ContentComponent.class);
+    doReturn(mockCatalogFramework).when(mockComponent).getCatalogFramework();
+
+    ContentEndpoint mockEndpoint = mock(ContentEndpoint.class);
+    doReturn(mockComponent).when(mockEndpoint).getComponent();
+
+    contentProducerDataAccessObject.createContentItem(
+        mockFileSystemPersistenceProvider, mockEndpoint, null, ENTRY_CREATE, "", headers);
+
+    verifyZeroInteractions(headers, mockCatalogFramework, mockComponent);
+  }
+
+  @Test
+  public void testProcessNullFileOnEntryUpdate() throws Exception {
+    Map<String, Object> headers = mock(Map.class);
+    CatalogFramework mockCatalogFramework = mock(CatalogFramework.class);
+    FileSystemPersistenceProvider mockFileSystemPersistenceProvider =
+        mock(FileSystemPersistenceProvider.class);
+
+    ContentComponent mockComponent = mock(ContentComponent.class);
+    doReturn(mockCatalogFramework).when(mockComponent).getCatalogFramework();
+
+    ContentEndpoint mockEndpoint = mock(ContentEndpoint.class);
+    doReturn(mockComponent).when(mockEndpoint).getComponent();
+
+    contentProducerDataAccessObject.createContentItem(
+        mockFileSystemPersistenceProvider, mockEndpoint, null, ENTRY_MODIFY, "", headers);
+
+    verifyZeroInteractions(headers, mockCatalogFramework, mockComponent);
+  }
+
+  @Test
+  public void testProcessNullFileOnEntryDelete() throws Exception {
+    Map<String, Object> headers = mock(Map.class);
+    CatalogFramework mockCatalogFramework = mock(CatalogFramework.class);
+    FileSystemPersistenceProvider mockFileSystemPersistenceProvider =
+        mock(FileSystemPersistenceProvider.class);
+
+    ContentComponent mockComponent = mock(ContentComponent.class);
+    doReturn(mockCatalogFramework).when(mockComponent).getCatalogFramework();
+
+    ContentEndpoint mockEndpoint = mock(ContentEndpoint.class);
+    doReturn(mockComponent).when(mockEndpoint).getComponent();
+
+    contentProducerDataAccessObject.createContentItem(
+        mockFileSystemPersistenceProvider, mockEndpoint, null, ENTRY_DELETE, "", headers);
+
+    verify(mockCatalogFramework, times(1)).delete(any(DeleteRequest.class));
   }
 
   @Test

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/AbstractDurableFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/AbstractDurableFileConsumer.java
@@ -88,7 +88,9 @@ public abstract class AbstractDurableFileConsumer extends GenericFileConsumer<Ev
     GenericFile<EventfulFileWrapper> genericFile = new GenericFile<>();
     genericFile.setEndpointPath(endpoint.getConfiguration().getDirectory());
     try {
-      if (file != null) {
+      if (file == null) {
+        genericFile.setFile(new EventfulFileWrapper(fileEvent, 1, null));
+      } else {
         genericFile.setFile(new EventfulFileWrapper(fileEvent, 1, file.toPath()));
         genericFile.setAbsoluteFilePath(file.getCanonicalPath());
       }
@@ -118,8 +120,10 @@ public abstract class AbstractDurableFileConsumer extends GenericFileConsumer<Ev
 
     @Override
     public void onFailure(Exchange exchange) {
-      INGEST_LOGGER.error(
-          "Delivery failed for {} event on {}", file, fileEvent.name(), exchange.getException());
+      if (INGEST_LOGGER.isErrorEnabled()) {
+        INGEST_LOGGER.error(
+            "Delivery failed for {} event on  {}", file, fileEvent.name(), exchange.getException());
+      }
     }
   }
 }

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableWebDavFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableWebDavFileConsumer.java
@@ -130,7 +130,11 @@ public class DurableWebDavFileConsumer extends AbstractDurableFileConsumer {
 
     @Override
     public void onFileDelete(DavEntry entry) {
-      processExchange(getExchange(entry, StandardWatchEventKinds.ENTRY_DELETE));
+      processExchange(
+          getExchange(
+              new File(entry.getLocation()),
+              StandardWatchEventKinds.ENTRY_DELETE,
+              entry.getLocation()));
     }
   }
 }

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableWebDavFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableWebDavFileConsumer.java
@@ -130,11 +130,7 @@ public class DurableWebDavFileConsumer extends AbstractDurableFileConsumer {
 
     @Override
     public void onFileDelete(DavEntry entry) {
-      processExchange(
-          getExchange(
-              new File(entry.getLocation()),
-              StandardWatchEventKinds.ENTRY_DELETE,
-              entry.getLocation()));
+      processExchange(getExchange(null, StandardWatchEventKinds.ENTRY_DELETE, entry.getLocation()));
     }
   }
 }

--- a/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
@@ -36,6 +36,7 @@ import ddf.catalog.content.operation.impl.UpdateStorageResponseImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.mime.MimeTypeMapper;
+import ddf.mime.MimeTypeResolutionException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
@@ -421,11 +422,17 @@ public class FileSystemStorageProvider implements StorageProvider {
     try (InputStream fileInputStream =
         file != null ? Files.newInputStream(file) : reference.toURL().openStream()) {
       mimeType = mimeTypeMapper.guessMimeType(fileInputStream, extension);
-    } catch (Exception e) {
-      LOGGER.info(
+    } catch (MimeTypeResolutionException e) {
+      LOGGER.debug(
           "Could not determine mime type for file extension = {}; defaulting to {}",
           extension,
           DEFAULT_MIME_TYPE);
+    } catch (IOException ie) {
+      LOGGER.debug(
+          "Error opening stream to external reference {}. Failing StorageProvider read.",
+          reference,
+          ie);
+      throw new StorageException("Cannot read " + reference + ".");
     }
 
     if (file != null) {

--- a/catalog/core/catalog-core-localstorageprovider/src/test/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProviderTest.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/test/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProviderTest.java
@@ -177,6 +177,20 @@ public class FileSystemStorageProviderTest {
     provider.read(new ReadStorageRequestImpl(uri, Collections.emptyMap()));
   }
 
+  @Test(expected = StorageException.class)
+  public void testReadDeletedRemoteReference() throws Exception {
+    CreateStorageResponse createResponse =
+        assertContentItem(
+            TEST_INPUT_CONTENTS,
+            NITF_MIME_TYPE,
+            TEST_INPUT_FILENAME,
+            Collections.singletonMap(
+                Constants.STORE_REFERENCE_KEY, "http://testHostName:12345/test.txt"));
+
+    URI uri = new URI(createResponse.getCreatedContentItems().get(0).getUri());
+    provider.read(new ReadStorageRequestImpl(uri, Collections.emptyMap()));
+  }
+
   @Test
   public void testUpdate() throws Exception {
     CreateStorageResponse createResponse =
@@ -377,8 +391,6 @@ public class FileSystemStorageProviderTest {
   public void testUpdateWithMultipleItems() throws Exception {
     CreateStorageResponse createResponse =
         assertContentItem(TEST_INPUT_CONTENTS, NITF_MIME_TYPE, TEST_INPUT_FILENAME);
-    URI unqualifiedUri = new URI(createResponse.getCreatedContentItems().get(0).getUri());
-
     createResponse =
         assertContentItemWithQualifier(
             TEST_INPUT_CONTENTS,

--- a/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
@@ -147,6 +147,8 @@
         <Logger name="org.apache.aries.spifly" level="warn"/>
         <Logger name="org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper" level="error"/>
         <Logger name="org.apache.cxf.phase.PhaseInterceptorChain" level="error"/>
+        <!-- Camel - Suppresses an NPE warning that is ignored by Camel -->
+        <Logger name="org.apache.camel.impl.DefaultUnitOfWork" level="error"/>
 
         <Root level="info">
             <AppenderRef ref="out"/>

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -107,8 +107,8 @@ log4j2.logger.org_apache_cxf_phase_PhaseInterceptorChain.level = ERROR
 
 # camel
 # Supresses an NPE warning that is ignored by Camel
-log4j2.logger.org_apache_camel_util_impl_unitofworkhelper.level = ERROR
-log4j2.logger.org_apache_camel_util_impl_unitofworkhelper.name = org.apache.camel.util.impl.UnitOfWorkHelper
+log4j2.logger.org_apache_camel_impl_defaultunitofwork.level = ERROR
+log4j2.logger.org_apache_camel_impl_defaultunitofwork.name = org.apache.camel.impl.DefaultUnitOfWork
 
 # Appenders configuration
 

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -105,6 +105,11 @@ log4j2.logger.org_apache_cxf_jaxrs_impl_WebApplicationExceptionMapper.level = ER
 log4j2.logger.org_apache_cxf_phase_PhaseInterceptorChain.name = org.apache.cxf.phase.PhaseInterceptorChain
 log4j2.logger.org_apache_cxf_phase_PhaseInterceptorChain.level = ERROR
 
+# camel
+# Supresses an NPE warning that is ignored by Camel
+log4j2.logger.org_apache_camel_util_impl_unitofworkhelper.level = ERROR
+log4j2.logger.org_apache_camel_util_impl_unitofworkhelper.name = org.apache.camel.util.impl.UnitOfWorkHelper
+
 # Appenders configuration
 
 # osgi-platformLogging


### PR DESCRIPTION
#### What does this PR do?
Back port of https://github.com/codice/ddf/pull/2604

#### Who is reviewing it? 
@AzGoalie @emmberk @brendan-hofmann

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard 
@lessarderic

#### How should this be tested? (List steps with links to updated documentation)
Follow instructions in description of https://codice.atlassian.net/browse/DDF-3372, except verify the exception does not occur.

Also verify that there is no Camel NPE warning when deleting a monitored item.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3372](https://codice.atlassian.net/browse/DDF-3372)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
