### PR TITLE
[2.11.x] DDF-3443: SAML ECP SOAP and PAOS Bindings Added to SAML Metadata

### DIFF
--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
@@ -412,6 +412,7 @@ public class AssertionConsumerService {
             Base64.getEncoder().encodeToString(encryptionCert.getEncoded()),
             logoutLocation,
             assertionConsumerServiceLocation,
+            assertionConsumerServiceLocation,
             assertionConsumerServiceLocation);
 
     Document doc = DOMUtils.createDocument();

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -946,6 +946,7 @@ public class IdpEndpoint implements Idp {
             nameIdFormats,
             SystemBaseUrl.constructUrl("/idp/login", true),
             SystemBaseUrl.constructUrl("/idp/login", true),
+            SystemBaseUrl.constructUrl("/idp/login", true),
             SystemBaseUrl.constructUrl("/idp/logout", true));
     Document doc = DOMUtils.createDocument();
     doc.appendChild(doc.createElement("root"));

--- a/platform/security/idp/security-idp-server/src/test/groovy/org/codice/ddf/security/idp/server/IdpEndpointSpecTest.groovy
+++ b/platform/security/idp/security-idp-server/src/test/groovy/org/codice/ddf/security/idp/server/IdpEndpointSpecTest.groovy
@@ -403,6 +403,7 @@ MIIC8DCCAlmgAwIBAgIJAIzc4FYrIp9pMA0GCSqGSIb3DQEBCwUAMIGEMQswCQYDVQQGEwJVUzELMAkG
 <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp1:8993/services/saml/logout"/>
 <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp1:8993/services/saml/sso" index="0"/>
 <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp1:8993/services/saml/sso" index="1"/>
+<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://sp1:8993/services/saml/sso"/>
 </md:SPSSODescriptor>
 </md:EntityDescriptor>/$
 
@@ -430,6 +431,7 @@ MIIC8DCCAlmgAwIBAgIJAIzc4FYrIp9pMA0GCSqGSIb3DQEBCwUAMIGEMQswCQYDVQQGEwJVUzELMAkG
 <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp2:8993/services/saml/logout"/>
 <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp2:8993/services/saml/sso" index="0"/>
 <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp2:8993/services/saml/sso" index="1"/>
