### PR TITLE
DDF-3376 Added migration decrypt command

### DIFF
--- a/distribution/docs/src/main/resources/content/_configuring/reusing-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/reusing-configurations.adoc
@@ -12,7 +12,9 @@ The Migration Export/Import capability allows administrators to export the curre
 To export the current configuration settings:
 
 . Run the command migration:export from the ${command-console}.
-. A file named `${branding-lowercase}-${project.version}.dar` will be created in the `exported` directory underneath `${home_directory}`. Copy this file to a secure location.
+. Files named `${branding-lowercase}-${project.version}.dar`, `${branding-lowercase}-${project.version}.dar.key`, and `${branding-lowercase}-${project.version}.dar.sha256` will be created in the `exported` directory underneath `${home_directory}`.
+The `.dar` file contains the encrypted information. The `.key` and `.sha256` files contains a validation checksum and the encryption key. Copy the '.dar' file to a secure location and copy the '.key' and '.sha256' to a different secure location.
+Keeping all 3 files together represents a security risk and should be avoided.
 
 To import previously exported configuration settings:
 
@@ -21,10 +23,18 @@ To import previously exported configuration settings:
 . Launch the newly installed ${branding}.
 . Step through the installation process.
 . Make sure to install and re-enable the ${branding} <<_starting_as_a_service_with_automatic_start_on_system_boot,service>> on the new system if it was installed and enabled on the original system
-. Copy the previously exported file from your secure location to the `exported` directory underneath `${home_directory}`. Create the directory if it does not exist.
+. Copy the previously exported files from your secure locations to the `exported` directory underneath `${home_directory}`. Create the directory if it does not exist.
 . Run the command migration:import from the ${command-console}.
 . ${branding} will automatically restart if the command is successful. Otherwise address any generated warnings before manually restarting ${branding}.
 . Finish <<_hardening_checklist,hardening>> the system (e.g. file and directory permissions).
+
+It is possible to decrypt the previously exported configuration settings but doing so is unsecure and appropriate measures should be taken to secure the resulting decrypted file.
+To decrypt the exported file:
+
+. Copy all 3 exported files (i.e. `.dar`, `.key`, and `.sha256`) to the `exported` directory underneath `${home_directory}`. Create the directory if it does not exist.
+. Run the command migration:decrypt from the ${command-console}.
+. A file named `${branding-lowercase}-${project.version}.zip` will be created in the `exported` directory underneath `${home_directory}`.
+This file represents the decrypted version of the `.dar` file.
 
 [IMPORTANT]
 ====

--- a/distribution/docs/src/main/resources/content/_configuring/reusing-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/reusing-configurations.adoc
@@ -13,7 +13,7 @@ To export the current configuration settings:
 
 . Run the command migration:export from the ${command-console}.
 . Files named `${branding-lowercase}-${project.version}.dar`, `${branding-lowercase}-${project.version}.dar.key`, and `${branding-lowercase}-${project.version}.dar.sha256` will be created in the `exported` directory underneath `${home_directory}`.
-The `.dar` file contains the encrypted information. The `.key` and `.sha256` files contains a validation checksum and the encryption key. Copy the '.dar' file to a secure location and copy the '.key' and '.sha256' to a different secure location.
+The `.dar` file contains the encrypted information. The `.key` and `.sha256` files contains the encryption key and a validation checksum. Copy the '.dar' file to a secure location and copy the '.key' and '.sha256' to a different secure location.
 Keeping all 3 files together represents a security risk and should be avoided.
 
 To import previously exported configuration settings:

--- a/distribution/docs/src/main/resources/content/_configuring/reusing-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/reusing-configurations.adoc
@@ -28,7 +28,7 @@ To import previously exported configuration settings:
 . ${branding} will automatically restart if the command is successful. Otherwise address any generated warnings before manually restarting ${branding}.
 . Finish <<_hardening_checklist,hardening>> the system (e.g. file and directory permissions).
 
-It is possible to decrypt the previously exported configuration settings but doing so is unsecure and appropriate measures should be taken to secure the resulting decrypted file.
+It is possible to decrypt the previously exported configuration settings but doing so is insecure and appropriate measures should be taken to secure the resulting decrypted file.
 To decrypt the exported file:
 
 . Copy all 3 exported files (i.e. `.dar`, `.key`, and `.sha256`) to the `exported` directory underneath `${home_directory}`. Create the directory if it does not exist.

--- a/platform/admin/core/admin-core-migration-commands/src/main/java/org/codice/ddf/migration/commands/DecryptCommand.java
+++ b/platform/admin/core/admin-core-migration-commands/src/main/java/org/codice/ddf/migration/commands/DecryptCommand.java
@@ -27,7 +27,7 @@ import org.osgi.service.event.EventAdmin;
   scope = MigrationCommand.NAMESPACE,
   name = "decrypt",
   description =
