### PR TITLE
DDF-3517 Suppress extraneous logs in ServiceManagerImpl

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerImpl.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerImpl.java
@@ -522,7 +522,10 @@ public class ServiceManagerImpl implements ServiceManager {
 
     while (!available) {
       Response response = get(path);
-      available = response.getStatusCode() == 200 && response.getBody().print().length() > 0;
+      available = response.getStatusCode() == 200 && response.getBody().asString().length() > 0;
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Response body: {}", response.getBody().asString());
+      }
       if (!available) {
         if (System.currentTimeMillis() > timeoutLimit) {
           printInactiveBundles();


### PR DESCRIPTION
#### What does this PR do?
Suppresses itest logs that aren't gated by a `LOGGER` in `ServiceManagerImpl`

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@tbatie @rzwiefel @adimka 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Full build

#### Any background context you want to provide?
This print statement causes roughly 14000 lines to be printed into build logs regardless of root logger level during itest setup.

#### What are the relevant tickets?
[DDF-3517](https://codice.atlassian.net/browse/DDF-3517)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
