### PR TITLE
DDF-3533 Fixed show/hide template CSS when header/footer not present

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces-templates/workspaces-templates.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspaces-templates/workspaces-templates.less
@@ -112,7 +112,7 @@
     opacity: 1;
   }
 
-  height: ~'calc(100vh - 2*@{minimumLineSize})';
+  height: @minimumLineSize + 2*@minimumButtonSize + 2*@minimumSpacing + 2*@minimumSpacing + 3*@minimumButtonSize;
   overflow: auto;
 
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes a CSS issue from #2820 with certain styles not being consistently applied depending on if a header/footer is present. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@mojogitoverhere @glenhein @Variadicism @brianfelix  

#### Select relevant component teams: 
@codice/ui 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@brendan-hofmann 

#### How should this be tested? (List steps with links to updated documentation)
Verify that the template gallery drawer functions properly regardless of whether or not a header/footer are configured in Admin UI -> Platform -> Platform UI Configuration.

#### Any background context you want to provide?
#2820 reworked the `More Templates` button to now hide all templates by default and expand to expose templates when pressed. Since templates are hardcoded at the moment, the idea was to expand to show just the 5 templates that we have and still leave workspaces visible. The CSS wasn't quite right and as a result, that behavior only currently applies when the system it's running on has headers/footers.

#### What are the relevant tickets?
[DDF-3533](https://codice.atlassian.net/browse/DDF-3533)
#### Screenshots (if appropriate)

Drawer Closed (with header and footer)
![image](https://user-images.githubusercontent.com/8922497/34964221-af9dac96-fa09-11e7-938d-2d0c52791812.png)
Drawer Open (with header and footer)
![image](https://user-images.githubusercontent.com/8922497/34964235-ca9a97ca-fa09-11e7-8cf8-12ab0e075a40.png)

Drawer Closed (no header or footer)
![image](https://user-images.githubusercontent.com/8922497/34964250-e62c5f6e-fa09-11e7-8556-b7cedb35d1bd.png)
Drawer Open (no header or footer)
![image](https://user-images.githubusercontent.com/8922497/34964261-eddb8640-fa09-11e7-8341-de819a314aa9.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
