### PR TITLE
DDF-3529 Fix UI session timeout redirect

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.js
@@ -22,7 +22,7 @@ var invalidateUrl = '/services/internal/session/invalidate?prevurl=';
 var idleNoticeDuration = 60000;
 // Length of inactivity that will trigger user timeout (15 minutes in ms by default)
 // See STIG V-69243
-var idleTimeoutThreshold = parseInt(properties.ui.timeout) > 0 ? parseInt(properties.ui.timeout) : 900000;
+var idleTimeoutThreshold = parseInt(properties.timeout) > 0 ? parseInt(properties.timeout) : 900000;
 
 function getIdleTimeoutDate() {
     return idleTimeoutThreshold + Date.now();
@@ -53,7 +53,9 @@ var sessionTimeoutModel = new (Backbone.Model.extend({
         }
     },
     setPromptTimer: function () {
-        this.promptTimer = setTimeout(this.showPrompt.bind(this), this.get('idleTimeoutDate') - idleNoticeDuration - Date.now());
+        var timeout = this.get('idleTimeoutDate') - idleNoticeDuration - Date.now();
+        timeout = Math.max(0, timeout);
+        this.promptTimer = setTimeout(this.showPrompt.bind(this), timeout);
     },
     showPrompt: function () {
         this.set('showPrompt', true);
@@ -65,7 +67,9 @@ var sessionTimeoutModel = new (Backbone.Model.extend({
         clearTimeout(this.promptTimer);
     },
     setLogoutTimer: function () {
-        this.logoutTimer = setTimeout(this.logout.bind(this), this.get('idleTimeoutDate') - Date.now());
+        var timeout = this.get('idleTimeoutDate') - Date.now();
+        timeout = Math.max(0, timeout);
+        this.logoutTimer = setTimeout(this.logout.bind(this), timeout);
     },
     clearLogoutTimer: function () {
         clearTimeout(this.logoutTimer);
@@ -80,6 +84,9 @@ var sessionTimeoutModel = new (Backbone.Model.extend({
         $(document).off('keydown.sessionTimeout mousedown.sessionTimeout mousemove.sessionTimeout');
     },
     logout: function () {
+        if (window.onbeforeunload != null) {
+          window.onbeforeunload = null;
+        }
         window.location.replace(invalidateUrl + window.location.pathname);
     },
     renew: function () {

--- a/distribution/docs/src/main/resources/content/_configuring/environment-hardening.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/environment-hardening.adoc
@@ -13,6 +13,10 @@
 It is recommended to apply the following security mitigations to the ${branding}.
 ====
 
+===== Known Issues with Environment Hardening
+The session timeout should be configured longer than the UI polling time or you may get session
+timeout errors in the UI.
+
 
 [cols="1,3,6",options="header]
 |===

--- a/platform/security/servlet/security-servlet-session-expiry/src/main/java/org/codice/ddf/security/servlet/expiry/SessionManagementService.java
+++ b/platform/security/servlet/security-servlet-session-expiry/src/main/java/org/codice/ddf/security/servlet/expiry/SessionManagementService.java
@@ -126,7 +126,7 @@ public class SessionManagementService {
   public Response getInvalidate(@Context HttpServletRequest request) {
     StringBuffer requestURL = request.getRequestURL();
     String requestQueryString = request.getQueryString();
-    return Response.temporaryRedirect(
+    return Response.seeOther(
             URI.create(
                 requestURL
                     .substring(0, requestURL.indexOf(rootContext))

--- a/platform/security/servlet/security-servlet-session-expiry/src/test/java/org/codice/ddf/security/servlet/expiry/SessionManagementServiceTest.java
+++ b/platform/security/servlet/security-servlet-session-expiry/src/test/java/org/codice/ddf/security/servlet/expiry/SessionManagementServiceTest.java
@@ -157,7 +157,7 @@ public class SessionManagementServiceTest {
             new StringBuffer("https://localhost:8993/services/internal/session/invalidate"));
     when(request.getQueryString()).thenReturn(null);
     Response invalidate = sessionManagementService.getInvalidate(request);
-    assertThat(invalidate.getStatus(), is(307));
+    assertThat(invalidate.getStatus(), is(303));
     assertThat(
         invalidate.getLocation(),
         is(equalTo(URI.create("https://localhost:8993/logout?noPrompt=true"))));
@@ -171,7 +171,7 @@ public class SessionManagementServiceTest {
                 "https://localhost:8993/services/internal/session/invalidate?prevurl=/admin/"));
     when(request.getQueryString()).thenReturn("prevurl=/admin/");
     Response invalidate = sessionManagementService.getInvalidate(request);
-    assertThat(invalidate.getStatus(), is(307));
+    assertThat(invalidate.getStatus(), is(303));
     assertThat(
         invalidate.getLocation(),
         is(equalTo(URI.create("https://localhost:8993/logout?noPrompt=true&prevurl=/admin/"))));


### PR DESCRIPTION
#### What does this PR do?
Fixes the session timeout redirect in the UI.
Changes the UI to respect the timeout specified.
Changes the redirect type (HTTP 303 instead of 307). 
Fixes the UI such that non-saved workspaces don't prevent the redirect. 

#### Who is reviewing it? 
@brendan-hofmann 
@adimka 
@brjeter 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)
Full build with tests.
1. Install DDF
2. Update the catalog timeout to 120000 (or something reasonable for testing) in 
3. Navigate to /search/catalog
4. Create a new workspace or edit existing workspace. Wait for the time configured in step 2.
5. Verify that the redirect to logout occurs after that time.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3529](https://codice.atlassian.net/browse/DDF-3529)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