-      "Decrypts an exported file. Decrypting an exported file is unsecure and appropriate measures should be taken to secure the resulting decrypted file."
+      "Decrypts an exported file. Decrypting an exported file is insecure and appropriate measures should be taken to secure the resulting decrypted file."
 )
 public class DecryptCommand extends MigrationCommand {
 

--- a/platform/admin/core/admin-core-migration-commands/src/main/java/org/codice/ddf/migration/commands/DecryptCommand.java
+++ b/platform/admin/core/admin-core-migration-commands/src/main/java/org/codice/ddf/migration/commands/DecryptCommand.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.migration.commands;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.api.console.Session;
+import org.codice.ddf.configuration.migration.ConfigurationMigrationService;
+import org.codice.ddf.security.common.Security;
+import org.osgi.service.event.EventAdmin;
+
+/** Command class used to export the system configuration and data. */
+@Service
+@Command(
+  scope = MigrationCommand.NAMESPACE,
+  name = "decrypt",
+  description =
+      "Decrypts an exported file. Decrypting an exported file is unsecure and appropriate measures should be taken to secure the resulting decrypted file."
+)
+public class DecryptCommand extends MigrationCommand {
+
+  public DecryptCommand() {}
+
+  @VisibleForTesting
+  DecryptCommand(
+      ConfigurationMigrationService service,
+      Security security,
+      EventAdmin eventAdmin,
+      Session session) {
+    super(service, security, eventAdmin, session);
+  }
+
+  @Override
+  protected Object executeWithSubject() {
+    postSystemNotice("decrypt");
+    configurationMigrationService.doDecrypt(exportDirectory, this::outputMessage);
+    return null;
+  }
+}

--- a/platform/admin/core/admin-core-migration-commands/src/test/java/org/codice/ddf/migration/commands/DecryptCommandTest.java
+++ b/platform/admin/core/admin-core-migration-commands/src/test/java/org/codice/ddf/migration/commands/DecryptCommandTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.migration.commands;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class DecryptCommandTest extends AbstractMigrationCommandSupport {
+
+  @Before
+  public void setup() throws Exception {
+    initCommand(new DecryptCommand(service, security, eventAdmin, session));
+  }
+
+  @Test
+  public void testConstructor() throws Exception {
+    final DecryptCommand command = new DecryptCommand();
+
+    Assert.assertThat(
+        command.exportDirectory, Matchers.equalTo(ddfHome.resolve(MigrationCommand.EXPORTED)));
+  }
+
+  @Test
+  public void testExecuteWithSubject() throws Exception {
+    command.executeWithSubject();
+
+    Mockito.verify(service).doDecrypt(Mockito.eq(exportedPath), Mockito.notNull());
+    verifyPostedEvent("decrypt");
+  }
+}

--- a/platform/migration/platform-migratable-api/pom.xml
+++ b/platform/migration/platform-migratable-api/pom.xml
@@ -104,7 +104,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/platform/migration/platform-migratable-api/src/main/java/org/codice/ddf/migration/MigrationOperation.java
+++ b/platform/migration/platform-migratable-api/src/main/java/org/codice/ddf/migration/MigrationOperation.java
@@ -21,5 +21,6 @@ package org.codice.ddf.migration;
  */
 public enum MigrationOperation {
   EXPORT,
-  IMPORT;
+  IMPORT,
+  DECRYPT
 }

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManager.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManager.java
@@ -221,6 +221,18 @@ public class ConfigurationMigrationManager implements ConfigurationMigrationServ
     }
   }
 
+  @VisibleForTesting
+  MigrationZipFile newZipFileFor(Path exportFile) {
+    Validate.notNull(exportFile, "invalid null export file");
+    try {
+      return new MigrationZipFile(exportFile);
+    } catch (FileNotFoundException e) {
+      throw new MigrationException(Messages.IMPORT_FILE_MISSING_ERROR, exportFile, e);
+    } catch (SecurityException | IOException e) {
+      throw new MigrationException(Messages.IMPORT_FILE_OPEN_ERROR, exportFile, e);
+    }
+  }
+
   private MigrationReportImpl doExport(
       Path exportDirectory, Optional<Consumer<MigrationMessage>> consumer) {
     Validate.notNull(exportDirectory, ConfigurationMigrationManager.INVALID_NULL_EXPORT_DIR);
@@ -404,16 +416,5 @@ public class ConfigurationMigrationManager implements ConfigurationMigrationServ
       return true;
     }
     return false;
-  }
-
-  private static MigrationZipFile newZipFileFor(Path exportFile) {
-    Validate.notNull(exportFile, "invalid null export file");
-    try {
-      return new MigrationZipFile(exportFile);
-    } catch (FileNotFoundException e) {
-      throw new MigrationException(Messages.IMPORT_FILE_MISSING_ERROR, exportFile, e);
-    } catch (SecurityException | IOException e) {
-      throw new MigrationException(Messages.IMPORT_FILE_OPEN_ERROR, exportFile, e);
-    }
   }
 }

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManager.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManager.java
@@ -66,6 +66,8 @@ public class ConfigurationMigrationManager implements ConfigurationMigrationServ
 
   private static final String INVALID_NULL_EXPORT_DIR = "invalid null export directory";
 
+  private static final String INVALID_NULL_CONSUMER = "invalid null consumer";
+
   private final List<Migratable> migratables;
 
   private final SystemService system;
