### PR TITLE
DDF-3472 Suppress camel cve that does not apply to DDF

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -108,6 +108,8 @@
         <cve>CVE-2014-0002</cve>
         <cve>CVE-2014-0003</cve>
         <cve>CVE-2017-3159</cve>
+        <cve>CVE-2017-12634</cve>
+        <cve>CVE-2017-12633</cve>
     </suppress>
 
     <!-- tika -->


### PR DESCRIPTION
#### What does this PR do?
Suppress camel cve that does not apply to DDF
These issues found are with camel-hessian and camel-castor in apache-camel and DDF only uses apache-camel for testing.

Issues found by owasp
https://nvd.nist.gov/vuln/detail/CVE-2017-12633#vulnDescriptionTitle
https://nvd.nist.gov/vuln/detail/CVE-2017-12634#vulnDescriptionTitle
#### Who is reviewing it? 
@brjeter @peterhuffer 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@brendan-hofmann
@jlcsmith

#### How should this be tested? (List steps with links to updated documentation)
CI build
#### What are the relevant tickets?
[DDF-3472](https://codice.atlassian.net/browse/DDF-3472)
