### PR TITLE
DDF-3363 Changed the use of object streams in DefaultUsersDeletionScheduler

### DIFF
--- a/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/DefaultUsersDeletionScheduler.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/main/java/org/codice/ddf/admin/insecure/defaults/service/DefaultUsersDeletionScheduler.java
@@ -15,11 +15,8 @@ package org.codice.ddf.admin.insecure.defaults.service;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -32,6 +29,7 @@ import java.util.stream.Stream;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ServiceStatus;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.commons.lang.StringUtils;
 import org.apache.karaf.jaas.modules.BackingEngine;
 import org.apache.karaf.jaas.modules.BackingEngineFactory;
 import org.codice.ddf.configuration.AbsolutePathResolver;
@@ -57,7 +55,7 @@ public class DefaultUsersDeletionScheduler {
   }
 
   public boolean scheduleDeletion() {
-    String cron = getCron();
+    String cron = getCronOrDelete();
     if (cron == null) {
       return false;
     }
@@ -83,7 +81,7 @@ public class DefaultUsersDeletionScheduler {
   }
 
   @VisibleForTesting
-  String getCron() {
+  String getCronOrDelete() {
     if (!getTempTimestampFilePath().toFile().exists()) {
 
       // Create temp file and add timestamp
@@ -117,20 +115,14 @@ public class DefaultUsersDeletionScheduler {
   private boolean createTempFile(Instant instant) {
     try {
       if (getTempTimestampFilePath().toFile().createNewFile()) {
-        return writeTimestamp(instant);
+        Files.write(
+            getTempTimestampFilePath(), instant.toString().getBytes(StandardCharsets.UTF_8));
+        return true;
       }
     } catch (IOException e) {
       LOGGER.debug("Unable to access the temporary file", e);
     }
     return false;
-  }
-
-  private boolean writeTimestamp(Instant instant) throws IOException {
-    try (ObjectOutputStream objectOutputStream =
-        new ObjectOutputStream(new FileOutputStream(getTempTimestampFilePath().toFile()))) {
-      objectOutputStream.writeObject(instant);
-      return true;
-    }
   }
 
   public static boolean removeDefaultUsers() {
@@ -182,11 +174,11 @@ public class DefaultUsersDeletionScheduler {
     if (!getTempTimestampFilePath().toFile().exists()) {
       return null;
     }
-    try (ObjectInputStream objectInputStream =
-        new ObjectInputStream(new FileInputStream(getTempTimestampFilePath().toFile()))) {
 
-      return (Instant) objectInputStream.readObject();
-    } catch (IOException | ClassNotFoundException e) {
+    try (Stream<String> lines = Files.lines(getTempTimestampFilePath(), StandardCharsets.UTF_8)) {
+      return lines.filter(StringUtils::isNotBlank).map(Instant::parse).findFirst().orElse(null);
+
+    } catch (IOException e) {
       LOGGER.debug("Unable to read installation date.", e);
       return null;
     }
@@ -207,9 +199,12 @@ public class DefaultUsersDeletionScheduler {
   }
 
   public boolean defaultUsersExist() {
-    try (Stream<String> defaultUsers = Files.lines(getUsersPropertiesFilePath())) {
-      return defaultUsers.filter(line -> !line.trim().isEmpty() && !line.startsWith("#")).count()
-          != 0;
+    try (Stream<String> defaultUsers =
+        Files.lines(getUsersPropertiesFilePath(), StandardCharsets.UTF_8)) {
+      return defaultUsers
+          .filter(StringUtils::isNotBlank)
+          .filter(line -> !line.startsWith("#"))
+          .anyMatch(line -> true);
     } catch (IOException e) {
       LOGGER.debug("Unable to access users.properties file.", e);
       return true;

--- a/platform/admin/core/admin-core-insecuredefaults/src/test/java/org/codice/ddf/admin/insecure/defaults/service/DefaultUsersDeletionSchedulerTest.java
+++ b/platform/admin/core/admin-core-insecuredefaults/src/test/java/org/codice/ddf/admin/insecure/defaults/service/DefaultUsersDeletionSchedulerTest.java
@@ -17,6 +17,7 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.codice.ddf.admin.insecure.defaults.service.DefaultUsersDeletionScheduler.getTempTimestampFilePath;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
@@ -24,13 +25,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.karaf.jaas.modules.BackingEngine;
@@ -73,7 +75,7 @@ public class DefaultUsersDeletionSchedulerTest {
         .when(context)
         .start();
     createTempFile();
-    writeTimestamp(Instant.now());
+    writeTimestamp(Instant.now().toString());
 
     scheduler.scheduleDeletion();
 
@@ -83,35 +85,35 @@ public class DefaultUsersDeletionSchedulerTest {
   @Test
   public void getCronTempFileExistsTest() throws Exception {
     createTempFile();
-    writeTimestamp(Instant.now());
+    writeTimestamp(Instant.now().toString());
 
-    String actual = scheduler.getCron();
+    String actual = scheduler.getCronOrDelete();
     assertNotNull("Incorrect cron calculation.", actual);
   }
 
   @Test
   public void getCronTempFileExistsAndOverdueTest() throws IOException {
     createTempFile();
-    writeTimestamp(Instant.now().minus(Duration.ofDays(4)));
+    writeTimestamp(Instant.now().minus(Duration.ofDays(4)).toString());
 
-    String actual = scheduler.getCron();
+    String actual = scheduler.getCronOrDelete();
     assertNull("Incorrect cron calculation.", actual);
   }
 
-  @Test(expected = ClassCastException.class)
-  public void writeToFileWithError() throws Exception {
+  @Test(expected = DateTimeParseException.class)
+  public void writeToFileNumberFormatException() throws Exception {
     createTempFile();
     writeTimestamp("Incorrect type");
 
-    String actual = scheduler.getCron();
+    String actual = scheduler.getCronOrDelete();
     assertNull("Incorrect error handling.", actual);
   }
 
   @Test
   public void removeDefaultUsersFromLongerFileTest() throws Exception {
-    writeUsersPropertiesFile("/mockLongUsers.properties");
+    writeUsersPropertiesFile();
 
-    // What removeDefaultUsers does (whichout having to do service properties
+    // What removeDefaultUsers does (without having to do service properties)
     BackingEngineFactory backingEngineFactory = new PropertiesBackingEngineFactory();
     BackingEngine backingEngine =
         backingEngineFactory.build(ImmutableMap.of("users", path.toString()));
@@ -124,7 +126,7 @@ public class DefaultUsersDeletionSchedulerTest {
   public void installationDateTest() throws IOException {
     Instant instant = Instant.ofEpochSecond(1508472513);
     createTempFile();
-    writeTimestamp(instant);
+    writeTimestamp(instant.toString());
 
     Instant actual = scheduler.installationDate();
     assertEquals("Incorrect Instant read.", instant, actual);
@@ -136,16 +138,14 @@ public class DefaultUsersDeletionSchedulerTest {
     DefaultUsersDeletionScheduler.setTempTimestampFilePath(tempFilePath);
   }
 
-  private void writeTimestamp(Object instant) throws IOException {
-    try (ObjectOutputStream objectOutputStream =
-        new ObjectOutputStream(new FileOutputStream(tempFilePath.toFile()))) {
-      objectOutputStream.writeObject(instant);
-    }
+  private void writeTimestamp(String instant) throws IOException {
+    Files.write(getTempTimestampFilePath(), instant.getBytes(StandardCharsets.UTF_8));
   }
 
-  private void writeUsersPropertiesFile(String name) throws Exception {
+  private void writeUsersPropertiesFile() throws Exception {
     try (FileChannel source =
-            new FileInputStream(Paths.get(getClass().getResource(name).toURI()).toFile())
+            new FileInputStream(
+                    Paths.get(getClass().getResource("/mockLongUsers.properties").toURI()).toFile())
                 .getChannel();
         FileChannel destination = new FileOutputStream(path.toFile()).getChannel()) {
       destination.transferFrom(source, 0, source.size());


### PR DESCRIPTION
#### What does this PR do?
Changes the use of object streams in DefaultUsersDeletionScheduler.
Note: These changes are also added in https://github.com/codice/ddf/pull/2673 fot the 2.11.x branch

#### Who is reviewing it? 
@brjeter 

#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Full build on both mac and windows
and
Manual verification
* This feature isn't on by default in DDF so after starting DDF go to `Admin Console → Admin → Default Users Deletion Scheduler → Enable user.properties automatic deletion` to turn it on
* Set the following log:
`log:set DEBUG org.codice.ddf.admin.insecure.defaults.service`
`log:set DEBUG org.apache.camel.impl`
`log:set DEBUG org.apache.karaf.jaas.modules.properties`
* Along with insecure defaults (which takes about 5 minutes to appear), you should be able to see a notice in the admin console that a `users.properties` file exists with a deletion date and time.
* Verify that:
	* the date and time displayed is exactly 3 days from your current date and time
	* the temporary file exists at `DDF_HOME/data/tmp/timestamp.bin`
	* you can see in the logs that the task is scheduled
		- `Creating endpoint uri=[quartz2://scheduler/deletionTimer?cron=0+34+8+28+10+%3F+2017], path=[scheduler/deletionTimer]`
		- `Job scheduler.deletionTimer (triggerType=CronTriggerImpl, jobClass=CamelJob) is scheduled. Next fire date is Sat Oct 28 08:34:00 MST 2017`

* Dismiss the alert and turn the feature back off. In a few minutes (up to 5) verify that:
	* The alert doesn't appear
	* `DDF_HOME/data/tmp/timestamp.bin`is deleted
	* you can see in the logs that the task is stopped
		- `The deletion of default users has been stopped successfully`
		- `Route: deletionJob is stopped, was consuming from: quartz2://scheduler/deletionTimer?cron=48+23+8+19+11+%3F+2017`

* Connect to LDAP
* Compute timestamp
	* Change your current time + 10 minutes to milliseconds
You could use http://www.ruddwire.com/handy-code/date-to-millisecond-calculators/#.Wg26AxNSzUI.
Note: don't forget to use GMT-0700
	* Subtract 257400000 from it
	* Compute `Instant.ofEpochMilli(257400000).toString()`
The result will be in the following format: 1970-01-03T23:30:00Z
You might need to do `Instant.ofEpochMilli(Long.parseLong("1510593000000")).toString()` if the number is too large.
	* Create the `DDF_HOME/data/tmp/timestamp.bin` file and write the `Instant` to it
* Turn the feature back on
* Wait for the alert to come back up with the deletion date 
		- The deletion date should be about 40 minutes from your current time
* After about 10 minutes (or 30 minutes before displayed time), check that the *users* in `DDF_HOME/etc/users.properties` (not the file) and the `DDF_HOME/data/tmp/timestamp.bin` file are deleted
Note: You will see `Default users have been deleted successfully.` in the logs
* After being inactive for 30 minutes
		- verify that you can't log back in with the default users
		- verify that you can log in with LDAP users

#### What are the relevant tickets?
[DDF-3363](https://codice.atlassian.net/browse/DDF-3363)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
For the general case, merging is gated on the following:

* Review by at least two contributors
* Review by at least two committers
* Successful CI
* Successful static analysis (SonarQube/Coverity/etc.)
* Heroing of change (details vary by ticket)

Certain exceptions may occur. For example, if there is a problem with the CI environment then a manually performed full build and static analysis check may be substituted _at the discretion of the repository maintainers_. Additionally, repository metadata such as this `PULL_REQUEST_TEMPLATE`, the repository `README`, and other non-functional items may be merged without requiring CI and static analysis.

Finally, an abbreviated review process may be in place for forward-port tickets immediately following branching and prior to branch divergence. In that case, approvals, CI, static analysis, and heroing that occur against the PR against the _release branch_ can be considered sufficient for reviewing the PR against the _master branch_.

Once the branches diverge, the process will return to normal.

Insofar as divergence is not a function of time but of change to the parent branch, the repository maintainers will determine when abbreviated review ends.

When abbreviated review is in effect, a note to that effect will be at the top of this template. Following is an example note:
```
##### ABBREVIATED REVIEW BETWEEN 2.12.X AND MASTER IS IN EFFECT
____

```

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
