### PR TITLE
DDF-3503 Ignored failing unit tests in catalog-plugin-videothumbnail

### DIFF
--- a/catalog/plugin/catalog-plugin-videothumbnail/src/test/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPluginTest.java
+++ b/catalog/plugin/catalog-plugin-videothumbnail/src/test/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPluginTest.java
@@ -51,7 +51,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -65,6 +67,11 @@ public class VideoThumbnailPluginTest {
   private VideoThumbnailPlugin videoThumbnailPlugin;
 
   private HashMap<String, Map> tmpContentPaths;
+
+  @BeforeClass
+  public static void setUpClass() {
+    Assume.assumeFalse("Skip unit tests on Windows. See DDF-3503.", SystemUtils.IS_OS_WINDOWS);
+  }
 
   @Before
   public void setUp() throws IOException, MimeTypeParseException, URISyntaxException {
@@ -343,8 +350,9 @@ public class VideoThumbnailPluginTest {
       ffmpegResourcePath = "linux/ffmpeg";
     } else if (SystemUtils.IS_OS_MAC) {
       ffmpegResourcePath = "osx/ffmpeg";
-    } else if (SystemUtils.IS_OS_WINDOWS) {
-      ffmpegResourcePath = "windows/ffmpeg.exe";
+      //      Skip unit tests on Windows. See DDF-3503.
+      //    } else if (SystemUtils.IS_OS_WINDOWS) {
+      //      ffmpegResourcePath = "windows/ffmpeg.exe";
     } else if (SystemUtils.IS_OS_SOLARIS) {
       ffmpegResourcePath = "solaris/ffmpeg";
     } else {


### PR DESCRIPTION
#### What does this PR do?
This PR ignores failing unit tests on Windows until the failures can be investigated in [DDF-3503](https://codice.atlassian.net/browse/DDF-3503).
#### Who is reviewing it? 
@oconnormi @mcalcote @LinkMJB @jrnorth 
#### Select relevant component teams: 
@codice/test 
@codice/build 
#### Choose 2 committers to review/merge the PR.
@coyotesqrl
@lessarderic
#### How should this be tested?
CI build on Windows Server 2016.
#### What are the relevant tickets?
[DDF-3503](https://codice.atlassian.net/browse/DDF-3503)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.