### PR TITLE
[2.11.x] DDF-3464 Update FilterPlugin to not filter warnings

### DIFF
--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -56,7 +56,7 @@
             <list/>
         </property>
         <property name="filterErrors" value="true"/>
-        <property name="filterWarnings" value="true"/>
+        <property name="filterWarnings" value="false"/>
     </bean>
 
 

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,12 +24,12 @@
                 default="invalid-state=system-admin" cardinality="100"/>
         <AD
                 description="Sets whether metacards with validation errors are filtered."
-                name="Filter errors" id="filterErrors" required="true" type="Boolean"
+                name="Filter errors" id="filterErrors" type="Boolean"
                 default="true"/>
         <AD
                 description="Sets whether metacards with validation warnings are filtered."
-                name="Filter warnings" id="filterWarnings" required="true" type="Boolean"
-                default="true"/>
+                name="Filter warnings" id="filterWarnings" type="Boolean"
+                default="false"/>
     </OCD>
 
     <OCD name="Metacard Validation Marker Plugin"

--- a/distribution/docs/src/main/resources/content/_tables/MetacardValidityFilterPlugin.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/MetacardValidityFilterPlugin.adoc
@@ -34,7 +34,7 @@
 |filterWarnings
 |Boolean
 |Sets whether metacards with validation warnings are filtered.
-|true
+|false
 |false
 
 |===


### PR DESCRIPTION
#### What does this PR do?
Updates the blueprint and metatype so the Validity Filter Plugin will not filter on warnings by default.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@brendan-hofmann 
@AzGoalie 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Full build. Verify the filter warnings checkbox is off in the admin ui.

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
For the general case, merging is gated on the following:

* Review by at least two contributors
* Review by at least two committers
* Successful CI
* Successful static analysis (SonarQube/Coverity/etc.)
* Heroing of change (details vary by ticket)

Certain exceptions may occur. For example, if there is a problem with the CI environment then a manually performed full build and static analysis check may be substituted _at the discretion of the repository maintainers_. Additionally, repository metadata such as this `PULL_REQUEST_TEMPLATE`, the repository `README`, and other non-functional items may be merged without requiring CI and static analysis.

Finally, an abbreviated review process may be in place for forward-port tickets immediately following branching and prior to branch divergence. In that case, approvals, CI, static analysis, and heroing that occur against the PR against the _release branch_ can be considered sufficient for reviewing the PR against the _master branch_.

Once the branches diverge, the process will return to normal.

Insofar as divergence is not a function of time but of change to the parent branch, the repository maintainers will determine when abbreviated review ends.

When abbreviated review is in effect, a note to that effect will be at the top of this template. Following is an example note:
```
##### ABBREVIATED REVIEW BETWEEN 2.12.X AND MASTER IS IN EFFECT
____

```

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
