### PR TITLE
DDF-3568 clean up ddf.home system property usages

### DIFF
--- a/broker/broker-app/src/main/resources/features.xml
+++ b/broker/broker-app/src/main/resources/features.xml
@@ -63,10 +63,10 @@
         <feature>transaction</feature>
         <feature>netty-core</feature>
         <feature>scr</feature>
-        <configfile finalname="etc/org.apache.activemq.artemis.cfg">
+        <configfile finalname="${karaf.etc}/org.apache.activemq.artemis.cfg">
             mvn:org.apache.activemq/artemis-features/${artemis.version}/cfg
         </configfile>
-        <configfile finalname="etc/artemis.xml">
+        <configfile finalname="${karaf.etc}/artemis.xml">
             mvn:org.apache.activemq/artemis-features/${artemis.version}/xml/artemis
         </configfile>
 

--- a/broker/broker-app/src/main/resources/features.xml
+++ b/broker/broker-app/src/main/resources/features.xml
@@ -63,10 +63,10 @@
         <feature>transaction</feature>
         <feature>netty-core</feature>
         <feature>scr</feature>
-        <configfile finalname="${karaf.etc}/org.apache.activemq.artemis.cfg">
+        <configfile finalname="${ddf.etc}/org.apache.activemq.artemis.cfg">
             mvn:org.apache.activemq/artemis-features/${artemis.version}/cfg
         </configfile>
-        <configfile finalname="${karaf.etc}/artemis.xml">
+        <configfile finalname="${ddf.etc}/artemis.xml">
             mvn:org.apache.activemq/artemis-features/${artemis.version}/xml/artemis
         </configfile>
 

--- a/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-backupplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,7 +34,7 @@
           destroy-method="shutdown">
         <cm:managed-properties persistent-id="ddf.catalog.backup.CatalogBackupPlugin"
                                update-strategy="container-managed"/>
