### PR TITLE
[2.11.x]DDF-3523 Upgrading beanutils version and suppressing CVE

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -24,7 +24,6 @@
     <packaging>pom</packaging>
     <name>DDF Catalog</name>
     <properties>
-        <commons-beanutils.version>1.9.2</commons-beanutils.version>
         <commons-weaver-privilizer-api.version>1.1</commons-weaver-privilizer-api.version>
         <commons-logging.version>1.2</commons-logging.version>
         <cglib.version>3.2.0</cglib.version>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -193,4 +193,13 @@
         </notes>
         <cve>CVE-2012-0881</cve>
     </suppress>
+
+    <suppress>
+        <notes>
+            This CVE has been addressed by upgrading commons-beanutils to version 1.9.3. OWASP will
+            continue to report the vulnerability since OWASP sees the DDF version instead of the actual version.
+            security-pdp-authzrealm-2.11.4-SNAPSHOT.jar (cpe:/a:apache:commons_beanutils:2.11.4, cpe:/a:apache:commons_collections:2.11.4, ddf.security.pdp:security-pdp-authzrealm:2.11.4-SNAPSHOT)
+        </notes>
+        <cve>CVE-2017-15708</cve>
+    </suppress>
 </suppressions>

--- a/platform/security/pom.xml
+++ b/platform/security/pom.xml
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.9.3</version>
+                <version>${commons-beanutils.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.validation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <!--END versions that should be kept in sync between Camel and Artemis features-->
         <jboss-logging.version>3.3.0.Final</jboss-logging.version>
         <jgroups.version>3.6.13.Final</jgroups.version>
-        <commons-beanutils.version>1.9.2</commons-beanutils.version>
+        <commons-beanutils.version>1.9.3</commons-beanutils.version>
         <netty.version>4.1.9.Final</netty.version>
         <geronimo-json-spec.version>1.0-alpha-1</geronimo-json-spec.version>
         <johnzon.version>0.9.5</johnzon.version>


### PR DESCRIPTION
#### What does this PR do?
- Upgrades the beanutils version which was using the vulnerable artifact as a transitive dependency.
- Suppressing the CVE still because OWASP is looking at the DDF version instead of the actual artifact's version.
#### Who is reviewing it? 
@blen-desta @emmberk 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl 
@shaundmorris 
#### How should this be tested? (List steps with links to updated documentation)
Full build
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3523](https://codice.atlassian.net/browse/DDF-3523)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
