### PR TITLE
[2.11.x] DDF-2970 Fixed remote delete result collection

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/RemoteDeleteOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/RemoteDeleteOperations.java
@@ -86,10 +86,9 @@ public class RemoteDeleteOperations {
           exceptions.add(
               new ProcessingDetailsImpl(store.getId(), null, "CatalogStore is not available"));
         } else {
-          // TODO: 4/27/17 Address bug in DDF-2970 for overwriting deleted metacards
           DeleteResponse response = store.delete(deleteRequest);
           properties.put(store.getId(), new ArrayList<>(response.getDeletedMetacards()));
-          metacards = response.getDeletedMetacards();
+          metacards.addAll(response.getDeletedMetacards());
         }
       } catch (IngestException e) {
         INGEST_LOGGER.error("Error deleting metacards for CatalogStore {}", store.getId(), e);


### PR DESCRIPTION
#### What does this PR do? 
- Previously the framework would overwrite the return collection instead of accumulating them into a set of results. Now the proper accumulation occurs


#### Who is reviewing it? 
anyone

#### Select relevant component teams: 
@codice/core-apis 

#### How should this be tested? (List steps with links to updated documentation)
remotely delete across two separate sources

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-2970

#### Checklist:
- [X] Update / Add Unit Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
