### PR TITLE
DDF-3555 Add the destination in LogoutResponse sent through HTTP-POST and fix not being able to read long LogoutRequest

### DIFF
--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/jaxrs/RestSecurity.java
@@ -50,6 +50,8 @@ public final class RestSecurity {
 
   public static final boolean GZIP_COMPATIBLE = true;
 
+  private RestSecurity() {}
+
   /**
    * Parses the incoming subject for a saml assertion and sets that as a header on the client.
    *
@@ -140,10 +142,20 @@ public final class RestSecurity {
   }
 
   public static String inflateBase64(String base64EncodedValue) throws IOException {
-    byte[] deflatedValue = Base64.getMimeDecoder().decode(base64EncodedValue);
+    byte[] deflatedValue = base64Decode(base64EncodedValue);
     InputStream is =
         new InflaterInputStream(
             new ByteArrayInputStream(deflatedValue), new Inflater(GZIP_COMPATIBLE));
     return IOUtils.toString(is, StandardCharsets.UTF_8.name());
+  }
+
+  /**
+   * Decodes Base64 encoded values
+   *
+   * @param base64EncodedValue value to decode
+   * @return the bytes of the decoded value
+   */
+  public static byte[] base64Decode(String base64EncodedValue) {
+    return Base64.getMimeDecoder().decode(base64EncodedValue);
   }
 }

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostRequestDecoder.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostRequestDecoder.java
@@ -16,11 +16,11 @@ package org.codice.ddf.security.idp.binding.post;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.codice.ddf.security.common.jaxrs.RestSecurity;
 import org.codice.ddf.security.idp.binding.api.RequestDecoder;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -39,7 +39,7 @@ public class PostRequestDecoder implements RequestDecoder {
       throw new IllegalArgumentException("Missing SAMLRequest on IdP request.");
     }
     String decodedRequest =
