### PR TITLE
DDF-3427 Aligned org.ops4j.pax.logging.cfg and log4j2.config.xml configurations

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
@@ -25,11 +25,6 @@
 #START DDF SETTINGS
 
 #
-# System branding
-#
-org.codice.ddf.system.branding=${branding-lowercase}
-
-#
 # Keystore and Truststore Java Properties
 #
 javax.net.ssl.keyStore=etc/keystores/serverKeystore.jks
@@ -68,6 +63,7 @@ org.codice.ddf.system.rootContext=/services
 #
 # System Information Properties
 #
+org.codice.ddf.system.branding=${branding-lowercase}
 org.codice.ddf.system.siteName=${sitename.default}
 org.codice.ddf.system.siteContact=
 org.codice.ddf.system.version=${project.version}

--- a/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
@@ -138,15 +138,30 @@
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>
 
-        <!-- CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console. -->
-        <Logger name="org.apache.cxf" level="warn"/>
+        <!--START Suppress logging for miscellaneous packages-->
+        <!--GraphqQL tends to log at warn/error level. This is not needed since we provide our own
+        logging.-->
+        <Logger name="graphql.execution" level="fatal"/>
         <Logger name="lux.solr" level="warn"/>
-        <Logger name="org.ops4j.pax.web.jsp" level="warn"/>
         <Logger name="org.apache.aries.spifly" level="warn"/>
+        <Logger name="org.apache.cxf" level="warn"/>
         <Logger name="org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper" level="error"/>
         <Logger name="org.apache.cxf.phase.PhaseInterceptorChain" level="error"/>
-        <!-- Camel - Suppresses an NPE warning that is ignored by Camel -->
+        <!--Suppress a NPE that can be disregarded that occurs when a null file is passed through
+        the Camel exchange on a delete event of a WebDav entry.-->
         <Logger name="org.apache.camel.impl.DefaultUnitOfWork" level="error"/>
+        <Logger name="org.ops4j.pax.web" level="warn"/>
+        <!--Logging for the UnregisterWebAppVisitorWC has been set to ERROR as paxweb logs
+        stacktraces at WARN on startup. This may be related to PAXWEB-1117. When Karaf upgrades
+        paxweb, we need to see if these stacktrace log messages go away (see DDF-3321) and remove
+        this suppression.-->
+        <Logger name="org.ops4j.pax.web.extender.war.internal.UnregisterWebAppVisitorWC"
+                level="error"/>
+        <Logger name="org.ops4j.pax.web.jsp" level="warn"/>
+        <!--Suppress a WARN level exception that does not have any impact on servlet initialization.
+        This is a result of suppressing SCR annotations in the GraphQLServlet.-->
+        <Logger name="org.ops4j.pax.web.utils.ServletContainerInitializerScanner" level="error"/>
+        <!--END Suppress logging for miscellaneous packages-->
 
         <Root level="info">
             <AppenderRef ref="out"/>

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -84,31 +84,38 @@ log4j2.logger.org_apache_lucene.appenderRef.solr.ref = solr
 log4j2.logger.org_apache_lucene.appenderRef.syslog.ref = syslog
 log4j2.logger.org_apache_lucene.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
 
-# CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console.
-log4j2.logger.org_apache_cxf.name = org.apache.cxf
-log4j2.logger.org_apache_cxf.level = WARN
+# START Suppress logging for miscellaneous packages
+# GraphqQL tends to log at warn/error level. This is not needed since we provide our own logging.
+log4j2.logger.graphql_execution.name = graphql.execution
+log4j2.logger.graphql_execution.level = FATAL
 log4j2.logger.lux_solr.name = lux.solr
 log4j2.logger.lux_solr.level = WARN
-log4j2.logger.org_ops4j_pax_web.name = org.ops4j.pax.web
-log4j2.logger.org_ops4j_pax_web.level = WARN
-log4j2.logger.org_ops4j_pax_web_jsp.name = org.ops4j.pax.web.jsp
-log4j2.logger.org_ops4j_pax_web_jsp.level = WARN
-# Logging for the UnregisterWebAppVisitorWC has been set to ERROR as paxweb logs stacktraces at WARN on startup. This may be
-# related to PAXWEB-1117. When Karaf upgrades paxweb, we need to see if these stacktrace log messages go away (see DDF-3321)
-# and remove this suppression.
-log4j2.logger.org_ops4j_pax_web_extender_war_internal_UnregisterWebAppVisitorWC.name = org.ops4j.pax.web.extender.war.internal.UnregisterWebAppVisitorWC
-log4j2.logger.org_ops4j_pax_web_extender_war_internal_UnregisterWebAppVisitorWC.level = ERROR
 log4j2.logger.org_apache_aries_spifly.name = org.apache.aries.spifly
 log4j2.logger.org_apache_aries_spifly.level = WARN
