### PR TITLE
[DDF-2.11.x] DDF-3448 Restrict sanitizeGeometryCql regex more

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -24,7 +24,7 @@ define([
 
         sanitizeGeometryCql: function (cqlString) {
             //sanitize polygons
-            let polygons = cqlString.match(/'POLYGON\(\(.*\)\)'/g);
+            let polygons = cqlString.match(/'POLYGON\(\((-?[0-9]*.?[0-9]* -?[0-9]*.?[0-9]*,?)*\)\)'/g);
             if (polygons) {
                 polygons.forEach((polygon) => {
                     cqlString = cqlString.replace(polygon, polygon.replace(/'/g, ''));
@@ -32,7 +32,7 @@ define([
             }
 
             //sanitize points
-            let points = cqlString.match(/'POINT\(.*\)'/g);
+            let points = cqlString.match(/'POINT\(-?[0-9]*.?[0-9]* -?[0-9]*.?[0-9]*\)'/g);
             if (points) {
                 points.forEach((point) => {
                     cqlString = cqlString.replace(point, point.replace(/'/g, ''));
@@ -40,7 +40,7 @@ define([
             }
 
             //sanitize linestrings
-            let linestrings = cqlString.match(/'LINESTRING\(.*\)'/g);
+            let linestrings = cqlString.match(/'LINESTRING\((-?[0-9]*.?[0-9]* -?[0-9]*.?[0-9]*.?)*\)'/g);
             if (linestrings) {
                 linestrings.forEach((linestring) => {
                     cqlString = cqlString.replace(linestring, linestring.replace(/'/g, ''));


### PR DESCRIPTION
#### What does this PR do?
Restricts the regex used in sanitizeGeometryCql to be more restrictive so it doesn't modify parts of the query that shouldn't be.

#### Who is reviewing it? 
@djblue 
@tbatie 
@mcalcote 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)

1. Set up DDF
2. Ingest data with spatial data
3. Construct a query using Intrigue that includes both a relative temporal criteria and a point-radius spatial criteria
4. Workspace does not become unresponsive

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
