### PR TITLE
DDF-3460 Make commons-system its own bundle

### DIFF
--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -95,7 +95,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>common-system</Embed-Dependency>
                         <Export-Package>
                             ddf.catalog*
                         </Export-Package>

--- a/catalog/core/catalog-core-metricsplugin/pom.xml
+++ b/catalog/core/catalog-core-metricsplugin/pom.xml
@@ -94,7 +94,6 @@
                             metrics-core,
                             metrics-collector,
                             rrd4j;scope=compile|runtime;artifactId=!slf4j-api,
-                            common-system,
                             catalog-core-api-impl;scope=!test,
                             platform-util
                         </Embed-Dependency>

--- a/catalog/core/catalog-core-resourcestatusplugin/pom.xml
+++ b/catalog/core/catalog-core-resourcestatusplugin/pom.xml
@@ -71,8 +71,7 @@
                             notifications,
                             activities,
                             hazelcast;scope=runtime|compile,
-                            catalog-core-api-impl;scope=!test,
-                            common-system
+                            catalog-core-api-impl;scope=!test
                         </Embed-Dependency>
                         <Private-Package>
                             ddf.catalog.cache.impl,

--- a/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
@@ -144,7 +144,6 @@
                         <Spring-Context>*;wait-for-dependencies:=true;timeout:=604800
                         </Spring-Context>
                         <Embed-Dependency>
-                            common-system,
                             platform-util
                         </Embed-Dependency>
                         <Import-Package>

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -140,7 +140,6 @@
                             json-smart,
                             catalog-core-api-impl,
                             catalog-core-actions,
-                            common-system,
                             platform-util,
                             commons-lang3,
                             asm

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/pom.xml
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/pom.xml
@@ -82,7 +82,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>JavaAPIforKml, catalog-core-api-impl, handlebars,
-                            antlr4-runtime, commons-lang3, common-system, platform-util
+                            antlr4-runtime, commons-lang3, platform-util
                         </Embed-Dependency>
                         <Import-Package>
                             !org.abego.treelayout.*,

--- a/catalog/spatial/registry/registry-policy-plugin/pom.xml
+++ b/catalog/spatial/registry/registry-policy-plugin/pom.xml
@@ -83,8 +83,7 @@
                             ddf-security-common,
                             catalog-core-api-impl;scope=!test,
                             platform-util-unavailableurls,
-                            platform-util,
-                            common-system
+                            platform-util
                         </Embed-Dependency>
                         <Import-Package>
                             ddf.catalog,

--- a/catalog/spatial/registry/registry-publication-action-provider/pom.xml
+++ b/catalog/spatial/registry/registry-publication-action-provider/pom.xml
@@ -97,7 +97,6 @@
                             platform-util,
                             registry-common,
                             catalog-core-api-impl,
-                            common-system,
                             commons-lang3,
                             ddf-security-common
                         </Embed-Dependency>

--- a/catalog/transformer/catalog-transformer-service-atom/pom.xml
+++ b/catalog/transformer/catalog-transformer-service-atom/pom.xml
@@ -91,7 +91,6 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            common-system,
                             catalog-core-api-impl;scope=!test
                         </Embed-Dependency>
                         <Private-Package>

--- a/libs/common-system/pom.xml
+++ b/libs/common-system/pom.xml
@@ -21,6 +21,7 @@
     </parent>
     <artifactId>common-system</artifactId>
     <name>DDF :: Common System</name>
+    <packaging>bundle</packaging>
     <dependencies>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -36,8 +37,13 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/libs/platform-configuration-impl/pom.xml
+++ b/libs/platform-configuration-impl/pom.xml
@@ -50,7 +50,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>common-system</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/admin/core/admin-core-impl/pom.xml
+++ b/platform/admin/core/admin-core-impl/pom.xml
@@ -122,7 +122,6 @@
                         <Embed-Dependency>
                             platform-util,
                             org.apache.felix.utils,
-                            common-system,
                             alerts,
                             boon
                         </Embed-Dependency>

--- a/platform/admin/core/admin-core-insecuredefaults/pom.xml
+++ b/platform/admin/core/admin-core-insecuredefaults/pom.xml
@@ -93,10 +93,9 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>common-system, alerts</Embed-Dependency>
+                        <Embed-Dependency>alerts</Embed-Dependency>
                         <Import-Package>*</Import-Package>
-                        <Export-Package>
-                        </Export-Package>
+                        <Export-Package/>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/admin/core/admin-core-migration-commands/pom.xml
+++ b/platform/admin/core/admin-core-migration-commands/pom.xml
@@ -121,7 +121,6 @@
               platform-util,
               platform-util-unavailableurls,
               ddf-security-common,
-              common-system,
               alerts
             </Embed-Dependency>
             <Export-Package/>

--- a/platform/metrics/platform-metrics-reporting/pom.xml
+++ b/platform/metrics/platform-metrics-reporting/pom.xml
@@ -101,8 +101,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>rrd4j,joda-time, commons-math, common-system,
-                            platform-util
+                        <Embed-Dependency>rrd4j,joda-time, commons-math, platform-util
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Import-Package>

