### PR TITLE
DDF-3504 Implemented lowBandwidth param for Intrigue

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -149,6 +149,7 @@
 @import 'visualization/table/table-rearrange';
 @import 'visualization/inspector/inspector';
 @import 'visualization/combined-map/combined-map';
+@import 'visualization/low-bandwidth-map/low-bandwidth-map.less';
 @import 'announcement/announcement';
 @import 'workspace-interactions/workspace-interactions';
 @import 'workspace-explore/workspace-explore';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -149,7 +149,7 @@
 @import 'visualization/table/table-rearrange';
 @import 'visualization/inspector/inspector';
 @import 'visualization/combined-map/combined-map';
-@import 'visualization/low-bandwidth-map/low-bandwidth-map.less';
+@import 'visualization/low-bandwidth-map/low-bandwidth-map';
 @import 'announcement/announcement';
 @import 'workspace-interactions/workspace-interactions';
 @import 'workspace-explore/workspace-explore';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
@@ -29,7 +29,6 @@ var OpenlayersView = require('component/visualization/maps/openlayers/openlayers
 var HistogramView = require('component/visualization/histogram/histogram.view');
 var CombinedMapView = require('component/visualization/combined-map/combined-map.view');
 var LowBandwidthMapView = require('component/visualization/low-bandwidth-map/low-bandwidth-map.view');
-var router = require('component/router/router');
 var Common = require('js/Common');
 var store = require('js/store');
 var user = require('component/singletons/user-instance');
@@ -99,11 +98,13 @@ function getGoldenLayoutSettings(){
     };
 }
 
+function registerComponent(marionetteView, name, ComponentView) {
+    registerComponent(marionetteView, name, ComponentView, {});
+}
 // see https://github.com/deepstreamIO/golden-layout/issues/239 for details on why the setTimeout is necessary
 // The short answer is it mostly has to do with making sure these ComponentViews are able to function normally (set up events, etc.)
