### PR TITLE
DDF-3452 Fixes import command to continue processing

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ImportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ImportCommand.java
@@ -165,7 +165,6 @@ public class ImportCommand extends CatalogCommands {
         switch (type) {
           case "metacard":
             {
-              metacards++;
               String metacardName = pathParts[NAME];
               Metacard metacard = null;
               try {
@@ -174,9 +173,12 @@ public class ImportCommand extends CatalogCommands {
                         new UncloseableBufferedInputStreamWrapper(zipInputStream), id);
               } catch (IOException | CatalogTransformerException e) {
                 LOGGER.debug("Could not transform metacard: {}", id);
+                entry = zipInputStream.getNextEntry();
+                continue;
               }
               metacard = applyInjectors(metacard, attributeInjectors);
               catalogProvider.create(new CreateRequestImpl(metacard));
+              metacards++;
               break;
             }
           case "content":


### PR DESCRIPTION
### Port of https://github.com/codice/ddf/pull/2662

#### What does this PR do? 
- Now when A single metacard fails to process, the import command will continue with the rest of the metacards instead of failing the rest of the transaction

#### Who is reviewing it? 
Anyone

#### Choose 2 committers to review/merge the PR. 
Anyone

#### How should this be tested? (List steps with links to updated documentation)
Ensure that when a single invalid metacard among a batch is imported, the rest of the valid metacards are imported.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3452

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
