### PR TITLE
DDF-3559 Bypassing IdP during initial install

### DIFF
--- a/distribution/docs/src/main/resources/content/_quickstart/quickstart-certificates.adoc
+++ b/distribution/docs/src/main/resources/content/_quickstart/quickstart-certificates.adoc
@@ -71,7 +71,6 @@ where:
 ** `DNS` - hostname
 ** `IP` - ip address (V4 or V6)
 ** `dirName` - directory name
-
 ****
 
 The `CertNew` scripts:
@@ -83,29 +82,34 @@ The `CertNew` scripts:
 
 To install a certificate signed by a different Certificate Authority, see <<_managing_keystores,Managing Keystores>>.
 
-Once the certificate has been updated the system user and `org.codice.ddf.system.hostname` property will also need to be updated to match the FQDN. Replace localhost with the FQDN in `${home_directory}/etc/users.properties`, `${home_directory}/etc/users.attributes` and `${home_directory}/etc/system.properties`.
-
-Finally, restart the ${branding} instance.
-Browse the ${admin-console} to test changes.
+After this proceed to <<_updating_settings_after_changing_certificates,Updating Settings After Changing Certificates>>.
 
 [WARNING]
 ====
 If the server's fully qualified domain name is not recognized, the name may need to be added to the network's DNS server.
 ====
 
-[TIP]
-====
-The ${branding} instance can be tested even if there is no entry for the FQDN in the DNS.
-First, test if the FQDN is already recognized.
-Execute this command:
+===== Dealing with Lack of DNS
 
-`ping <FQDN>`
+In some cases DNS may not be available and the system will need to be configured to work with IP addresses.
 
-If the command responds with an error message such as unknown host, then modify the system's `hosts` file to point the server's FQDN to the loopback address.
-For example:
+Options can be given to the CertNew Scripts to generate certs that will work in this scenario.
 
-`127.0.0.1 <FQDN>`
-====
+.*NIX
+****
+From ${home_directory}/etc/certs/ run:
+
+`sh CertNew.sh -cn <IP> -san "IP:<IP>"`
+****
+
+.Windows
+****
+From ${home_directory}/etc/certs/ run:
+
+`CertNew -cn <IP> -san "IP:<IP>"`
+****
+
+After this proceed to <<_updating_settings_after_changing_certificates,Updating Settings After Changing Certificates>>, and be sure to use the IP address instead of the FQDN.
 
 ==== Creating Self-Signed Certificates
 
@@ -142,3 +146,19 @@ The following steps demonstrate signing a certificate for the `tokenissuer` user
 `$> openssl ca -out tokenissuer.crt -infiles tokenissuer.req`
 
 These certificates will be used during system configuration to replace the default certificates.
+
+==== Updating Settings After Changing Certificates
+
+After changing the certificates it will be necessary to update the system user and the `org.codice.ddf.system.hostname` property with the value of either the FQDN or the IP.
+
+FQDNs should be used wherever possible. In the absence of DNS, however, IP addresses can be used.
+
+Replace `localhost` with the FQDN or the IP in `${home_directory}/etc/users.properties`, `${home_directory}/etc/users.attributes`, and `${home_directory}/etc/system.properties`.
+
+[TIP]
+====
+On linux this can be accomplished with a single command:
+`sed -i 's/localhost/<FQDN|IP>/g' ${home_directory}/etc/users.* ${home_directory}/etc/system.properties`
+====
+
+Finally, restart the ${branding} instance. Navigate to the ${admin-console} to test changes.

--- a/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc
+++ b/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc
@@ -149,3 +149,16 @@ This installation directory will be referred to as `${home_directory}`.
 ----
 ${branding-lowercase}${at-symbol}local>
 ----
+
+=== Quick Install of ${branding} on a remote headless server
+
+If ${branding} is being installed on a remote server that has no user interface some additional steps must be taken prior to starting the system.
+
+. Update any references to localhost in the following files. These references to localhost should be updated to match either the hostname or IP of the system.
+** `${home_directory}/etc/system.properties`
+** `${home_directory}/etc/users.properties`
+** `${home_directory}/etc/users.attributes`
+. From the console go to ${home_directory}/etc/certs.
+.. If using a hostname run: `sh CertNew.sh -cn <hostname> -san "DNS:<hostname>"` (or `CertNew -cn <hostname> -san "DNS:<hostname>"` on windows).
+.. If using an IP address run: `sh CertNew.sh -cn <IP> -san "IP:<IP>"` (or `CertNew -cn <IP> -san "IP:<IP>"` on windows).
+. Proceed with starting the system and continue as usual.


### PR DESCRIPTION
#### What does this PR do?

Adds an authentication type for `/admin=BASIC` that gets removed after install
Updates documentation to explain how to generate certs that are valid for IP addresses

#### Who is reviewing it? 

@emmberk @peterhuffer 

#### Choose 2 committers to review/merge the PR. 

@clockard @figliold 

#### How should this be tested? (List steps with links to updated documentation)

1. Follow the added section in the quickstart guide.
2. Start the system.
3. Access admin ui installer via `https://<FQDN>:8993/admin`
4. Confirm that login works via idp
5. Starting with a clean system, repeat using IP instead of FQDN in all steps.

#### What are the relevant tickets?
[DDF-3559](https://codice.atlassian.net/browse/DDF-3559)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
