### PR TITLE
[2.11.x]DDF-3510 Modals to no longer be dismissible by clicking outside or pressing the ESC key

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ModalSource.view.js
@@ -64,6 +64,9 @@ define([
             details: '.modal-details',
             buttons: '.source-buttons'
         },
+        behaviors: [{
+            behaviorClass: Utils.modalDismissalBehavior
+        }],
         serializeData: function () {
             var data = {};
 

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
@@ -32,7 +32,6 @@ define([
         'text!templates/sourceRow.handlebars'
     ],
     function (ich, Marionette, _, $, Q, ModalSource, EmptyView, Service, Status, wreqr, Utils, deleteModal, deleteSource, sourcePage, sourceList, sourceRow) {
-
         var SourceView = {};
 
         ich.addTemplate('deleteModal', deleteModal);
@@ -282,6 +281,10 @@ define([
                 'click .deleteSource': 'toggleChecks',
                 'click .selectSourceDelete': 'toggleChecks'
             },
+            behaviors: [{
+                behaviorClass: Utils.modalDismissalBehavior
+            }],
+
             toggleChecks: function (e) {
                 var view = this;
                 var checked = e.target.checked;

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Utils.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Utils.js
@@ -57,6 +57,14 @@ function ($,_, Marionette) {
         }
     });
 
+    var ModalExplicitDismissalBehavior = Marionette.Behavior.extend({
+        onRender: function() {
+            this.$el.modal({
+                backdrop: 'static',
+                keyboard: false
+            });
+        }
+    });
 
     var Utils = {
         /**
@@ -88,7 +96,11 @@ function ($,_, Marionette) {
                 spinnerSelector: spinnerSelector,
                 callback: toExec
             });
-        }
+        },
+        /**
+         * Modal to not be dismissible by clicking outside or by pressing the ESC key
+         */
+        modalDismissalBehavior : ModalExplicitDismissalBehavior
     };
 
     return Utils;

--- a/platform/admin/ui/src/main/webapp/templates/configuration/configurationRow.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/configuration/configurationRow.handlebars
@@ -12,7 +12,7 @@
  **/
  --}}
 <td class="column1 indent">
-    <a href='#{{uuid}}' class='editLink' data-toggle="modal">
+    <a href='#{{uuid}}' class='editLink' data-toggle="modal" data-backdrop="static" data-keyboard="false">
         {{displayName}}
     </a>
     <div class="config-modal-container">

--- a/platform/admin/ui/src/main/webapp/templates/configuration/serviceRow.handlebars
+++ b/platform/admin/ui/src/main/webapp/templates/configuration/serviceRow.handlebars
@@ -12,7 +12,7 @@
  **/
  --}}
 <td colspan="3">
-    <a href='#{{uuid}}service' class='newLink' data-toggle="modal">
+    <a href='#{{uuid}}service' class='newLink' data-toggle="modal" data-backdrop="static" data-keyboard="false">
         {{name}}
     </a>
     <hr class="service-divider"/>

--- a/platform/security/servlet/security-servlet-logout/src/main/webapp/js/main.js
+++ b/platform/security/servlet/security-servlet-logout/src/main/webapp/js/main.js
@@ -1,11 +1,6 @@
 /*global $, window, decodeURI */
 (function () {
     var prevUrl = $.url().param('prevurl');
-    $('#modal').on('click', function () {
-        $(this).addClass('is-hidden');
-        window.top.location.reload();
-
-    });
 
     $.get("/services/platform/config/ui", function (data) {
         $('.nav img').attr('src', "data:image/png;base64," + data.productImage);
@@ -23,7 +18,6 @@
         var doLogout = function (action) {
             $('iframe').attr('src', action.url);
             $('#modal').removeClass('is-hidden');
-
         };
 
         if (actions.length !== 0) {
@@ -44,7 +38,8 @@
                     var $user = $('<td></td>');
                     $user.html(action.auth);
                     var $logout = $('<td></td>');
-                    var $button = $('<button>').text('Logout')
+                    var $button = $('<button>').attr('id', 'logoutButton')
+                        .text('Logout')
                         .addClass('btn btn-primary float-right')
                         .click(function () {
                             doLogout(action);

--- a/platform/security/servlet/security-servlet-logout/src/main/webapp/less/style.less
+++ b/platform/security/servlet/security-servlet-logout/src/main/webapp/less/style.less
@@ -89,7 +89,7 @@ iframe {
 
 .logout-msg {
     text-align: center;
-    position: absolute;
+    position: relative;
     top: 50%;
     transform: translateY(-50%);
     width: 100%;


### PR DESCRIPTION
DDF-3510 Modals no longer be dismissible by clicking outside or pressing the ESC key

#### What does this PR do?
Removes the ability for modals to be dismissed by clicking outside or pressing the ESC key. Modals affected are configuration, sources and logout.

#### Who is reviewing it? 
@vinamartin @mcalcote @djblue @peterhuffer 

#### Choose 2 committers to review/merge the PR. 
@figliold
@shaundmorris 

#### How should this be tested?

- Add/Edit Configuration modals
- Add/Edit/Delete Sources modals
- Logout IFrame
should not be dismissible by clicking outside or my pressing the ESC key and function as expected.

#### Any background context you want to provide?
Accidental modal dismissals caused loss of work and incomplete logouts.

#### What are the relevant tickets?
[DDF-3510](https://codice.atlassian.net/browse/DDF-3510)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
