### PR TITLE
DDF-3418 Fixes datepicker issue with opening upwards

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
@@ -67,11 +67,16 @@ define([
             this.updatePosition();
             this.addResizeHandler();
         },
-        updatePosition: function(){
-            var inputCoordinates = this.$el.find('.input-group.date')[0].getBoundingClientRect();
-            $('body > .bootstrap-datetimepicker-widget').css('left', inputCoordinates.left)
-                .css('top', inputCoordinates.top + inputCoordinates.height)
-                .css('width', inputCoordinates.width);
+        updatePosition: function () {
+            let datepicker = $('body').find('.bootstrap-datetimepicker-widget:last');
+            let inputCoordinates = this.$el.find('.input-group.date')[0].getBoundingClientRect();
+            let top = datepicker.hasClass('bottom') ? inputCoordinates.top + inputCoordinates.height : inputCoordinates.top - datepicker.outerHeight();
+            datepicker.css({
+                'top': top + 'px',
+                'bottom': 'auto',
+                'left': inputCoordinates.left + 'px',
+                'width': inputCoordinates.width + 'px'
+            });
         },
         addResizeHandler: function(){
             $(window).on('resize.datePicker', this.updatePosition.bind(this));


### PR DESCRIPTION
#### What does this PR do? 
 - Previously the datepicker would not appear if it was forced to open upwards.
 - https://github.com/Eonasdan/bootstrap-datetimepicker/issues/790 details some of the methods people have found for correcting the position when attaching to the body.  The positioning method now takes this into account.

#### Who is reviewing it? 
@bdeining 
@millerw8 
@jlcsmith
@mackncheesiest 
@adimka 

#### How should this be tested? (List steps with links to updated documentation)
Open a datepicker that only has room to open upwards and verify it's visible.

#### Any background context you want to provide?
https://github.com/Eonasdan/bootstrap-datetimepicker/issues/790 details others who have ran into this issue.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3418#### Screenshots (if appropriate)

![screen shot 2018-01-18 at 7 17 58 pm](https://user-images.githubusercontent.com/11984853/35131647-9a82acb2-fc84-11e7-88a6-26dda10d4742.png)
![screen shot 2018-01-18 at 7 17 48 pm](https://user-images.githubusercontent.com/11984853/35131648-9aa04ace-fc84-11e7-84d3-312d1097419c.png)
