### PR TITLE
[2.11.x] DDF-3444 Fixing doubled anyText filter in Intrigue basic query

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -351,9 +351,10 @@ define([
             var filters = [];
 
             var text = this.basicText.currentView.model.getValue()[0];
-            text = text === "" ? '*' : text;
-            var matchCase = this.basicTextMatch.currentView.model.getValue()[0];
-            filters.push(CQLUtils.generateFilter(matchCase, 'anyText', text));
+            if (text !== "") {
+                var matchCase = this.basicTextMatch.currentView.model.getValue()[0];
+                filters.push(CQLUtils.generateFilter(matchCase, 'anyText', text));
+            }
 
             this.basicTime.currentView.constructFilter().forEach((timeFilter) => {
                 filters.push(timeFilter);
@@ -380,12 +381,8 @@ define([
                 filters.push(typeFilter)
             }
 
-            var text = this.basicText.currentView.model.getValue()[0];
-            text = text === "" ? '*' : text;
-
-            if (filters.length === 0 || text !== '*') {
-                var matchCase = this.basicTextMatch.currentView.model.getValue()[0];
-                filters.unshift(CQLUtils.generateFilter(matchCase, 'anyText', text));
+            if (filters.length === 0) {
+                filters.unshift(CQLUtils.generateFilter('ILIKE', 'anyText', '*'));
             }
 
             return {


### PR DESCRIPTION
#### What does this PR do?

Fixes an issue where the Basic query in Intrigue results in a cql filter being generated with a doubled anyText parameter

#### Who is reviewing it? 

@peterhuffer @emmberk @AzGoalie 

#### Select relevant component teams: 

@codice/ui 

#### Choose 2 committers to review/merge the PR. 

@andrewkfiedler @clockard 

#### How should this be tested? (List steps with links to updated documentation)

Create a basic query and observe the cql contents being sent out to ensure that the anyText term is only present once

#### What are the relevant tickets?

[DDF-3444](https://codice.atlassian.net/browse/DDF-3444)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
