### PR TITLE
DDF-3513 Adds user pref for previewing images by hover

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -212,3 +212,5 @@
 @import 'dropdown/map-settings/dropdown.map-settings.less';
 @import 'about/about';
 @import 'about-menu/about-menu';
+@import 'hover-preview/hover-preview';
+@import 'dropdown/hover-preview/dropdown.hover-preview.less';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.hbs
@@ -11,15 +11,7 @@
  *
  **/
  --}}
-<div class="theme-font-size">
-</div>
-<div class="theme-spacing-mode">
-</div>
-<div class="theme-animation">
-</div>
-<div class="theme-hover-preview">
-</div>
-<div class="theme-theme">
-</div>
-<div class="theme-custom">
-</div>
+<img src="{{getImageSrc metacard.properties.thumbnail}}">
+<button class="is-primary" title="Click to open image in a new window.">
+    <span class="fa fa-search-plus"></span>
+</button>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.less
@@ -1,0 +1,20 @@
+@{customElementNamespace}dropdown.is-hover-preview {
+    display: inline-block;
+    position: relative;
+    text-align: left;
+
+    img:hover + button,
+    button:hover {
+        display: block;
+    }
+
+    button {
+        display: none;
+        position: absolute;
+        bottom: 0%;
+        right: 0%;
+        width: @minimumButtonSize;
+        height: @minimumButtonSize;
+        line-height: @minimumButtonSize;
+    }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/dropdown/hover-preview/dropdown.hover-preview.view.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+    'marionette',
+    'underscore',
+    'jquery',
+    '../dropdown.view',
+    './dropdown.hover-preview.hbs',
+    'component/hover-preview/hover-preview.view',
+    'properties',
+    'lodash/merge',
+    'js/Common',
+    'component/singletons/user-instance'
+], function (Marionette, _, $, DropdownView, template, ComponentView, properties, _merge, Common, user) {
+
+    return DropdownView.extend({
+        template: template,
+        className: 'is-hover-preview',
+        componentToShow: ComponentView,
+        events: {
+            'mouseenter button': 'handleMouseEnter',
+            'mouseleave button': 'handleMouseLeave',
+            'click button': 'handleClick'   
+        },
+        handleMouseEnter: function() {
+            if (user.getHoverPreview()) {
+                this.model.open();
+            }
+        },
+        handleMouseLeave: function() {
+            this.model.close();
+        },
+        handleClick: function() {
+            window.open(Common.getImageSrc(this.options.modelForComponent.get('metacard').get('properties').get('thumbnail')));
+        },
+        initialize: function(){
+            DropdownView.prototype.initialize.call(this);
+        },
+        initializeComponentModel: function(){
+            //override if you need more functionality
+            this.modelForComponent = this.options.modelForComponent;
+        },
+        listenToComponent: function(){
+            //override if you need more functionality
+        },
+        serializeData: function(){
+            return this.options.modelForComponent.toJSON();
+        }
+    });
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/hover-preview/hover-preview.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/hover-preview/hover-preview.hbs
@@ -11,15 +11,4 @@
  *
  **/
  --}}
