### PR TITLE
[2.11.x] DDF-3447 Add product name to file exported from migration:export

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -124,6 +124,13 @@
       <fileMode>0755</fileMode>
     </fileSet>
 
+    <!-- Exported Empty Directory -->
+    <fileSet>
+      <directory>${setup.folder}</directory>
+      <outputDirectory>/exported</outputDirectory>
+      <excludes><exclude>**/*</exclude></excludes>
+    </fileSet>
+    
     <!-- HTML & PDF Documentation -->
     <fileSet>
       <directory>${setup.folder}/docs</directory>

--- a/distribution/docs/src/main/resources/content/_configuring/exporting-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/exporting-configurations.adoc
@@ -34,7 +34,7 @@ image::exporting_configuration_step3.png[Exporting Step 3]
 To export the current ${branding} configuration from the ${command-console}:
 
 . Run the command migration:export from the ${command-console}.
-. A file named `exported-${project.version}.zip` will be created in the `exported` directory underneath `${home_directory}`, but an alternative location can be specified with the `migration:export`. Copy this file to a secure place.
+. A file named `${branding-lowercase}-${project.version}.dar` will be created in the `exported` directory underneath `${home_directory}`, but an alternative location can be specified with the `migration:export`. Copy this file to a secure place.
 
 ****
 

--- a/distribution/docs/src/main/resources/content/_configuring/reusing-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/reusing-configurations.adoc
@@ -12,7 +12,7 @@ The Migration Export/Import capability allows administrators to export the curre
 To export the current configuration settings:
 
 . Run the command migration:export from the ${command-console}.
-. A file named `exported-${project.version}.zip` will be created in the `exported` directory underneath `${home_directory}`. Copy this file to a secure place.
+. A file named `${branding-lowercase}-${project.version}.dar` will be created in the `exported` directory underneath `${home_directory}`. Copy this file to a secure place.
 
 To import previously exported configuration settings:
 

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ExportMigrationManagerImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ExportMigrationManagerImpl.java
@@ -120,21 +120,26 @@ public class ExportMigrationManagerImpl implements Closeable {
   /**
    * Proceed with the export migration operation.
    *
+   * @param productBranding the product branding being exported
    * @param productVersion the product version being exported
-   * @throws IllegalArgumentException if <code>productVersion</code> is <code>null</code>
+   * @throws IllegalArgumentException if <code>productBranding</code> or </code><code>productVersion
+   *     </code> is <code>null</code>
    * @throws MigrationException to stop the export operation
    */
