### PR TITLE
DDF-3544 Renamed QUALIFIER constant in ddf.catalog.content.data.ContentItem to fix code smell

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/data/ContentItem.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/content/data/ContentItem.java
@@ -38,7 +38,7 @@ public interface ContentItem {
 
   String DEFAULT_FILE_NAME = "content_store_file.bin";
 
-  String QUALIFIER = "qualifier";
+  String QUALIFIER_KEYWORD = "qualifier";
 
   /**
    * Return the globally unique ID for the content item.

--- a/catalog/core/catalog-core-contentresourcereader/src/main/java/org/codice/ddf/catalog/content/resource/reader/ContentResourceReader.java
+++ b/catalog/core/catalog-core-contentresourcereader/src/main/java/org/codice/ddf/catalog/content/resource/reader/ContentResourceReader.java
@@ -157,14 +157,14 @@ public class ContentResourceReader implements ResourceReader {
       String contentId = resourceUri.getSchemeSpecificPart();
       if (contentId != null && !contentId.isEmpty()) {
         if (arguments != null
-            && arguments.get(ContentItem.QUALIFIER) instanceof String
-            && StringUtils.isNotBlank((String) arguments.get(ContentItem.QUALIFIER))) {
+            && arguments.get(ContentItem.QUALIFIER_KEYWORD) instanceof String
+            && StringUtils.isNotBlank((String) arguments.get(ContentItem.QUALIFIER_KEYWORD))) {
           try {
             resourceUri =
                 new URI(
                     resourceUri.getScheme(),
                     resourceUri.getSchemeSpecificPart(),
-                    (String) arguments.get(ContentItem.QUALIFIER));
+                    (String) arguments.get(ContentItem.QUALIFIER_KEYWORD));
           } catch (URISyntaxException e) {
             throw new ResourceNotFoundException("Unable to create with qualifier", e);
           }

--- a/catalog/core/catalog-core-contentresourcereader/src/main/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProvider.java
+++ b/catalog/core/catalog-core-contentresourcereader/src/main/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProvider.java
@@ -70,7 +70,7 @@ public class DerivedContentActionProvider implements MultiActionProvider {
 
                   builder.addParameters(
                       Collections.singletonList(
-                          new BasicNameValuePair(ContentItem.QUALIFIER, qualifier)));
+                          new BasicNameValuePair(ContentItem.QUALIFIER_KEYWORD, qualifier)));
                   return Optional.of(
                       new ActionImpl(
                           ID,

--- a/catalog/core/catalog-core-contentresourcereader/src/test/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProviderTest.java
+++ b/catalog/core/catalog-core-contentresourcereader/src/test/java/org/codice/ddf/catalog/content/resource/reader/DerivedContentActionProviderTest.java
@@ -85,7 +85,7 @@ public class DerivedContentActionProviderTest {
     assertThat(actions.get(0).getUrl(), notNullValue());
     assertThat(
         actions.get(0).getUrl().getQuery(),
-        containsString(ContentItem.QUALIFIER + "=" + QUALIFIER_VALUE));
+        containsString(ContentItem.QUALIFIER_KEYWORD + "=" + QUALIFIER_VALUE));
   }
 
   @Test

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CacheKey.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CacheKey.java
@@ -72,7 +72,7 @@ public class CacheKey {
     if (propertyNames != null) {
       for (String propertyName : propertyNames) {
         if (ResourceRequest.OPTION_ARGUMENT.equals(propertyName)
-            || ContentItem.QUALIFIER.equals(propertyName)) {
+            || ContentItem.QUALIFIER_KEYWORD.equals(propertyName)) {
           properties = "_" + propertyName + "-" + resourceRequest.getPropertyValue(propertyName);
           break;
         }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/ResourceOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/ResourceOperations.java
@@ -553,7 +553,9 @@ public class ResourceOperations extends DescribableImpl {
         resourceUri = (URI) value;
         URI truncatedUri = resourceUri;
         if (StringUtils.isNotBlank(resourceUri.getFragment())) {
-          resourceRequest.getProperties().put(ContentItem.QUALIFIER, resourceUri.getFragment());
+          resourceRequest
+              .getProperties()
+              .put(ContentItem.QUALIFIER_KEYWORD, resourceUri.getFragment());
           try {
             // Creating the truncated URL this way is important to preserve encoding!!
             String uriString = resourceUri.toString();

--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -259,12 +259,14 @@ public class URLResourceReader implements ResourceReader {
         || resourceURI.getScheme().equals(URL_HTTPS_SCHEME)) {
       LOGGER.debug("Resource URI is HTTP or HTTPS");
 
-      final Serializable qualifierSerializable = properties.get(ContentItem.QUALIFIER);
+      final Serializable qualifierSerializable = properties.get(ContentItem.QUALIFIER_KEYWORD);
       if (qualifierSerializable instanceof String) {
         final String qualifier = (String) qualifierSerializable;
         if (StringUtils.isNotBlank(qualifier)) {
           resourceURI =
-              UriBuilder.fromUri(resourceURI).queryParam(ContentItem.QUALIFIER, qualifier).build();
+              UriBuilder.fromUri(resourceURI)
+                  .queryParam(ContentItem.QUALIFIER_KEYWORD, qualifier)
+                  .build();
         }
       }
 

--- a/catalog/core/catalog-core-urlresourcereader/src/test/java/ddf/catalog/resource/impl/URLResourceReaderTest.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/test/java/ddf/catalog/resource/impl/URLResourceReaderTest.java
@@ -408,7 +408,7 @@ public class URLResourceReaderTest {
 
     final String qualifierValue = "qualifierValue";
     final String expectedWebClientUri =
-        String.format("%s&%s=%s", uri, ContentItem.QUALIFIER, qualifierValue);
+        String.format("%s&%s=%s", uri, ContentItem.QUALIFIER_KEYWORD, qualifierValue);
     // verify that we got the entire resource
     verifyFileFromURLResourceReader(
         uri, JPEG_FILE_NAME_1, JPEG_MIME_TYPE, null, qualifierValue, 5, expectedWebClientUri);
@@ -800,7 +800,7 @@ public class URLResourceReaderTest {
     }
 
     if (qualifier != null) {
-      arguments.put(ContentItem.QUALIFIER, qualifier);
+      arguments.put(ContentItem.QUALIFIER_KEYWORD, qualifier);
     }
 
     TestURLResourceReader resourceReader = new TestURLResourceReader(mimeTypeMapper);


### PR DESCRIPTION
#### What does this PR do?
This PR renames field `ddf.catalog.content.data.ContentItem#QUALIFIER` to prevent any misunderstanding/clash with field `ddf.catalog.content.data.impl.ContentItemImpl#qualifer`.
#### Who is reviewing it? 
@AzGoalie @peterhuffer 
#### Select relevant component teams: 
@codice/core-apis 
#### Choose 2 committers to review/merge the PR. 
@clockard 
@coyotesqrl 
#### How should this be tested?
Full build.
#### What are the relevant tickets?
[DDF-3544](https://codice.atlassian.net/browse/DDF-3544)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.