### PR TITLE
DDF-3539 Added to the wait in SortedQueryMonitorTest's interruptThirdFuture

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SortedQueryMonitorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SortedQueryMonitorTest.java
@@ -219,7 +219,8 @@ public class SortedQueryMonitorTest {
 
     with()
         .await()
-        .atMost(200, TimeUnit.MILLISECONDS)
+        .atMost(5, TimeUnit.MINUTES) // It won't wait 5 minutes
+        .pollInterval(1, TimeUnit.MILLISECONDS)
         .until(
             () -> {
               queryMonitor.run();


### PR DESCRIPTION
#### What does this PR do?
Increased the atMost wait time and added pollInterval in `SortedQueryMonitorTest`'s `interruptThirdFuture` test

#### Who is reviewing it? 
@mackncheesiest @LinkMJB 

#### Choose 2 committers to review/merge the PR. 
@coyotesqrl
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Full build. Make sure test doesn't fail when run repeatedly (use run until failure on IntelliJ).

#### What are the relevant tickets?
[DDF-3539](https://codice.atlassian.net/browse/DDF-3539)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
