### PR TITLE
[2.11.x] DDF-3449 Fixed deleting non-bottom Map Layers

### DIFF
--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
@@ -295,6 +295,9 @@ const providers = (state = List(), { type, path, value = emptyProvider(state.siz
 
       if (value === null) {
         return state.remove(index)
+          .map((layer, i) =>
+            layer.setIn(['layer', 'order'], i)
+              .update(updateBufferFromLayer))
       }
 
       const previousType = state.getIn([index, 'layer', 'type'])


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue where the map layers could not immediately be saved after deleting a layer.
#### Who is reviewing it? 
@djblue @peterhuffer 
#### Select relevant component teams:
@codice/ui 
#### Choose 2 committers to review/merge the PR.
@clockard
@millerw8
#### How should this be tested?
1. In the `Admin Console` -> `Catalog` -> `Map Layers` tab, add some map layers (the details don't need to be filled in to test this PR).
2. Run through some edge cases of deleting the top, bottom, and middle map layers. Also, confirm that moving layers up and down still works before and after deleting layers.
3. Confirm that
    - The order of the map layers is updated correctly in the json in the `Advanced Configuration`
    - There isn't an error message, like `Order should be between 0 and 2`, that blocks saving.
#### What are the relevant tickets?
[DDF-3449](https://codice.atlassian.net/browse/DDF-3449)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.