### PR TITLE
[2.11.x] DDF-3549 Download links for federated products in Intrigue should point to the local DDF instead of the remote one

### DIFF
--- a/catalog/transformer/catalog-transformer-xml/pom.xml
+++ b/catalog/transformer/catalog-transformer-xml/pom.xml
@@ -19,7 +19,6 @@
         <artifactId>transformer</artifactId>
         <version>2.11.5-SNAPSHOT</version>
     </parent>
-    <groupId>ddf.catalog.transformer</groupId>
     <artifactId>catalog-transformer-xml</artifactId>
     <packaging>bundle</packaging>
     <name>DDF :: Catalog :: Transformer :: XML</name>

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
@@ -33,9 +33,11 @@ import ddf.catalog.transformer.xml.binding.ShortElement;
 import ddf.catalog.transformer.xml.binding.StringElement;
 import ddf.catalog.transformer.xml.binding.StringxmlElement;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -68,10 +70,10 @@ public class AdaptedMetacard implements Metacard {
 
   private Attribute id;
 
-  // Suppressing Warnings and using ArrayList rather than List here because
-  // ArrayList implements Serializable (List does not).
+  // Suppressing Warnings and using HashSet rather than Set here because
+  // HashSet implements Serializable (Set does not).
   @SuppressWarnings("all")
-  private ArrayList<Attribute> attributes = new ArrayList<Attribute>();
+  private HashSet<Attribute> attributes = new HashSet<>();
 
   public AdaptedMetacard(Metacard metacard) {
     if (metacard == null) {
@@ -160,7 +162,7 @@ public class AdaptedMetacard implements Metacard {
     @XmlElement(name = "string", namespace = METACARD_URI, type = StringElement.class),
     @XmlElement(name = "stringxml", namespace = METACARD_URI, type = StringxmlElement.class)
   })
-  protected List<Attribute> getAttributes() {
+  protected Set<Attribute> getAttributes() {
     return attributes;
   }
 
@@ -177,14 +179,12 @@ public class AdaptedMetacard implements Metacard {
     if (Metacard.ID.equals(name)) {
       return this.id;
     }
-    for (Attribute attribute : attributes) {
-      if (attribute == null || StringUtils.isEmpty(attribute.getName())) {
-        continue;
-      } else if (name.equals(attribute.getName())) {
-        return attribute;
-      }
-    }
-    return null;
+    return attributes
+        .stream()
+        .filter(Objects::nonNull)
+        .filter(attr -> name.equals(attr.getName()))
+        .findFirst()
+        .orElse(null);
   }
 
   /*
@@ -193,9 +193,8 @@ public class AdaptedMetacard implements Metacard {
    * @see ddf.catalog.data.MetacardImpl#setAttribute(ddf.catalog.data.Attribute)
    */
   @Override
-  public final void setAttribute(Attribute attribute) {
+  public final void setAttribute(@Nullable Attribute attribute) {
     if (attribute != null) {
-
       if (Metacard.ID.equals(attribute.getName())) {
         this.id = attribute;
       } else {

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestAdaptedMetacard.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestAdaptedMetacard.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transform.xml;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.transformer.xml.adapter.AdaptedMetacard;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestAdaptedMetacard {
+  private static final Attribute ID = new AttributeImpl(Core.ID, "metacard-id");
+
+  private static final Attribute DOWNLOAD_URL =
+      new AttributeImpl(Core.RESOURCE_DOWNLOAD_URL, "https://localhost:8993/download");
+
+  private static final Attribute DESCRIPTION = new AttributeImpl(Core.DESCRIPTION, "Description");
+
+  private static final Attribute DESCRIPTION_ALT =
+      new AttributeImpl(Core.DESCRIPTION, "Alternative description");
+
+  private AdaptedMetacardUnderTest metacard = new AdaptedMetacardUnderTest();
+
+  private int expectedCollectionSize;
+
+  private int expectedDescriptorCount;
+
+  @Before
+  public void setup() {
+    metacard.setAttribute(ID);
+    metacard.setAttribute(DOWNLOAD_URL);
+    metacard.setAttribute(DESCRIPTION);
+
+    expectedCollectionSize = metacard.getInternalCount();
+    expectedDescriptorCount = metacard.getDescriptorCount();
+
+    assertThat(metacard.getAttributesThroughDescriptors(), hasSize(expectedDescriptorCount));
+    assertThat(metacard.getAttributesInternal(), hasSize(expectedCollectionSize));
+  }
+
+  @Test
+  public void testCannotAddNullAttribute() {
+    metacard.setAttribute(null);
+    assertThat(metacard.getAttributesThroughDescriptors(), hasSize(expectedDescriptorCount));
+    assertThat(metacard.getAttributesInternal(), hasSize(expectedCollectionSize));
+  }
+
+  @Test
+  public void testCannotDuplicateAttributes() {
+    metacard.setAttribute(DESCRIPTION_ALT);
+    assertThat(metacard.getAttributesThroughDescriptors(), hasSize(expectedDescriptorCount));
+    assertThat(metacard.getAttributesInternal(), hasSize(expectedCollectionSize));
+  }
+
+  @Test
+  public void testGetAttributeNullName() {
+    assertThat(metacard.getAttribute(null), is(nullValue()));
+  }
+
+  @Test
+  public void testGetAttributeEmptyName() {
+    assertThat(metacard.getAttribute(""), is(nullValue()));
+  }
+
+  @Test
+  public void testGetAttributeId() {
+    assertThat(metacard.getAttribute(Core.ID), is(new AttributeImpl(Core.ID, "metacard-id")));
+  }
+
+  @Test
+  public void testGetValidAttribute() {
+    assertThat(
+        metacard.getAttribute(Core.DESCRIPTION),
+        is(new AttributeImpl(Core.DESCRIPTION, "Description")));
+  }
+
+  @Test
+  public void testGetNonExistentAttribute() {
+    assertThat(metacard.getAttribute("nonexistent"), is(nullValue()));
+  }
+
+  static class AdaptedMetacardUnderTest extends AdaptedMetacard {
+    Set<Attribute> getAttributesInternal() {
+      return getAttributes();
+    }
+
+    int getInternalCount() {
+      return getAttributes().size();
+    }
+
+    List<Attribute> getAttributesThroughDescriptors() {
+      return getMetacardType()
+          .getAttributeDescriptors()
+          .stream()
+          .map(AttributeDescriptor::getName)
+          .map(this::getAttribute)
+          .collect(Collectors.toList());
+    }
+
+    int getDescriptorCount() {
+      return getMetacardType().getAttributeDescriptors().size();
+    }
+  }
+}

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestXmlInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/TestXmlInputTransformer.java
@@ -69,10 +69,7 @@ public class TestXmlInputTransformer {
     for (AttributeDescriptor descriptor : metacard.getMetacardType().getAttributeDescriptors()) {
       Attribute attribute = metacard.getAttribute(descriptor.getName());
       LOGGER.info(
-          "\t"
-              + descriptor.getName()
-              + ": "
-              + ((attribute == null) ? attribute : attribute.getValue()));
+          "\t" + descriptor.getName() + ": " + ((attribute == null) ? null : attribute.getValue()));
     }
 
     assertThat(metacard.getMetacardType().getName(), is(BasicTypes.BASIC_METACARD.getName()));
@@ -97,10 +94,7 @@ public class TestXmlInputTransformer {
     for (AttributeDescriptor descriptor : metacard.getMetacardType().getAttributeDescriptors()) {
       Attribute attribute = metacard.getAttribute(descriptor.getName());
       LOGGER.info(
-          "\t"
-              + descriptor.getName()
-              + ": "
-              + ((attribute == null) ? attribute : attribute.getValue()));
+          "\t" + descriptor.getName() + ": " + ((attribute == null) ? null : attribute.getValue()));
     }
   }
 
@@ -112,10 +106,7 @@ public class TestXmlInputTransformer {
     for (AttributeDescriptor descriptor : metacard.getMetacardType().getAttributeDescriptors()) {
       Attribute attribute = metacard.getAttribute(descriptor.getName());
       LOGGER.info(
-          "\t"
-              + descriptor.getName()
-              + ": "
-              + ((attribute == null) ? attribute : attribute.getValue()));
+          "\t" + descriptor.getName() + ": " + ((attribute == null) ? null : attribute.getValue()));
     }
 
     LOGGER.info("ID: {}", metacard.getId());
@@ -168,10 +159,7 @@ public class TestXmlInputTransformer {
     for (AttributeDescriptor descriptor : metacard.getMetacardType().getAttributeDescriptors()) {
       Attribute attribute = metacard.getAttribute(descriptor.getName());
       LOGGER.info(
-          "\t"
-              + descriptor.getName()
-              + ": "
-              + ((attribute == null) ? attribute : attribute.getValue()));
+          "\t" + descriptor.getName() + ": " + ((attribute == null) ? null : attribute.getValue()));
     }
 
     assertThat(metacard.getMetacardType().getName(), is(BasicTypes.BASIC_METACARD.getName()));


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where AdaptedMetacard was not cleaning out stale attribute values when new ones were set. 

#### Who is reviewing it? 
#### Choose 2 committers to review/merge the PR. 
@beyelerb 
@coyotesqrl

#### How should this be tested?
TBD

#### Any background context you want to provide?
TBD

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3549

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