+<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://sp2:8993/services/saml/sso"/>
 </md:SPSSODescriptor>
 </md:EntityDescriptor>/$
 }

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
@@ -81,6 +81,10 @@ public class SamlProtocol {
   public static final String REDIRECT_BINDING =
       "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
 
+  public static final String SOAP_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:SOAP";
+
+  public static final String PAOS_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:PAOS";
+
   public static final String POST_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
 
   /** Input factory */
@@ -218,11 +222,11 @@ public class SamlProtocol {
       (HeaderBuilder) builderFactory.getBuilder(Header.DEFAULT_ELEMENT_NAME);
 
   public enum Binding {
-    HTTP_POST("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"),
-    HTTP_REDIRECT("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"),
-    HTTP_ARTIFACT("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"),
-    SOAP("urn:oasis:names:tc:SAML:2.0:bindings:SOAP"),
-    PAOS("urn:oasis:names:tc:SAML:2.0:bindings:PAOS");
+    HTTP_POST(POST_BINDING),
+    HTTP_REDIRECT(REDIRECT_BINDING),
+    HTTP_ARTIFACT(SOAP_BINDING),
+    SOAP(SOAP_BINDING),
+    PAOS(PAOS_BINDING);
 
     private final String uri;
 
@@ -316,6 +320,7 @@ public class SamlProtocol {
     return status;
   }
 
+  @SuppressWarnings("squid:S00107")
   public static EntityDescriptor createIdpMetadata(
       String entityId,
       String signingCert,
@@ -323,6 +328,7 @@ public class SamlProtocol {
       List<String> nameIds,
       String singleSignOnLocationRedirect,
       String singleSignOnLocationPost,
+      String singleSignOnLocationSoap,
       String singleLogOutLocation) {
     EntityDescriptor entityDescriptor = entityDescriptorBuilder.buildObject();
     entityDescriptor.setEntityID(entityId);
@@ -384,6 +390,13 @@ public class SamlProtocol {
       idpssoDescriptor.getSingleLogoutServices().add(singleLogoutServicePost);
     }
 
+    if (StringUtils.isNotBlank(singleSignOnLocationSoap)) {
+      SingleSignOnService singleSignOnServiceSoap = singleSignOnServiceBuilder.buildObject();
+      singleSignOnServiceSoap.setBinding(SOAP_BINDING);
+      singleSignOnServiceSoap.setLocation(singleSignOnLocationSoap);
+      idpssoDescriptor.getSingleSignOnServices().add(singleSignOnServiceSoap);
+    }
+
     idpssoDescriptor.setWantAuthnRequestsSigned(true);
 
     idpssoDescriptor.addSupportedProtocol(SUPPORTED_PROTOCOL);
@@ -399,7 +412,8 @@ public class SamlProtocol {
       String encryptionCert,
       String singleLogOutLocation,
       String assertionConsumerServiceLocationRedirect,
-      String assertionConsumerServiceLocationPost) {
+      String assertionConsumerServiceLocationPost,
+      String assertionConsumerServiceLocationPaos) {
     EntityDescriptor entityDescriptor = entityDescriptorBuilder.buildObject();
     entityDescriptor.setEntityID(entityId);
     SPSSODescriptor spSsoDescriptor = spSsoDescriptorBuilder.buildObject();
@@ -458,6 +472,15 @@ public class SamlProtocol {
       assertionConsumerService.setIndex(acsIndex++);
       assertionConsumerService.setLocation(assertionConsumerServiceLocationPost);
       spSsoDescriptor.getAssertionConsumerServices().add(assertionConsumerService);
+    }
+
+    if (StringUtils.isNotBlank(assertionConsumerServiceLocationPaos)) {
+      AssertionConsumerService assertionConsumerServicePaos =
+          assertionConsumerServiceBuilder.buildObject();
+      assertionConsumerServicePaos.setBinding(PAOS_BINDING);
+      assertionConsumerServicePaos.setIndex(acsIndex++);
+      assertionConsumerServicePaos.setLocation(assertionConsumerServiceLocationPaos);
+      spSsoDescriptor.getAssertionConsumerServices().add(assertionConsumerServicePaos);
     }
 
     spSsoDescriptor.addSupportedProtocol(SUPPORTED_PROTOCOL);

--- a/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/SamlProtocolTest.java
+++ b/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/SamlProtocolTest.java
@@ -13,17 +13,25 @@
  */
 package ddf.security.samlp;
 
+import static ddf.security.samlp.SamlProtocol.PAOS_BINDING;
+import static ddf.security.samlp.SamlProtocol.POST_BINDING;
+import static ddf.security.samlp.SamlProtocol.REDIRECT_BINDING;
+import static ddf.security.samlp.SamlProtocol.SOAP_BINDING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.junit.Test;
 import org.opensaml.saml.saml2.core.AttributeQuery;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 import org.opensaml.saml.saml2.core.LogoutResponse;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SingleSignOnService;
 
 public class SamlProtocolTest {
 
@@ -50,6 +58,7 @@ public class SamlProtocolTest {
             Arrays.asList("mynameid"),
             "redirectlocation",
             "postlocation",
+            "soaplocation",
             "logoutlocation");
     assertEquals("myid", entityDescriptor.getEntityID());
     assertEquals(
@@ -83,20 +92,7 @@ public class SamlProtocolTest {
             .getNameIDFormats()
             .get(0)
             .getFormat());
-    assertEquals(
-        "redirectlocation",
-        entityDescriptor
-            .getIDPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
-            .getSingleSignOnServices()
-            .get(0)
-            .getLocation());
-    assertEquals(
-        "postlocation",
-        entityDescriptor
-            .getIDPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
-            .getSingleSignOnServices()
-            .get(1)
-            .getLocation());
+
     assertEquals(
         "logoutlocation",
         entityDescriptor
@@ -104,6 +100,41 @@ public class SamlProtocolTest {
             .getSingleLogoutServices()
             .get(0)
             .getLocation());
+
+    List<SingleSignOnService> ssoServices =
+        entityDescriptor
+            .getIDPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
+            .getSingleSignOnServices();
+
+    assertTrue(
+        ssoServices
+            .stream()
+            .filter(
+                service ->
+                    service.getBinding().equals(REDIRECT_BINDING)
+                        && service.getLocation().equals("redirectlocation"))
+            .findFirst()
+            .isPresent());
+
+    assertTrue(
+        ssoServices
+            .stream()
+            .filter(
+                service ->
+                    service.getBinding().equals(POST_BINDING)
+                        && service.getLocation().equals("postlocation"))
+            .findFirst()
+            .isPresent());
+
+    assertTrue(
+        ssoServices
+            .stream()
+            .filter(
+                service ->
+                    service.getBinding().equals(SOAP_BINDING)
+                        && service.getLocation().equals("soaplocation"))
+            .findFirst()
+            .isPresent());
   }
 
   @Test
@@ -115,7 +146,8 @@ public class SamlProtocolTest {
             "myencryptioncert",
             "logoutlocation",
             "redirectlocation",
-            "postlocation");
+            "postlocation",
+            "paoslocation");
     assertEquals("myid", entityDescriptor.getEntityID());
     assertEquals(
         "mysigningcert",
@@ -141,20 +173,7 @@ public class SamlProtocolTest {
             .getX509Certificates()
             .get(0)
             .getValue());
-    assertEquals(
-        "redirectlocation",
-        entityDescriptor
-            .getSPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
-            .getAssertionConsumerServices()
-            .get(0)
-            .getLocation());
-    assertEquals(
-        "postlocation",
-        entityDescriptor
-            .getSPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
-            .getAssertionConsumerServices()
-            .get(1)
-            .getLocation());
+
     assertEquals(
         "logoutlocation",
         entityDescriptor
@@ -162,6 +181,41 @@ public class SamlProtocolTest {
             .getSingleLogoutServices()
             .get(0)
             .getLocation());
+
+    List<AssertionConsumerService> acServices =
+        entityDescriptor
+            .getSPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
+            .getAssertionConsumerServices();
+
+    assertTrue(
+        acServices
+            .stream()
+            .filter(
+                service ->
+                    service.getBinding().equals(REDIRECT_BINDING)
+                        && service.getLocation().equals("redirectlocation"))
+            .findFirst()
+            .isPresent());
+
+    assertTrue(
+        acServices
+            .stream()
+            .filter(
+                service ->
+                    service.getBinding().equals(POST_BINDING)
+                        && service.getLocation().equals("postlocation"))
+            .findFirst()
+            .isPresent());
+
+    assertTrue(
+        acServices
+            .stream()
+            .filter(
+                service ->
+                    service.getBinding().equals(PAOS_BINDING)
+                        && service.getLocation().equals("paoslocation"))
+            .findFirst()
+            .isPresent());
   }
 
   @Test


### PR DESCRIPTION
### Backport of https://github.com/codice/ddf/pull/2636

-------

 - /services/idp/login/metadata now has a SingleSignOnService with a SOAP
Binding and /services/idp/login Location

- /services/saml/sso/metadata now has a AssertionConsumerService with a PAOS
Binding and /services/saml/sso Location

#### What does this PR do?
Adds SOAP and PAOS bindings to the SAML metadata.

#### Who is reviewing it? 
@vinamartin 
@ahoffer 

#### Select relevant component teams: 
@codice/security 

#### Choose 2 committers to review/merge the PR. 
@rzwiefel
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Hit `services/idp/login/metadata` and `/services/saml/sso/metadata` endpoints and make sure that the new bindings are present.

#### What are the relevant tickets?
[DDF-3443](https://codice.atlassian.net/browse/DDF-3443)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.