-        new String(Base64.getMimeDecoder().decode(samlRequest), StandardCharsets.UTF_8);
+        new String(RestSecurity.base64Decode(samlRequest), StandardCharsets.UTF_8);
     ByteArrayInputStream tokenStream =
         new ByteArrayInputStream(decodedRequest.getBytes(StandardCharsets.UTF_8));
     Document authnDoc;

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -1137,7 +1137,8 @@ public class IdpEndpoint implements Idp {
     try {
       if (samlRequest != null) {
         LogoutRequest logoutRequest =
-            logoutMessage.extractSamlLogoutRequest(RestSecurity.inflateBase64(samlRequest));
+            logoutMessage.extractSamlLogoutRequest(
+                new String(RestSecurity.base64Decode(samlRequest), StandardCharsets.UTF_8));
         validatePost(request, logoutRequest);
         return handleLogoutRequest(
             cookie, logoutState, logoutRequest, SamlProtocol.Binding.HTTP_POST, relayState);
@@ -1255,6 +1256,14 @@ public class IdpEndpoint implements Idp {
                 SystemBaseUrl.constructUrl(IDP_LOGOUT, true),
                 status,
                 logoutState.getOriginalRequestId());
+
+        ((LogoutResponse) logoutObject)
+            .setDestination(
+                getServiceProvidersMap()
+                    .get(entityId)
+                    .getLogoutService(SamlProtocol.Binding.HTTP_POST)
+                    .getUrl());
+
         relay = logoutState.getInitialRelayState();
         logoutStates.decode(cookie.getValue(), true);
         samlType = SamlProtocol.Type.RESPONSE;

--- a/platform/security/idp/security-idp-server/src/test/groovy/org/codice/ddf/security/idp/server/IdpEndpointSpecTest.groovy
+++ b/platform/security/idp/security-idp-server/src/test/groovy/org/codice/ddf/security/idp/server/IdpEndpointSpecTest.groovy
@@ -1,5 +1,19 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.ddf.security.idp.server
 
+import com.google.common.collect.ImmutableList
 import ddf.security.encryption.EncryptionService
 import ddf.security.samlp.LogoutMessage
 import ddf.security.samlp.ValidationException
@@ -12,7 +26,6 @@ import org.opensaml.saml.common.SignableSAMLObject
 import org.opensaml.saml.saml2.core.*
 import org.opensaml.saml.saml2.core.impl.LogoutRequestBuilder
 import org.opensaml.saml.saml2.core.impl.LogoutResponseBuilder
-import org.opensaml.saml.saml2.core.SessionIndex
 import org.opensaml.xmlsec.signature.SignableXMLObject
 import org.w3c.dom.Element
 import spock.lang.Specification
@@ -20,6 +33,7 @@ import spock.lang.Specification
 import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletRequest
 import javax.xml.stream.XMLStreamException
+import java.nio.charset.StandardCharsets
 
 class IdpEndpointSpecTest extends Specification {
     @Rule
@@ -384,6 +398,56 @@ class IdpEndpointSpecTest extends Specification {
         then:
         exception = thrown(IdpException)
         exception.cause instanceof XMLStreamException
+    }
+
+    def "verify destination is present in LogoutResponse"(){
+        setup:
+        String samlRequest = "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c2FtbDJwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbDJwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIERlc3RpbmF0aW9uPSJodHRwczovL2xvY2FsaG9zdDo4OTkzL3NlcnZpY2VzL2lkcC9sb2dvdXQiIElEPSJhMmI3ODY3MDA0MTdqYjNqMzdoZTdqNzBqNTI4YTM1IiBJc3N1ZUluc3RhbnQ9IjIwMTgtMDEtMThUMTY6MTQ6MDAuOTU0WiIgVmVyc2lvbj0iMi4wIj48c2FtbDI6SXNzdWVyIHhtbG5zOnNhbWwyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIj5odHRwOi8vbG9jYWxob3N0OjgwL3NwcmluZy1zZWN1cml0eS1zYW1sMi1zYW1wbGUvc2FtbC9tZXRhZGF0YTwvc2FtbDI6SXNzdWVyPjxkczpTaWduYXR1cmUgeG1sbnM6ZHM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyMiPjxkczpTaWduZWRJbmZvPjxkczpDYW5vbmljYWxpemF0aW9uTWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS8xMC94bWwtZXhjLWMxNG4jIi8+PGRzOlNpZ25hdHVyZU1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyNyc2Etc2hhMSIvPjxkczpSZWZlcmVuY2UgVVJJPSIjYTJiNzg2NzAwNDE3amIzajM3aGU3ajcwajUyOGEzNSI+PGRzOlRyYW5zZm9ybXM+PGRzOlRyYW5zZm9ybSBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyNlbnZlbG9wZWQtc2lnbmF0dXJlIi8+PGRzOlRyYW5zZm9ybSBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjwvZHM6VHJhbnNmb3Jtcz48ZHM6RGlnZXN0TWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI3NoYTEiLz48ZHM6RGlnZXN0VmFsdWU+WHFxMWQzS3E5L01jZ3NaSlRkY1dNdThLVGlRPTwvZHM6RGlnZXN0VmFsdWU+PC9kczpSZWZlcmVuY2U+PC9kczpTaWduZWRJbmZvPjxkczpTaWduYXR1cmVWYWx1ZT5pbU1xNk9HZHVYUmFnWW1kQVRzNEhzQy96bXljNHhUWjhsSHhxaFJsZWRzanM3R0Y2TDZ4RkhUR0ZCQ3BHODRtazR4cVRWU2thSEs1aVUySlh4VFBxUWpNd1NMbXlyeCtOS3BqbWc1Q2hnL0RUSFMvQS9YYTU5SnIyN1NOTGhTSGw0aWZrUEdvdDlHcE5BcEttUTBhYVRHaHlYUE5KN1JYb1doRTZhZXovWHdnbzBxMFI2SlQ0UWJGRVlFQUVjT0hxL2kxZFNWakNWQnN1TUlId0E1OHJFZHBFejI0MkhpYmpXVTFXL1lnZTU5dmlrK1NMUXp2RERFMDBGNnBweU5WZ0laVkFIWFhFODZndm5xZlQzYmJLK1dVV3NVbklBM2JJQVZtSU42aWhQbXdBb0YxOUVSdVVHbzd2aS9xUjlLSk9rWmRXRE5leUt6OVVCenRmWG5YZ2c9PTwvZHM6U2lnbmF0dXJlVmFsdWU+PGRzOktleUluZm8+PGRzOlg1MDlEYXRhPjxkczpYNTA5Q2VydGlmaWNhdGU+TUlJRFVqQ0NBcnVnQXdJQkFnSUlWQlpoVllBRk1pZ3dEUVlKS29aSWh2Y05BUUVGQlFBd2dZUXhDekFKQmdOVkJBWVRBbFZUTVFzdwpDUVlEVlFRSUV3SkJXakVNTUFvR0ExVUVDaE1EUkVSR01Rd3dDZ1lEVlFRTEV3TkVaWFl4R1RBWEJnTlZCQU1URUVSRVJpQkVaVzF2CklGSnZiM1FnUTBFeE1UQXZCZ2txaGtpRzl3MEJDUUVXSW1WdFlXbHNRV1JrY21WemN6MWtaR1p5YjI5MFkyRkFaWGhoYlhCc1pTNXYKY21jd0hoY05NVGd3TVRBMU1ESXhNekkxV2hjTk1Ua3dNVEExTURJeE16STFXakJLTVFzd0NRWURWUVFHRXdKVlV6RUxNQWtHQTFVRQpDQXdDUVZveEREQUtCZ05WQkFvTUEwUkVSakVNTUFvR0ExVUVDd3dEUkdWMk1SSXdFQVlEVlFRRERBbHNiMk5oYkdodmMzUXdnZ0VpCk1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRQ3gyMmJnY1p0L0ZTMXh5S0JBS2lrRTVnTGlpemNFMVlWODBWdmEKaytEVnBPcUx4c2VidW9GL2lXakMyRWRJK1VCZkh6K2ZkTmxtbzJVa09MQ1R5VS90MGFSZFJkWnVQU28vM2ViUXRsRW15cEtKNjQ3dApIZVFzUEVPMS9Fc1lQZlBtRmVTWHZIUU5RZWxUYTlJWlFlMTErK0JoaERyTWNVTkNEMWRuajdrTE5GVkNuSzNwTGhqbjFCTCtweDNFCmt3bXFCZnBoSG0xVGo3V3pCSWY2Q2JCQ3B0WVNUY3FxbGRIelhzcXl5TnZTcVJxZWxkR1p2Vkhsb0xPTnd0OWJ6VFZrOHlibWIxRVAKajJqSU1VeFRPeGEwZFZVS0plSVozenlaNFZLekxmY2pVblhnbU5BcVgyVHl0eWpFODUwOVlFc1p2SExST3c0VkRWS1pVazUxcVZtQgpBZ01CQUFHamdZRXdmekFKQmdOVkhSTUVBakFBTUNjR0NXQ0dTQUdHK0VJQkRRUWFGaGhHVDFJZ1ZFVlRWRWxPUnlCUVZWSlFUMU5GCklFOU9URmt3SFFZRFZSME9CQllFRkV4U0hTZ2Zrbzl6UThyM0VKYXRNMFIyUUlZQ01COEdBMVVkSXdRWU1CYUFGT0ZVeDVmZkNzSy8KcVY5NFhqc0xLK1JJRjczR01Ba0dBMVVkRVFRQ01BQXdEUVlKS29aSWh2Y05BUUVGQlFBRGdZRUFkdzBtZ1BySVVVc1lKelRMSWN3bwo2TjdQY2p2YitOMUQvRjh3VHRtR2VjRWY3UG5zUm9RQkpJenViVDVYc1psWUFTVWhybE51TkFUSXpkSnkzc3hhbVY4OTBXcmxuVWZXClpIcVg3dnZFSWFnY205RXMvdTJiYTViU1h2NGZnd0VEdCtXdUhwQUpZSkxPZjN1aEE4ck9rZ0t1SVVVcDlYeG5waWw2TUNNeHBMcz08L2RzOlg1MDlDZXJ0aWZpY2F0ZT48L2RzOlg1MDlEYXRhPjwvZHM6S2V5SW5mbz48L2RzOlNpZ25hdHVyZT48c2FtbDI6TmFtZUlEIHhtbG5zOnNhbWwyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIiBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpuYW1laWQtZm9ybWF0OnBlcnNpc3RlbnQiIE5hbWVRdWFsaWZpZXI9Imh0dHA6Ly9jeGYuYXBhY2hlLm9yZy9zdHMiPmFkbWluPC9zYW1sMjpOYW1lSUQ+PHNhbWwycDpTZXNzaW9uSW5kZXg+Nzk3ODwvc2FtbDJwOlNlc3Npb25JbmRleD48L3NhbWwycDpMb2dvdXRSZXF1ZXN0Pg=="
+        String relayState = "relayState"
+        def request = Mock(HttpServletRequest) {
+            getCookies() >> {
+                [Mock(Cookie) {
+                    getName() >> Idp.COOKIE
+                    getValue() >> "cookieValue"
+                }]
+            }
+        }
+
+        idpEndpoint.logoutMessage = Mock(LogoutMessage) {
+            extractSamlLogoutRequest(_ as String) >> Mock(LogoutRequest) {
+                getIssuer() >> Mock(Issuer) {
+                    getValue() >> sp1entityid
+                }
+                getNameID() >> Mock(NameID) {
+                    getValue() >> "nameId"
+                }
+                getID() >> "requestId"
+            }
+            buildLogoutResponse(_ as String, _ as String, _ as String) >>
+                    { String issuer, String statusCode, String inResponseTo ->
+                        return new LogoutResponseBuilder().buildObject()
+                    }
+        }
+
+        idpEndpoint.setSpMetadata(ImmutableList.of(sp1metadata, sp2metadata))
+
+        when:
+        def response = idpEndpoint.processPostLogout(
+                samlRequest,
+                null,
+                relayState,
+                request)
+
+        then:
+        //Check destination
+        String responseString = response.getEntity().toString()
+        int valueStartIndex = responseString.indexOf("value")
+        int valueEndIndex = responseString.indexOf("/", valueStartIndex)
+        String value = responseString.substring(valueStartIndex, valueEndIndex).replace("value=\"", "")
+        String logoutResponse = new String(Base64.getMimeDecoder().decode(value), StandardCharsets.UTF_8)
+
+        logoutResponse.indexOf("Destination") != -1
+        logoutResponse.contains(sp1entityid)
     }
 
     String sp1entityid = "https://sp1:8993/services/saml"


### PR DESCRIPTION
Forward port of https://github.com/codice/ddf/pull/2863
#### What does this PR do?
- Adds the destination in `LogoutResponse`s sent through HTTP-POST
- Fixes not being able to read long `LogoutRequest`s though HTTP-POST 

#### Who is reviewing it? 
@Lambeaux @brjeter @bakejeyner 

#### Choose 2 committers to review/merge the PR. 
@coyotesqrl
@stustison 

#### How should this be tested? (List steps with links to updated documentation)
Try using different SP's and verify that the destination is present in the `LogoutResponse`.
Test using Spring's SP. Contact me for how to do that.

#### Any background context you want to provide?
When trying to use Spring's SP with DDF's IdP, we get a `org.opensaml.xml.security.SecurityException` with the message `SAML message intended destination (required by binding) was not present`

In https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf, section 3.5.5.2, we have:

```
If the message is signed, the Destination XML attribute in the root SAML element 
of the protocol message MUST contain the URL to which the sender has instructed
the user agent to deliver the message. The recipient MUST then verify that the value
matches the location at which the message has been received.
```

#### What are the relevant tickets?
[DDF-3555](https://codice.atlassian.net/browse/DDF-3555)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
