### PR TITLE
DDF-3531 Moved logic to checking latitudes to after  projection transformation

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -29,13 +29,14 @@ define([
         function translateFromOpenlayersCoordinates(coords) {
             var coordinates = [];
             _.each(coords, function (point) {
+                point = ol.proj.transform([point[0], point[1]], properties.projection, 'EPSG:4326');
                 if (point[1] > 90) {
                     point[1] = 89.9;
                 }
                 else if (point[1] < -90) {
                     point[1] = -89.9;
                 }
-                coordinates.push(ol.proj.transform([point[0], point[1]], properties.projection, 'EPSG:4326'));
+                coordinates.push(point);
             });
             return coordinates;
         }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -49,13 +49,14 @@ define([
 
                 _.each(coords, function(item) {
                     _.each(item, function(point) {
+                        point = ol.proj.transform([point[0], point[1]], properties.projection, 'EPSG:4326');
                         if (point[1] > 90) {
                             point[1] = 89.9;
                         }
                         else if (point[1] < -90) {
                             point[1] = -89.9;
                         }
-                        coordinates.push(ol.proj.transform([point[0], point[1]], properties.projection, 'EPSG:4326'));
+                        coordinates.push(point);
                     });
                 });
 


### PR DESCRIPTION
#### What does this PR do?
Removed logic to checking 'y' value to be between -90 and 90 prior to transforming from the native projection.

This logic fails on my degree based projections such as EPSG:3857.  This check should not be done, instead relying on the library to check and normalize values.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/UI
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)

First, to witness the bug:
Set the UI projection to EPSG:3857
Open up the UI and 2D Map
Draw a lineString or a Polygon in a query on the 2D map.
Observe that all latitude values end up being very small.  The shapes end up on the equator, and the values in the text boxes are very small

Repeating the steps with this PR shall resolve that issue.
For the sake of regression, confirm drawing these shapes in EPSG:4326 are still successful.  Attempt to zoom way out and draw shapes above and below the poles to verify not having these checks doesn't break anything.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3531](https://codice.atlassian.net/browse/DDF-3531)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/4419422/34596093-0a980662-f1ab-11e7-9311-64b919b88d93.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.

  