### PR TITLE
DDF-3451 Add wildcard everything matching support to XstreamPathConverter

### DIFF
--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestXstreamPathConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TestXstreamPathConverter.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.spatial.ogc.csw.catalog.converter;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -58,6 +59,8 @@ public class TestXstreamPathConverter {
 
   private static final Path POLYGON_GML_ID_PATH = new Path("/Polygon/@id");
 
+  private static final Path LINEAR_RING_ALL_PATH = new Path("/Polygon/exterior/LinearRing/*");
+
   private static final String GML_NAMESPACE = "";
 
   private XStream xstream;
@@ -80,7 +83,8 @@ public class TestXstreamPathConverter {
     argumentHolder = xstream.newDataHolder();
 
     Set<Path> paths = new LinkedHashSet<>();
-    paths.addAll(Arrays.asList(POLYGON_POS_PATH, BAD_PATH, POLYGON_GML_ID_PATH));
+    paths.addAll(
+        Arrays.asList(POLYGON_POS_PATH, BAD_PATH, POLYGON_GML_ID_PATH, LINEAR_RING_ALL_PATH));
     argumentHolder.put(XstreamPathConverter.PATH_KEY, paths);
   }
 
@@ -208,6 +212,18 @@ public class TestXstreamPathConverter {
         (XstreamPathValueTracker) xstream.unmarshal(reader, null, argumentHolder);
 
     assertThat(pathValueTracker.getFirstValue(POLYGON_GML_ID_PATH), is("p1"));
+  }
+
+  @Test
+  public void testAllNestedPath() throws XMLStreamException {
+    XMLStreamReader streamReader =
+        XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(GML_XML));
+    HierarchicalStreamReader reader = new StaxReader(new QNameMap(), streamReader);
+    XstreamPathValueTracker pathValueTracker =
+        (XstreamPathValueTracker) xstream.unmarshal(reader, null, argumentHolder);
+
+    assertThat(
+        pathValueTracker.getAllValues(LINEAR_RING_ALL_PATH), hasItem("-180.000000 90.000000"));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Adds support for wildcard matching a path to the XstreamPathConverter

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@adimka 
@glenhein 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Full build with tests.

#### Any background context you want to provide?
This adds support to wildcard match paths and append all children under the wildcard node as a value.

#### What are the relevant tickets?
[DDF-3451](https://codice.atlassian.net/browse/DDF-3451)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