-log4j2.logger.org_apache_cxf_jaxrs_impl_WebApplicationExceptionMapper.name = org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper
-log4j2.logger.org_apache_cxf_jaxrs_impl_WebApplicationExceptionMapper.level = ERROR
-log4j2.logger.org_apache_cxf_phase_PhaseInterceptorChain.name = org.apache.cxf.phase.PhaseInterceptorChain
-log4j2.logger.org_apache_cxf_phase_PhaseInterceptorChain.level = ERROR
-
-# camel
-# Supresses an NPE warning that is ignored by Camel
-log4j2.logger.org_apache_camel_impl_defaultunitofwork.level = ERROR
+log4j2.logger.org_apache_cxf.name = org.apache.cxf
+log4j2.logger.org_apache_cxf.level = WARN
+log4j2.logger.org_apache_cxf_jaxrs_impl_webapplicationexceptionmapper.name = org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper
+log4j2.logger.org_apache_cxf_jaxrs_impl_webapplicationexceptionmapper.level = ERROR
+log4j2.logger.org_apache_cxf_phase_phaseinterceptorchain.name = org.apache.cxf.phase.PhaseInterceptorChain
+log4j2.logger.org_apache_cxf_phase_phaseinterceptorchain.level = ERROR
+# Suppress a NPE that can be disregarded that occurs when a null file is passed through the Camel
+# exchange on a delete event of a WebDav entry.
 log4j2.logger.org_apache_camel_impl_defaultunitofwork.name = org.apache.camel.impl.DefaultUnitOfWork
+log4j2.logger.org_apache_camel_impl_defaultunitofwork.level = ERROR
+log4j2.logger.org_ops4j_pax_web.name = org.ops4j.pax.web
+log4j2.logger.org_ops4j_pax_web.level = WARN
+# Logging for the UnregisterWebAppVisitorWC has been set to ERROR as paxweb logs stacktraces at WARN
+# on startup. This may be related to PAXWEB-1117. When Karaf upgrades paxweb, we need to see if
+# these stacktrace log messages go away (see DDF-3321) and remove this suppression.
+log4j2.logger.org_ops4j_pax_web_extender_war_internal_unregisterwebappvisitorwc.name = org.ops4j.pax.web.extender.war.internal.UnregisterWebAppVisitorWC
+log4j2.logger.org_ops4j_pax_web_extender_war_internal_unregisterwebappvisitorwc.level = ERROR
+log4j2.logger.org_ops4j_pax_web_jsp.name = org.ops4j.pax.web.jsp
+log4j2.logger.org_ops4j_pax_web_jsp.level = WARN
+# Suppress a WARN level exception that does not have any impact on servlet initialization. This is a
+# result of suppressing SCR annotations in the GraphQLServlet.
+log4j2.logger.org_ops4j_pax_web_utils_servletcontainerinitializerscanner.name = org.ops4j.pax.web.utils.ServletContainerInitializerScanner
+log4j2.logger.org_ops4j_pax_web_utils_servletcontainerinitializerscanner.level = ERROR
+# END Suppress logging for miscellaneous packages
 
 # Appenders configuration
 

--- a/distribution/docs/src/main/resources/content/_configuring/auditing.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/auditing.adoc
@@ -71,3 +71,9 @@ In the event the system is unable to write to the `security.log` file, ${brandin
 If the system is unable to write to the `security.log` file on system startup, fallback logging will be unavailable.
 Verify that the `security.log` file is properly configured and contains logs before configuring a fall back.
 ====
+
+[WARNING]
+====
+The Karaf console command `log:set` currently does not work for the `log4j2.xml` configuration.
+//See https://issues.apache.org/jira/browse/KARAF-5354
+====


### PR DESCRIPTION
#### What does this PR do?
This PR fixed some discrepancies between `org.ops4j.pax.logging.cfg` and `log4j2.config.xml`.
#### Who is reviewing it? 
@gordocanchola @peterhuffer 
#### Choose 2 committers to review/merge the PR. 
@bdeining
@clockard
#### How should this be tested?

- Confirm that both log configuration files include the same suppressions.
- Confirm that logging still works when DDF is running.
- Follow the Documentation (`Enabling Fallback Audit Logging`) to switch to use the `log4j2.config.xml`, and confirm that logging still works when DDF is running.

#### Any background context you want to provide?
Is is a required hardening step to use the `log4j2.config.xml` configuration file, so it should match `org.ops4j.pax.logging.cfg`.
#### What are the relevant tickets?
[DDF-3427](https://codice.atlassian.net/browse/DDF-3427)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
For the general case, merging is gated on the following:
- [ ] Review by at least two contributors
- [ ] Review by at least two committers
- [ ] Successful CI
- [ ] Successful static analysis (SonarQube/Coverity/etc.)
- [ ] Heroing of change (details vary by ticket)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
