### PR TITLE
DDF-3569 Update UI to use unique ID for user preferences

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -250,11 +250,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codice.ddf</groupId>
-            <artifactId>alerts</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.codice.thirdparty</groupId>
             <artifactId>geotools-suite</artifactId>
             <version>${org.geotools.bundle.version}</version>
@@ -342,8 +337,7 @@
                             quartz-jobs,
                             spark-core,
                             spatial4j,
-                            versioning-common,
-                            alerts
+                            versioning-common
                         </Embed-Dependency>
                         <Web-ContextPath>/search/catalog</Web-ContextPath>
                         <_wab>src/main/webapp,${project.build.directory}/webapp</_wab>

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/WorkspacePolicyExtension.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/WorkspacePolicyExtension.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
+import ddf.security.SubjectIdentity;
 import ddf.security.permission.CollectionPermission;
 import ddf.security.permission.KeyValueCollectionPermission;
 import ddf.security.permission.KeyValuePermission;
@@ -43,8 +44,12 @@ public class WorkspacePolicyExtension implements PolicyExtension {
 
   private WorkspaceSecurityConfiguration config;
 
-  public WorkspacePolicyExtension(WorkspaceSecurityConfiguration config) {
+  private SubjectIdentity subjectIdentity;
+
+  public WorkspacePolicyExtension(
+      WorkspaceSecurityConfiguration config, SubjectIdentity subjectIdentity) {
     this.config = config;
+    this.subjectIdentity = subjectIdentity;
   }
 
   private List<KeyValuePermission> getPermissions(KeyValueCollectionPermission collection) {
@@ -79,12 +84,12 @@ public class WorkspacePolicyExtension implements PolicyExtension {
   }
 
   private Predicate<CollectionPermission> owner(Map<String, Set<String>> permissions) {
-    return predicate(permissions, Core.METACARD_OWNER, config.getOwnerAttribute());
+    return predicate(permissions, Core.METACARD_OWNER, subjectIdentity.getIdentityAttribute());
   }
 
   private Predicate<CollectionPermission> individuals(Map<String, Set<String>> permissions) {
     return predicate(
-        permissions, SecurityAttributes.ACCESS_INDIVIDUALS, config.getOwnerAttribute());
+        permissions, SecurityAttributes.ACCESS_INDIVIDUALS, subjectIdentity.getIdentityAttribute());
   }
 
   private Predicate<CollectionPermission> groups(Map<String, Set<String>> permissions) {

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -71,8 +71,7 @@
 
     <bean id="workspacePreIngestPlugin"
           class="org.codice.ddf.catalog.ui.security.WorkspacePreIngestPlugin">
-        <argument ref="workspaceSecurityConfiguration" />
-        <argument ref="eventAdmin"/>
+        <argument ref="subjectIdentity"/>
     </bean>
 
     <bean id="noteMetacardType" class="org.codice.ddf.catalog.ui.metacard.notes.NoteMetacardType"/>
@@ -107,11 +106,12 @@
                 update-strategy="container-managed"/>
     </bean>
 
-    <reference id="eventAdmin" interface="org.osgi.service.event.EventAdmin"/>
+    <reference id="subjectIdentity" interface="ddf.security.SubjectIdentity"/>
 
     <bean id="workspacePolicyExtension"
           class="org.codice.ddf.catalog.ui.security.WorkspacePolicyExtension">
         <argument ref="workspaceSecurityConfiguration" />
+        <argument ref="subjectIdentity" />
     </bean>
 
 
@@ -259,6 +259,7 @@
     <bean id="userApplication" class="org.codice.ddf.catalog.ui.security.UserApplication">
         <argument ref="persistentStore"/>
         <argument ref="endpointUtil"/>
+        <argument ref="subjectIdentity"/>
     </bean>
 
     <bean id="rootReqSupplier" class="org.codice.ddf.catalog.ui.RootContextRequestSupplier"/>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.security.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.security.xml
@@ -17,12 +17,6 @@
 
     <OCD name="Workspace Security"
          id="org.codice.ddf.catalog.ui.security">
-        <AD id="ownerAttribute"
-            name="Owner Attribute"
-            description="The name of the attribute to determine an owner."
-            required="true"
-            type="String"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
 
         <AD id="systemUserAttribute"
             name="System User Attribute"

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -273,6 +273,7 @@ define([
                 preferences: new User.Preferences(),
                 isGuest: true,
                 username: 'guest',
+                userid: 'guest',
                 roles: ['guest']
             };
         },

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/WorkspacePreIngestPluginTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/WorkspacePreIngestPluginTest.java
@@ -16,6 +16,9 @@ package org.codice.ddf.catalog.ui.security;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -29,38 +32,35 @@ import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.impl.CreateRequestImpl;
 import ddf.catalog.operation.impl.OperationTransactionImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
-import ddf.catalog.plugin.StopProcessingException;
+import ddf.security.SubjectIdentity;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.SortedSet;
+import org.apache.shiro.subject.Subject;
 import org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceMetacardImpl;
 import org.junit.Before;
 import org.junit.Test;
 
 public class WorkspacePreIngestPluginTest {
 
-  private WorkspaceSecurityConfiguration config;
+  private static final String TEST_ID_ATTR =
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
 
-  private boolean alerted;
+  private SubjectIdentity subjectIdentity;
 
   @Before
   public void setUp() {
-    alerted = false;
-    config = new WorkspaceSecurityConfiguration();
+    subjectIdentity = mock(SubjectIdentity.class);
+    when(subjectIdentity.getUniqueIdentifier(any())).thenReturn("owner");
   }
 
   private WorkspacePreIngestPlugin makePlugin(Map<String, SortedSet<String>> attrs) {
-    return new WorkspacePreIngestPlugin(config, null) {
-      protected Map<String, SortedSet<String>> getSubjectAttributes() {
-        return attrs;
-      }
+    Subject subject = mock(Subject.class);
 
-      protected String getSubjectName() {
-        return "test";
-      }
-
-      protected void alertMissingClaim(String ownerAttribute) {
-        alerted = true;
+    return new WorkspacePreIngestPlugin(subjectIdentity) {
+      @Override
+      protected Subject getSubject() {
+        return subject;
       }
     };
   }
@@ -76,54 +76,15 @@ public class WorkspacePreIngestPluginTest {
 
   @Test
   public void testCreateWorkspaceSuccess() throws Exception {
+    when(subjectIdentity.getIdentityAttribute()).thenReturn(TEST_ID_ATTR);
     Map<String, SortedSet<String>> attrs =
-        ImmutableMap.of(config.getOwnerAttribute(), ImmutableSortedSet.of("owner"));
+        ImmutableMap.of(TEST_ID_ATTR, ImmutableSortedSet.of("owner"));
 
     WorkspacePreIngestPlugin wpip = makePlugin(attrs);
     WorkspaceMetacardImpl workspace = new WorkspaceMetacardImpl();
 
     wpip.process(new CreateRequestImpl(workspace));
     assertThat(workspace.getOwner(), is("owner"));
-  }
-
-  @Test
-  public void testCreateWorkspaceSuccessWithOverride() throws Exception {
-    final String override = "override";
-
-    Map<String, SortedSet<String>> attrs =
-        ImmutableMap.of(override, ImmutableSortedSet.of("owner"));
-    config.setOwnerAttribute(override);
-
-    WorkspacePreIngestPlugin wpip = makePlugin(attrs);
-    WorkspaceMetacardImpl workspace = new WorkspaceMetacardImpl();
-
-    wpip.process(new CreateRequestImpl(workspace));
-    assertThat(workspace.getOwner(), is("owner"));
-  }
-
-  @Test(expected = StopProcessingException.class)
-  public void testCreateWorkspaceFailure() throws Exception {
-    WorkspacePreIngestPlugin wpip = makePlugin(ImmutableMap.of());
-    wpip.process(new CreateRequestImpl(new WorkspaceMetacardImpl()));
-  }
-
-  @Test(expected = StopProcessingException.class)
-  public void testCreateWorkspaceFailureWithOverride() throws Exception {
-    final String override = "override";
-
-    Map<String, SortedSet<String>> attrs =
-        ImmutableMap.of(config.getOwnerAttribute(), ImmutableSortedSet.of("owner"));
-    config.setOwnerAttribute(override);
-
-    WorkspacePreIngestPlugin wpip = makePlugin(attrs);
-    wpip.process(new CreateRequestImpl(new WorkspaceMetacardImpl()));
-  }
-
-  @Test(expected = StopProcessingException.class)
-  public void testCreateAlertOnFailure() throws Exception {
-    WorkspacePreIngestPlugin wpip = makePlugin(ImmutableMap.of());
-    wpip.process(new CreateRequestImpl(new WorkspaceMetacardImpl()));
-    assertThat(alerted, is(true));
   }
 
   private UpdateRequest updateRequest(Metacard prev, Metacard next) {

--- a/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
+++ b/catalog/ui/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpoint.java
@@ -17,6 +17,7 @@ import ddf.action.ActionRegistry;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.filter.FilterAdapter;
 import ddf.catalog.filter.FilterBuilder;
+import ddf.security.SubjectIdentity;
 import java.util.concurrent.ExecutorService;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -63,6 +64,8 @@ public class CometdEndpoint extends CometDServlet {
 
   private transient SearchController searchController;
 
+  private transient SubjectIdentity subjectIdentity;
+
   /**
    * Create a new CometdEndpoint
    *
@@ -77,7 +80,8 @@ public class CometdEndpoint extends CometDServlet {
       BundleContext bundleContext,
       EventAdmin eventAdmin,
       ActionRegistry actionRegistry,
-      ExecutorService executorService) {
+      ExecutorService executorService,
+      SubjectIdentity subjectIdentity) {
     LOGGER.trace("Constructing Cometd Endpoint");
     this.filterBuilder = filterBuilder;
     this.searchController =
@@ -86,6 +90,7 @@ public class CometdEndpoint extends CometDServlet {
     this.notificationController =
         new NotificationController(persistentStore, bundleContext, eventAdmin);
     this.activityController = new ActivityController(persistentStore, bundleContext, eventAdmin);
+    this.subjectIdentity = subjectIdentity;
 
     LOGGER.trace("Exiting CometdEndpoint constructor. ");
   }
@@ -150,7 +155,7 @@ public class CometdEndpoint extends CometDServlet {
 
       searchController.setBayeuxServer(bayeuxServer);
       searchService = new SearchService(filterBuilder, searchController);
-      UserService userService = new UserService(persistentStore);
+      UserService userService = new UserService(persistentStore, subjectIdentity);
       WorkspaceService workspaceService = new WorkspaceService(persistentStore);
       cometdAnnotationProcessor.process(userService);
       cometdAnnotationProcessor.process(workspaceService);

--- a/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/search-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -52,6 +52,8 @@
         <argument ref="actionsProviders"/>
     </bean>
 
+    <reference id="subjectIdentity" interface="ddf.security.SubjectIdentity"/>
+
     <bean class="org.codice.ddf.ui.searchui.query.endpoint.CometdEndpoint" id="cometdEndpoint" destroy-method="destroy">
         <cm:managed-properties persistent-id="org.codice.ddf.ui.search.standard.endpoint"
                                update-strategy="container-managed"/>
@@ -63,6 +65,7 @@
         <argument ref="eventAdmin"/>
         <argument ref="actionRegistry"/>
         <argument ref="searchThreadPool"/>
+        <argument ref="subjectIdentity" />
     </bean>
 
     <service interface="javax.servlet.Servlet" ref="cometdEndpoint">

--- a/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpointTest.java
+++ b/catalog/ui/search-ui/search-endpoint/src/test/java/org/codice/ddf/ui/searchui/query/endpoint/CometdEndpointTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.filter.FilterAdapter;
 import ddf.catalog.filter.FilterBuilder;
+import ddf.security.SubjectIdentity;
 import java.util.Collections;
 import java.util.concurrent.Executors;
 import javax.servlet.ServletConfig;
@@ -142,7 +143,8 @@ public class CometdEndpointTest {
                 mock(BundleContext.class),
                 mock(EventAdmin.class),
                 new ActionRegistryImpl(Collections.EMPTY_LIST, Collections.EMPTY_LIST),
-                Executors.newSingleThreadExecutor()));
+                Executors.newSingleThreadExecutor(),
+                mock(SubjectIdentity.class)));
     doNothing().when(cometdEndpoint).init();
   }
 

--- a/catalog/ui/search-ui/standard/src/main/webapp/js/model/user.js
+++ b/catalog/ui/search-ui/standard/src/main/webapp/js/model/user.js
@@ -175,7 +175,8 @@ define([
             user.set({
                 preferences: preferences,
                 isGuest: true,
-                username: 'guest'
+                username: 'guest',
+                userid: 'guest'
             });
 
             preferences.set('mapColors', this.getFallbackMapColors());

--- a/catalog/ui/search-ui/standard/test.js
+++ b/catalog/ui/search-ui/standard/test.js
@@ -47,6 +47,7 @@ app.listen = function() {
             bayeux.getClient().publish('/service/user', {
                 "successful": true,
                 "user": {
+                    "userid" : "Guest",
                     "username": "Guest",
                     "isGuest": "true"
                 }

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/impl/SubjectIdentityImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/impl/SubjectIdentityImpl.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.impl;
+
+import ddf.security.SubjectIdentity;
+import ddf.security.SubjectUtils;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
+import org.apache.commons.lang.StringUtils;
+import org.apache.shiro.subject.Subject;
+
+public class SubjectIdentityImpl implements SubjectIdentity {
+  private String identityAttribute;
+
+  /**
+   * Get a subject's unique identifier. 1. If the configured unique identifier if present 2. Email
+   * address if present 3. Username not, user name is returned.
+   *
+   * @param subject
+   * @return subject unique identifier
+   */
+  @Override
+  public String getUniqueIdentifier(Subject subject) {
+    Optional<String> owner = getSubjectAttribute(subject).stream().findFirst();
+    if (owner.isPresent()) {
+      return owner.get();
+    }
+
+    String identifier = SubjectUtils.getEmailAddress(subject);
+    if (StringUtils.isNotBlank(identifier)) {
+      return identifier;
+    }
+
+    return SubjectUtils.getName(subject);
+  }
+
+  private SortedSet<String> getSubjectAttribute(Subject subject) {
+    Map<String, SortedSet<String>> attrs = SubjectUtils.getSubjectAttributes(subject);
+
+    if (attrs.containsKey(identityAttribute)) {
+      return attrs.get(identityAttribute);
+    }
+
+    return Collections.emptySortedSet();
+  }
+
+  public String getIdentityAttribute() {
+    return identityAttribute;
+  }
+
+  public void setIdentityAttribute(String identityAttribute) {
+    this.identityAttribute = identityAttribute;
+  }
+}

--- a/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -75,4 +75,15 @@
     <service id="sessionListenerService" ref="sessionListener"
              interface="javax.servlet.http.HttpSessionListener"/>
 
+    <bean id="subjectIdentityImpl"
+      class="ddf.security.impl.SubjectIdentityImpl">
+        <cm:managed-properties
+          persistent-id="ddf.security.SubjectIdentity"
+          update-strategy="container-managed"/>
+        <property name="identityAttribute" value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+    </bean>
+
+    <service id="subjectIdentity" ref="subjectIdentityImpl"
+      interface="ddf.security.SubjectIdentity"/>
+
 </blueprint>

--- a/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/core/security-core-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -26,7 +26,23 @@
             (Does not apply when NameIDFormat is of the following: X509, persistent, kerberos or unspecified, and the username is not empty).-"/>
     </OCD>
 
+    <OCD description="Subject Identity Configuration"
+      name="Subject Identity"
+      id="ddf.security.SubjectIdentity">
+
+        <AD id="identityAttribute"
+          name="Identity Attribute"
+          description="The name of the attribute to determine identity of a user."
+          required="true"
+          type="String"
+          default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+    </OCD>
+
     <Designate pid="ddf.security.service.SecurityManager">
         <Object ocdref="ddf.security.service.SecurityManager"/>
+    </Designate>
+
+    <Designate pid="ddf.security.SubjectIdentity">
+        <Object ocdref="ddf.security.SubjectIdentity"/>
     </Designate>
 </metatype:MetaData>

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/impl/SubjectIdentityTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/impl/SubjectIdentityTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.impl;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import ddf.security.Subject;
+import ddf.security.SubjectUtils;
+import ddf.security.assertion.SecurityAssertion;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.session.mgt.SimpleSession;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.apache.shiro.subject.SimplePrincipalCollection;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+
+public class SubjectIdentityTest {
+
+  private static final String TEST_NAME = "test01";
+
+  private SubjectIdentityImpl subjectIdentity;
+
+  @Before
+  public void setUp() {
+    subjectIdentity = new SubjectIdentityImpl();
+  }
+
+  @Test
+  public void testUniqueIdentifierWithAttribute() {
+    final String identifier = "guest12345";
+    Map<String, List<String>> attrs =
+        ImmutableMap.of("identifier", Collections.singletonList(identifier));
+    Subject subject = getSubjectWithAttributes(attrs);
+    subjectIdentity.setIdentityAttribute("identifier");
+    assertThat(subjectIdentity.getUniqueIdentifier(subject), is(identifier));
+  }
+
+  @Test
+  public void testUniqueIdentifierWithEmail() {
+    final String email = "guest@localhost";
+    Map<String, List<String>> attrs =
+        ImmutableMap.of(SubjectUtils.EMAIL_ADDRESS_CLAIM_URI, Collections.singletonList(email));
+    Subject subject = getSubjectWithAttributes(attrs);
+    assertThat(subjectIdentity.getUniqueIdentifier(subject), is(email));
+  }
+
+  @Test
+  public void testUniqueIdentifierNoEmail() {
+    org.apache.shiro.subject.Subject subject;
+    org.apache.shiro.mgt.SecurityManager secManager = new DefaultSecurityManager();
+    PrincipalCollection principals = new SimplePrincipalCollection(TEST_NAME, "testrealm");
+    subject =
+        new Subject.Builder(secManager)
+            .principals(principals)
+            .session(new SimpleSession())
+            .buildSubject();
+    assertThat(TEST_NAME, is(subjectIdentity.getUniqueIdentifier(subject)));
+  }
+
+  private Subject getSubjectWithAttributes(Map<String, List<String>> attributes) {
+
+    Subject subject = mock(Subject.class);
+    PrincipalCollection pc = mock(PrincipalCollection.class);
+    SecurityAssertion assertion = mock(SecurityAssertion.class);
+    AttributeStatement as = mock(AttributeStatement.class);
+
+    List<Attribute> attrs =
+        attributes.entrySet().stream().map(this::getAttribute).collect(Collectors.toList());
+
+    doReturn(pc).when(subject).getPrincipals();
+    doReturn(assertion).when(pc).oneByType(SecurityAssertion.class);
+    doReturn(ImmutableList.of(assertion)).when(pc).byType(SecurityAssertion.class);
+    doReturn(Collections.singletonList(as)).when(assertion).getAttributeStatements();
+    doReturn(attrs).when(as).getAttributes();
+
+    return subject;
+  }
+
+  private Attribute getAttribute(Map.Entry<String, List<String>> attribute) {
+    Attribute attr = mock(Attribute.class);
+
+    doReturn(attribute.getKey()).when(attr).getName();
+
+    doReturn(attribute.getValue().stream().map(this::getXSString).collect(Collectors.toList()))
+        .when(attr)
+        .getAttributeValues();
+
+    return attr;
+  }
+
+  private XSString getXSString(String str) {
+    XSString xstr = mock(XSString.class);
+    doReturn(str).when(xstr).getValue();
+    return xstr;
+  }
+}

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/SubjectIdentity.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/SubjectIdentity.java
@@ -11,27 +11,25 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.catalog.ui.security;
+package ddf.security;
 
-public class WorkspaceSecurityConfiguration {
+import org.apache.shiro.subject.Subject;
 
-  private String systemUserAttribute = Constants.ROLES_CLAIM_URI;
+/** Provides methods for determining identity properties of a Subject */
+public interface SubjectIdentity {
 
-  private String systemUserAttributeValue = "admin";
+  /**
+   * Get a subject's unique identifier.
+   *
+   * @param subject
+   * @return unique identifier for the subject
+   */
+  String getUniqueIdentifier(Subject subject);
 
-  public String getSystemUserAttribute() {
-    return systemUserAttribute;
-  }
-
-  public void setSystemUserAttribute(String systemUserAttribute) {
-    this.systemUserAttribute = systemUserAttribute.trim();
-  }
-
-  public String getSystemUserAttributeValue() {
-    return systemUserAttributeValue;
-  }
-
-  public void setSystemUserAttributeValue(String systemUserAttributeValue) {
-    this.systemUserAttributeValue = systemUserAttributeValue.trim();
-  }
+  /**
+   * Subject attribute used for identity
+   *
+   * @return
+   */
+  String getIdentityAttribute();
 }


### PR DESCRIPTION
#### What does this PR do?
Updates UI to store user preferences by Unique ID instead of username. The unique ID method has been added to SecurityUtils and will first attempt to return an email address and then the username. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@mojogitoverhere  
@bdeining 
@djblue 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full build with tests.
1. Launch UI as a user
2. Make a preference change
3. Navigate to https://localhost:8993/solr/#/preferences/query and query.
4. Ensure that the `id_txt` field is the correct email address for that user.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3569](https://codice.atlassian.net/browse/DDF-3569)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
