### PR TITLE
[2.11.x] DDF-3346 Modified findbugs dependencies to be scoped as provided

### DIFF
--- a/catalog/async/catalog-async-data-api/pom.xml
+++ b/catalog/async/catalog-async-data-api/pom.xml
@@ -30,6 +30,12 @@
             <artifactId>catalog-core-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/async/catalog-async-data/pom.xml
+++ b/catalog/async/catalog-async-data/pom.xml
@@ -41,6 +41,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>ddf.lib</groupId>
             <artifactId>spock-shaded</artifactId>
             <version>${project.version}</version>

--- a/catalog/core/catalog-core-api-impl/pom.xml
+++ b/catalog/core/catalog-core-api-impl/pom.xml
@@ -44,6 +44,12 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
             <scope>test</scope>

--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -83,7 +83,8 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
-            <scope>compile</scope>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/catalog/core/catalog-core-localstorageprovider/pom.xml
+++ b/catalog/core/catalog-core-localstorageprovider/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>ddf.mime.core</groupId>
             <artifactId>mime-core-impl</artifactId>
             <scope>test</scope>

--- a/catalog/core/catalog-core-validationparser/pom.xml
+++ b/catalog/core/catalog-core-validationparser/pom.xml
@@ -61,6 +61,8 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/catalog/plugin/catalog-plugin-metacardingest-network/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/pom.xml
@@ -45,6 +45,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -516,9 +516,10 @@
                 <version>${logback.classic.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
+               <groupId>com.google.code.findbugs</groupId>
                 <artifactId>findbugs</artifactId>
                 <version>${findbugs.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>ddf.platform</groupId>

--- a/catalog/spatial/geocoding/spatial-geocoding-geocoder/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-geocoder/pom.xml
@@ -63,6 +63,12 @@
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/spatial/registry/registry-source-configuration-handler/pom.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/pom.xml
@@ -63,6 +63,18 @@
             <artifactId>platform-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>ddf.platform</groupId>
             <artifactId>platform-parser-xml</artifactId>
             <version>${project.version}</version>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-connectedsource/pom.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-connectedsource/pom.xml
@@ -105,6 +105,8 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/pom.xml
@@ -105,6 +105,8 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/catalog/transformer/catalog-transformer-propertyjson-metacard/pom.xml
+++ b/catalog/transformer/catalog-transformer-propertyjson-metacard/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>ddf.lib</groupId>
             <artifactId>spock-shaded</artifactId>
             <version>${project.version}</version>

--- a/catalog/transformer/catalog-transformer-tika-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/pom.xml
@@ -83,6 +83,12 @@
             <artifactId>Saxon-HE</artifactId>
             <version>${saxon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/catalog/ui/catalog-ui-enumeration/pom.xml
+++ b/catalog/ui/catalog-ui-enumeration/pom.xml
@@ -41,6 +41,12 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -255,6 +255,12 @@
             <artifactId>alerts</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distribution/test/thirdparty/restito/pom.xml
+++ b/distribution/test/thirdparty/restito/pom.xml
@@ -36,6 +36,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
             <version>${findbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/platform/admin/admin-configuration-configinstaller/pom.xml
+++ b/platform/admin/admin-configuration-configinstaller/pom.xml
@@ -49,7 +49,8 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.1</version>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/platform/migration/platform-migratable-api/pom.xml
+++ b/platform/migration/platform-migratable-api/pom.xml
@@ -42,7 +42,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
             <version>${findbugs.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/platform/migration/platform-migration/pom.xml
+++ b/platform/migration/platform-migration/pom.xml
@@ -96,7 +96,7 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>findbugs</artifactId>
       <version>${findbugs.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/platform/security/certificate/security-certificate-generator/pom.xml
+++ b/platform/security/certificate/security-certificate-generator/pom.xml
@@ -75,7 +75,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
             <version>${findbugs.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/platform/security/sts/security-sts-server/pom.xml
+++ b/platform/security/sts/security-sts-server/pom.xml
@@ -109,6 +109,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
             <version>${findbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/platform/solr/solr-factory/pom.xml
+++ b/platform/solr/solr-factory/pom.xml
@@ -115,7 +115,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs</artifactId>
             <version>${findbugs.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
#### What does this PR do?
This PR addresses CVE-2010-0538 by adding findbugs dependency at provided scope instead of relying on transient dependencies which will be also removed in DDF for the same reason.

#### Who is reviewing it? 
@tbatie 
@emanns95 

#### Choose 2 committers to review/merge the PR.
@clockard
@coyotesqrl
@figliold

#### How should this be tested?
Run OWASP using `mvn clean install -Powasp -DskipStatic=true -DwebBuildEnv=dev -DskipTests=true` and check report.

#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-374](https://codice.atlassian.net/browse/CAL-374)
[DDF-3446](https://codice.atlassian.net/browse/DDF-3446)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