-  public void doExport(String productVersion) {
+  public void doExport(String productBranding, String productVersion) {
+    Validate.notNull(productBranding, "invalid null product branding");
     Validate.notNull(productVersion, "invalid null product version");
     final String ddfHome = System.getProperty("ddf.home");
 
     LOGGER.debug(
-        "Exporting product [{}] under [{}] with version [{}] to [{}]...",
+        "Exporting {} product [{}] under [{}] with version [{}] to [{}]...",
+        productBranding,
         productVersion,
         ddfHome,
         MigrationContextImpl.CURRENT_VERSION,
         exportFile);
     metadata.put(MigrationContextImpl.METADATA_VERSION, MigrationContextImpl.CURRENT_VERSION);
+    metadata.put(MigrationContextImpl.METADATA_PRODUCT_BRANDING, productBranding);
     metadata.put(MigrationContextImpl.METADATA_PRODUCT_VERSION, productVersion);
     metadata.put(MigrationContextImpl.METADATA_DATE, new Date().toString());
     metadata.put(MigrationContextImpl.METADATA_DDF_HOME, ddfHome);

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/Messages.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/Messages.java
@@ -66,6 +66,9 @@ public final class Messages {
   public static final String IMPORT_UNSUPPORTED_VERSION_ERROR =
       "Import error: unsupported exported version [%s]; currently supporting [%s].";
 
+  public static final String IMPORT_MISMATCH_PRODUCT_ERROR =
+      "Import error: mismatched product [%s]; expecting [%s].";
+
   public static final String IMPORT_MISMATCH_PRODUCT_VERSION_ERROR =
       "Import error: mismatched product version [%s]; expecting [%s].";
 
@@ -91,9 +94,9 @@ public final class Messages {
   public static final String IMPORT_SECURITY_ERROR =
       "Import security error: failed to import from file [%s]; %s.";
 
-  public static final String EXPORTING_DATA = "Exporting data to file [%s].";
+  public static final String EXPORTING_DATA = "Exporting %s data to file [%s].";
 
-  public static final String IMPORTING_DATA = "Importing data from file [%s].";
+  public static final String IMPORTING_DATA = "Importing %s data from file [%s].";
 
   public static final String EXPORT_SYSTEM_PROPERTY_ERROR =
       "Export error: system property [%s] is set to [%s] that %s; %s.";

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/MigrationContextImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/MigrationContextImpl.java
@@ -42,6 +42,7 @@ import org.codice.ddf.migration.MigrationReport;
  * <pre>
  *     {
  *       "version": "1.0",
+ *       "product.branding": "ddf",
  *       "product.version": "2.11.0-SNAPSHOT",
  *       "date": "Tue Aug 01 12:39:21 MST 2017"
  *       "migratables": {
@@ -111,6 +112,7 @@ import org.codice.ddf.migration.MigrationReport;
  *
  * <ul>
  *   <li>'version' is used to keep track of the migration version used during export
+ *   <li>'product.branding' is used to keep track of the brand of the system that exported the file
  *   <li>'product.version' is used to keep track of the version of the system the exported zip file
  *       was created from
  *   <li>'date' is used to keep track of the date when the exported zip file was created
@@ -149,6 +151,8 @@ import org.codice.ddf.migration.MigrationReport;
  * @param <R> the type of report for this context
  */
 public class MigrationContextImpl<R extends MigrationReport> implements MigrationContext {
+
+  public static final String METADATA_PRODUCT_BRANDING = "product.branding";
 
   public static final String METADATA_PRODUCT_VERSION = "product.version";
 

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
@@ -97,6 +97,8 @@ public class ConfigurationAdminMigratableTest {
 
   private static final String DDF_EXPORTED_TAG_TEMPLATE = "exported_from_%s";
 
+  private static final String SUPPORTED_BRANDING = "test";
+
   private static final String SUPPORTED_VERSION = "1.0";
 
   private static final String DEFAULT_FILE_EXT = "config";
@@ -218,7 +220,7 @@ public class ConfigurationAdminMigratableTest {
     Assert.assertThat("The export report has errors.", exportReport.hasErrors(), is(false));
     Assert.assertThat("The export report has warnings.", exportReport.hasWarnings(), is(false));
     Assert.assertThat("Export was not successful.", exportReport.wasSuccessful(), is(true));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName).toRealPath();
     Assert.assertThat("Export zip does not exist.", exportedZip.toFile().exists(), is(true));
     Assert.assertThat("Exported zip is empty.", exportedZip.toFile().length(), greaterThan(0L));
@@ -353,7 +355,16 @@ public class ConfigurationAdminMigratableTest {
     System.setProperty(DDF_HOME_SYSTEM_PROP_KEY, ddfHome.toRealPath().toString());
     Path etcDir = ddfHome.resolve("etc");
     Files.createDirectory(etcDir);
+    setupBrandingFile(SUPPORTED_BRANDING);
     setupVersionFile(SUPPORTED_VERSION);
+  }
+
+  private void setupBrandingFile(String branding) throws IOException {
+    final Path brandingFile = ddfHome.resolve("Branding.txt");
+
+    Files.createFile(brandingFile);
+    FileUtils.writeStringToFile(
+        brandingFile.toFile().getCanonicalFile(), branding, StandardCharsets.UTF_8);
   }
 
   private void setupVersionFile(String version) throws IOException {

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/AbstractMigrationSupport.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/AbstractMigrationSupport.java
@@ -51,9 +51,12 @@ import org.mockito.Mockito;
 
 /** Base class for test cases which handles setup for DDF_HOME. */
 public class AbstractMigrationSupport {
+
   protected static final String MIGRATABLE_ID = "test-migratable";
 
   protected static final String VERSION = "3.1415";
+
+  protected static final String PRODUCT_BRANDING = "test";
 
   protected static final String PRODUCT_VERSION = "test-1.0";
 
@@ -343,6 +346,7 @@ public class AbstractMigrationSupport {
   }
 
   public static class ZipEntry extends java.util.zip.ZipEntry {
+
     private final byte[] content;
 
     private ZipEntry(java.util.zip.ZipEntry ze, byte[] content) {

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ExportMigrationManagerImplTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ExportMigrationManagerImplTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 public class ExportMigrationManagerImplTest extends AbstractMigrationReportSupport {
+
   private static final String MIGRATABLE_ID2 = "test-migratable-2";
 
   private static final String MIGRATABLE_ID3 = "test-migratable-3";
@@ -140,7 +141,7 @@ public class ExportMigrationManagerImplTest extends AbstractMigrationReportSuppo
 
   @Test
   public void testDoExport() throws Exception {
-    mgr.doExport(PRODUCT_VERSION);
+    mgr.doExport(PRODUCT_BRANDING, PRODUCT_VERSION);
 
     assertMetaData(mgr.getMetadata());
 
@@ -157,9 +158,17 @@ public class ExportMigrationManagerImplTest extends AbstractMigrationReportSuppo
 
     thrown.expect(Matchers.sameInstance(me));
 
-    mgr.doExport(PRODUCT_VERSION);
+    mgr.doExport(PRODUCT_BRANDING, PRODUCT_VERSION);
 
     Mockito.verify(migratable3, Mockito.never()).doExport(Mockito.notNull());
+  }
+
+  @Test
+  public void testDoExportWithNullProductBranding() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(Matchers.containsString("null product branding"));
+
+    mgr.doExport(null, PRODUCT_VERSION);
   }
 
   @Test
@@ -167,12 +176,12 @@ public class ExportMigrationManagerImplTest extends AbstractMigrationReportSuppo
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(Matchers.containsString("null product version"));
 
-    mgr.doExport(null);
+    mgr.doExport(PRODUCT_BRANDING, null);
   }
 
   @Test
   public void testClose() throws Exception {
-    mgr.doExport(PRODUCT_VERSION);
+    mgr.doExport(PRODUCT_BRANDING, PRODUCT_VERSION);
 
     mgr.close();
 
@@ -235,11 +244,14 @@ public class ExportMigrationManagerImplTest extends AbstractMigrationReportSuppo
   }
 
   private void assertMetaData(Map<String, Object> metadata) {
-    Assert.assertThat(metadata, Matchers.aMapWithSize(5));
+    Assert.assertThat(metadata, Matchers.aMapWithSize(6));
     Assert.assertThat(
         metadata,
         Matchers.hasEntry(
             MigrationContextImpl.METADATA_VERSION, MigrationContextImpl.CURRENT_VERSION));
+    Assert.assertThat(
+        metadata,
+        Matchers.hasEntry(MigrationContextImpl.METADATA_PRODUCT_BRANDING, PRODUCT_BRANDING));
     Assert.assertThat(
         metadata,
         Matchers.hasEntry(MigrationContextImpl.METADATA_PRODUCT_VERSION, PRODUCT_VERSION));

--- a/platform/platform-migratable/src/test/java/org/codice/ddf/platform/migratable/impl/PlatformMigratableTest.java
+++ b/platform/platform-migratable/src/test/java/org/codice/ddf/platform/migratable/impl/PlatformMigratableTest.java
@@ -147,6 +147,8 @@ public class PlatformMigratableTest {
 
   private static final Path SERVICE_WRAPPER_2 = Paths.get("bin", "setenv-wrapper.conf");
 
+  private static final String SUPPORTED_BRANDING = "test";
+
   private static final String SUPPORTED_VERSION = "1.0";
 
   private static final String UNSUPPORTED_VERSION = "666.0";
@@ -223,7 +225,7 @@ public class PlatformMigratableTest {
     assertThat("The export report has errors.", exportReport.hasErrors(), is(false));
     assertThat("The export report has warnings.", exportReport.hasWarnings(), is(false));
     assertThat("Export was not successful.", exportReport.wasSuccessful(), is(true));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName).toRealPath();
     assertThat("Export zip does not exist.", exportedZip.toFile().exists(), is(true));
     assertThat("Exported zip is empty.", exportedZip.toFile().length(), greaterThan(0L));
@@ -276,7 +278,7 @@ public class PlatformMigratableTest {
     assertThat("The export report has errors.", exportReport.hasErrors(), is(false));
     assertThat("The export report has warnings.", exportReport.hasWarnings(), is(false));
     assertThat("Export was not successful.", exportReport.wasSuccessful(), is(true));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName).toRealPath();
     assertThat("Export zip does not exist.", exportedZip.toFile().exists(), is(true));
     assertThat("Exported zip is empty.", exportedZip.toFile().length(), greaterThan(0L));
@@ -326,7 +328,7 @@ public class PlatformMigratableTest {
     assertThat("The export report doesn't not have errors.", exportReport.hasErrors(), is(true));
     assertThat("The export report has warnings.", exportReport.hasWarnings(), is(false));
     assertThat("Export was successful.", exportReport.wasSuccessful(), is(false));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName);
     assertThat(
         String.format("Export zip [%s] exists.", exportedZip),
@@ -383,7 +385,7 @@ public class PlatformMigratableTest {
     assertThat("The export report has errors.", exportReport.hasErrors(), is(false));
     assertThat("The export report does not have warnings.", exportReport.hasWarnings(), is(true));
     assertThat("Export was not successful.", exportReport.wasSuccessful(), is(true));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName).toRealPath();
     assertThat(
         String.format("Export zip [%s] does not exist.", exportedZip),
@@ -458,6 +460,7 @@ public class PlatformMigratableTest {
     Path binDir = ddfHome.resolve("bin");
     Files.createDirectory(binDir);
     System.setProperty(DDF_HOME_SYSTEM_PROP_KEY, ddfHome.toRealPath().toString());
+    setupBrandingFile(SUPPORTED_BRANDING);
     setupVersionFile(SUPPORTED_VERSION);
     setupKeystores(tag);
     for (Path path : REQUIRED_SYSTEM_FILES) {
@@ -531,6 +534,14 @@ public class PlatformMigratableTest {
             TRUSTSTORE_SYSTEM_PROP_KEY, TRUSTSTORE_PATH_SYSTEM_PROP_VALUE.toString());
       }
     }
+  }
+
+  private void setupBrandingFile(String branding) throws IOException {
+    final Path brandingFile = ddfHome.resolve("Branding.txt");
+
+    Files.createFile(brandingFile);
+    FileUtils.writeStringToFile(
+        brandingFile.toFile().getCanonicalFile(), branding, StandardCharsets.UTF_8);
   }
 
   private void setupVersionFile(String version) throws IOException {

--- a/platform/security/security-migratable/src/test/java/org/codice/ddf/security/migratable/impl/SecurityMigratableTest.java
+++ b/platform/security/security-migratable/src/test/java/org/codice/ddf/security/migratable/impl/SecurityMigratableTest.java
@@ -80,6 +80,8 @@ import org.mockito.runners.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class SecurityMigratableTest {
+  private static final String SUPPORTED_BRANDING = "test";
+
   private static final String SUPPORTED_VERSION = "1.0";
 
   private static final String UNSUPPORTED_VERSION = "666.0";
@@ -171,7 +173,7 @@ public class SecurityMigratableTest {
     assertThat("The export report has errors.", exportReport.hasErrors(), is(false));
     assertThat("The export report has warnings.", exportReport.hasWarnings(), is(false));
     assertThat("Export was not successful.", exportReport.wasSuccessful(), is(true));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName).toRealPath();
     assertThat("Export zip does not exist.", exportedZip.toFile().exists(), is(true));
     assertThat("Exported zip is empty.", exportedZip.toFile().length(), greaterThan(0L));
@@ -222,7 +224,7 @@ public class SecurityMigratableTest {
     assertThat("The export report has errors.", exportReport.hasErrors(), is(false));
     assertThat("The export report has warnings.", exportReport.hasWarnings(), is(false));
     assertThat("Export was not successful.", exportReport.wasSuccessful(), is(true));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName).toRealPath();
     assertThat("Export zip does not exist.", exportedZip.toFile().exists(), is(true));
     assertThat("Exported zip is empty.", exportedZip.toFile().length(), greaterThan(0L));
@@ -266,7 +268,7 @@ public class SecurityMigratableTest {
     assertThat("The export report has errors.", exportReport.hasErrors(), is(false));
     assertThat("The export report has warnings.", exportReport.hasWarnings(), is(false));
     assertThat("Export was not successful.", exportReport.wasSuccessful(), is(true));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName).toRealPath();
     assertThat("Export zip does not exist.", exportedZip.toFile().exists(), is(true));
     assertThat("Exported zip is empty.", exportedZip.toFile().length(), greaterThan(0L));
@@ -321,7 +323,7 @@ public class SecurityMigratableTest {
     assertThat("The export report has errors.", exportReport.hasErrors(), is(false));
     assertThat("The export report has warnings.", exportReport.hasWarnings(), is(false));
     assertThat("Export was not successful.", exportReport.wasSuccessful(), is(true));
-    String exportedZipBaseName = String.format("exported-%s.zip", SUPPORTED_VERSION);
+    String exportedZipBaseName = String.format("%s-%s.dar", SUPPORTED_BRANDING, SUPPORTED_VERSION);
     Path exportedZip = exportDir.resolve(exportedZipBaseName).toRealPath();
     assertThat("Export zip does not exist.", exportedZip.toFile().exists(), is(true));
     assertThat("Exported zip is empty.", exportedZip.toFile().length(), greaterThan(0L));
@@ -357,6 +359,7 @@ public class SecurityMigratableTest {
     Path binDir = ddfHome.resolve("bin");
     Files.createDirectory(binDir);
     System.setProperty(DDF_HOME_SYSTEM_PROP_KEY, ddfHome.toRealPath().toString());
+    setupBrandingFile(SUPPORTED_BRANDING);
     setupVersionFile(SUPPORTED_VERSION);
     for (Path path : PROPERTIES_FILES) {
       Path p = ddfHome.resolve(path);
@@ -377,6 +380,14 @@ public class SecurityMigratableTest {
 
     setupCrl(tag);
     setupPdpFiles(tag);
+  }
+
+  private void setupBrandingFile(String branding) throws IOException {
+    final Path brandingFile = ddfHome.resolve("Branding.txt");
+
+    Files.createFile(brandingFile);
+    FileUtils.writeStringToFile(
+        brandingFile.toFile().getCanonicalFile(), branding, StandardCharsets.UTF_8);
   }
 
   private void setupVersionFile(String version) throws IOException {


### PR DESCRIPTION
#### What does this PR do?
This PR changes the filename format for exported file to include the brand name and to use the upcoming extension from [DDF-3376](https://codice.atlassian.net/browse/DDF-3376). It also pre-creates an empty exported dir at unzip time.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@emanns95 
@oconnormi 
@tbatie 
@Lambeaux 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@rzwiefel 
@figliold
#### How should this be tested? (List steps with links to updated documentation)
Unzip distro and verify the exported directory is created with no files in it. Perform a migration export and verify the file created is ddf-<version>.dar. Perform a migration import and verify it finds the same file.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3447](https://codice.atlassian.net/browse/DDF-3447)
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
