### PR TITLE
DDF-3534 MetacardIterator now correctly handles multivalued attributes

### DIFF
--- a/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/MetacardIterator.java
+++ b/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/MetacardIterator.java
@@ -29,6 +29,8 @@ import java.util.NoSuchElementException;
  * @see java.util.Iterator
  */
 class MetacardIterator implements Iterator<Serializable> {
+  private static final String MULTIVALUE_DELIMITER = "\n";
+
   private List<AttributeDescriptor> attributeDescriptorList;
 
   private Metacard metacard;
@@ -65,7 +67,19 @@ class MetacardIterator implements Iterator<Serializable> {
     index++;
 
     if (attribute != null) {
-      return attribute.getValue();
+      if (attributeDescriptor.isMultiValued()) {
+        StringBuilder valuesBuilder = new StringBuilder();
+        List<Serializable> values = attribute.getValues();
+        for (int i = 0; i < values.size(); i++) {
+          if (i > 0) {
+            valuesBuilder.append(MULTIVALUE_DELIMITER);
+          }
+          valuesBuilder.append(values.get(i));
+        }
+        return valuesBuilder.toString();
+      } else {
+        return attribute.getValue();
+      }
     }
 
     return "";

--- a/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/MetacardIterator.java
+++ b/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/MetacardIterator.java
@@ -69,7 +69,7 @@ class MetacardIterator implements Iterator<Serializable> {
 
     if (attribute != null) {
       if (attributeDescriptor.isMultiValued()) {
-        return StringUtils.join(attribute.getValues(), "\n");
+        return StringUtils.join(attribute.getValues(), MULTIVALUE_DELIMITER);
       } else {
         return attribute.getValue();
       }

--- a/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/MetacardIterator.java
+++ b/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/MetacardIterator.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * An implementation of java.util.Iterator which iterates over Metacard attribute values.
@@ -68,15 +69,7 @@ class MetacardIterator implements Iterator<Serializable> {
 
     if (attribute != null) {
       if (attributeDescriptor.isMultiValued()) {
-        StringBuilder valuesBuilder = new StringBuilder();
-        List<Serializable> values = attribute.getValues();
-        for (int i = 0; i < values.size(); i++) {
-          if (i > 0) {
-            valuesBuilder.append(MULTIVALUE_DELIMITER);
-          }
-          valuesBuilder.append(values.get(i));
-        }
-        return valuesBuilder.toString();
+        return StringUtils.join(attribute.getValues(), "\n");
       } else {
         return attribute.getValue();
       }

--- a/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/MetacardIteratorTest.java
+++ b/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/MetacardIteratorTest.java
@@ -81,7 +81,7 @@ public class MetacardIteratorTest {
     METACARD_DATA_MAP.clear();
 
     String attributeName = "multivalued";
-    List<Serializable> values = Arrays.asList("value1", "value2");
+    List<Serializable> values = Arrays.asList("value1", "value2", "value3");
     Attribute attribute = buildAttribute(attributeName, values);
     METACARD_DATA_MAP.put(attributeName, attribute);
     ATTRIBUTE_DESCRIPTOR_LIST.add(buildAttributeDescriptor(attributeName, true));
@@ -89,7 +89,7 @@ public class MetacardIteratorTest {
     Metacard metacard = buildMetacard();
     Iterator<Serializable> iterator = new MetacardIterator(metacard, ATTRIBUTE_DESCRIPTOR_LIST);
     assertThat(iterator.hasNext(), is(true));
-    assertThat(iterator.next(), is(valuesToString(values)));
+    assertThat(iterator.next(), is("value1\nvalue2\nvalue3"));
   }
 
   @Test(expected = NoSuchElementException.class)
@@ -137,16 +137,5 @@ public class MetacardIteratorTest {
     when(attribute.getValue()).thenReturn(values.get(0));
     when(attribute.getValues()).thenReturn(values);
     return attribute;
-  }
-
-  private String valuesToString(List<Serializable> values) {
-    StringBuilder valuesBuilder = new StringBuilder();
-    for (int i = 0; i < values.size(); i++) {
-      if (i > 0) {
-        valuesBuilder.append("\n");
-      }
-      valuesBuilder.append(values.get(i));
-    }
-    return valuesBuilder.toString();
   }
 }

--- a/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/MetacardIteratorTest.java
+++ b/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/MetacardIteratorTest.java
@@ -68,7 +68,6 @@ public class MetacardIteratorTest {
 
     for (int i = 0; i < ATTRIBUTE_DATA.length; i++) {
       assertThat(iterator.hasNext(), is(true));
-
       assertThat(iterator.next(), is(ATTRIBUTE_DATA[i][1]));
     }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug in the MetacardIterator where the `next()` method would only output the first value of multivalued attributes. This caused some values to be missing when search results were exported as CSV from the Table viewer in Intrigue.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@adimka @brianfelix @glenhein @dcruver @mackncheesiest @Variadicism @troymohl
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@millerw8 

#### How should this be tested? (List steps with links to updated documentation)
Manually ingest some data that has some multivalued attributes and export it as CSV in the Table viewer in Intrigue. Verify that all values are shown in the CSV.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3534](https://codice.atlassian.net/browse/DDF-3534)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