-<div class="theme-font-size">
-</div>
-<div class="theme-spacing-mode">
-</div>
-<div class="theme-animation">
-</div>
-<div class="theme-hover-preview">
-</div>
-<div class="theme-theme">
-</div>
-<div class="theme-custom">
-</div>
+<img src="{{getImageSrc metacard.properties.thumbnail}}">

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/hover-preview/hover-preview.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/hover-preview/hover-preview.less
@@ -1,0 +1,5 @@
+@{customElementNamespace}hover-preview {
+    .customElement;
+
+    text-align: center;
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/hover-preview/hover-preview.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/hover-preview/hover-preview.view.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+var Marionette = require('marionette');
+var template = require('./hover-preview.hbs');
+var CustomElements = require('js/CustomElements');
+
+module.exports = Marionette.ItemView.extend({
+    template: template,
+    tagName: CustomElements.register('hover-preview')
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.hbs
@@ -35,7 +35,6 @@
         <div class="content-body">
             {{#if metacard.properties.thumbnail}}
                 <div class="detail-thumbnail details-property" data-help="{{getAlias 'thumbnail'}}">
-                    <img src="{{getImageSrc metacard.properties.thumbnail}}">
                 </div>
             {{/if}}
             {{#each customDetail}}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/result-item/result-item.view.js
@@ -32,10 +32,11 @@ define([
     'component/singletons/metacard-definitions',
     'moment',
     'component/singletons/sources-instance',
+    'component/dropdown/hover-preview/dropdown.hover-preview.view',
     'behaviors/button.behavior'
 ], function (Backbone, Marionette, _, $, template, CustomElements, IconHelper, store, Common, DropdownModel,
              MetacardInteractionsDropdownView, ResultIndicatorView, properties, router, user,
-             metacardDefinitions, moment, sources) {
+             metacardDefinitions, moment, sources, HoverPreviewDropdown) {
 
     return Marionette.LayoutView.extend({
         template: template,
@@ -54,7 +55,8 @@ define([
         },
         regions: {
             resultActions: '.result-actions',
-            resultIndicator: '.container-indicator'
+            resultIndicator: '.container-indicator',
+            resultThumbnail: '.detail-thumbnail'
         },
         behaviors: {
             button: {}
@@ -110,6 +112,15 @@ define([
             this.resultIndicator.show(new ResultIndicatorView({
                 model: this.model
             }));
+            this.handleResultThumbnail();
+        },
+        handleResultThumbnail: function() {
+            if (this.model.get('metacard').get('properties').get('thumbnail')) {
+                this.resultThumbnail.show(new HoverPreviewDropdown({
+                    model: new DropdownModel(),
+                    modelForComponent: this.model
+                }));
+            }
         },
         addConfiguredResultProperties: function(result){
             result.showSource = false;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/theme-settings/theme-settings.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/theme-settings/theme-settings.view.js
@@ -52,6 +52,7 @@ module.exports = Marionette.LayoutView.extend({
         spacingMode: '.theme-spacing-mode',
         theme: '.theme-theme',
         animationMode: '.theme-animation',
+        hoverPreview: '.theme-hover-preview',
         customPrimaryColor: '.theme-customPrimaryColor',
         customPositiveColor: '.theme-customPositiveColor',
         customNegativeColor: '.theme-customNegativeColor',
@@ -68,6 +69,7 @@ module.exports = Marionette.LayoutView.extend({
         this.showFontSize();
         this.showSpacingMode();
         this.showAnimation();
+        this.showHoverPreview();
         this.showTheme();
         this.showCustomColors();
         this.handleTheme();
@@ -131,6 +133,29 @@ module.exports = Marionette.LayoutView.extend({
         this.animationMode.currentView.turnOnLimitedWidth();
         this.animationMode.currentView.turnOnEditing();
         this.listenTo(animationModel, 'change:value', this.saveAnimationChanges);
+    },
+    showHoverPreview: function(){
+        var hoverPreviewModel = new Property({
+            label: 'Preview Full Image on Hover',
+            value: [user.getHoverPreview()],
+            enum: [
+                {
+                    label: 'On',
+                    value: true
+                },
+                {
+                    label: 'Off',
+                    value: false
+                }
+            ],
+            id: 'Full Image on Hover'
+        });
+        this.hoverPreview.show(new PropertyView({
+            model: hoverPreviewModel
+        }));
+        this.hoverPreview.currentView.turnOnLimitedWidth();
+        this.hoverPreview.currentView.turnOnEditing();
+        this.listenTo(hoverPreviewModel, 'change:value', this.saveHoverPreviewChanges);
     },
     showFontSize: function(){
         var fontSizeModel = new Property({
@@ -215,6 +240,12 @@ module.exports = Marionette.LayoutView.extend({
         preferences.set('animation', newAnimationMode);
         getPreferences(user).savePreferences();
     },  
+    saveHoverPreviewChanges: function(){
+        var preferences = getPreferences(user);
+        var newHoverPreview = this.hoverPreview.currentView.model.getValue()[0];
+        preferences.set('hoverPreview', newHoverPreview);
+        getPreferences(user).savePreferences();
+    }, 
     saveSpacingChanges: function(){
         var preferences = getPreferences(user);
         var newSpacingMode = this.spacingMode.currentView.model.getValue()[0];

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.hbs
@@ -14,12 +14,20 @@
 {{#each this.properties}}
     {{#unless hidden}}
         <td data-property="{{this.property}}" class="{{this.class}} {{#if hidden}}is-hidden-column{{/if}}" data-value="{{this.value}}">
-            {{#if this.html}}
-                {{{this.html}}}
-            {{else}}
-                <div>
+            <div>
+            {{#each this.value}}
+                <span data-value="{{this}}" title="{{getAlias ../this.property}}: {{this}}">
+                    {{#ifUrl this}}
+                        <a href="{{this}}" target="_blank">{{getAlias ../this.property}}</a>
+                    {{else}}
+                        {{this}}
+                    {{/ifUrl}}
+                </span>
+            {{/each}}
+            </div>
+            <div class="for-bold">
                 {{#each this.value}}
-                    <span data-value="{{this}}" title="{{getAlias ../this.property}}: {{this}}">
+                    <span data-value="{{this}}">
                         {{#ifUrl this}}
                             <a href="{{this}}" target="_blank">{{getAlias ../this.property}}</a>
                         {{else}}
@@ -27,19 +35,7 @@
                         {{/ifUrl}}
                     </span>
                 {{/each}}
-                </div>
-                <div class="for-bold">
-                    {{#each this.value}}
-                        <span data-value="{{this}}">
-                            {{#ifUrl this}}
-                                <a href="{{this}}" target="_blank">{{getAlias ../this.property}}</a>
-                            {{else}}
-                                {{this}}
-                            {{/ifUrl}}
-                        </span>
-                    {{/each}}
-                </div>
-            {{/if}}
+            </div>
         </td>
     {{/unless}}
 {{/each}}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.less
@@ -19,8 +19,8 @@
 
   img {
     display: inline;
-    min-height: @minimumButtonSize;
-    min-width: 200px;
+    min-height: 2*@minimumButtonSize;
+    min-width: 2*@minimumButtonSize;
     max-width: 200px;
     max-height: 200px;
   }
@@ -38,22 +38,6 @@
     position: relative;
     top: -1px;
     .is-bold();
-  }
-  
-  td.is-thumbnail {
-    button {
-      width: @minimumButtonSize;
-      height: @minimumButtonSize;
-      position: absolute;
-      right: @mediumSpacing;
-      bottom: @minimumSpacing;
-      display: none;
-    }
-
-    &:hover button,
-    button:hover {
-      display: block;
-    }
   }
 }
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -24,12 +24,17 @@ var metacardDefinitions = require('component/singletons/metacard-definitions');
 var Common = require('js/Common');
 var user = require('component/singletons/user-instance');
 var properties = require('properties');
+var HoverPreviewDropdown = require('component/dropdown/hover-preview/dropdown.hover-preview.view');
+var DropdownModel = require('component/dropdown/dropdown');
 
-module.exports = Marionette.ItemView.extend({
+module.exports = Marionette.LayoutView.extend({
     className: 'is-tr',
     tagName: CustomElements.register('result-row'),
     events: {
         'click .result-download': 'triggerDownload'
+    },
+    regions: {
+        resultThumbnail: '.is-thumbnail'
     },
     attributes: function() {
         return {
@@ -55,6 +60,15 @@ module.exports = Marionette.ItemView.extend({
     onRender: function() {
         this.checkIfDownloadable();
         this.$el.attr(this.attributes());
+        this.handleResultThumbnail();
+    },
+    handleResultThumbnail: function() {
+        if (this.model.get('metacard').get('properties').get('thumbnail')) {
+            this.resultThumbnail.show(new HoverPreviewDropdown({
+                model: new DropdownModel(),
+                modelForComponent: this.model
+            }));
+        }
     },
     checkIfDownloadable: function(){
         this.$el.toggleClass('is-downloadable', this.model.get('metacard').get('properties').get('resource-download-url') !== undefined);
@@ -80,7 +94,6 @@ module.exports = Marionette.ItemView.extend({
                 if (value.constructor !== Array){
                     value = [value];
                 }
-                var html;
                 var className = 'is-text';
                 if (value && metacardDefinitions.metacardTypes[property]) {
                     switch (metacardDefinitions.metacardTypes[property].type) {
@@ -94,14 +107,11 @@ module.exports = Marionette.ItemView.extend({
                     }
                 }
                 if (property === 'thumbnail') {
-                    var escapedValue = Common.escapeHTML(value);
-                    html = '<img src="' +  Common.getImageSrc(escapedValue) + '"><button class="is-primary result-download"><span class="fa fa-download"></span></button>';
                     className = "is-thumbnail";
                 }
                 return {
                     property: property,
                     value: value,
-                    html: html,
                     class: className,
                     hidden: hiddenColumns.indexOf(property) >= 0 || properties.isHidden(property) || metacardDefinitions.isHiddenTypeExceptThumbnail(property)
                 };

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -146,7 +146,8 @@ define([
                 goldenLayoutMetacard: undefined,
                 goldenLayoutAlert: undefined,
                 theme: new Theme(),
-                animation: true
+                animation: true,
+                hoverPreview: true
             };
         },
         relations: [
@@ -254,6 +255,9 @@ define([
         getSummaryShown: function(){
             return this.get('inspector-summaryShown');
         },
+        getHoverPreview: function() {
+            return this.get('hoverPreview');
+        },
         parse: function(data, options){
             if (options && options.drop) {
                 return {};
@@ -284,6 +288,9 @@ define([
         },
         getSummaryShown: function(){
             return this.get('preferences').getSummaryShown();
+        },
+        getHoverPreview: function() {
+            return this.get('preferences').getHoverPreview();
         }
     });
 
@@ -320,6 +327,9 @@ define([
         },
         getUserReadableDate: function(date){
             return moment(date).format(this.get('user').get('preferences').get('timeFormat'));
+        },
+        getHoverPreview: function() {
+            return this.get('user').getHoverPreview();
         },
         parse: function (body) {
             if (body.isGuest) {


### PR DESCRIPTION
#### What does this PR do?
 - Adds user preference to preview images by hovering.

#### Who is reviewing it? 
@bdeining
@jlcsmith
@mackncheesiest 
@mojogitoverhere 

#### How should this be tested? (List steps with links to updated documentation)
Turn on full image preview on hover.  Then go to the result previews and hover over an image and hover over the zoom icon.  This will pop open a full view of the image.  Click to see the image in a new window.

Turn off full image preview on hover.  Then go to the result previews and hover over an image and hover over the zoom icon.  Verify nothing pops up.  Verify you can still click the icon to see the image in a new window.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3513

#### Screenshots (if appropriate)
![screen shot 2018-01-17 at 11 58 41 am](https://user-images.githubusercontent.com/11984853/35061317-2452518e-fb7e-11e7-9810-e37914876b8f.png)
![screen shot 2018-01-17 at 11 58 33 am](https://user-images.githubusercontent.com/11984853/35061318-246c8144-fb7e-11e7-9348-92dda49f4d70.png)
![screen shot 2018-01-17 at 11 58 20 am](https://user-images.githubusercontent.com/11984853/35061319-248c2c24-fb7e-11e7-8a2a-ec54f8191bd2.png)
