### PR TITLE
DDF-3438 Updates cesium component to destroy itself when closed

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -671,7 +671,9 @@ module.exports = function CesiumMap(insertionElement, selectionInterface, notifi
             });
             shapes = [];
         },
-        destroy: function() {}
+        destroy: function() {
+            map.destroy();
+        }
     });
 
     return exposedMethods;


### PR DESCRIPTION
#### What does this PR do?
 - Updates cesium component to destroy itself when closed
 - Without destruction, cpu percentages never return to normal levels.  With destruction, the cpu returns to 0% over time.

#### Who is reviewing it? 
@millerw8 
@bdeining 
@pklinef 
@kcwire 

#### How should this be tested? (List steps with links to updated documentation)
Use firefox for this one.  Open the browser to `about:performance` and have another window side by side with the Intrigue UI.  Watch the cpu levels in the `about:performance` tab.  Go to the view with golden layout and open up Cesium if it isn't already open (the 3d map).  Once open, close it.  Verify that over time the cpu levels in `about:performance` return to 0% for that tab.

If you have an old instance running, you can verify the old behavior, where closing cesium didn't let the cpu return to 0%.  Instead, it would continue to burn cycles.  

#### Any background context you want to provide?
This appears to mainly be an issue in Firefox, so best to test there.  

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3438