-        <property name="rootBackupDir" value="${ddf.home}/data/backup"/>
+        <property name="rootBackupDir" value="${ddf.data}/backup"/>
         <property name="subDirLevels" value="2"/>
         <property name="terminationTimeoutSeconds" value="30"/>
         <property name="executor" ref="executorService"/>

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ImportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ImportCommand.java
@@ -263,7 +263,7 @@ public class ImportCommand extends CatalogCommands {
   private ZipValidator initZipValidator() {
     ZipValidator zipValidator = new ZipValidator();
     zipValidator.setSignaturePropertiesPath(
-        Paths.get(System.getProperty("ddf.home"), "/etc/ws-security/server/signature.properties")
+        Paths.get(System.getProperty("ddf.etc"), "/ws-security/server/signature.properties")
             .toString());
     zipValidator.init();
     return zipValidator;

--- a/catalog/core/catalog-core-localstorageprovider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-localstorageprovider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,7 +22,7 @@
         <cm:managed-properties
                 persistent-id="org.codice.ddf.catalog.content.impl.FileSystemStorageProvider"
                 update-strategy="container-managed"/>
-        <property name="baseContentDirectory" value="${ddf.home}/data"/>
+        <property name="baseContentDirectory" value="${ddf.data}"/>
         <property name="mimeTypeMapper" ref="mimeTypeMapper"/>
     </bean>
 

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/SolrCommands.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/SolrCommands.java
@@ -43,7 +43,7 @@ public abstract class SolrCommands implements Action {
   private static final String ZOOKEEPER_HOSTS_PROP = "solr.cloud.zookeeper";
 
   protected static final Path SYSTEM_PROPERTIES_PATH =
-      Paths.get(System.getProperty("ddf.home"), "etc", "system.properties");
+      Paths.get(System.getProperty("ddf.etc"), "system.properties");
 
   private static final Color ERROR_COLOR = Ansi.Color.RED;
 

--- a/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/BackupCommandTest.java
+++ b/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/BackupCommandTest.java
@@ -87,6 +87,8 @@ public class BackupCommandTest {
 
   private static final String DDF_HOME_PROP = "ddf.home";
 
+  private static final String DDF_ETC_PROP = "ddf.etc";
+
   private static final String DEFAULT_DDF_HOME = "/opt/ddf";
 
   private static final Path SYSTEM_PROPERTIES_PATH =
@@ -120,6 +122,7 @@ public class BackupCommandTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     setDdfHome();
+    setDdfEtc();
     createDefaultMiniSolrCloudCluster();
     addDocument("1");
   }
@@ -1025,6 +1028,10 @@ public class BackupCommandTest {
 
   private static void setDdfHome() {
     System.setProperty(DDF_HOME_PROP, DEFAULT_DDF_HOME);
+  }
+
+  private static void setDdfEtc() {
+    System.setProperty(DDF_ETC_PROP, Paths.get(DEFAULT_DDF_HOME, "etc").toString());
   }
 
   private void setupSolrClientType(String solrClientType) {

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -46,7 +46,7 @@
 
     <bean id="deprecatedProductCache" class="ddf.catalog.cache.impl.ResourceCacheImpl"
           destroy-method="teardownCache">
-        <argument value="${ddf.home}/data/Product_Cache"/>
+        <argument value="${ddf.data}/Product_Cache"/>
     </bean>
 
     <bean id="productCache" class="org.codice.ddf.catalog.resource.cache.impl.ResourceCacheImpl">

--- a/catalog/core/catalog-core-urlresourcereader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,7 +26,7 @@
       <argument ref="mimeTypeMapper"/>
       <property name="rootResourceDirectories">
         <set>
-          <value type="java.lang.String">${ddf.home}/data/products</value>
+          <value type="java.lang.String">${ddf.data}/products</value>
         </set>
       </property>
   </bean>

--- a/catalog/ftp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ftp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -45,7 +45,7 @@
         <argument ref="uuidGenerator"/>
     </bean>
     <bean id="userManager" class="ddf.catalog.ftp.UserManagerImpl">
-        <property name="uploadDirectory" value="${ddf.home}/data/products"/>
+        <property name="uploadDirectory" value="${ddf.data}/products"/>
         <property name="karafLocalRoles" value="${karaf.local.roles}"/>
         <argument ref="securityManager"/>
     </bean>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -37,7 +37,7 @@
                 </list>
             </property>
             <property name="outputPathTemplate"
-                      value="data/backup/metacard/{{substring id 0 3}}/{{substring id 3 6}}/{{id}}.xml"/>
+                      value="${ddf.data}/backup/metacard/{{substring id 0 3}}/{{substring id 3 6}}/{{id}}.xml"/>
         </cm:managed-component>
     </cm:managed-service-factory>
 

--- a/catalog/plugin/catalog-plugin-metacardbackup-s3storage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-s3storage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -31,7 +31,7 @@
             <property name="metacardTransformerId" value="metadata"/>
             <property name="keepDeletedMetacards" value="false"/>
             <property name="backupInvalidMetacards" value="true"/>
-            <property name="objectTemplate" value="data/backup/metacard/{{substring id 0 3}}/{{substring id 3 6}}/{{id}}.xml"/>
+            <property name="objectTemplate" value="${ddf.data}/backup/metacard/{{substring id 0 3}}/{{substring id 3 6}}/{{id}}.xml"/>
             <property name="s3AccessKey" value="" />
             <property name="s3SecretKey" value="" />
             <property name="s3Endpoint" value="" />

--- a/catalog/solr/catalog-solr-solrclient/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/solr/catalog-solr-solrclient/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,7 +19,10 @@
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
            http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
            http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-           http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
+           http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0">
+
+    <ext:property-placeholder/>
 
     <bean class="ddf.catalog.source.solr.rest.SolrRest" id="solrRestClient" init-method="init">
         <cm:managed-properties persistent-id="ddf.catalog.source.solr.rest.SolrRest"

--- a/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -69,7 +69,7 @@
 
     <bean id="indexInitializer" class="org.codice.ddf.spatial.geocoding.index.IndexInitializer"
         init-method="init" destroy-method="destroy">
-        <property name="defaultGeoNamesDataPath" value="data/default_geonames_data.zip"/>
+        <property name="defaultGeoNamesDataPath" value="${ddf.data}/default_geonames_data.zip"/>
         <property name="indexer" ref="geonamesIndexer"/>
         <property name="extractor" ref="geoExtractor"/>
         <property name="executor" ref="executorService"/>

--- a/catalog/spatial/geowebcache/geowebcache-app/src/main/resources/features.xml
+++ b/catalog/spatial/geowebcache/geowebcache-app/src/main/resources/features.xml
@@ -33,7 +33,7 @@
         <bundle>mvn:org.codice.geowebcache/geowebcache-server-standalone/${gwc-server.version}/war
         </bundle>
 
-        <configfile finalname="/etc/geowebcache.xml">
+        <configfile finalname="${karaf.etc}/geowebcache.xml">
             mvn:org.codice.geowebcache/geowebcache-server-standalone/${gwc-server.version}/xml/geowebcache
         </configfile>
     </feature>

--- a/catalog/spatial/geowebcache/geowebcache-app/src/main/resources/features.xml
+++ b/catalog/spatial/geowebcache/geowebcache-app/src/main/resources/features.xml
@@ -33,7 +33,7 @@
         <bundle>mvn:org.codice.geowebcache/geowebcache-server-standalone/${gwc-server.version}/war
         </bundle>
 
-        <configfile finalname="${karaf.etc}/geowebcache.xml">
+        <configfile finalname="${ddf.etc}/geowebcache.xml">
             mvn:org.codice.geowebcache/geowebcache-server-standalone/${gwc-server.version}/xml/geowebcache
         </configfile>
     </feature>

--- a/catalog/transformer/catalog-transformer-zip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-zip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@
 
     <bean id="zipValidation" class="org.codice.ddf.catalog.transformer.zip.ZipValidator" init-method="init">
         <property name="signaturePropertiesPath"
-                  value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+                  value="${ddf.etc}/ws-security/server/signature.properties"/>
     </bean>
 
     <bean id="zipCompression" class="org.codice.ddf.catalog.transformer.zip.ZipCompression">

--- a/catalog/ui/search-ui-app/src/main/resources/features.xml
+++ b/catalog/ui/search-ui-app/src/main/resources/features.xml
@@ -20,7 +20,7 @@
     <feature name="catalog-ui" version="${project.version}" description="Catalog UI">
         <feature prerequisite="true">spatial-app</feature>
         <feature prerequisite="true">camel-http</feature>
-        <configfile finalname="${karaf.etc}/org.codice.ddf.catalog.ui.config.config" override="false">
+        <configfile finalname="${ddf.etc}/org.codice.ddf.catalog.ui.config.config" override="false">
             mvn:ddf.ui/search-ui-app/${project.version}/properties/catalog-ui-config
         </configfile>
 
@@ -43,7 +43,7 @@
 
     <feature name="search-ui-app" version="${project.version}"
              description="The Standard Search UI is an application that not only provides results in a html format but also provides a convenient, simple querying user interface.\nThe left pane of the SearchUI contains basic fields to query the Catalog and other Sources. The right pane consists of a map.\nIt includes both standard (3d globe) and simple (text page) versions.">
-        <configfile finalname="${karaf.etc}/org.codice.ddf.ui.searchui.filter.RedirectServlet.config" override="false">mvn:ddf.ui/search-ui-app/${project.version}/config/redirect</configfile>
+        <configfile finalname="${ddf.etc}/org.codice.ddf.ui.searchui.filter.RedirectServlet.config" override="false">mvn:ddf.ui/search-ui-app/${project.version}/config/redirect</configfile>
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">catalog-versioning-plugin</feature>
         <feature prerequisite="true">catalog-core-validator</feature>

--- a/catalog/ui/search-ui-app/src/main/resources/features.xml
+++ b/catalog/ui/search-ui-app/src/main/resources/features.xml
@@ -20,7 +20,7 @@
     <feature name="catalog-ui" version="${project.version}" description="Catalog UI">
         <feature prerequisite="true">spatial-app</feature>
         <feature prerequisite="true">camel-http</feature>
-        <configfile finalname="/etc/org.codice.ddf.catalog.ui.config.config" override="false">
+        <configfile finalname="${karaf.etc}/org.codice.ddf.catalog.ui.config.config" override="false">
             mvn:ddf.ui/search-ui-app/${project.version}/properties/catalog-ui-config
         </configfile>
 
@@ -43,7 +43,7 @@
 
     <feature name="search-ui-app" version="${project.version}"
              description="The Standard Search UI is an application that not only provides results in a html format but also provides a convenient, simple querying user interface.\nThe left pane of the SearchUI contains basic fields to query the Catalog and other Sources. The right pane consists of a map.\nIt includes both standard (3d globe) and simple (text page) versions.">
-        <configfile finalname="/etc/org.codice.ddf.ui.searchui.filter.RedirectServlet.config" override="false">mvn:ddf.ui/search-ui-app/${project.version}/config/redirect</configfile>
+        <configfile finalname="${karaf.etc}/org.codice.ddf.ui.searchui.filter.RedirectServlet.config" override="false">mvn:ddf.ui/search-ui-app/${project.version}/config/redirect</configfile>
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">catalog-versioning-plugin</feature>
         <feature prerequisite="true">catalog-core-validator</feature>

--- a/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
@@ -25,6 +25,8 @@
 #START DDF SETTINGS
 
 # DDF Environment Settings
+ddf.etc=${karaf.etc}
+ddf.data=${karaf.data}
 derby.system.home=${karaf.home}/data/derby
 
 #

--- a/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
@@ -83,16 +83,16 @@ org.codice.ddf.system.registry-id=
 # For Solr External Provider:
 solr.client=HttpSolrClient
 solr.http.url=_DO_NOT_EXPAND_${org.codice.ddf.system.protocol}_DO_NOT_EXPAND_${org.codice.ddf.system.hostname}:_DO_NOT_EXPAND_${org.codice.ddf.system.httpsPort}/solr
-solr.data.dir=_DO_NOT_EXPAND_${karaf.home}/data/solr
+solr.data.dir=_DO_NOT_EXPAND_${ddf.data}/solr
 
 # For Solr Cloud Provider:
 # solr.client=CloudSolrClient
-# solr.data.dir=_DO_NOT_EXPAND_${karaf.home}/data/solr
+# solr.data.dir=_DO_NOT_EXPAND_${ddf.data}/solr
 # solr.cloud.zookeeper=zookeeperhost1:2181,zookeeperhost2:2181,zookeeperhost3:2181
 
 # For Solr Embedded Provider:
 # solr.client=EmbeddedSolrServer
-# solr.data.dir=_DO_NOT_EXPAND_${karaf.home}/data/solr
+# solr.data.dir=_DO_NOT_EXPAND_${ddf.data}/solr
 
 
 #

--- a/distribution/ddf-common/src/main/resources/etc/artemis-backup.xml
+++ b/distribution/ddf-common/src/main/resources/etc/artemis-backup.xml
@@ -35,10 +35,10 @@
 
         <!-- this could be ASYNCIO or NIO -->
         <journal-type>ASYNCIO</journal-type>
-        <paging-directory>${ddf.home:.}/data/artemis/paging</paging-directory>
-        <bindings-directory>${ddf.home:.}/data/artemis/bindings</bindings-directory>
-        <journal-directory>${ddf.home:.}/data/artemis/journal</journal-directory>
-        <large-messages-directory>${ddf.home:.}/data/artemis/large-messages
+        <paging-directory>${ddf.data:.}/artemis/paging</paging-directory>
+        <bindings-directory>${ddf.data:.}/artemis/bindings</bindings-directory>
+        <journal-directory>${ddf.data:.}/artemis/journal</journal-directory>
+        <large-messages-directory>${ddf.data:.}/artemis/large-messages
         </large-messages-directory>
 
         <journal-datasync>true</journal-datasync>

--- a/distribution/ddf-common/src/main/resources/etc/artemis.xml
+++ b/distribution/ddf-common/src/main/resources/etc/artemis.xml
@@ -35,10 +35,10 @@
 
         <!-- this could be ASYNCIO or NIO -->
         <journal-type>ASYNCIO</journal-type>
-        <paging-directory>${ddf.home:.}/data/artemis/paging</paging-directory>
-        <bindings-directory>${ddf.home:.}/data/artemis/bindings</bindings-directory>
-        <journal-directory>${ddf.home:.}/data/artemis/journal</journal-directory>
-        <large-messages-directory>${ddf.home:.}/data/artemis/large-messages
+        <paging-directory>${ddf.data:.}/artemis/paging</paging-directory>
+        <bindings-directory>${ddf.data:.}/artemis/bindings</bindings-directory>
+        <journal-directory>${ddf.data:.}/artemis/journal</journal-directory>
+        <large-messages-directory>${ddf.data:.}/artemis/large-messages
         </large-messages-directory>
 
         <journal-datasync>true</journal-datasync>

--- a/distribution/sdk/sample-soap-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/distribution/sdk/sample-soap-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,11 +27,11 @@
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
 
     <bean id="encryptionProps" class="ddf.security.sts.PropertiesWrapper">
-        <argument value="${ddf.home}/etc/ws-security/issuer/encryption.properties"/>
+        <argument value="${ddf.etc}/ws-security/issuer/encryption.properties"/>
     </bean>
 
     <bean id="signatureProps" class="ddf.security.sts.PropertiesWrapper">
-        <argument value="${ddf.home}/etc/ws-security/issuer/signature.properties"/>
+        <argument value="${ddf.etc}/ws-security/issuer/signature.properties"/>
     </bean>
 
     <jaxws:endpoint id="soapEndpoint" implementor="#soapImpl"

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/command/AbstractProfileCommand.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/command/AbstractProfileCommand.java
@@ -40,7 +40,7 @@ public abstract class AbstractProfileCommand implements Action {
 
   protected PrintStream console = System.out;
 
-  protected Path profilePath = Paths.get(System.getProperty("ddf.home"), "etc", "profiles");
+  protected Path profilePath = Paths.get(System.getProperty("ddf.etc"), "profiles");
 
   void setProfilePath(Path profilePath) {
     this.profilePath = profilePath;

--- a/platform/admin/core/admin-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/core/admin-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,8 +36,8 @@
                 <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role</value>
             </list>
         </argument>
-        <argument value="${ddf.home}/etc/ws-security/attributeMap.properties"/>
-        <argument value="${ddf.home}/etc/ws-security/profiles.json"/>
+        <argument value="${ddf.etc}/ws-security/attributeMap.properties"/>
+        <argument value="${ddf.etc}/ws-security/profiles.json"/>
     </bean>
 
     <bean id="configurationAdminImpl" class="org.codice.ddf.admin.core.impl.ConfigurationAdminImpl">

--- a/platform/country-converter/platform-country-converter-local/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/country-converter/platform-country-converter-local/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,7 +28,7 @@
         <cm:managed-properties
                 persistent-id="org.codice.ddf.internal.country.converter.local.LocalCountryCodeConverter"
                 update-strategy="container-managed"/>
-        <property name="countryCodeMappingsFile" value="${ddf.home}/etc/fipsToIso.properties"/>
+        <property name="countryCodeMappingsFile" value="${ddf.etc}/fipsToIso.properties"/>
     </bean>
 
     <service id="LocalCountryCodeConverter"

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -929,10 +929,10 @@
         <bundle>mvn:ddf.mime.core/mime-core-configurableresolver/${project.version}</bundle>
         <bundle>mvn:org.apache.tika/tika-core/${tika.version}</bundle>
         <bundle>mvn:org.codice.thirdparty/tika-bundle/${tika.thirdparty.bundle.version}</bundle>
-        <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver-csw.config">mvn:ddf.platform/platform-app/${project.version}/config/csw</configfile>
-        <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver-geojson.config">mvn:ddf.platform/platform-app/${project.version}/config/geojson</configfile>
-        <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver-nitf.config">mvn:ddf.platform/platform-app/${project.version}/config/nitf</configfile>
-        <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver-xml.config">mvn:ddf.platform/platform-app/${project.version}/config/xml</configfile>
+        <configfile finalname="${karaf.etc}/DDF_Custom_Mime_Type_Resolver-csw.config">mvn:ddf.platform/platform-app/${project.version}/config/csw</configfile>
+        <configfile finalname="${karaf.etc}/DDF_Custom_Mime_Type_Resolver-geojson.config">mvn:ddf.platform/platform-app/${project.version}/config/geojson</configfile>
+        <configfile finalname="${karaf.etc}/DDF_Custom_Mime_Type_Resolver-nitf.config">mvn:ddf.platform/platform-app/${project.version}/config/nitf</configfile>
+        <configfile finalname="${karaf.etc}/DDF_Custom_Mime_Type_Resolver-xml.config">mvn:ddf.platform/platform-app/${project.version}/config/xml</configfile>
     </feature>
 
     <feature name="mime-tika-resolver" version="${project.version}"
@@ -1198,10 +1198,10 @@
         <feature>decanter-sla</feature>
         <feature>decanter-simple-scheduler</feature>
         <feature>persistence-core</feature>
-        <configfile override="true" finalname="/etc/org.apache.karaf.decanter.sla.checker.cfg">
+        <configfile override="true" finalname="${karaf.etc}/org.apache.karaf.decanter.sla.checker.cfg">
             mvn:ddf.platform/platform-app/${project.version}/config/sla
         </configfile>
-        <configfile override="true" finalname="/etc/org.apache.karaf.decanter.scheduler.simple.cfg">
+        <configfile override="true" finalname="${karaf.etc}/org.apache.karaf.decanter.scheduler.simple.cfg">
             mvn:ddf.platform/platform-app/${project.version}/config/scheduler
         </configfile>
     </feature>

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -929,10 +929,10 @@
         <bundle>mvn:ddf.mime.core/mime-core-configurableresolver/${project.version}</bundle>
         <bundle>mvn:org.apache.tika/tika-core/${tika.version}</bundle>
         <bundle>mvn:org.codice.thirdparty/tika-bundle/${tika.thirdparty.bundle.version}</bundle>
-        <configfile finalname="${karaf.etc}/DDF_Custom_Mime_Type_Resolver-csw.config">mvn:ddf.platform/platform-app/${project.version}/config/csw</configfile>
-        <configfile finalname="${karaf.etc}/DDF_Custom_Mime_Type_Resolver-geojson.config">mvn:ddf.platform/platform-app/${project.version}/config/geojson</configfile>
-        <configfile finalname="${karaf.etc}/DDF_Custom_Mime_Type_Resolver-nitf.config">mvn:ddf.platform/platform-app/${project.version}/config/nitf</configfile>
-        <configfile finalname="${karaf.etc}/DDF_Custom_Mime_Type_Resolver-xml.config">mvn:ddf.platform/platform-app/${project.version}/config/xml</configfile>
+        <configfile finalname="${ddf.etc}/DDF_Custom_Mime_Type_Resolver-csw.config">mvn:ddf.platform/platform-app/${project.version}/config/csw</configfile>
+        <configfile finalname="${ddf.etc}/DDF_Custom_Mime_Type_Resolver-geojson.config">mvn:ddf.platform/platform-app/${project.version}/config/geojson</configfile>
+        <configfile finalname="${ddf.etc}/DDF_Custom_Mime_Type_Resolver-nitf.config">mvn:ddf.platform/platform-app/${project.version}/config/nitf</configfile>
+        <configfile finalname="${ddf.etc}/DDF_Custom_Mime_Type_Resolver-xml.config">mvn:ddf.platform/platform-app/${project.version}/config/xml</configfile>
     </feature>
 
     <feature name="mime-tika-resolver" version="${project.version}"
@@ -1198,10 +1198,10 @@
         <feature>decanter-sla</feature>
         <feature>decanter-simple-scheduler</feature>
         <feature>persistence-core</feature>
-        <configfile override="true" finalname="${karaf.etc}/org.apache.karaf.decanter.sla.checker.cfg">
+        <configfile override="true" finalname="${ddf.etc}/org.apache.karaf.decanter.sla.checker.cfg">
             mvn:ddf.platform/platform-app/${project.version}/config/sla
         </configfile>
-        <configfile override="true" finalname="${karaf.etc}/org.apache.karaf.decanter.scheduler.simple.cfg">
+        <configfile override="true" finalname="${ddf.etc}/org.apache.karaf.decanter.scheduler.simple.cfg">
             mvn:ddf.platform/platform-app/${project.version}/config/scheduler
         </configfile>
     </feature>

--- a/platform/platform-app/src/main/resources/features.xml
+++ b/platform/platform-app/src/main/resources/features.xml
@@ -986,7 +986,7 @@
         <bundle>mvn:ddf.platform.solr/solr-banana/${project.version}/war</bundle>
         <bundle>mvn:ddf.platform.solr/solr-banana-provisioner/${project.version}</bundle>
 
-        <configfile finalname="/data/solr/banana/conf/schema.xml">
+        <configfile finalname="${ddf.data}/solr/banana/conf/schema.xml">
             mvn:ddf.platform.solr/solr-banana/${project.version}/xml/bananaschema
         </configfile>
         <configfile finalname="/examples/banana/DefaultDashboard.json">

--- a/platform/platform-paxweb-jettyconfig/src/main/resources/access.xml
+++ b/platform/platform-paxweb-jettyconfig/src/main/resources/access.xml
@@ -14,7 +14,7 @@
 <configuration>
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>data/log/%d{yyyy_MM_dd}.request.log</fileNamePattern>
+      <fileNamePattern><SystemProperty name="ddf.data" default="data"/>/log/%d{yyyy_MM_dd}.request.log</fileNamePattern>
     </rollingPolicy>
     <append>true</append>
     <encoder>

--- a/platform/security/common/src/main/java/org/codice/ddf/security/common/OutgoingSubjectRetrievalInterceptor.java
+++ b/platform/security/common/src/main/java/org/codice/ddf/security/common/OutgoingSubjectRetrievalInterceptor.java
@@ -51,7 +51,7 @@ public class OutgoingSubjectRetrievalInterceptor extends AbstractPhaseIntercepto
     super(Phase.PRE_STREAM);
     tokenFactory = new PKIAuthenticationTokenFactory();
     tokenFactory.setSignaturePropertiesPath(
-        System.getProperty("ddf.home") + "/etc/ws-security/server/signature.properties");
+        System.getProperty("ddf.etc") + "/ws-security/server/signature.properties");
     tokenFactory.init();
     securityManager = Security.getInstance().getSecurityManager();
   }

--- a/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -43,8 +43,8 @@
     <bean id="configSecurityLogger" class="ddf.security.config.impl.ConfigurationSecurityLogger"/>
 
     <bean id="crypto" class="ddf.security.samlp.SystemCrypto">
-        <argument value="${ddf.home}/etc/ws-security/server/encryption.properties"/>
-        <argument value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+        <argument value="${ddf.etc}/ws-security/server/encryption.properties"/>
+        <argument value="${ddf.etc}/ws-security/server/signature.properties"/>
         <argument ref="encryptionService"/>
     </bean>
 

--- a/platform/security/encryption/platform-security-encryption-commands/src/test/java/ddf/security/command/EncryptCommandTest.java
+++ b/platform/security/encryption/platform-security-encryption-commands/src/test/java/ddf/security/command/EncryptCommandTest.java
@@ -36,7 +36,8 @@ public class EncryptCommandTest {
   public void setUp() throws Exception {
     ddfHome = Files.createTempDirectory("encrypt").toFile();
     System.setProperty("ddf.home", ddfHome.toString());
-    String path = new File(System.getProperty("ddf.home").concat("/etc/certs")).getCanonicalPath();
+    System.setProperty("ddf.etc", ddfHome.getAbsolutePath().concat("/etc"));
+    String path = new File(System.getProperty("ddf.etc").concat("/certs")).getCanonicalPath();
     new File(path).mkdirs();
   }
 

--- a/platform/security/encryption/platform-security-encryption-impl/src/main/java/ddf/security/encryption/impl/EncryptionServiceImpl.java
+++ b/platform/security/encryption/platform-security-encryption-impl/src/main/java/ddf/security/encryption/impl/EncryptionServiceImpl.java
@@ -30,7 +30,7 @@ public class EncryptionServiceImpl implements EncryptionService {
   private final Crypter crypter;
 
   public EncryptionServiceImpl() {
-    String passwordDirectory = System.getProperty("ddf.home").concat("/etc/certs");
+    String passwordDirectory = System.getProperty("ddf.etc").concat("/certs");
 
     synchronized (EncryptionServiceImpl.class) {
       if (!new File(passwordDirectory.concat("/meta")).exists()) {

--- a/platform/security/encryption/platform-security-encryption-impl/src/test/java/ddf/security/encryption/impl/EncryptionServiceImplTest.java
+++ b/platform/security/encryption/platform-security-encryption-impl/src/test/java/ddf/security/encryption/impl/EncryptionServiceImplTest.java
@@ -34,7 +34,8 @@ public class EncryptionServiceImplTest {
   public void setUp() throws Exception {
     ddfHome = Files.createTempDirectory("encrypt").toFile();
     System.setProperty("ddf.home", ddfHome.getAbsolutePath());
-    String path = new File(System.getProperty("ddf.home").concat("/etc/certs")).getCanonicalPath();
+    System.setProperty("ddf.etc", ddfHome.getAbsolutePath().concat("/etc"));
+    String path = new File(System.getProperty("ddf.etc").concat("/certs")).getCanonicalPath();
     new File(path).mkdirs();
   }
 
@@ -45,7 +46,7 @@ public class EncryptionServiceImplTest {
 
   @Test
   public void testBadSetup() throws Exception {
-    System.setProperty("ddf.home", ddfHome.getAbsolutePath() + System.nanoTime());
+    System.setProperty("ddf.etc", ddfHome.getAbsolutePath() + System.nanoTime());
     final String unencryptedPassword = "protect";
 
     final EncryptionServiceImpl encryptionService = new EncryptionServiceImpl();

--- a/platform/security/expansion/security-expansion-metacardattr-map/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/expansion/security-expansion-metacardattr-map/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,7 @@
         <cm:managed-properties persistent-id="ddf.security.metacard.attribute.mapping"
                                update-strategy="component-managed" update-method="update"/>
         <property name="attributeSeparator" value=" "/>
-        <property name="expansionFileName" value="${ddf.home}/etc/pdp/ddf-metacard-attribute-ruleset.cfg"/>
+        <property name="expansionFileName" value="${ddf.etc}/pdp/ddf-metacard-attribute-ruleset.cfg"/>
     </bean>
 
     <service ref="metacardAttributeExpansion" interface="ddf.security.expansion.Expansion"

--- a/platform/security/expansion/security-expansion-metacardattr-map/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/expansion/security-expansion-metacardattr-map/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,7 +24,7 @@
 
         <AD description="Location of the file containing the attribute expansion rules."
             name="Expansion Rules Configuration File Location" id="expansionFileName" type="String"
-            default="${ddf.home}/etc/pdp/ddf-metacard-attribute-ruleset.cfg"/>
+            default="${ddf.etc}/pdp/ddf-metacard-attribute-ruleset.cfg"/>
     </OCD>
 
     <Designate pid="ddf.security.metacard.attribute.mapping">

--- a/platform/security/expansion/security-expansion-userattr-map/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/expansion/security-expansion-userattr-map/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,7 @@
         <cm:managed-properties persistent-id="ddf.security.user.attribute.mapping"
                                update-strategy="component-managed" update-method="update"/>
         <property name="attributeSeparator" value=" "/>
-        <property name="expansionFileName" value="${ddf.home}/etc/pdp/ddf-user-attribute-ruleset.cfg"/>
+        <property name="expansionFileName" value="${ddf.etc}/pdp/ddf-user-attribute-ruleset.cfg"/>
     </bean>
 
     <service ref="userAttributeExpansion" interface="ddf.security.expansion.Expansion" ranking="3">

--- a/platform/security/expansion/security-expansion-userattr-map/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/expansion/security-expansion-userattr-map/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,7 +24,7 @@
 
         <AD description="Location of the file containing the attribute expansion rules."
             name="Expansion Rules Configuration File Location" id="expansionFileName" type="String"
-            default="${ddf.home}/etc/pdp/ddf-user-attribute-ruleset.cfg"/>
+            default="${ddf.etc}/pdp/ddf-user-attribute-ruleset.cfg"/>
     </OCD>
 
     <Designate pid="ddf.security.user.attribute.mapping">

--- a/platform/security/filter/security-filter-login/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/filter/security-filter-login/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,7 +26,7 @@
                                update-strategy="container-managed"/>
         <property name="securityManager" ref="securityManager"/>
         <property name="signaturePropertiesFile"
-                  value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+                  value="${ddf.etc}/ws-security/server/signature.properties"/>
         <property name="sessionFactory">
             <reference interface="ddf.security.http.SessionFactory"
                        filter="(id=http)"/>

--- a/platform/security/handler/security-handler-guest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/handler/security-handler-guest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,7 @@
           class="org.codice.ddf.security.handler.api.PKIAuthenticationTokenFactory"
           init-method="init">
         <property name="signaturePropertiesPath"
-                  value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+                  value="${ddf.etc}/ws-security/server/signature.properties"/>
     </bean>
 
     <bean id="handler" class="org.codice.ddf.security.handler.guest.GuestHandler">

--- a/platform/security/handler/security-handler-pki/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/handler/security-handler-pki/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@
           class="org.codice.ddf.security.handler.api.PKIAuthenticationTokenFactory"
           init-method="init">
         <property name="signaturePropertiesPath"
-                  value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+                  value="${ddf.etc}/ws-security/server/signature.properties"/>
     </bean>
 
     <bean id="handler" class="org.codice.ddf.security.handler.pki.PKIHandler">

--- a/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -43,8 +43,8 @@
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
 
     <bean id="crypto" class="ddf.security.samlp.SystemCrypto">
-        <argument value="${ddf.home}/etc/ws-security/server/encryption.properties"/>
-        <argument value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+        <argument value="${ddf.etc}/ws-security/server/encryption.properties"/>
+        <argument value="${ddf.etc}/ws-security/server/signature.properties"/>
         <argument ref="encryptionService"/>
     </bean>
 

--- a/platform/security/idp/security-idp-server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -45,7 +45,7 @@
           class="org.codice.ddf.security.handler.api.PKIAuthenticationTokenFactory"
           init-method="init">
         <property name="signaturePropertiesPath"
-                  value="${ddf.home}/etc/ws-security/issuer/signature.properties"/>
+                  value="${ddf.etc}/ws-security/issuer/signature.properties"/>
     </bean>
 
     <bean id="logoutStates" class="ddf.security.samlp.impl.RelayStates" />
@@ -53,8 +53,8 @@
     <bean id="idp" class="org.codice.ddf.security.idp.server.IdpEndpoint" init-method="init">
         <cm:managed-properties persistent-id="org.codice.ddf.security.idp.server.IdpEndpoint"
                                update-strategy="container-managed"/>
-        <argument value="${ddf.home}/etc/ws-security/issuer/signature.properties"/>
-        <argument value="${ddf.home}/etc/ws-security/issuer/encryption.properties"/>
+        <argument value="${ddf.etc}/ws-security/issuer/signature.properties"/>
+        <argument value="${ddf.etc}/ws-security/issuer/encryption.properties"/>
         <argument ref="encryptionService" />
         <property name="securityManager" ref="securityManager"/>
         <property name="tokenFactory" ref="tokenFactory" />

--- a/platform/security/pdp/security-pdp-authzrealm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@
     <bean id="pdpAuthzRealm" class="ddf.security.pdp.realm.AuthzRealm">
         <cm:managed-properties persistent-id="ddf.security.pdp.realm.AuthzRealm"
                                update-strategy="container-managed"/>
-        <argument value="${ddf.home}/etc/pdp/policies"/>
+        <argument value="${ddf.etc}/pdp/policies"/>
         <argument ref="xmlParser"/>
     </bean>
 

--- a/platform/security/security-services-app/src/main/resources/features.xml
+++ b/platform/security/security-services-app/src/main/resources/features.xml
@@ -64,7 +64,7 @@
 
     <feature name="security-pdp-authz" version="${project.version}"
              description="Security PDP.">
-        <configfile finalname="/etc/ddf.security.pdp.realm.AuthzRealm.config">mvn:ddf.security/security-services-app/${project.version}/config/pdp</configfile>
+        <configfile finalname="${karaf.etc}/ddf.security.pdp.realm.AuthzRealm.config">mvn:ddf.security/security-services-app/${project.version}/config/pdp</configfile>
         <feature prerequisite="true">security-expansion</feature>
         <feature prerequisite="true">security-expansion-user-attributes</feature>
         <feature prerequisite="true">security-expansion-metacard-attributes</feature>
@@ -101,7 +101,7 @@
     <feature name="security-sts-server" version="${project.version}"
              description="Security STS.">
         <feature prerequisite="true">sts-prereqs</feature>
-        <configfile finalname="/etc/ws-security/attributeMap.properties">
+        <configfile finalname="${karaf.etc}/ws-security/attributeMap.properties">
             mvn:ddf.security.sts/security-sts-ldapclaimshandler/${project.version}/properties/attributeMap
         </configfile>
         <bundle>mvn:ddf.security.sts/security-sts-server/${project.version}</bundle>
@@ -143,7 +143,7 @@
 
     <feature name="ldap-embedded-default-claimshandler-config" version="${project.version}" description="Installs a default embedded ldap login config">
         <configfile
-                finalname="/etc/Claims_Handler_Manager-ddf.security.sts.claimsHandler.ClaimsHandlerManager.config"
+                finalname="${karaf.etc}/Claims_Handler_Manager-ddf.security.sts.claimsHandler.ClaimsHandlerManager.config"
                 override="false">
             mvn:ddf.security/security-services-app/${project.version}/config/ddf.security.sts.claimsHandler.ClaimsHandlerManager
         </configfile>
@@ -151,7 +151,7 @@
 
     <feature name="ldap-embedded-default-stslogin-config" version="${project.version}" description="Installs a default embedded ldap claims handler config">
         <configfile
-                finalname="/etc/Ldap_Login_Config-ddf.ldap.ldaplogin.LdapLoginConfig.config"
+                finalname="${karaf.etc}/Ldap_Login_Config-ddf.ldap.ldaplogin.LdapLoginConfig.config"
                 override="false">
             mvn:ddf.security/security-services-app/${project.version}/config/ddf.ldap.ldaplogin.LdapLoginConfig
         </configfile>

--- a/platform/security/security-services-app/src/main/resources/features.xml
+++ b/platform/security/security-services-app/src/main/resources/features.xml
@@ -64,7 +64,7 @@
 
     <feature name="security-pdp-authz" version="${project.version}"
              description="Security PDP.">
-        <configfile finalname="${karaf.etc}/ddf.security.pdp.realm.AuthzRealm.config">mvn:ddf.security/security-services-app/${project.version}/config/pdp</configfile>
+        <configfile finalname="${ddf.etc}/ddf.security.pdp.realm.AuthzRealm.config">mvn:ddf.security/security-services-app/${project.version}/config/pdp</configfile>
         <feature prerequisite="true">security-expansion</feature>
         <feature prerequisite="true">security-expansion-user-attributes</feature>
         <feature prerequisite="true">security-expansion-metacard-attributes</feature>
@@ -101,7 +101,7 @@
     <feature name="security-sts-server" version="${project.version}"
              description="Security STS.">
         <feature prerequisite="true">sts-prereqs</feature>
-        <configfile finalname="${karaf.etc}/ws-security/attributeMap.properties">
+        <configfile finalname="${ddf.etc}/ws-security/attributeMap.properties">
             mvn:ddf.security.sts/security-sts-ldapclaimshandler/${project.version}/properties/attributeMap
         </configfile>
         <bundle>mvn:ddf.security.sts/security-sts-server/${project.version}</bundle>
@@ -143,7 +143,7 @@
 
     <feature name="ldap-embedded-default-claimshandler-config" version="${project.version}" description="Installs a default embedded ldap login config">
         <configfile
-                finalname="${karaf.etc}/Claims_Handler_Manager-ddf.security.sts.claimsHandler.ClaimsHandlerManager.config"
+                finalname="${ddf.etc}/Claims_Handler_Manager-ddf.security.sts.claimsHandler.ClaimsHandlerManager.config"
                 override="false">
             mvn:ddf.security/security-services-app/${project.version}/config/ddf.security.sts.claimsHandler.ClaimsHandlerManager
         </configfile>
@@ -151,7 +151,7 @@
 
     <feature name="ldap-embedded-default-stslogin-config" version="${project.version}" description="Installs a default embedded ldap claims handler config">
         <configfile
-                finalname="${karaf.etc}/Ldap_Login_Config-ddf.ldap.ldaplogin.LdapLoginConfig.config"
+                finalname="${ddf.etc}/Ldap_Login_Config-ddf.ldap.ldaplogin.LdapLoginConfig.config"
                 override="false">
             mvn:ddf.security/security-services-app/${project.version}/config/ddf.ldap.ldaplogin.LdapLoginConfig
         </configfile>

--- a/platform/security/sts/security-sts-attributequeryclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-attributequeryclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,8 +23,8 @@
     <reference id="encryptionService" interface="ddf.security.encryption.EncryptionService"/>
 
     <bean id="crypto" class="ddf.security.samlp.SystemCrypto">
-        <argument value="${ddf.home}/etc/ws-security/server/encryption.properties"/>
-        <argument value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+        <argument value="${ddf.etc}/ws-security/server/encryption.properties"/>
+        <argument value="${ddf.etc}/ws-security/server/signature.properties"/>
         <argument ref="encryptionService"/>
     </bean>
 
@@ -58,11 +58,11 @@
     </bean>
 
     <bean id="encryptionProperties" class="ddf.security.sts.PropertiesWrapper">
-        <argument value="${ddf.home}/etc/ws-security/server/encryption.properties"/>
+        <argument value="${ddf.etc}/ws-security/server/encryption.properties"/>
     </bean>
 
     <bean id="signatureProperties" class="ddf.security.sts.PropertiesWrapper">
-        <argument value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+        <argument value="${ddf.etc}/ws-security/server/signature.properties"/>
     </bean>
 
     <service ref="attributeQueryHandler" interface="org.apache.cxf.sts.claims.ClaimsHandler"/>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -58,7 +58,7 @@
             <property name="objectClass" value="groupOfNames"/>
             <property name="memberNameAttribute" value="member"/>
             <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
-            <property name="propertyFileLocation" value="${ddf.home}/etc/ws-security/attributeMap.properties"/>
+            <property name="propertyFileLocation" value="${ddf.etc}/ws-security/attributeMap.properties"/>
             <property name="overrideCertDn" value="false" />
             <property name="bindMethod" value="Simple" />
             <cm:managed-properties persistent-id=""

--- a/platform/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-pkivalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -40,7 +40,7 @@
           class="org.codice.ddf.security.validator.pki.PKITokenValidator" init-method="init">
         <cm:managed-properties persistent-id="org.codice.ddf.security.validator.pki" update-strategy="container-managed"/>
         <property name="signaturePropertiesPath"
-                  value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+                  value="${ddf.etc}/ws-security/server/signature.properties"/>
         <property name="realms">
             <list value-type="java.lang.String">
                 <value>karaf</value>

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,14 +32,14 @@
                   value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role"/>
         <property name="idClaimType"
                   value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"/>
-        <property name="propertyFileLocation" value="${ddf.home}/etc/users.properties"/>
+        <property name="propertyFileLocation" value="${ddf.etc}/users.properties"/>
     </bean>
 
     <bean id="attributeClaimsHandler" class="org.codice.ddf.security.sts.claims.property.UsersAttributesFileClaimsHandler" init-method="init">
         <cm:managed-properties
                 persistent-id="org.codice.ddf.security.sts.claims.property.PropertyFileClaimsHandler"
                 update-strategy="container-managed"/>
-        <property name="usersAttributesFileLocation" value="${ddf.home}/etc/users.attributes"/>
+        <property name="usersAttributesFileLocation" value="${ddf.etc}/users.attributes"/>
     </bean>
 
     <service ref="roleClaimsHandler" interface="org.apache.cxf.sts.claims.ClaimsHandler"/>

--- a/platform/security/sts/security-sts-realm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-realm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,9 +32,9 @@
                   value="{http://docs.oasis-open.org/ws-sx/ws-trust/200512/}STS_Port"/>
         <property name="serviceName"
                   value="{http://docs.oasis-open.org/ws-sx/ws-trust/200512/}SecurityTokenService"/>
-        <property name="signatureProperties" value="${ddf.home}/etc/ws-security/server/signature.properties"/>
-        <property name="encryptionProperties" value="${ddf.home}/etc/ws-security/server/encryption.properties"/>
-        <property name="tokenProperties" value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+        <property name="signatureProperties" value="${ddf.etc}/ws-security/server/signature.properties"/>
+        <property name="encryptionProperties" value="${ddf.etc}/ws-security/server/encryption.properties"/>
+        <property name="tokenProperties" value="${ddf.etc}/ws-security/server/signature.properties"/>
         <property name="assertionType"
                   value="http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0"/>
         <property name="keyType" value="http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer"/>
@@ -69,9 +69,9 @@
                   value="{http://docs.oasis-open.org/ws-sx/ws-trust/200512/}STS_Port"/>
         <property name="serviceName"
                   value="{http://docs.oasis-open.org/ws-sx/ws-trust/200512/}SecurityTokenService"/>
-        <property name="signatureProperties" value="${ddf.home}/etc/ws-security/server/signature.properties"/>
-        <property name="encryptionProperties" value="${ddf.home}/etc/ws-security/server/encryption.properties"/>
-        <property name="tokenProperties" value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+        <property name="signatureProperties" value="${ddf.etc}/ws-security/server/signature.properties"/>
+        <property name="encryptionProperties" value="${ddf.etc}/ws-security/server/encryption.properties"/>
+        <property name="tokenProperties" value="${ddf.etc}/ws-security/server/signature.properties"/>
         <property name="assertionType"
                   value="http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0"/>
         <property name="keyType" value="http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer"/>

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
@@ -185,17 +185,17 @@
     <!-- PROPERTY CONFIGURATION -->
     <bean id="propertyCallbackHandler" class="ddf.security.sts.PropertyCallbackHandler">
         <property name="signatureProperties"
-                  value="file:${ddf.home}/etc/ws-security/issuer/signature.properties"/>
+                  value="file:${ddf.etc}/ws-security/issuer/signature.properties"/>
         <property name="encryptionProperties"
-                  value="file:${ddf.home}/etc/ws-security/issuer/encryption.properties"/>
+                  value="file:${ddf.etc}/ws-security/issuer/encryption.properties"/>
     </bean>
 
     <bean id="encryptionProps" class="ddf.security.sts.PropertiesWrapper">
-        <argument value="${ddf.home}/etc/ws-security/issuer/encryption.properties"/>
+        <argument value="${ddf.etc}/ws-security/issuer/encryption.properties"/>
     </bean>
 
     <bean id="signatureProps" class="ddf.security.sts.PropertiesWrapper">
-        <argument value="${ddf.home}/etc/ws-security/issuer/signature.properties"/>
+        <argument value="${ddf.etc}/ws-security/issuer/signature.properties"/>
     </bean>
 
     <bean id="STSProperties" class="ddf.security.sts.StaticStsProperties">

--- a/platform/security/sts/security-sts-x509validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-x509validator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -38,7 +38,7 @@
     <bean id="x509PathTokenValidator"
           class="org.codice.ddf.security.validator.x509.X509PathTokenValidator" init-method="init">
         <property name="signaturePropertiesPath"
-                  value="${ddf.home}/etc/ws-security/server/signature.properties"/>
+                  value="${ddf.etc}/ws-security/server/signature.properties"/>
     </bean>
 
     <service ref="x509PathTokenValidator"


### PR DESCRIPTION
#### What does this PR do?

Cleans up several types of usages of ddf.home
  * Updates features files that place config files under `etc` to use `${ddf.etc}/` instead of `${ddf.home}/etc`
  * Updates features files that refer to `${ddf.home}/data` to use `${ddf.data}/`
  * Updates usages of system properties in production code

Additionally includes a fix for [DDF-3653](https://codice.atlassian.net/browse/DDF-3652)

#### Who is reviewing it? 

@emmberk @AzGoalie @peterhuffer 

#### Choose 2 committers to review/merge the PR. 
@clockard @lessarderic 

#### Additional Background

There was inconsistent usage of the `configfile` element in features files. Some used `finalname="/etc/...` or `finalname="etc/...` which always places relative `DDF_HOME`.
Updating this to `${karaf.etc}` allows for the locations to be overridden at runtime and does not give the impression that files may be created under `/etc/` even though they wouldn't be.

#### What are the relevant tickets?
[DDF-3568](https://codice.atlassian.net/browse/DDF-3568)
[DDF-3653](https://codice.atlassian.net/browse/DDF-3652)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
