### PR TITLE
[2.11.x] DDF-3555 Add the destination in LogoutResponse sent through HTTP-POST and fix not being able to read long LogoutRequest

### DIFF
--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -50,6 +50,8 @@ public final class RestSecurity {
 
   public static final boolean GZIP_COMPATIBLE = true;
 
+  private RestSecurity() {}
+
   /**
    * Parses the incoming subject for a saml assertion and sets that as a header on the client.
    *
@@ -140,10 +142,20 @@ public final class RestSecurity {
   }
 
   public static String inflateBase64(String base64EncodedValue) throws IOException {
-    byte[] deflatedValue = Base64.getMimeDecoder().decode(base64EncodedValue);
+    byte[] deflatedValue = base64Decode(base64EncodedValue);
     InputStream is =
         new InflaterInputStream(
             new ByteArrayInputStream(deflatedValue), new Inflater(GZIP_COMPATIBLE));
     return IOUtils.toString(is, StandardCharsets.UTF_8.name());
+  }
+
+  /**
+   * Decodes Base64 encoded values
+   *
+   * @param base64EncodedValue value to decode
+   * @return the bytes of the decoded value
+   */
+  public static byte[] base64Decode(String base64EncodedValue) {
+    return Base64.getMimeDecoder().decode(base64EncodedValue);
   }
 }

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostRequestDecoder.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostRequestDecoder.java
@@ -16,11 +16,11 @@ package org.codice.ddf.security.idp.binding.post;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.codice.ddf.security.idp.binding.api.RequestDecoder;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -39,7 +39,7 @@ public class PostRequestDecoder implements RequestDecoder {
       throw new IllegalArgumentException("Missing SAMLRequest on IdP request.");
     }
     String decodedRequest =
-        new String(Base64.getMimeDecoder().decode(samlRequest), StandardCharsets.UTF_8);
+        new String(RestSecurity.base64Decode(samlRequest), StandardCharsets.UTF_8);
     ByteArrayInputStream tokenStream =
         new ByteArrayInputStream(decodedRequest.getBytes(StandardCharsets.UTF_8));
     Document authnDoc;

--- a/platform/security/idp/security-idp-server/src/test/groovy/org/codice/ddf/security/idp/server/IdpEndpointSpecTest.groovy
+++ b/platform/security/idp/security-idp-server/src/test/groovy/org/codice/ddf/security/idp/server/IdpEndpointSpecTest.groovy
@@ -439,9 +439,6 @@ class IdpEndpointSpecTest extends Specification {
                 request)
         
         then:
-        // Verify the request was read correctly
-        notThrown(Exception)
-
         //Check destination
         String responseString = response.getEntity().toString()
         int valueStartIndex = responseString.indexOf("value")


### PR DESCRIPTION
#### What does this PR do?
- Adds the destination in `LogoutResponse`s sent through HTTP-POST
- Fixes not being able to read long `LogoutRequest`s though HTTP-POST 

#### Who is reviewing it? 
@Lambeaux @brjeter @bakejeyner 

#### Choose 2 committers to review/merge the PR. 
@coyotesqrl
@stustison 

#### How should this be tested? (List steps with links to updated documentation)
Try using different SP's and verify that the destination is present in the `LogoutResponse`.
Test using Spring's SP. Contact me for how to do that.

#### Any background context you want to provide?
When trying to use Spring's SP with DDF's IdP, we get a `org.opensaml.xml.security.SecurityException` with the message `SAML message intended destination (required by binding) was not present`

In https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf, section 3.5.5.2, we have:

```
If the message is signed, the Destination XML attribute in the root SAML element 
of the protocol message MUST contain the URL to which the sender has instructed
the user agent to deliver the message. The recipient MUST then verify that the value
matches the location at which the message has been received.
```

#### What are the relevant tickets?
[DDF-3555](https://codice.atlassian.net/browse/DDF-3555)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
