### PR TITLE
DDF-3544 Renamed constants in geotools function impls to fix code smell

### DIFF
--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/filter/delegate/FilterToTextDelegate.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/filter/delegate/FilterToTextDelegate.java
@@ -25,11 +25,11 @@ public class FilterToTextDelegate extends FilterDelegate<String> {
   @Override
   public String propertyIsEqualTo(String functionName, List<Object> arguments, Object literal) {
     switch (functionName) {
-      case DivisibleByFunction.FUNCTION_NAME:
+      case DivisibleByFunction.FUNCTION_NAME_STRING:
         return propertyIsDivisibleBy((String) arguments.get(0), (Long) arguments.get(1))
             + '='
             + literal;
-      case ProximityFunction.FUNCTION_NAME:
+      case ProximityFunction.FUNCTION_NAME_STRING:
         return propertyIsInProximityTo(
                 (String) arguments.get(0), (Integer) arguments.get(1), (String) arguments.get(2))
             + '='

--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/DivisibleByFunction.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/DivisibleByFunction.java
@@ -28,20 +28,20 @@ import org.opengis.filter.expression.Literal;
 public class DivisibleByFunction extends FunctionExpressionImpl {
   public static final int NUM_PARAMETERS = 2;
 
-  public static final String FUNCTION_NAME = "divisibleBy";
+  public static final String FUNCTION_NAME_STRING = "divisibleBy";
 
-  public static final FunctionName NAME =
+  public static final FunctionName FUNCTION_NAME =
       FunctionExpressionImpl.functionName(
-          FUNCTION_NAME, "return:Boolean", "property:String", "divisor:Long");
+          FUNCTION_NAME_STRING, "return:Boolean", "property:String", "divisor:Long");
 
   public DivisibleByFunction(List<Expression> parameters, Literal fallback) {
-    super(NAME);
+    super(FUNCTION_NAME);
 
     notNull(parameters, "Parameters are required");
     isTrue(
         parameters.size() == NUM_PARAMETERS,
         String.format(
-            "%s expression requires at least %s parameters", FUNCTION_NAME, NUM_PARAMETERS));
+            "%s expression requires at least %s parameters", FUNCTION_NAME_STRING, NUM_PARAMETERS));
 
     setParameters(parameters);
     setFallbackValue(fallback);

--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/FuzzyFunction.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/FuzzyFunction.java
@@ -31,18 +31,19 @@ import org.slf4j.LoggerFactory;
  * @deprecated
  */
 public class FuzzyFunction extends FunctionExpressionImpl {
-  public static final String FUNCTION_NAME = "fuzzy";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FuzzyFunction.class);
 
-  public static final FunctionName NAME =
+  public static final String FUNCTION_NAME_STRING = "fuzzy";
+
+  public static final FunctionName FUNCTION_NAME =
       new FunctionNameImpl(
-          FUNCTION_NAME,
+          FUNCTION_NAME_STRING,
           Expression.class,
           FunctionNameImpl.parameter("expression", Expression.class));
 
   public FuzzyFunction(List<Expression> parameters, Literal fallback) {
-    super(FUNCTION_NAME, fallback);
+    super(FUNCTION_NAME_STRING, fallback);
 
     LOGGER.debug("INSIDE: FuzzyFunction constructor");
 
@@ -53,7 +54,7 @@ public class FuzzyFunction extends FunctionExpressionImpl {
       throw new IllegalArgumentException("fuzzy( expression ) requires 1 parameter only");
     }
     this.params = parameters;
-    this.functionName = NAME;
+    this.functionName = FUNCTION_NAME;
 
     LOGGER.debug("EXITING: FuzzyFunction constructor");
   }

--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/GeoToolsFunctionFactory.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/GeoToolsFunctionFactory.java
@@ -31,7 +31,10 @@ public class GeoToolsFunctionFactory implements FunctionFactory {
 
   private static final List<FunctionName> FUNCTION_NAMES =
       Collections.unmodifiableList(
-          Arrays.asList(FuzzyFunction.NAME, ProximityFunction.NAME, DivisibleByFunction.NAME));
+          Arrays.asList(
+              FuzzyFunction.FUNCTION_NAME,
+              ProximityFunction.FUNCTION_NAME,
+              DivisibleByFunction.FUNCTION_NAME));
 
   @Override
   public List<FunctionName> getFunctionNames() {
@@ -49,18 +52,18 @@ public class GeoToolsFunctionFactory implements FunctionFactory {
     String methodName = "function";
     LOGGER.trace("ENTERING: {}", methodName);
 
-    if (FuzzyFunction.NAME.getName().equals(name.getLocalPart())) {
+    if (FuzzyFunction.FUNCTION_NAME.getName().equals(name.getLocalPart())) {
       LOGGER.trace("EXITING: {} - returning FuzzyFunction instance", methodName);
       return new FuzzyFunction(args, fallback);
     }
 
-    if (ProximityFunction.NAME.getName().equals(name.getLocalPart())) {
-      LOGGER.trace("Inside function : returning {}", ProximityFunction.NAME);
+    if (ProximityFunction.FUNCTION_NAME.getName().equals(name.getLocalPart())) {
+      LOGGER.trace("Inside function : returning {}", ProximityFunction.FUNCTION_NAME);
       return new ProximityFunction(args, fallback);
     }
 
-    if (DivisibleByFunction.NAME.getName().equals(name.getLocalPart())) {
-      LOGGER.trace("Inside function : returning {}", DivisibleByFunction.NAME);
+    if (DivisibleByFunction.FUNCTION_NAME.getName().equals(name.getLocalPart())) {
+      LOGGER.trace("Inside function : returning {}", DivisibleByFunction.FUNCTION_NAME);
       return new DivisibleByFunction(args, fallback);
     }
 

--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/ProximityFunction.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/ProximityFunction.java
@@ -26,11 +26,15 @@ public class ProximityFunction extends FunctionImpl {
 
   public static final int NUM_PARAMETERS = 3;
 
-  public static final String FUNCTION_NAME = "proximity";
+  public static final String FUNCTION_NAME_STRING = "proximity";
 
-  public static final FunctionName NAME =
+  public static final FunctionName FUNCTION_NAME =
       functionName(
-          FUNCTION_NAME, "result:Boolean", "property:String", "distance:Integer", "text:String:2,");
+          FUNCTION_NAME_STRING,
+          "result:Boolean",
+          "property:String",
+          "distance:Integer",
+          "text:String:2,");
 
   public ProximityFunction(List<Expression> parameters, Literal fallback) {
     notNull(parameters, "Parameters are required");
@@ -38,9 +42,9 @@ public class ProximityFunction extends FunctionImpl {
         parameters.size() == NUM_PARAMETERS,
         String.format("Proximity expression requires at least %s parameters", NUM_PARAMETERS));
 
-    this.setName(FUNCTION_NAME);
+    this.setName(FUNCTION_NAME_STRING);
     this.setParameters(parameters);
     this.setFallbackValue(fallback);
-    this.functionName = NAME;
+    this.functionName = FUNCTION_NAME;
   }
 }

--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/TemporalFilter.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/impl/filter/TemporalFilter.java
@@ -51,7 +51,7 @@ public class TemporalFilter {
   /**
    * Absolute time search
    *
-   * @param dateStart
+   * @param startDate
    * @param endDate
    */
   public TemporalFilter(Date startDate, Date endDate) {
@@ -61,8 +61,8 @@ public class TemporalFilter {
   /**
    * Absolute time search, parses incoming strings to dates.
    *
-   * @param dtStartStr
-   * @param dtEndStr
+   * @param startDate
+   * @param endDate
    */
   public TemporalFilter(String startDate, String endDate) {
     this(parseDate(startDate), parseDate(endDate));
@@ -102,7 +102,7 @@ public class TemporalFilter {
    * Sets dates and performs basic validation. dtStart and dtEnd may be null, but not at the same
    * time.
    *
-   * @param dtStart lower bound of the temporal range search. When null it is set to time 0.
+   * @param startDate lower bound of the temporal range search. When null it is set to time 0.
    * @param endDate upper bound of the temporal range search. When null it is set to now.
    */
   private void setDates(Date startDate, Date endDate) {

--- a/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/filter/FuzzyFunctionTest.java
+++ b/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/filter/FuzzyFunctionTest.java
@@ -44,6 +44,6 @@ public class FuzzyFunctionTest {
     exprs.add(Expression.NIL);
     // When: I try to create a Fuzzy Function with null parameters
     FuzzyFunction func = new FuzzyFunction(exprs, null);
-    assertEquals("fuzzy", FuzzyFunction.NAME.getName());
+    assertEquals("fuzzy", FuzzyFunction.FUNCTION_NAME.getName());
   }
 }

--- a/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/filter/GeoToolsFunctionFactoryTest.java
+++ b/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/filter/GeoToolsFunctionFactoryTest.java
@@ -38,9 +38,9 @@ public class GeoToolsFunctionFactoryTest {
   public void testGetFunctionNames() {
     List<FunctionName> functionNames = toTest.getFunctionNames();
     assertThat(functionNames, hasSize(3));
-    assertThat(functionNames.get(0).getName(), is(FuzzyFunction.NAME.getName()));
-    assertThat(functionNames.get(1).getName(), is(ProximityFunction.NAME.getName()));
-    assertThat(functionNames.get(2).getName(), is(DivisibleByFunction.NAME.getName()));
+    assertThat(functionNames.get(0).getName(), is(FuzzyFunction.FUNCTION_NAME.getName()));
+    assertThat(functionNames.get(1).getName(), is(ProximityFunction.FUNCTION_NAME.getName()));
+    assertThat(functionNames.get(2).getName(), is(DivisibleByFunction.FUNCTION_NAME.getName()));
   }
 
   @Test
@@ -50,7 +50,7 @@ public class GeoToolsFunctionFactoryTest {
 
   @Test(expected = NullPointerException.class)
   public void testFunctionForValidNameWithNullExpressionList() {
-    toTest.function(FuzzyFunction.NAME.getName(), null, null);
+    toTest.function(FuzzyFunction.FUNCTION_NAME.getName(), null, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -58,16 +58,16 @@ public class GeoToolsFunctionFactoryTest {
     List<Expression> expr = new ArrayList<>();
     expr.add(Expression.NIL);
     expr.add(Expression.NIL);
-    Function result = toTest.function(FuzzyFunction.NAME.getName(), expr, null);
-    assertThat(result.getName(), is(FuzzyFunction.NAME.getName()));
+    Function result = toTest.function(FuzzyFunction.FUNCTION_NAME.getName(), expr, null);
+    assertThat(result.getName(), is(FuzzyFunction.FUNCTION_NAME.getName()));
   }
 
   @Test
   public void testFuzzyFunction() {
     List<Expression> expr = new ArrayList<>();
     expr.add(Expression.NIL);
-    Function result = toTest.function(FuzzyFunction.NAME.getName(), expr, null);
-    assertThat(result.getName(), is(FuzzyFunction.NAME.getName()));
+    Function result = toTest.function(FuzzyFunction.FUNCTION_NAME.getName(), expr, null);
+    assertThat(result.getName(), is(FuzzyFunction.FUNCTION_NAME.getName()));
   }
 
   @Test
@@ -76,7 +76,7 @@ public class GeoToolsFunctionFactoryTest {
     expr.add(Expression.NIL);
     expr.add(Expression.NIL);
     expr.add(Expression.NIL);
-    Function result = toTest.function(ProximityFunction.NAME.getName(), expr, null);
-    assertThat(result.getName(), is(ProximityFunction.NAME.getName()));
+    Function result = toTest.function(ProximityFunction.FUNCTION_NAME.getName(), expr, null);
+    assertThat(result.getName(), is(ProximityFunction.FUNCTION_NAME.getName()));
   }
 }

--- a/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/filter/ProximityFunctionTest.java
+++ b/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/filter/ProximityFunctionTest.java
@@ -43,6 +43,6 @@ public class ProximityFunctionTest {
     exprs.add(Expression.NIL);
     exprs.add(Expression.NIL);
     ProximityFunction func = new ProximityFunction(exprs, null);
-    assertThat(func.getName(), is(ProximityFunction.NAME.getName()));
+    assertThat(func.getName(), is(ProximityFunction.FUNCTION_NAME.getName()));
   }
 }

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -171,13 +171,13 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
     // the literal should be cast to the functions return type (i.e. not necessarily boolean)
     // arguments should be assumed to be in the correct order and can be cast directly.
     switch (functionName) {
-      case DivisibleByFunction.FUNCTION_NAME:
+      case DivisibleByFunction.FUNCTION_NAME_STRING:
         // the return type is boolean so cast the literal to boolean and in effect this is just a
         // NOT so we will update the query as such
         not = (Boolean) literal ? "" : "!";
         query = propertyIsDivisibleBy((String) arguments.get(0), (Long) arguments.get(1));
         return query.setQuery(not + query.getQuery());
-      case ProximityFunction.FUNCTION_NAME:
+      case ProximityFunction.FUNCTION_NAME_STRING:
         not = (Boolean) literal ? "" : "!";
         query =
             propertyIsInProximityTo(

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrFilterBuilder.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/TestSolrFilterBuilder.java
@@ -56,7 +56,7 @@ public class TestSolrFilterBuilder extends GeotoolsFilterBuilder {
 
   public Filter proximity(String attribute, int distance, String searchTerms) {
     FunctionImpl function = new FunctionImpl();
-    function.setName(ProximityFunction.NAME.getName());
+    function.setName(ProximityFunction.FUNCTION_NAME.getName());
     List<Expression> parameters = new ArrayList<>();
     parameters.add(factory.literal(attribute));
     parameters.add(factory.literal(distance));

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/ExtendedGeotoolsFunctionFactory.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/ExtendedGeotoolsFunctionFactory.java
@@ -33,7 +33,7 @@ public class ExtendedGeotoolsFunctionFactory extends GeoToolsFunctionFactory {
   @Override
   public List<FunctionName> getFunctionNames() {
     List<FunctionName> functionNames = new ArrayList<>(super.getFunctionNames());
-    functionNames.add(PropertyIsFuzzyFunction.NAME);
+    functionNames.add(PropertyIsFuzzyFunction.FUNCTION_NAME);
     return functionNames;
   }
 
@@ -44,7 +44,7 @@ public class ExtendedGeotoolsFunctionFactory extends GeoToolsFunctionFactory {
 
   @Override
   public Function function(Name name, List<Expression> args, Literal fallback) {
-    if (PropertyIsFuzzyFunction.NAME.getName().equals(name.getLocalPart())) {
+    if (PropertyIsFuzzyFunction.FUNCTION_NAME.getName().equals(name.getLocalPart())) {
       return new PropertyIsFuzzyFunction(args, fallback);
     }
     return super.function(name, args, fallback);

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/PropertyIsFuzzyFunction.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/PropertyIsFuzzyFunction.java
@@ -25,22 +25,23 @@ import org.opengis.filter.expression.Literal;
  * org.opengis.filter.PropertyIsLike} filter marked to be searched in a fuzzy manner.
  */
 public class PropertyIsFuzzyFunction extends FunctionExpressionImpl {
-  public static final String FUNCTION_NAME = "PropertyIsFuzzy";
 
-  public static final FunctionName NAME =
+  public static final String FUNCTION_NAME_STRING = "PropertyIsFuzzy";
+
+  public static final FunctionName FUNCTION_NAME =
       new FunctionNameImpl(
-          FUNCTION_NAME,
+          FUNCTION_NAME_STRING,
           Expression.class,
           FunctionNameImpl.parameter("expression", Expression.class));
 
   public PropertyIsFuzzyFunction(List<Expression> parameters, Literal fallback) {
-    super(FUNCTION_NAME, fallback);
+    super(FUNCTION_NAME_STRING, fallback);
 
     if (parameters == null || parameters.size() != 2) {
       throw new IllegalArgumentException("PropertyIsFuzzy requires 2 parameters");
     }
     this.params = parameters;
-    this.functionName = NAME;
+    this.functionName = FUNCTION_NAME;
   }
 
   public Expression getPropertyName() {


### PR DESCRIPTION
#### What does this PR do?
This PR renames fields in 
- `ddf.catalog.impl.filter.DivisibleByFunction`
- `ddf.catalog.impl.filter.FuzzyFunction`
- `ddf.catalog.impl.filter.ProximityFunction`
to prevent any misunderstanding/clash with field `org.geotools.filter.FunctionExpressionImpl#name`.

This PR also renames fields in `org.codice.ddf.spatial.ogc.csw.catalog.common.PropertyIsFuzzyFunction` to prevent any misunderstanding/clash with field `org.geotools.filter.FunctionImpl#name`.
#### Who is reviewing it? 
@AzGoalie @peterhuffer 
#### Select relevant component teams: 
@codice/core-apis 
#### Choose 2 committers to review/merge the PR. 
@clockard 
@coyotesqrl 
#### How should this be tested?
Full build.
#### What are the relevant tickets?
[DDF-3544](https://codice.atlassian.net/browse/DDF-3544)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.