--- a/platform/platform-app/pom.xml
+++ b/platform/platform-app/pom.xml
@@ -352,6 +352,11 @@
             <artifactId>tika-bundle</artifactId>
             <version>${tika.thirdparty.bundle.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>common-system</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!--START dependencies for enterprise features in platform-app features-->
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -1064,6 +1064,7 @@
         <feature dependency="true" version="${spring.version}_1">spring</feature>
         <feature prerequisite="true">pax-http-jetty</feature>
         <feature prerequisite="true">pax-jetty</feature>
+        <bundle>mvn:ddf.lib/common-system/${project.version}</bundle>
         <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
         <bundle start-level="30">mvn:ddf.platform/platform-filter-delegate/${project.version}</bundle>
     </feature>
@@ -1087,6 +1088,7 @@
         <feature prerequisite="true">camel-http</feature>
         <feature prerequisite="true">camel-quartz2</feature>
         <feature prerequisite="true">commons</feature>
+        <bundle>mvn:ddf.lib/common-system/${project.version}</bundle>
         <bundle dependency="true">mvn:ch.qos.cal10n/cal10n-api/0.7.4</bundle>
         <bundle dependency="true">mvn:org.slf4j/slf4j-ext/${org.slf4j.version}</bundle>
         <bundle dependency="true">mvn:org.ops4j.base/ops4j-base-lang/${org.ops4j-base-lang}</bundle>

--- a/platform/platform-configuration/pom.xml
+++ b/platform/platform-configuration/pom.xml
@@ -87,7 +87,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            json-smart,common-system,org.apache.felix.utils,commons-lang3,asm
+                            json-smart,org.apache.felix.utils,commons-lang3,asm
                         </Embed-Dependency>
                     </instructions>
                 </configuration>

--- a/platform/security/cas/security-cas-client/pom.xml
+++ b/platform/security/cas/security-cas-client/pom.xml
@@ -103,7 +103,6 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Version>${project.version}</Bundle-Version>
-                        <Embed-Dependency>common-system</Embed-Dependency>
                         <Export-Package>
                             ddf.security.cas.client;version=${project.version}
                         </Export-Package>
@@ -116,7 +115,8 @@
                             org.jasig.cas.client.proxy,
                             org.jasig.cas.client.validation,
                             org.osgi.service.blueprint;version="[1.0.0,2.0.0)",
-                            org.slf4j;version="[1.7,2)"
+                            org.slf4j;version="[1.7,2)",
+                            org.codice.ddf.configuration
                         </Import-Package>
                         <Bundle-ClassPath>.,WEB-INF/classes,WEB-INF/lib/guava-17.0.jar
                         </Bundle-ClassPath>

--- a/platform/security/cas/security-cas-cxfservletfilter/pom.xml
+++ b/platform/security/cas/security-cas-cxfservletfilter/pom.xml
@@ -54,7 +54,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>common-system</Embed-Dependency>
                         <Export-Package/>
                     </instructions>
                 </configuration>

--- a/platform/security/filter/security-filter-login/pom.xml
+++ b/platform/security/filter/security-filter-login/pom.xml
@@ -140,7 +140,6 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
                             platform-util,
-                            common-system,
                             ddf-security-common,
                             httpclient,httpcore,
                             platform-util-unavailableurls

--- a/platform/security/idp/security-idp-client/pom.xml
+++ b/platform/security/idp/security-idp-client/pom.xml
@@ -177,7 +177,6 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            common-system,
                             ddf-security-common,
                             platform-util-unavailableurls,
                             platform-util,

--- a/platform/security/idp/security-idp-server/pom.xml
+++ b/platform/security/idp/security-idp-server/pom.xml
@@ -354,7 +354,6 @@
                             platform-util,
                             antlr4-runtime,
                             commons-lang3,
-                            common-system,
                             jetty-servlets,
                             security-core-impl,
                             httpcore,

--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -203,7 +203,6 @@
                             httpcore,
                             google-http-client,
                             opensaml-soap-impl,
-                            common-system,
                             alerts
                         </Embed-Dependency>
                         <Export-Package>

--- a/platform/security/policy/security-policy-context/pom.xml
+++ b/platform/security/policy/security-policy-context/pom.xml
@@ -44,7 +44,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>common-system</Embed-Dependency>
                         <Export-Package>
                             org.codice.ddf.security.policy.context.impl
                         </Export-Package>

--- a/platform/security/servlet/security-servlet-logout/pom.xml
+++ b/platform/security/servlet/security-servlet-logout/pom.xml
@@ -207,7 +207,6 @@
                         <Embed-Dependency>
                             boon,
                             commons-lang3,
-                            common-system,
                             ddf-security-common,
                             httpclient,
                             httpcore,

--- a/platform/security/sts/security-sts-server/pom.xml
+++ b/platform/security/sts/security-sts-server/pom.xml
@@ -119,11 +119,9 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            common-system,
                             cxf-services-sts-core,
                             security-sts-x509delegationhandler,
                             security-sts-bstdelegationhandler,
-                            common-system,
                             httpclient,httpcore,
                             platform-util-unavailableurls,
                             ddf-security-common,


### PR DESCRIPTION
#### What does this PR do?
Makes the common-system module it's own bundle and removes common-system from bundle embed sections. This was pulled out of https://github.com/codice/ddf/pull/2713 to be it's own pr
#### Who is reviewing it? 
@emmberk @AzGoalie @peterhuffer 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)

@bdeining
@coyotesqrl
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
CI build and verify installs successfully

#### What are the relevant tickets?
[DDF-3460](https://codice.atlassian.net/browse/DDF-3460)