@@ -150,7 +152,7 @@ public class ConfigurationMigrationManager implements ConfigurationMigrationServ
 
   @Override
   public MigrationReport doExport(Path exportDirectory, Consumer<MigrationMessage> consumer) {
-    Validate.notNull(consumer, "invalid null consumer");
+    Validate.notNull(consumer, ConfigurationMigrationManager.INVALID_NULL_CONSUMER);
     // start the access control starting with this class' privileges; thus ignoring whoever called
     // us
     return AccessUtils.doPrivileged(() -> doExport(exportDirectory, Optional.ofNullable(consumer)));
@@ -165,7 +167,7 @@ public class ConfigurationMigrationManager implements ConfigurationMigrationServ
 
   @Override
   public MigrationReport doImport(Path exportDirectory, Consumer<MigrationMessage> consumer) {
-    Validate.notNull(consumer, "invalid null consumer");
+    Validate.notNull(consumer, ConfigurationMigrationManager.INVALID_NULL_CONSUMER);
     // start the access control starting with this class' privileges; thus ignoring whoever called
     // us
     return AccessUtils.doPrivileged(() -> doImport(exportDirectory, Optional.of(consumer)));
@@ -180,7 +182,7 @@ public class ConfigurationMigrationManager implements ConfigurationMigrationServ
 
   @Override
   public MigrationReport doDecrypt(Path exportDirectory, Consumer<MigrationMessage> consumer) {
-    Validate.notNull(consumer, "invalid null consumer");
+    Validate.notNull(consumer, ConfigurationMigrationManager.INVALID_NULL_CONSUMER);
     // start the access control starting with this class' privileges; thus ignoring whoever called
     // us
     return AccessUtils.doPrivileged(

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationService.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationService.java
@@ -75,4 +75,29 @@ public interface ConfigurationMigrationService {
    *     <code>null</code>
    */
   MigrationReport doImport(Path exportDirectory, Consumer<MigrationMessage> consumer);
+
+  /**
+   * Decrypts an exported file from the specified path.
+   *
+   * @param exportDirectory path to decrypt configurations from
+   * @return a migration report for the decrypt operation
+   * @throws IllegalArgumentException if <code>exportDirectory</code> is <code>null</code>
+   */
+  MigrationReport doDecrypt(Path exportDirectory);
+
+  /**
+   * Decrypts an exported file from the specified path.
+   *
+   * <p><i>Note:</i> This version of the <code>doDecrypt()</code> method will callback the provided
+   * consumer every time a migration message is recorded. The message will also be recorded with the
+   * report returned at the completion of the operation.
+   *
+   * @param exportDirectory path to decrypt configurations from
+   * @param consumer a consumer to call whenever a new migration message is recorded during the
+   *     operation
+   * @return a migration report for the decrypt operation
+   * @throws IllegalArgumentException if <code>exportDirectory</code> or <code>consumer</code> is
+   *     <code>null</code>
+   */
+  MigrationReport doDecrypt(Path exportDirectory, Consumer<MigrationMessage> consumer);
 }

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImpl.java
@@ -55,7 +55,7 @@ public class DecryptMigrationManagerImpl implements Closeable {
     try {
       return new ZipOutputStream(
           new BufferedOutputStream(new FileOutputStream(decryptFile.toFile())));
-    } catch (SecurityException | FileNotFoundException e) {
+    } catch (FileNotFoundException e) {
       throw new MigrationException(Messages.DECRYPT_FILE_CREATE_ERROR, decryptFile, e);
     }
   }
@@ -113,7 +113,7 @@ public class DecryptMigrationManagerImpl implements Closeable {
         ddfHome,
         exportFile,
         decryptFile);
-    zip.stream().forEach(this::decrypt);
+    zip.stream().forEach(this::copyToOutputZipFile);
   }
 
   @Override
@@ -138,7 +138,7 @@ public class DecryptMigrationManagerImpl implements Closeable {
   }
 
   @VisibleForTesting
-  void decrypt(ZipEntry entry) {
+  void copyToOutputZipFile(ZipEntry entry) {
     InputStream is = null;
 
     try {

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImpl.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.migration;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.Validate;
+import org.codice.ddf.migration.MigrationException;
+import org.codice.ddf.migration.MigrationOperation;
+import org.codice.ddf.migration.MigrationReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** The decrypt migration manager decrypts an exported file. */
+public class DecryptMigrationManagerImpl implements Closeable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DecryptMigrationManagerImpl.class);
+
+  private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+  @SuppressWarnings(
+      "squid:S2095" /* up to the caller of this method to close it; exception is thrown if the stream cannot be created in the first place */)
+  private static ZipOutputStream newZipOutputStreamFor(Path decryptFile) {
+    Validate.notNull(decryptFile, "invalid null decrypt file");
+    try {
+      return new ZipOutputStream(
+          new BufferedOutputStream(new FileOutputStream(decryptFile.toFile())));
+    } catch (SecurityException | FileNotFoundException e) {
+      throw new MigrationException(Messages.DECRYPT_FILE_CREATE_ERROR, decryptFile, e);
+    }
+  }
+
+  private final MigrationReport report;
+
+  private final MigrationZipFile zip;
+
+  private final ZipOutputStream zipOutputStream;
+
+  private final Path exportFile;
+
+  private final Path decryptFile;
+
+  private final boolean close = false;
+
+  /**
+   * Creates a new migration manager for a decrypt operation.
+   *
+   * @param report the migration report where warnings and errors can be recorded
+   * @param zip the exported zip file
+   * @param decryptFile the file where to decrypt the exorted zip
+   * @throws MigrationException if a failure occurs while processing the zip file (the error will
+   *     not be recorded with the report)
+   * @throws IllegalArgumentException if <code>report</code> is <code>null</code> or if it is not
+   *     for a decrypt migration operation or if <code>zip</code> or <code>decryptFile</code> is
+   *     <code>null</code>
+   */
+  public DecryptMigrationManagerImpl(
+      MigrationReport report, MigrationZipFile zip, Path decryptFile) {
+    this(report, zip, decryptFile, DecryptMigrationManagerImpl.newZipOutputStreamFor(decryptFile));
+  }
+
+  @VisibleForTesting
+  DecryptMigrationManagerImpl(
+      MigrationReport report, MigrationZipFile zip, Path decryptFile, ZipOutputStream zos) {
+    Validate.notNull(report, "invalid null report");
+    Validate.notNull(zip, "invalid null zip file");
+    Validate.notNull(decryptFile, "invalid decrypt file");
+    Validate.isTrue(
+        report.getOperation() == MigrationOperation.DECRYPT, "invalid migration operation");
+    this.report = report;
+    this.exportFile = zip.getZipPath();
+    this.zip = zip;
+    this.decryptFile = decryptFile;
+    this.zipOutputStream = zos;
+  }
+
+  /**
+   * Proceeds with the decryp operation.
+   *
+   * @param productBranding the product branding being decrypted
+   * @param productVersion the product version being decrypted
+   * @throws IllegalArgumentException if <code>productBranding</code> or </code><code>productVersion
+   *     </code> is <code>null</code>
+   * @throws MigrationException to stop the decrypt operation
+   */
+  public void doDecrypt(String productBranding, String productVersion) {
+    Validate.notNull(productBranding, "invalid null product branding");
+    Validate.notNull(productVersion, "invalid null product version");
+    final String ddfHome = System.getProperty("ddf.home");
+
+    LOGGER.debug(
+        "Decrypting {} product [{}] under [{}] from [{}] to [{}]...",
+        productBranding,
+        productVersion,
+        ddfHome,
+        exportFile,
+        decryptFile);
+    zip.stream().forEach(this::decrypt);
+  }
+
+  @Override
+  public void close() throws IOException {
+    IOUtils.closeQuietly(zip); // we don't care if we cannot close the input zip file or not
+    zipOutputStream.close();
+  }
+
+  public MigrationReport getReport() {
+    return report;
+  }
+
+  public Path getExportFile() {
+    return exportFile;
+  }
+
+  public Path getDecryptedFile() {
+    return decryptFile;
+  }
+
+  @VisibleForTesting
+  void decrypt(ZipEntry entry) {
+    InputStream is = null;
+
+    try {
+      final ZipEntry ze = new ZipEntry(entry.getName());
+
+      ze.setTime(entry.getTime());
+      zipOutputStream.putNextEntry(ze);
+      if (!entry.isDirectory()) {
+        is = zip.getInputStream(entry);
+        IOUtils.copy(is, zipOutputStream);
+      }
+    } catch (IOException e) {
+      getReport().record(new MigrationException(Messages.DECRYPT_PATH_ERROR, entry.getName(), e));
+    } finally {
+      IOUtils.closeQuietly(is); // we do not care about failing to close this stream
+    }
+  }
+}

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ExportMigrationManagerImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ExportMigrationManagerImpl.java
@@ -62,7 +62,7 @@ public class ExportMigrationManagerImpl implements Closeable {
 
   private final Path exportFile;
 
-  private CipherUtils cipherUtils;
+  private final CipherUtils cipherUtils;
 
   private boolean closed = false;
 
@@ -91,6 +91,7 @@ public class ExportMigrationManagerImpl implements Closeable {
         ExportMigrationManagerImpl.newZipOutputStreamFor(exportFile));
   }
 
+  @VisibleForTesting
   ExportMigrationManagerImpl(
       MigrationReport report,
       Path exportFile,

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ExportMigrationManagerImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ExportMigrationManagerImpl.java
@@ -126,7 +126,7 @@ public class ExportMigrationManagerImpl implements Closeable {
     try {
       return new ZipOutputStream(
           new BufferedOutputStream(new FileOutputStream(exportFile.toFile())));
-    } catch (SecurityException | FileNotFoundException e) {
+    } catch (FileNotFoundException e) {
       throw new MigrationException(Messages.EXPORT_FILE_CREATE_ERROR, exportFile, e);
     }
   }

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ImportMigrationManagerImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ImportMigrationManagerImpl.java
@@ -119,7 +119,7 @@ public class ImportMigrationManagerImpl implements Closeable {
       // process migratables' metadata
       JsonUtils.getMapFrom(metadata, MigrationContextImpl.METADATA_MIGRATABLES)
           .forEach((id, o) -> getContextFor(id).processMetadata(JsonUtils.convertToMap(o)));
-    } catch (SecurityException | IOException e) {
+    } catch (IOException e) {
       IOUtils.closeQuietly(zip);
       throw new MigrationException(Messages.IMPORT_FILE_READ_ERROR, exportFile, e);
     } catch (RuntimeException e) {

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ImportMigrationManagerImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ImportMigrationManagerImpl.java
@@ -68,8 +68,8 @@ public class ImportMigrationManagerImpl implements Closeable {
    * @throws MigrationException if a failure occurs while processing the zip file (the error will
    *     not be recorded with the report)
    * @throws IllegalArgumentException if <code>report</code> is <code>null</code> or if it is not
-   *     for an import migration operation or if <code>exportFile</code> or <code>migratables</code>
-   *     is <code>null</code>
+   *     for an import migration operation or if <code>zip</code> or <code>migratables</code> is
+   *     <code>null</code>
    */
   public ImportMigrationManagerImpl(
       MigrationReport report, MigrationZipFile zip, Stream<? extends Migratable> migratables) {

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/Messages.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/Messages.java
@@ -26,11 +26,16 @@ public final class Messages {
 
   public static final String IMPORT_FAILURE = "Failed to import from file [%s].";
 
+  public static final String DECRYPT_FAILURE = "Failed to decrypt file [%s].";
+
   public static final String EXPORT_SUCCESS_WITH_WARNINGS =
       "Successfully exported to file [%s] with warnings; make sure to review.";
 
   public static final String IMPORT_SUCCESS_WITH_WARNINGS =
       "Successfully imported from file [%s] with warnings; make sure to review.";
+
+  public static final String DECRYPT_SUCCESS_WITH_WARNINGS =
+      "Successfully decrypted file [%s] to [%s] with warnings; make sure to review.";
 
   public static final String RESTART_SYSTEM_WHEN_WARNINGS =
       "Please restart the system for changes to take effect after addressing all reported warnings.";
@@ -38,6 +43,8 @@ public final class Messages {
   public static final String EXPORT_SUCCESS = "Successfully exported to file [%s].";
 
   public static final String IMPORT_SUCCESS = "Successfully imported from file [%s].";
+
+  public static final String DECRYPT_SUCCESS = "Successfully decrypted file [%s] to [%s].";
 
   public static final String RESTARTING_SYSTEM =
       "Restarting the system for changes to take effect.";
@@ -51,6 +58,9 @@ public final class Messages {
   public static final String EXPORT_FILE_CLOSE_ERROR =
       "Export error: failed to close export file [%s]; %s.";
 
+  public static final String DECRYPT_FILE_CLOSE_ERROR =
+      "Decrypt error: failed to close decrypted file [%s]; %s.";
+
   public static final String IMPORT_FILE_MISSING_ERROR =
       "Import error: missing export file [%s]; %s.";
 
@@ -59,6 +69,9 @@ public final class Messages {
 
   public static final String EXPORT_FILE_CREATE_ERROR =
       "Export error: failed to create export file [%s]; %s.";
+
+  public static final String DECRYPT_FILE_CREATE_ERROR =
+      "Decrypt error: failed to create decrypted file [%s]; %s.";
 
   public static final String IMPORT_FILE_READ_ERROR =
       "Import error: failed to read export file [%s]; %s.";
@@ -78,21 +91,8 @@ public final class Messages {
   public static final String IMPORT_ZIP_CHECKSUM_INVALID =
       "Import error: incorrect checksum for export file [%s].";
 
-  public static final String IMPORT_KEY_OPEN_ERROR = "Import error: failed to open key file [%s].";
-
-  public static final String IMPORT_KEY_DECODE_ERROR =
-      "Import error: could not decode key file [%s].";
-
-  public static final String IMPORT_KEY_INVALID_ERROR =
-      "Import error: invalid key file used for import [%s].";
-
-  public static final String EXPORT_KEY_INVALID_ERROR = "Export error: invalid key used for export";
-
-  public static final String EXPORT_KEY_IO_ERROR =
-      "Export error: failed to write decryption key file [%s].";
-
-  public static final String IMPORT_ENTRY_READ_ERROR =
-      "Import error: unable to read entry from zip";
+  public static final String DECRYPT_ZIP_CHECKSUM_INVALID =
+      "Decrypt error: incorrect checksum for export file [%s].";
 
   public static final String EXPORT_METADATA_CREATE_ERROR =
       "Export error: failed to create metadata; %s.";
@@ -107,15 +107,23 @@ public final class Messages {
   public static final String IMPORT_INTERNAL_ERROR =
       "Unexpected internal error: failed to import from file [%s]; %s.";
 
+  public static final String DECRYPT_INTERNAL_ERROR =
+      "Unexpected internal error: failed to decrypt file [%s]; %s.";
+
   public static final String EXPORT_SECURITY_ERROR =
       "Export security error: failed to export to file [%s]; %s.";
 
   public static final String IMPORT_SECURITY_ERROR =
       "Import security error: failed to import from file [%s]; %s.";
 
+  public static final String DECRYPT_SECURITY_ERROR =
+      "Decrypt security error: failed to decrypt file [%s]; %s.";
+
   public static final String EXPORTING_DATA = "Exporting %s data to file [%s].";
 
   public static final String IMPORTING_DATA = "Importing %s data from file [%s].";
+
+  public static final String DECRYPTING_DATA = "Decrypting %s data from file [%s] to [%s].";
 
   public static final String EXPORT_SYSTEM_PROPERTY_ERROR =
       "Export error: system property [%s] is set to [%s] that %s; %s.";
@@ -179,6 +187,9 @@ public final class Messages {
   public static final String EXPORT_PATH_ERROR = "Export error: path [%s] %s; %s.";
 
   public static final String IMPORT_PATH_ERROR = "Import error: path [%s] %s.";
+
+  public static final String DECRYPT_PATH_ERROR =
+      "Decrypt error: path [%s] could not be decrypted; %s.";
 
   public static final String IMPORT_PATH_NOT_EXPORTED_ERROR =
       "Import error: path [%s] was not exported.";

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/MigrationReportImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/MigrationReportImpl.java
@@ -108,7 +108,8 @@ public class MigrationReportImpl implements MigrationReport {
     } else {
       level = "message";
     }
-    LOGGER.debug("migration {}: {}", level, msg);
+    // second 'msg' is used to log the stack trace in case msg is an exception
+    LOGGER.debug("migration {}: {}", level, msg, msg);
     messages.add(msg);
     consumer.ifPresent(c -> c.accept(msg));
     return this;

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/AbstractMigrationSupport.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/AbstractMigrationSupport.java
@@ -149,7 +149,7 @@ public class AbstractMigrationSupport {
 
         if (ze == null) {
           return entries;
-        } else if (!ze.isDirectory()) {
+        } else {
           entries.put(ze.getName(), new MigrationZipEntry(ze, IOUtils.toByteArray(zin)));
         }
       }

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImplTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImplTest.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.configuration.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.base.Charsets;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import org.codice.ddf.migration.MigrationException;
+import org.codice.ddf.migration.MigrationOperation;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.StringDescription;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mockito;
+
+public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupport {
+
+  private static final String NAME = "name";
+
+  private static final String CONTENT = "content";
+
+  private Path exportFile;
+
+  private Path decryptFile;
+
+  private DecryptMigrationManagerImpl mgr;
+
+  private final MigrationZipFile zip = Mockito.mock(MigrationZipFile.class);
+
+  public DecryptMigrationManagerImplTest() {
+    super(MigrationOperation.DECRYPT);
+  }
+
+  @Before
+  public void setup() throws Exception {
+    final Path exportedDir = ddfHome.resolve(createDirectory("exported"));
+
+    exportFile = exportedDir.resolve("exported.dar");
+    decryptFile = exportedDir.resolve("exported.zip");
+
+    Mockito.when(zip.getZipPath()).thenReturn(exportFile);
+    Mockito.when(zip.getChecksumPath())
+        .thenReturn(MigrationZipConstants.getDefaultChecksumPathFor(exportFile));
+    Mockito.when(zip.getKeyPath())
+        .thenReturn(MigrationZipConstants.getDefaultKeyPathFor(exportFile));
+
+    mgr =
+        Mockito.mock(
+            DecryptMigrationManagerImpl.class,
+            Mockito.withSettings()
+                .useConstructor(report, zip, decryptFile)
+                .defaultAnswer(Mockito.CALLS_REAL_METHODS));
+  }
+
+  private MigrationZipEntry getMetadataZipEntry(
+      Optional<String> version, Optional<String> productBranding, Optional<String> productVersion)
+      throws IOException {
+    final MigrationZipEntry ze = Mockito.mock(MigrationZipEntry.class);
+
+    Mockito.when(ze.getName()).thenReturn(MigrationContextImpl.METADATA_FILENAME.toString());
+    Mockito.when(ze.isDirectory()).thenReturn(false);
+    // use answer to ensure we create a new stream each time if called multiple times
+    Mockito.doAnswer(
+            AdditionalAnswers.answer(
+                zea -> new ByteArrayInputStream("test".getBytes(Charsets.UTF_8))))
+        .when(zip)
+        .getInputStream(ze);
+    return ze;
+  }
+
+  @Test
+  public void testConstructor() throws Exception {
+    Assert.assertThat(mgr.getReport(), Matchers.sameInstance(report));
+    Assert.assertThat(mgr.getExportFile(), Matchers.sameInstance(exportFile));
+    Assert.assertThat(mgr.getDecryptedFile(), Matchers.sameInstance(decryptFile));
+  }
+
+  @Test
+  public void testConstructorWithNullReport() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(Matchers.containsString("null report"));
+
+    new DecryptMigrationManagerImpl(null, zip, decryptFile);
+  }
+
+  @Test
+  public void testConstructorWithInvalidReport() throws Exception {
+    final MigrationReportImpl report =
+        new MigrationReportImpl(MigrationOperation.EXPORT, Optional.empty());
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(Matchers.containsString("invalid migration operation"));
+
+    new DecryptMigrationManagerImpl(report, zip, decryptFile);
+  }
+
+  @Test
+  public void testConstructorWithNullExportFile() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(Matchers.containsString("null zip file"));
+
+    new DecryptMigrationManagerImpl(report, null, decryptFile);
+  }
+
+  @Test
+  public void testConstructorWithNullDecryptFile() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(Matchers.containsString("null decrypt file"));
+
+    new DecryptMigrationManagerImpl(report, zip, null);
+  }
+
+  @Test
+  public void testDoDecrypt() throws Exception {
+    final ZipEntry ze = new ZipEntry("1");
+    final ZipEntry ze2 = new ZipEntry("2");
+    final ZipEntry ze3 = new ZipEntry("3");
+
+    Mockito.doReturn(Stream.of(ze, ze2, ze3)).when(zip).stream();
+    Mockito.doNothing().when(mgr).decrypt(Mockito.notNull());
+
+    mgr.doDecrypt(PRODUCT_BRANDING, PRODUCT_VERSION);
+
+    Mockito.verify(mgr).doDecrypt(PRODUCT_BRANDING, PRODUCT_VERSION);
+    Mockito.verify(mgr).decrypt(ze);
+    Mockito.verify(mgr).decrypt(ze2);
+    Mockito.verify(mgr).decrypt(ze3);
+
+    Mockito.verifyNoMoreInteractions(mgr);
+  }
+
+  @Test
+  public void testDecrypt() throws Exception {
+    final ZipEntry ze = Mockito.mock(ZipEntry.class);
+
+    Mockito.doReturn(NAME).when(ze).getName();
+    Mockito.doReturn(false).when(ze).isDirectory();
+    Mockito.doReturn(new ByteArrayInputStream(CONTENT.getBytes(Charset.defaultCharset())))
+        .when(zip)
+        .getInputStream(ze);
+
+    mgr.decrypt(ze);
+    mgr.close();
+
+    Mockito.verify(zip).getInputStream(ze);
+
+    final Map<String, MigrationZipEntry> entries =
+        AbstractMigrationSupport.getEntriesFrom(decryptFile);
+
+    Assert.assertThat(entries, Matchers.aMapWithSize(1));
+    Assert.assertThat(entries, Matchers.hasKey(NAME));
+    final MigrationZipEntry entry = entries.get(NAME);
+
+    Assert.assertThat(entry.isDirectory(), Matchers.equalTo(false));
+    Assert.assertThat(entry.getContentAsString(), Matchers.equalTo(CONTENT));
+  }
+
+  @Test
+  public void testDecryptWithDirectoryEntry() throws Exception {
+    // a directory entry in a zip ends with / no matter the OS
+    final String name = NAME + "/";
+    final ZipEntry ze = Mockito.mock(ZipEntry.class);
+
+    Mockito.doReturn(name).when(ze).getName();
+    Mockito.doReturn(true).when(ze).isDirectory();
+
+    mgr.decrypt(ze);
+    mgr.close();
+
+    Mockito.verify(zip, Mockito.never()).getInputStream(ze);
+
+    final Map<String, MigrationZipEntry> entries =
+        AbstractMigrationSupport.getEntriesFrom(decryptFile);
+
+    Assert.assertThat(entries, Matchers.aMapWithSize(1));
+    Assert.assertThat(entries, Matchers.hasKey(name));
+    final MigrationZipEntry entry = entries.get(name);
+
+    Assert.assertThat(entry.isDirectory(), Matchers.equalTo(true));
+    Assert.assertThat(entry.getContent().length, Matchers.equalTo(0));
+  }
+
+  @Test
+  public void testDecryptWithIOException() throws Exception {
+    final IOException e = new IOException("testing");
+    final ZipEntry ze = Mockito.mock(ZipEntry.class);
+
+    Mockito.doReturn(NAME).when(ze).getName();
+    Mockito.doReturn(false).when(ze).isDirectory();
+    Mockito.doThrow(e).when(zip).getInputStream(ze);
+
+    mgr.decrypt(ze);
+    mgr.close();
+
+    reportHasErrorMessage(Matchers.containsString("path [" + NAME + "] could not be decrypted"));
+  }
+
+  private void reportHasErrorMessage(Matcher<String> matcher) {
+    final List<MigrationException> es = report.errors().collect(Collectors.toList());
+    final long count = es.stream().filter((e) -> matcher.matches(e.getMessage())).count();
+    final Description d = new StringDescription();
+
+    matcher.describeTo(d);
+
+    assertThat(
+        "There are "
+            + count
+            + " matching error(s) with "
+            + d
+            + " in the migration report.\nErrors are: "
+            + es.stream()
+                .map(MigrationException::getMessage)
+                .collect(Collectors.joining("\",\n\t\"", "[\n\t\"", "\"\n]")),
+        count,
+        equalTo(1L));
+  }
+}

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImplTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImplTest.java
@@ -125,20 +125,20 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
     final ZipEntry ze3 = new ZipEntry("3");
 
     Mockito.doReturn(Stream.of(ze, ze2, ze3)).when(zip).stream();
-    Mockito.doNothing().when(mgr).decrypt(Mockito.notNull());
+    Mockito.doNothing().when(mgr).copyToOutputZipFile(Mockito.notNull());
 
     mgr.doDecrypt(PRODUCT_BRANDING, PRODUCT_VERSION);
 
     Mockito.verify(mgr).doDecrypt(PRODUCT_BRANDING, PRODUCT_VERSION);
-    Mockito.verify(mgr).decrypt(ze);
-    Mockito.verify(mgr).decrypt(ze2);
-    Mockito.verify(mgr).decrypt(ze3);
+    Mockito.verify(mgr).copyToOutputZipFile(ze);
+    Mockito.verify(mgr).copyToOutputZipFile(ze2);
+    Mockito.verify(mgr).copyToOutputZipFile(ze3);
 
     Mockito.verifyNoMoreInteractions(mgr);
   }
 
   @Test
-  public void testDecrypt() throws Exception {
+  public void testCopyToOutputZipFile() throws Exception {
     final ZipEntry ze = Mockito.mock(ZipEntry.class);
 
     Mockito.doReturn(NAME).when(ze).getName();
@@ -147,7 +147,7 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
         .when(zip)
         .getInputStream(ze);
 
-    mgr.decrypt(ze);
+    mgr.copyToOutputZipFile(ze);
     mgr.close();
 
     Mockito.verify(zip).getInputStream(ze);
@@ -164,7 +164,7 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
   }
 
   @Test
-  public void testDecryptWithDirectoryEntry() throws Exception {
+  public void testCopyToOutputZipFileWithDirectoryEntry() throws Exception {
     // a directory entry in a zip ends with / no matter the OS
     final String name = NAME + "/";
     final ZipEntry ze = Mockito.mock(ZipEntry.class);
@@ -172,7 +172,7 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
     Mockito.doReturn(name).when(ze).getName();
     Mockito.doReturn(true).when(ze).isDirectory();
 
-    mgr.decrypt(ze);
+    mgr.copyToOutputZipFile(ze);
     mgr.close();
 
     Mockito.verify(zip, Mockito.never()).getInputStream(ze);
@@ -189,7 +189,7 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
   }
 
   @Test
-  public void testDecryptWithIOException() throws Exception {
+  public void testCopyToOutputZipFileWithIOException() throws Exception {
     final IOException e = new IOException("testing");
     final ZipEntry ze = Mockito.mock(ZipEntry.class);
 
@@ -197,7 +197,7 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
     Mockito.doReturn(false).when(ze).isDirectory();
     Mockito.doThrow(e).when(zip).getInputStream(ze);
 
-    mgr.decrypt(ze);
+    mgr.copyToOutputZipFile(ze);
     mgr.close();
 
     reportHasErrorMessage(Matchers.containsString("path [" + NAME + "] could not be decrypted"));

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImplTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/DecryptMigrationManagerImplTest.java
@@ -16,7 +16,6 @@ package org.codice.ddf.configuration.migration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.google.common.base.Charsets;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -36,7 +35,6 @@ import org.hamcrest.StringDescription;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
 
 public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupport {
@@ -76,22 +74,6 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
             Mockito.withSettings()
                 .useConstructor(report, zip, decryptFile)
                 .defaultAnswer(Mockito.CALLS_REAL_METHODS));
-  }
-
-  private MigrationZipEntry getMetadataZipEntry(
-      Optional<String> version, Optional<String> productBranding, Optional<String> productVersion)
-      throws IOException {
-    final MigrationZipEntry ze = Mockito.mock(MigrationZipEntry.class);
-
-    Mockito.when(ze.getName()).thenReturn(MigrationContextImpl.METADATA_FILENAME.toString());
-    Mockito.when(ze.isDirectory()).thenReturn(false);
-    // use answer to ensure we create a new stream each time if called multiple times
-    Mockito.doAnswer(
-            AdditionalAnswers.answer(
-                zea -> new ByteArrayInputStream("test".getBytes(Charsets.UTF_8))))
-        .when(zip)
-        .getInputStream(ze);
-    return ze;
   }
 
   @Test
@@ -177,8 +159,8 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
     Assert.assertThat(entries, Matchers.hasKey(NAME));
     final MigrationZipEntry entry = entries.get(NAME);
 
-    Assert.assertThat(entry.isDirectory(), Matchers.equalTo(false));
-    Assert.assertThat(entry.getContentAsString(), Matchers.equalTo(CONTENT));
+    Assert.assertThat(entry.isDirectory(), equalTo(false));
+    Assert.assertThat(entry.getContentAsString(), equalTo(CONTENT));
   }
 
   @Test
@@ -202,8 +184,8 @@ public class DecryptMigrationManagerImplTest extends AbstractMigrationReportSupp
     Assert.assertThat(entries, Matchers.hasKey(name));
     final MigrationZipEntry entry = entries.get(name);
 
-    Assert.assertThat(entry.isDirectory(), Matchers.equalTo(true));
-    Assert.assertThat(entry.getContent().length, Matchers.equalTo(0));
+    Assert.assertThat(entry.isDirectory(), equalTo(true));
+    Assert.assertThat(entry.getContent().length, equalTo(0));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Provides a decrypt command for the exported migration file.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@tbatie 
@emanns95 
@oconnormi 
@Lambeaux 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
@figliold
@lessarderic
@millerw8
@ricklarsen - Documentation
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Execute a migrate:export from the command line and then execute migrate:decrypt, A .zip file should be generated and contain all exported decrypted files.

#### Any background context you want to provide?
Now that we are encrypting the exported file, it is now much harder to troubleshoot or debug enhancements to the migration framework. The new migrate:decrypt command  can be used to peek at the content of an exported file.

#### What are the relevant tickets?
[DDF-3376](https://codice.atlassian.net/browse/DDF-3376)

#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
