### PR TITLE
DDF-3468 Updates $.whenAll to have a consistent resolve

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/jquery.whenAll.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/jquery.whenAll.js
@@ -16,14 +16,14 @@ define([
     ],
     function ($) {
 
-        $.whenAll = function( firstParam ) {
+        $.whenAll = function() {
             var args = arguments,
                 sliceDeferred = [].slice,
                 i = 0,
                 length = args.length,
                 count = length,
                 rejected,
-                deferred = length <= 1 && firstParam && $.isFunction( firstParam.promise ) ? firstParam : $.Deferred();
+                deferred = $.Deferred();
 
             function resolveFunc( i, reject ) {
                 return function( value ) {
@@ -39,19 +39,15 @@ define([
                 };
             }
 
-            if ( length > 1 ) {
-                for( ; i < length; i++ ) {
-                    if ( args[ i ] && $.isFunction( args[ i ].promise ) ) {
-                        args[ i ].promise().then( resolveFunc(i), resolveFunc(i, true) );
-                    } else {
-                        --count;
-                    }
+            for( ; i < length; i++ ) {
+                if ( args[ i ] && $.isFunction( args[ i ].promise ) ) {
+                    args[ i ].promise().then( resolveFunc(i), resolveFunc(i, true) );
+                } else {
+                    --count;
                 }
-                if ( !count ) {
-                    deferred.resolveWith( deferred, args );
-                }
-            } else if ( deferred !== firstParam ) {
-                deferred.resolveWith( deferred, length ? [ firstParam ] : [] );
+            }
+            if ( count === 0 ) {
+                deferred.resolveWith( deferred, args );
             }
             return deferred.promise();
         };


### PR DESCRIPTION
#### What does this PR do?
 - Previously if only 1 argument was supplied the resolve ended up being called differently (it used the deferred / promise passed in directly).  This could cause issues in areas of the code that rely on the resolution of the whenAll.  Developers would need to check whether or not they passed in an array of size 1 in order to know how to handle the resolution of the whenAll.  Now developers can depend on it returning an array of responses.

#### Who is reviewing it? 
@adimka 
@mackncheesiest 
@troymohl 
@millerw8 

#### How should this be tested? (List steps with links to updated documentation)
Turn off the cache in the Admin UI and make sure you don't have any extra sources (just local).  
Update the notifications enum in the Admin UI to allow a shorter notification period (maybe 10 seconds?).
Go to the UI (or refresh if you already have it open).
Create a query and turn on notifications (bell icon by query), and select the interval.
Inject new data that matches the query.
Wait up to interval.
Notice that the notification bell in the upper right indicates new data found.

#### Any background context you want to provide?
This could be solving issues in areas other than notifications, but that's where it showed up first. 
 Previously the $.whenAll could return just a response instead of [response].  Now it will always return an array of responses.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3468