### PR TITLE
DDF-3544 Refactored download status constants in catalog-core-standardframework to new class to fix code smell

### DIFF
--- a/catalog/admin/catalog-admin-downloadmanager/src/main/java/org/codice/ddf/catalog/admin/downloadmanager/DownloadManagerServiceMBean.java
+++ b/catalog/admin/catalog-admin-downloadmanager/src/main/java/org/codice/ddf/catalog/admin/downloadmanager/DownloadManagerServiceMBean.java
@@ -27,11 +27,8 @@ public interface DownloadManagerServiceMBean {
    * Function to get information about every download.
    *
    * @return Returns the information in an array of maps, where each map holds information about a
-   *     specific download; attributes are: "percent" (percent completed) "downloadId" (randomly
-   *     generated downloadId assigned to each download at its beginning) "status" (status of
-   *     download, e.g. "COMPLETED", "IN_PROGRESS" etc) "bytesDownloaded" (count of bytes that have
-   *     been downloaded to cache) "fileName" (name of the file being downloaded) "user" (identifer
-   *     of the user performing the download)
+   *     specific download.
+   * @see ddf.catalog.resource.download.ReliableResourceStatus.DownloadStatus
    */
   List<Map<String, String>> getAllDownloadsStatus();
 
@@ -40,15 +37,15 @@ public interface DownloadManagerServiceMBean {
    *
    * @param downloadIdentifier The randomly generated downloadId string assigned to the download at
    *     its start.
-   * @return Returns a map of attributes describing the download; see {@link
-   *     this.getAllDownloadsStatus} for details.
+   * @return Returns a map of attributes describing the download.
+   * @see ddf.catalog.resource.download.ReliableResourceStatus.DownloadStatus
    */
   Map<String, String> getDownloadStatus(String downloadIdentifier);
 
   /**
    * Function to get all downloads.
    *
-   * @return Returns an array of downloadIdentifier Strings
+   * @return Returns an array of downloadIdentifier Strings.
    */
   List<String> getAllDownloads();
 
@@ -57,14 +54,16 @@ public interface DownloadManagerServiceMBean {
    *
    * @param userId The id of the user.
    * @return Returns an array of downloadIdentifier Strings, similar to {@link
-   *     this.getAllDownloads}.
+   *     DownloadManagerServiceMBean#getAllDownloads()}.
    */
   List<String> getAllDownloads(String userId);
 
   /**
-   * Function to remove the map entry corresponding to the downloadIdentifer passed it. This means
-   * it will no longer be returned by {@link this.getAllDownloadsStatus}, {@link
-   * this.getDownloadStatus}, or {@link this.getAllDownloads}.
+   * Function to remove the map entry corresponding to the downloadIdentifier passed it. This means
+   * it will no longer be returned by {@link DownloadManagerServiceMBean#getAllDownloadsStatus()},
+   * {@link DownloadManagerServiceMBean#getAllDownloadsStatus()}, {{@link
+   * DownloadManagerServiceMBean#getAllDownloads()}, or {@link
+   * DownloadManagerServiceMBean#getAllDownloads(String)}.
    *
    * @param downloadIdentifier The randomly generated downloadId string assigned to the download at
    *     its start.

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfo.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfo.java
@@ -29,12 +29,13 @@ public interface DownloadStatusInfo {
 
   /**
    * Adds a {@link ddf.catalog.resource.download.ReliableResourceDownloadManager} to the Map, which
-   * is used by {@link this.getDownloadStatus}. Currently this is called in {@link
+   * is used by {@link DownloadStatusInfo#getAllDownloads()}. Currently this is called in {@link
    * ddf.catalog.resource.download.ReliableResourceDownloadManager}
    *
    * @param downloadIdentifier Randomly generated String assigned to download at its start.
-   * @param downloadManager The Object that handles the download; {@link this} uses it to gather
-   *     information about the download.
+   * @param downloader The Object that handles the download; used to gather information about the
+   *     download.
+   * @param resourceResponse
    */
   void addDownloadInfo(
       String downloadIdentifier,
@@ -62,15 +63,16 @@ public interface DownloadStatusInfo {
    *
    * @param downloadIdentifier The randomly generated downloadId string assigned to the download at
    *     its start.
-   * @return Returns a map of attributes describing the download; see {@link
-   *     this.getAllDownloadsStatus} for details.
+   * @return Returns a map of attributes describing the download.
+   * @see ddf.catalog.resource.download.DownloadStatus
    */
   Map<String, String> getDownloadStatus(String downloadIdentifier);
 
   /**
    * Function to remove the map entry corresponding to the downloadIdentifer passed it. This means
-   * it will no longer be returned by {@link this.getAllDownloadsStatus}, {@link
-   * this.getDownloadStatus}, or {@link this.getAllDownloads}.
+   * it will no longer be returned by {@link DownloadStatusInfo#getAllDownloads()}, {@link
+   * DownloadStatusInfo#getAllDownloads(String)}, or {@link
+   * DownloadStatusInfo#getDownloadStatus(String)}.
    *
    * @param downloadIdentifier The randomly generated downloadId string assigned to the download at
    *     its start.

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
@@ -14,6 +14,7 @@
 package ddf.catalog.event.retrievestatus;
 
 import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.resource.download.DownloadStatus;
 import ddf.catalog.resource.download.ReliableResourceDownloader;
 import ddf.security.SubjectUtils;
 import java.util.ArrayList;
@@ -90,16 +91,18 @@ public class DownloadStatusInfoImpl implements DownloadStatusInfo {
       Long downloadedBytes = downloader.getReliableResourceInputStreamBytesCached();
       try {
         Long totalBytes = Long.parseLong(downloader.getResourceSize());
-        statusMap.put("percent", Long.toString((downloadedBytes * 100) / totalBytes));
+        statusMap.put(
+            DownloadStatus.PERCENT_KEY, Long.toString((downloadedBytes * 100) / totalBytes));
 
       } catch (Exception e) {
-        statusMap.put("percent", UNKNOWN);
+        statusMap.put(DownloadStatus.PERCENT_KEY, UNKNOWN);
       }
-      statusMap.put("downloadId", downloadIdentifier);
-      statusMap.put("status", downloader.getReliableResourceInputStreamState());
-      statusMap.put("bytesDownloaded", Long.toString(downloadedBytes));
-      statusMap.put("fileName", downloader.getResourceResponse().getResource().getName());
-      statusMap.put("user", downloadUsers.get(downloadIdentifier));
+      statusMap.put(DownloadStatus.DOWNLOAD_ID_KEY, downloadIdentifier);
+      statusMap.put(DownloadStatus.STATUS_KEY, downloader.getReliableResourceInputStreamState());
+      statusMap.put(DownloadStatus.BYTES_DOWNLOADED_KEY, Long.toString(downloadedBytes));
+      statusMap.put(
+          DownloadStatus.FILE_NAME_KEY, downloader.getResourceResponse().getResource().getName());
+      statusMap.put(DownloadStatus.USER_KEY, downloadUsers.get(downloadIdentifier));
     }
     return statusMap;
   }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadInfo.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadInfo.java
@@ -21,20 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/** Class that encapsulates the state of an ongoiong download. */
-class DownloadInfo {
-
-  private static final String DOWNLOAD_ID = "downloadId";
-
-  private static final String FILE_NAME = "fileName";
-
-  private static final String BYTES_DOWNLOADED = "bytesDownloaded";
-
-  private static final String PERCENT = "percent";
-
-  private static final String USER = "user";
-
-  private static final String STATUS = "status";
+/** Class that encapsulates the state of an ongoing download. */
+public class DownloadInfo {
 
   private String downloadId;
 
@@ -60,6 +48,7 @@ class DownloadInfo {
    *
    * @param downloadStatus map containing the different attributes that will be used to initialize
    *     this {@link DownloadInfo} object
+   * @see DownloadStatus
    */
   public DownloadInfo(Map<String, String> downloadStatus) {
     parse(downloadStatus);
@@ -96,20 +85,21 @@ class DownloadInfo {
   private void parse(Map<String, String> downloadStatus) {
     notNull(downloadStatus, "Download status map cannot be null");
 
-    downloadId = downloadStatus.get(DOWNLOAD_ID);
-    fileName = downloadStatus.get(FILE_NAME);
-    status = downloadStatus.get(STATUS);
+    downloadId = downloadStatus.get(DownloadStatus.DOWNLOAD_ID_KEY);
+    fileName = downloadStatus.get(DownloadStatus.FILE_NAME_KEY);
+    status = downloadStatus.get(DownloadStatus.STATUS_KEY);
 
     try {
-      bytesDownloaded = Long.parseLong(downloadStatus.getOrDefault(BYTES_DOWNLOADED, "0"));
+      bytesDownloaded =
+          Long.parseLong(downloadStatus.getOrDefault(DownloadStatus.BYTES_DOWNLOADED_KEY, "0"));
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException("Bytes downloaded must be a number");
     }
 
-    percentDownloaded = downloadStatus.getOrDefault(PERCENT, "0");
+    percentDownloaded = downloadStatus.getOrDefault(DownloadStatus.PERCENT_KEY, "0");
 
-    if (downloadStatus.containsKey(USER)) {
-      users.add(downloadStatus.get(USER));
+    if (downloadStatus.containsKey(DownloadStatus.USER_KEY)) {
+      users.add(downloadStatus.get(DownloadStatus.USER_KEY));
     }
 
     notBlank(this.downloadId, "Download ID cannot be null");

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadStatus.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/DownloadStatus.java
@@ -13,18 +13,28 @@
  */
 package ddf.catalog.resource.download;
 
-/**
- * The current status of a single product download. Since a product retrieval may go through several
- * retry attempts during the download process, it is possible for the download status to have
- * several of these values over the entire span of the download. For example, a product download
- * could be interrupted due to a brief network connection drop, and then the download could complete
- * successfully.
- */
-public enum DownloadStatus {
-  RESOURCE_DOWNLOAD_COMPLETE,
-  RESOURCE_DOWNLOAD_INTERRUPTED,
-  RESOURCE_DOWNLOAD_CANCELED,
-  CLIENT_OUTPUT_STREAM_EXCEPTION,
-  CACHED_FILE_OUTPUT_STREAM_EXCEPTION,
-  PRODUCT_INPUT_STREAM_EXCEPTION
-};
+public final class DownloadStatus {
+
+  /**
+   * map key that indicates the randomly generated downloadId assigned to each download at its
+   * beginning
+   */
+  public static final String DOWNLOAD_ID_KEY = "downloadId";
+
+  /** map key that indicates the name of the file being downloaded */
+  public static final String FILE_NAME_KEY = "fileName";
+
+  /** map key that indicates the count of bytes that have been downloaded to cache */
+  public static final String BYTES_DOWNLOADED_KEY = "bytesDownloaded";
+
+  /** map key that indicates the percent completed */
+  public static final String PERCENT_KEY = "percent";
+
+  /** map key that indicates the user performing the download */
+  public static final String USER_KEY = "user";
+
+  /** map key that indicates the status of download, e.g. "COMPLETED", "IN_PROGRESS" etc */
+  public static final String STATUS_KEY = "status";
+
+  private DownloadStatus() {}
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceCallable.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceCallable.java
@@ -14,6 +14,7 @@
 package ddf.catalog.resource.download;
 
 import com.google.common.io.CountingOutputStream;
+import ddf.catalog.resource.download.ReliableResourceStatus.DownloadStatus;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -30,6 +30,7 @@ import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.resource.ResourceNotSupportedException;
 import ddf.catalog.resource.data.ReliableResource;
 import ddf.catalog.resource.download.DownloadManagerState.DownloadState;
+import ddf.catalog.resource.download.ReliableResourceStatus.DownloadStatus;
 import ddf.catalog.resource.impl.ResourceImpl;
 import ddf.catalog.resourceretriever.ResourceRetriever;
 import java.io.File;
@@ -555,12 +556,13 @@ public class ReliableResourceDownloader implements Runnable {
       // If caching was not successful, then remove this product from the pending cache list
       // (Otherwise partially cached files will remain in pending list and returned to
       // subsequent clients)
-      if (reliableResourceStatus.getDownloadStatus() != DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE) {
+      if (!DownloadStatus.RESOURCE_DOWNLOAD_COMPLETE.equals(
+          reliableResourceStatus.getDownloadStatus())) {
         if (doCaching) {
           resourceCache.removePendingCacheEntry(reliableResource.getKey());
         }
-        if (reliableResourceStatus.getDownloadStatus()
-            == DownloadStatus.RESOURCE_DOWNLOAD_CANCELED) {
+        if (DownloadStatus.RESOURCE_DOWNLOAD_CANCELED.equals(
+            reliableResourceStatus.getDownloadStatus())) {
           this.downloadState.setDownloadState(DownloadManagerState.DownloadState.CANCELED);
         } else {
           this.downloadState.setDownloadState(DownloadManagerState.DownloadState.FAILED);

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceStatus.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceStatus.java
@@ -16,9 +16,9 @@ package ddf.catalog.resource.download;
 /**
  * Provides the status of the product caching thread @ReliableResourceCallable, and the total number
  * of bytes read from the product's @InputStream. If the entire product @InputStream was read
- * successfully a value of -1 is returned for bytes read. The @DownloadStatus indicates if the
- * caching was successful or whether an exception in reading or writing to one of the streams was
- * encountered.
+ * successfully a value of -1 is returned for bytes read. The {@link
+ * ReliableResourceStatus#downloadStatus} indicates if the caching was successful or whether an
+ * exception in reading or writing to one of the streams was encountered.
  */
 public class ReliableResourceStatus {
 
@@ -63,5 +63,21 @@ public class ReliableResourceStatus {
             + message;
 
     return s;
+  }
+
+  /**
+   * The current status of a single product download. Since a product retrieval may go through
+   * several retry attempts during the download process, it is possible for the download status to
+   * have several of these values over the entire span of the download. For example, a product
+   * download could be interrupted due to a brief network connection drop, and then the download
+   * could complete successfully.
+   */
+  public enum DownloadStatus {
+    RESOURCE_DOWNLOAD_COMPLETE,
+    RESOURCE_DOWNLOAD_INTERRUPTED,
+    RESOURCE_DOWNLOAD_CANCELED,
+    CLIENT_OUTPUT_STREAM_EXCEPTION,
+    CACHED_FILE_OUTPUT_STREAM_EXCEPTION,
+    PRODUCT_INPUT_STREAM_EXCEPTION
   }
 }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
@@ -24,6 +24,7 @@ import ddf.catalog.operation.ResourceRequest;
 import ddf.catalog.resource.ResourceReader;
 import ddf.catalog.resource.download.DownloadException;
 import ddf.catalog.resource.download.DownloadManagerState;
+import ddf.catalog.resource.download.DownloadStatus;
 import ddf.catalog.resource.download.ReliableResourceDownloadManager;
 import ddf.catalog.resource.download.ReliableResourceDownloaderConfig;
 import ddf.catalog.resource.impl.URLResourceReader;
@@ -41,13 +42,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DownloadsStatusEventListenerTest {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(DownloadsStatusEventListenerTest.class);
 
   private static ReliableResourceDownloadManager testDownloadManager;
 
@@ -118,21 +114,18 @@ public class DownloadsStatusEventListenerTest {
   private void testGetDownloadStatusHelper(
       Map<String, Integer> idToBytes, String status, String fileName) {
     List<String> allDownloads = testDownloadStatusInfo.getAllDownloads();
-    LOGGER.debug(allDownloads.toString());
     for (String item : allDownloads) {
-      Map<String, String> downloadInfo = testDownloadStatusInfo.getDownloadStatus(item);
-      for (Map.Entry<String, String> downloadItem : downloadInfo.entrySet()) {
-        LOGGER.debug(downloadItem.getKey() + ": " + downloadItem.getValue());
-      }
+      Map<String, String> downloadStatus = testDownloadStatusInfo.getDownloadStatus(item);
       if (idToBytes.get(item) == null) {
         idToBytes.put(item, 0);
       }
-      LOGGER.debug(downloadInfo.get("bytesDownloaded"));
-      assertTrue(idToBytes.get(item) <= Integer.parseInt(downloadInfo.get("bytesDownloaded")));
-      System.out.println(downloadInfo.get("status"));
-      assertTrue(status.equals(downloadInfo.get("status")));
-      assertTrue(fileName.equals(downloadInfo.get("fileName")));
-      idToBytes.put(item, Integer.parseInt(downloadInfo.get("bytesDownloaded")));
+      assertTrue(
+          idToBytes.get(item)
+              <= Integer.parseInt(downloadStatus.get(DownloadStatus.BYTES_DOWNLOADED_KEY)));
+      assertTrue(downloadStatus.get(DownloadStatus.STATUS_KEY).equals(status));
+      assertTrue(downloadStatus.get(DownloadStatus.FILE_NAME_KEY).equals(fileName));
+      idToBytes.put(
+          item, Integer.parseInt(downloadStatus.get(DownloadStatus.BYTES_DOWNLOADED_KEY)));
     }
   }
 }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
@@ -42,6 +42,7 @@ import ddf.catalog.resource.Resource;
 import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.resource.ResourceNotSupportedException;
 import ddf.catalog.resource.data.ReliableResource;
+import ddf.catalog.resource.download.ReliableResourceStatus.DownloadStatus;
 import ddf.catalog.resourceretriever.ResourceRetriever;
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;


### PR DESCRIPTION
#### What does this PR do?
This PR refactors download status fields in `ddf.catalog.resource.download.DownloadInfo` to a new class to prevent any misunderstanding/clash with corresponding fields.

This PR also fixes some javadoc links.
#### Who is reviewing it? 
@AzGoalie @peterhuffer @harrison-tarr 
#### Select relevant component teams: 
@codice/core-apis 
#### Choose 2 committers to review/merge the PR. 
@clockard 
@coyotesqrl 
#### How should this be tested?
Full build.
#### What are the relevant tickets?
[DDF-3544](https://codice.atlassian.net/browse/DDF-3544)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.