### PR TITLE
DDF-3455 when local catalog is disabled, do not let the local catalog be used as a default

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/query-src/dropdown.query-src.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/query-src/dropdown.query-src.hbs
@@ -42,9 +42,11 @@
                     </span>
                 {{/each}}
                 {{#unless sources}}
-                    <span class="text-src is-available">
-                        Local Only ({{localCatalog}})
-                    </span>
+                    {{#if isLocalCatalogEnabled}}
+                        <span class="text-src is-available">
+                            Local Only ({{localCatalog}})
+                        </span>
+                    {{/if}}
                 {{/unless}}
             {{/if}}
         </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/query-src/dropdown.query-src.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/query-src/dropdown.query-src.view.js
@@ -20,8 +20,9 @@ define([
     '../dropdown.view',
     './dropdown.query-src.hbs',
     'component/query-src/query-src.view',
-    'component/singletons/sources-instance'
-], function (Marionette, _, $, DropdownView, template, ComponentView, sources) {
+    'component/singletons/sources-instance',
+    'properties'
+], function (Marionette, _, $, DropdownView, template, ComponentView, sources, properties) {
 
     return DropdownView.extend({
         template: template,
@@ -44,7 +45,8 @@ define([
                     return srcs.indexOf(src.id) !== -1;
                 }),
                 enterprise: this.model.get('federation') === 'enterprise',
-                localCatalog: sources.localCatalog
+                localCatalog: sources.localCatalog,
+                isLocalCatalogEnabled: !properties.isDisableLocalCatalog()
             };
         }
     });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -96,7 +96,9 @@ define([
 
                 switch (data.federation) {
                     case 'local':
-                        data.src = [Sources.localCatalog];
+                        if (!properties.isDisableLocalCatalog()) {
+                            data.src = [Sources.localCatalog];
+                        }
                         break;
                     case 'enterprise':
                         data.src = _.pluck(Sources.toJSON(), 'id');


### PR DESCRIPTION
#### What does this PR do?
when local catalog is disabled, do not let the local catalog be used as a default

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@bdeining 
@troymohl 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui
@andrewkfiedler 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@lessarderic
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
1) build and install
2) In the Catalog UI Search admin config, check the box "Disable Local Catalog".
3) In the UI, create an advanced query and de-select the 'All Sources'.
4) Click Search. Should see an error message about no sources being selected.
5) Edit the query and select the local source.
6) Click Search. Should see an error message about no sources being selected.
7)  In the Catalog UI Search admin config, uncheck the box "Disable Local Catalog".
8) Refresh the UI page.
9) In the UI, create an advanced query and make sure the 'All Sources' is selected.
10) Click Search.  The search should not throw an error.
11) Edit the query and select the local source.
12) Click Search.  The search should not throw an error.
13) Edit the query and de-select all sources.
14) Click Search.  The search should not throw an error.

#### Any background context you want to provide?
This is for downstream projects that do not support a local catalog.

#### What are the relevant tickets?
[DDF-3455](https://codice.atlassian.net/browse/DDF-3455)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