-function registerComponent(marionetteView, name, ComponentView) {
-    var options = marionetteView.options;
-    options = _.extend({}, options, {lowBandwidth: router.get('lowBandwidth'), desiredContainer: name});
+function registerComponent(marionetteView, name, ComponentView, componentOptions) {
+    var options = _.extend({}, marionetteView.options, componentOptions);
     marionetteView.goldenLayout.registerComponent(name, function (container, componentState) {
         container.on('open', () => {
             setTimeout(function () {
@@ -221,9 +222,9 @@ module.exports = Marionette.LayoutView.extend({
     registerGoldenLayoutComponents: function(){
         registerComponent(this, 'inspector', InspectorView);
         registerComponent(this, 'table', TableView);
-        registerComponent(this, 'cesium', LowBandwidthMapView);
+        registerComponent(this, 'cesium', LowBandwidthMapView, {desiredContainer: 'cesium'});
         registerComponent(this, 'histogram', HistogramView);
-        registerComponent(this, 'openlayers', LowBandwidthMapView);
+        registerComponent(this, 'openlayers', LowBandwidthMapView, {desiredContainer: 'openlayers'});
     },
     detectIfGoldenLayoutMaximised: function(){
         this.$el.toggleClass('is-maximised', isMaximised(this.goldenLayout.root));

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
@@ -28,6 +28,8 @@ var InspectorView = require('component/visualization/inspector/inspector.view');
 var OpenlayersView = require('component/visualization/maps/openlayers/openlayers.view');
 var HistogramView = require('component/visualization/histogram/histogram.view');
 var CombinedMapView = require('component/visualization/combined-map/combined-map.view');
+var LowBandwidthMapView = require('component/visualization/low-bandwidth-map/low-bandwidth-map.view');
+var router = require('component/router/router');
 var Common = require('js/Common');
 var store = require('js/store');
 var user = require('component/singletons/user-instance');
@@ -101,6 +103,7 @@ function getGoldenLayoutSettings(){
 // The short answer is it mostly has to do with making sure these ComponentViews are able to function normally (set up events, etc.)
 function registerComponent(marionetteView, name, ComponentView) {
     var options = marionetteView.options;
+    options = _.extend({}, options, {lowBandwidth: router.get('lowBandwidth'), desiredContainer: name});
     marionetteView.goldenLayout.registerComponent(name, function (container, componentState) {
         container.on('open', () => {
             setTimeout(function () {
@@ -218,9 +221,9 @@ module.exports = Marionette.LayoutView.extend({
     registerGoldenLayoutComponents: function(){
         registerComponent(this, 'inspector', InspectorView);
         registerComponent(this, 'table', TableView);
-        registerComponent(this, 'cesium', CombinedMapView);
+        registerComponent(this, 'cesium', LowBandwidthMapView);
         registerComponent(this, 'histogram', HistogramView);
-        registerComponent(this, 'openlayers', OpenlayersView);
+        registerComponent(this, 'openlayers', LowBandwidthMapView);
     },
     detectIfGoldenLayoutMaximised: function(){
         this.$el.toggleClass('is-maximised', isMaximised(this.goldenLayout.root));

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
@@ -1,3 +1,4 @@
+{{!--
 /**
  * Copyright (c) Codice Foundation
  *
@@ -9,25 +10,15 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, document*/
-define([
-    'jquery',
-    'underscore',
-    'backbone'
-], function ($, _, Backbone) {
-
-    return new (Backbone.Model.extend({
-        defaults: {
-            name: undefined,
-            path: undefined,
-            args: undefined,
-            lowBandwidth: false
-        },
-        initialize: function(){
-            this.listenTo(this, 'change:name', this.handleChangeName);
-        },
-        handleChangeName: function(){
-            $('html').attr('data-route', this.get('name'));
-        }
-    }))();
-});
+ --}}
+<div class="low-bandwidth-confirmation">
+    <h3 align="center">
+    Low-bandwidth mode is enabled. Please confirm that you want this component to load despite potential bandwidth limitations. 
+    </h3>
+    <button class="low-bandwidth-button is-positive" align="center">
+        <span>Continue</span>
+    </button>
+</div>
+<div class="map-container">
+    
+</div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
@@ -13,7 +13,7 @@
  --}}
 <div class="low-bandwidth-confirmation">
     <h3 align="center">
-    Low-bandwidth mode is enabled. Please confirm that you want this component to load despite potential bandwidth limitations. 
+    Low-bandwidth mode is enabled. Please confirm that you want this component to load despite potential bandwidth implications. Choosing to continue may cause available connection resources to be exhausted, and you or other users on your network may experience slowdowns or extended periods of waiting while necessary resources are fetched. 
     </h3>
     <button class="low-bandwidth-button is-positive" align="center">
         <span>Continue</span>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.less
@@ -1,0 +1,25 @@
+@{customElementNamespace}low-bandwidth-map {
+    .customElement;
+
+    > .low-bandwidth-confirmation {
+        button {
+            position: relative;
+            width: 100%;
+            height: 5*@minimumButtonSize;
+            line-height: 5*@minimumButtonSize;
+        }
+        .customElement;
+        overflow: auto;
+        padding: 20px;
+    
+        * + * {
+            margin-top: 20px;
+        }
+    }
+
+    > .map-container {
+        .customElement;
+    }
+
+    
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.view.js
@@ -15,17 +15,11 @@
 /*global require, window*/
 var _ = require('underscore');
 var $ = require('jquery');
-var wreqr = require('wreqr');
 var template = require('./low-bandwidth-map.hbs');
 var Marionette = require('marionette');
 var CustomElements = require('js/CustomElements');
 var CombinedMapView = require('component/visualization/combined-map/combined-map.view');
 var OpenlayersView = require('component/visualization/maps/openlayers/openlayers.view');
-var InspectorView = require('component/visualization/inspector/inspector.view');
-var Common = require('js/Common');
-var store = require('js/store');
-var user = require('component/singletons/user-instance');
-var featureDetection = require('component/singletons/feature-detection');
 var router = require('component/router/router');
 
 module.exports = Marionette.LayoutView.extend({
@@ -40,7 +34,7 @@ module.exports = Marionette.LayoutView.extend({
     },
 
     initialize: function(options) {
-        this.options = options;
+        this.options = _.extend({}, options, {lowBandwidth: router.get('lowBandwidth')});
     },
 
     onRender: function() {
@@ -51,7 +45,7 @@ module.exports = Marionette.LayoutView.extend({
 
     continueLoading: function() {
         this.$el.find('.low-bandwidth-confirmation').addClass('is-hidden');
-        if (this.options.desiredContainer == 'cesium') {
+        if (this.options.desiredContainer === 'cesium') {
             this.mapContainer.show(new CombinedMapView(this.options));
         } else {
             this.mapContainer.show(new OpenlayersView(this.options));

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.view.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require, window*/
+var _ = require('underscore');
+var $ = require('jquery');
+var wreqr = require('wreqr');
+var template = require('./low-bandwidth-map.hbs');
+var Marionette = require('marionette');
+var CustomElements = require('js/CustomElements');
+var CombinedMapView = require('component/visualization/combined-map/combined-map.view');
+var OpenlayersView = require('component/visualization/maps/openlayers/openlayers.view');
+var InspectorView = require('component/visualization/inspector/inspector.view');
+var Common = require('js/Common');
+var store = require('js/store');
+var user = require('component/singletons/user-instance');
+var featureDetection = require('component/singletons/feature-detection');
+var router = require('component/router/router');
+
+module.exports = Marionette.LayoutView.extend({
+    tagName: CustomElements.register('low-bandwidth-map'),
+    template: template,
+    regions: {
+        mapContainer: ' .map-container'
+    },
+
+    events: {
+        'click .low-bandwidth-button' : 'continueLoading'
+    },
+
+    initialize: function(options) {
+        this.options = options;
+    },
+
+    onRender: function() {
+        if (!this.options.lowBandwidth) {
+            this.continueLoading();
+        }
+    },
+
+    continueLoading: function() {
+        this.$el.find('.low-bandwidth-confirmation').addClass('is-hidden');
+        if (this.options.desiredContainer == 'cesium') {
+            this.mapContainer.show(new CombinedMapView(this.options));
+        } else {
+            this.mapContainer.show(new OpenlayersView(this.options));
+        }
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
@@ -100,6 +100,11 @@ define([
             'about(/)': 'openAbout'
         },
         initialize: function(){
+            if (window.location.search.indexOf('lowBandwidth') !== -1) {
+                router.set({
+                    lowBandwidth: true
+                });
+            }
             this.listenTo(wreqr.vent, 'router:navigate', this.handleNavigate);
             /*
                HACK:  listeners for the router aren't setup (such as the onRoute or controller)
@@ -119,12 +124,6 @@ define([
             hideViews();
             var self = this;
             var queryForMetacards, queryForMetacard;
-            var lowBandwidth = args.includes('lowBandwidth') || router.get('lowBandwidth');
-        
-            router.set({
-                lowBandwidth: lowBandwidth
-            });
-
             switch(name){
                 case 'openWorkspace':
                     var workspaceId = args[0];

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
@@ -64,7 +64,7 @@ define([
                 //console.log('route to specific workspace:'+workspaceId);
             },
             home: function(){
-               // console.log('route to workspaces home');
+                //console.log('route to workspaces home');
             },
             workspaces: function(){
                 //console.log('route to workspaces home');
@@ -119,6 +119,12 @@ define([
             hideViews();
             var self = this;
             var queryForMetacards, queryForMetacard;
+            var lowBandwidth = args.includes('lowBandwidth') || router.get('lowBandwidth');
+        
+            router.set({
+                lowBandwidth: lowBandwidth
+            });
+
             switch(name){
                 case 'openWorkspace':
                     var workspaceId = args[0];

--- a/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
@@ -404,4 +404,4 @@ Notifications can be checked/dismissed by clicking the *Notifications* icon (ima
 ==== ${catalog-ui} Low Bandwidth Mode
 
 Low bandwidth mode can be enabled by passing in a `?lowBandwidth` parameter along with any URL targeting the ${catalog-ui} endpoint.
-Ex: `${secure_url}/search/catalog/#workspaces?lowBandwidth`. Currently, enabling this parameter causes the system to prompt the user for confirmation before loading potentially bandwidth-intensive components like the 2D or 3D Maps.
+Ex: `${secure_url}/search/catalog/?lowBandwidth#workspaces`. Currently, enabling this parameter causes the system to prompt the user for confirmation before loading potentially bandwidth-intensive components like the 2D or 3D Maps.

--- a/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
@@ -400,3 +400,8 @@ image::catalog-ui-settings-options.png[]
 ==== ${catalog-ui} Notifications
 
 Notifications can be checked/dismissed by clicking the *Notifications* icon (image:notifications-icon.png[]) on the navigation bar.
+
+==== ${catalog-ui} Low Bandwidth Mode
+
+Low bandwidth mode can be enabled by passing in a `?lowBandwidth` parameter along with any URL targeting the ${catalog-ui} endpoint.
+Ex: `${secure_url}/search/catalog/#workspaces?lowBandwidth`. Currently, enabling this parameter causes the system to prompt the user for confirmation before loading potentially bandwidth-intensive components like the 2D or 3D Maps.


### PR DESCRIPTION
#### What does this PR do?
Adds a `?lowBandwidth` parameter for use in Intrigue to allow for better UX in bandwidth-restricted environments

#### Who is reviewing it? 
@mojogitoverhere @Variadicism @rzwiefel @djblue 

#### Select relevant component teams: 
@codice/ui 

#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)
Verify functionality of `?lowBandwidth` param across various browsers

#### Any background context you want to provide?
At the moment, passing in the `?lowBandwidth` URL parameter to any URL targeting Intrigue simply causes the UI to prompt the user for confirmation before loading either the openlayers or cesium maps. Future changes can be made with respect to other "low bandwidth" improvements. 

#### What are the relevant tickets?
[DDF-3504](https://codice.atlassian.net/browse/DDF-3504)

#### Screenshots (if appropriate)
3D Map
![image](https://user-images.githubusercontent.com/8922497/34133227-ddf5b1f6-e410-11e7-888e-fa998366c6d0.png)

2D Map
![image](https://user-images.githubusercontent.com/8922497/34133244-ee32d9cc-e410-11e7-8a4c-e012af63415a.png)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
