### PR TITLE
DDF-3571 Minor SAML Spec compliance fixes

### DIFF
--- a/platform/security/common/src/main/java/ddf/security/samlp/impl/SamlValidator.java
+++ b/platform/security/common/src/main/java/ddf/security/samlp/impl/SamlValidator.java
@@ -110,16 +110,18 @@ public abstract class SamlValidator {
 
   void checkRedirectSignature(String reqres) throws ValidationException {
     try {
-      String signedParts =
-          String.format(
-              "%s=%s&RelayState=%s&SigAlg=%s",
-              reqres,
-              URLEncoder.encode(builder.samlString, "UTF-8"),
-              builder.relayState,
-              URLEncoder.encode(builder.sigAlgo, "UTF-8"));
+      StringBuilder signedParts =
+          new StringBuilder(reqres)
+              .append("=")
+              .append(URLEncoder.encode(builder.samlString, "UTF-8"));
+      String relayState = builder.relayState;
+      if (relayState != null) {
+        signedParts.append("&RelayState=").append(relayState);
+      }
+      signedParts.append("&SigAlg=").append(URLEncoder.encode(builder.sigAlgo, "UTF-8"));
 
       if (!builder.simpleSign.validateSignature(
-          signedParts, builder.signature, builder.signingCertificate)) {
+          signedParts.toString(), builder.signature, builder.signingCertificate)) {
         throw new ValidationException("Signature verification failed for redirect binding.");
       }
     } catch (SimpleSign.SignatureException | UnsupportedEncodingException e) {

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
@@ -450,17 +450,20 @@ public class IdpHandler implements AuthenticationHandler {
       if (idpssoDescriptor == null) {
         throw new ServletException("IdP metadata is missing. No IDPSSODescriptor present.");
       }
-      String queryParams =
-          String.format(
-              "SAMLRequest=%s&RelayState=%s",
-              encodeAuthnRequest(
-                  createAndSignAuthnRequest(false, idpssoDescriptor.getWantAuthnRequestsSigned()),
-                  false),
-              URLEncoder.encode(relayState, "UTF-8"));
+      StringBuilder queryParams =
+          new StringBuilder("SAMLRequest=")
+              .append(
+                  encodeAuthnRequest(
+                      createAndSignAuthnRequest(
+                          false, idpssoDescriptor.getWantAuthnRequestsSigned()),
+                      false));
+      if (relayState != null) {
+        queryParams.append("&RelayState=").append(URLEncoder.encode(relayState, "UTF-8"));
+      }
       idpRequest = idpMetadata.getSingleSignOnLocation() + "?" + queryParams;
       UriBuilder idpUri = new UriBuilderImpl(new URI(idpRequest));
 
-      simpleSign.signUriString(queryParams, idpUri);
+      simpleSign.signUriString(queryParams.toString(), idpUri);
 
       redirectUrl = idpUri.build().toString();
     } catch (UnsupportedEncodingException e) {

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/api/impl/ValidatorImpl.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/api/impl/ValidatorImpl.java
@@ -98,10 +98,8 @@ public abstract class ValidatorImpl implements Validator {
   @Override
   public void validateRelayState(String relayState) {
     LOGGER.debug("Validating RelayState");
-    if (relayState == null || relayState.length() < 0 || relayState.length() > 80) {
-      LOGGER.info(
-          "RelayState has invalid size: {}",
-          (relayState == null) ? "no RelayState" : relayState.length());
+    if (relayState != null && relayState.length() > 80) {
+      LOGGER.warn("RelayState has invalid size: {}", relayState.length());
     }
   }
 

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostResponseCreator.java
@@ -40,6 +40,7 @@ import org.w3c.dom.Document;
 public class PostResponseCreator extends ResponseCreatorImpl implements ResponseCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PostResponseCreator.class);
+  private static final String SURROUND_WITH_TWO_PARENTHESES = "{{%s}}";
 
   public PostResponseCreator(
       SystemCrypto systemCrypto,
@@ -75,11 +76,18 @@ public class PostResponseCreator extends ResponseCreatorImpl implements Response
         Base64.getEncoder().encodeToString(assertionResponse.getBytes(StandardCharsets.UTF_8));
     String assertionConsumerServiceURL = getAssertionConsumerServiceURL(authnRequest);
     String submitFormUpdated =
-        responseTemplate.replace("{{" + Idp.ACS_URL + "}}", assertionConsumerServiceURL);
-    submitFormUpdated = submitFormUpdated.replace("{{" + Idp.SAML_TYPE + "}}", "SAMLResponse");
+        responseTemplate.replace(
+            String.format(SURROUND_WITH_TWO_PARENTHESES, Idp.ACS_URL), assertionConsumerServiceURL);
     submitFormUpdated =
-        submitFormUpdated.replace("{{" + Idp.SAML_RESPONSE + "}}", encodedSamlResponse);
-    submitFormUpdated = submitFormUpdated.replace("{{" + Idp.RELAY_STATE + "}}", relayState);
+        submitFormUpdated.replace(
+            String.format(SURROUND_WITH_TWO_PARENTHESES, Idp.SAML_TYPE), "SAMLResponse");
+    submitFormUpdated =
+        submitFormUpdated.replace(
+            String.format(SURROUND_WITH_TWO_PARENTHESES, Idp.SAML_RESPONSE), encodedSamlResponse);
+    submitFormUpdated =
+        submitFormUpdated.replace(
+            String.format(SURROUND_WITH_TWO_PARENTHESES, Idp.RELAY_STATE),
+            relayState != null ? relayState : "");
     Response.ResponseBuilder ok = Response.ok(submitFormUpdated);
     if (cookie != null) {
       ok = ok.cookie(cookie);

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
@@ -98,7 +98,9 @@ public class RedirectResponseCreator extends ResponseCreatorImpl implements Resp
     String assertionConsumerServiceURL = getAssertionConsumerServiceURL(authnRequest);
     UriBuilder uriBuilder = UriBuilder.fromUri(assertionConsumerServiceURL);
     uriBuilder.queryParam(SSOConstants.SAML_RESPONSE, encodedResponse);
-    uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState != null ? relayState : "");
+    if (relayState != null) {
+      uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState);
+    }
     getSimpleSign().signUriString(requestToSign.toString(), uriBuilder);
     LOGGER.debug("Signing successful.");
     return uriBuilder.build();

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
@@ -91,13 +91,15 @@ public class RedirectResponseCreator extends ResponseCreatorImpl implements Resp
             RestSecurity.deflateAndBase64Encode(
                 DOM2Writer.nodeToString(OpenSAMLUtil.toDom(samlResponse, doc, false))),
             "UTF-8");
-    String requestToSign =
-        String.format("SAMLResponse=%s&RelayState=%s", encodedResponse, relayState);
+    StringBuilder requestToSign = new StringBuilder("SAMLResponse=").append(encodedResponse);
+    if (relayState != null) {
+      requestToSign.append("&RelayState=").append(relayState);
+    }
     String assertionConsumerServiceURL = getAssertionConsumerServiceURL(authnRequest);
     UriBuilder uriBuilder = UriBuilder.fromUri(assertionConsumerServiceURL);
     uriBuilder.queryParam(SSOConstants.SAML_RESPONSE, encodedResponse);
-    uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState);
-    getSimpleSign().signUriString(requestToSign, uriBuilder);
+    uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState != null ? relayState : "");
+    getSimpleSign().signUriString(requestToSign.toString(), uriBuilder);
     LOGGER.debug("Signing successful.");
     return uriBuilder.build();
   }

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/soap/SoapResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/soap/SoapResponseCreator.java
@@ -83,7 +83,7 @@ public class SoapResponseCreator extends ResponseCreatorImpl implements Response
         responseTemplate.replace("{{" + Idp.SAML_RESPONSE + "}}", assertionResponse);
 
     String ecpResponse = createEcpResponse(authnRequest);
-    String ecpRelayState = createEcpRelayState(relayState);
+    String ecpRelayState = relayState != null ? createEcpRelayState(relayState) : "";
     String ecpRequestAuthenticated = createEcpRequestAuthenticated(authnRequest);
     submitFormUpdated = submitFormUpdated.replace("{{" + Idp.ECP_RESPONSE + "}}", ecpResponse);
     submitFormUpdated = submitFormUpdated.replace("{{" + Idp.ECP_RELAY_STATE + "}}", ecpRelayState);

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -887,6 +887,7 @@ public class IdpEndpoint implements Idp, SessionHandler {
                 getPresignPlugins(),
                 spMetadata,
                 SUPPORTED_BINDINGS);
+        template = submitForm;
       } else if (HTTP_REDIRECT_BINDING.equals(assertionConsumerServiceBinding)
           && !(binding instanceof RedirectBinding)) {
         binding =
@@ -896,6 +897,7 @@ public class IdpEndpoint implements Idp, SessionHandler {
                 getPresignPlugins(),
                 spMetadata,
                 SUPPORTED_BINDINGS);
+        template = redirectPage;
       }
       org.opensaml.saml.saml2.core.Response encodedSaml =
           handleLogin(
@@ -1393,7 +1395,7 @@ public class IdpEndpoint implements Idp, SessionHandler {
         LogoutRequest logoutRequest =
             logoutMessage.buildLogoutRequest(
                 logoutState.getNameId(),
-                SystemBaseUrl.constructUrl(IDP_LOGOUT, true),
+                SystemBaseUrl.constructUrl(IDP_LOGIN, true),
                 logoutState.getSessionIndexes());
         logoutState.setCurrentRequestId(logoutRequest.getID());
         logoutObject = logoutRequest;
@@ -1406,7 +1408,7 @@ public class IdpEndpoint implements Idp, SessionHandler {
             logoutState.isPartialLogout() ? StatusCode.PARTIAL_LOGOUT : StatusCode.SUCCESS;
         logoutObject =
             logoutMessage.buildLogoutResponse(
-                SystemBaseUrl.constructUrl(IDP_LOGOUT, true),
+                SystemBaseUrl.constructUrl(IDP_LOGIN, true),
                 status,
                 logoutState.getOriginalRequestId());
 
@@ -1464,12 +1466,15 @@ public class IdpEndpoint implements Idp, SessionHandler {
             RestSecurity.deflateAndBase64Encode(
                 DOM2Writer.nodeToString(OpenSAMLUtil.toDom(samlResponse, doc, false))),
             "UTF-8");
-    String requestToSign =
-        String.format("%s=%s&RelayState=%s", samlType.getKey(), encodedResponse, relayState);
+    StringBuilder requestToSign =
+        new StringBuilder(samlType.getKey()).append("=").append(encodedResponse);
+    if (relayState != null) {
+      requestToSign.append("&RelayState=").append(relayState);
+    }
     UriBuilder uriBuilder = UriBuilder.fromUri(targetUrl);
     uriBuilder.queryParam(samlType.getKey(), encodedResponse);
     uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState == null ? "" : relayState);
-    new SimpleSign(systemCrypto).signUriString(requestToSign, uriBuilder);
+    new SimpleSign(systemCrypto).signUriString(requestToSign.toString(), uriBuilder);
     LOGGER.debug("Signing successful.");
     return Response.ok(HtmlResponseTemplate.getRedirectPage(uriBuilder.build().toString())).build();
   }

--- a/platform/security/idp/security-idp-server/src/test/java/org/codice/ddf/security/idp/server/IdpEndpointTest.java
+++ b/platform/security/idp/security-idp-server/src/test/java/org/codice/ddf/security/idp/server/IdpEndpointTest.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.security.idp.server;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -129,6 +130,11 @@ public class IdpEndpointTest {
 
   String soapRequest =
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <soapenv:Header> <ecp:RelayState xmlns:ecp=\"urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp\" soapenv:actor=\"http://schemas.xmlsoap.org/soap/actor/next\" soapenv:mustUnderstand=\"1\">relaystate</ecp:RelayState> </soapenv:Header> <soapenv:Body>"
+          + authNRequestGetForce
+          + "</soapenv:Body></soapenv:Envelope>";
+
+  String soapRequestWithoutRelayState =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <soapenv:Header/> <soapenv:Body>"
           + authNRequestGetForce
           + "</soapenv:Body></soapenv:Envelope>";
 
@@ -906,6 +912,52 @@ public class IdpEndpointTest {
 
     activeSessions = idpEndpoint.getActiveSessionsSecure();
     assertThat(activeSessions.size(), is(0));
+  }
+
+  @Test
+  public void testNullRelayState() throws Exception {
+    idpEndpoint.setStrictSignature(false);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    when(request.isSecure()).thenReturn(true);
+
+    Response postLoginResponse = idpEndpoint.showPostLogin(authNRequestPost, null, request);
+    Response getLoginResponse =
+        idpEndpoint.showGetLogin(authNRequestGet, null, signatureAlgorithm, signature, request);
+    Response soapLoginResponse =
+        idpEndpoint.doSoapLogin(
+            new ByteArrayInputStream(soapRequestWithoutRelayState.getBytes(StandardCharsets.UTF_8)),
+            request);
+
+    // Verify no exceptions (NPE) are thrown and relay state is not present
+    assertTrue(!postLoginResponse.getEntity().toString().contains("RelayState"));
+    assertTrue(!getLoginResponse.getEntity().toString().contains("RelayState"));
+    assertTrue(!soapLoginResponse.getEntity().toString().contains("<ecp:RelayState"));
+  }
+
+  @Test
+  public void testRelayStateIsPresent() throws Exception {
+    idpEndpoint.setStrictSignature(false);
+    String relayState = "relaystate";
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    when(request.isSecure()).thenReturn(true);
+
+    Response postLoginResponse = idpEndpoint.showPostLogin(authNRequestPost, relayState, request);
+    Response getLoginResponse =
+        idpEndpoint.showGetLogin(
+            authNRequestGet, relayState, signatureAlgorithm, signature, request);
+    Response soapLoginResponse =
+        idpEndpoint.doSoapLogin(
+            new ByteArrayInputStream(soapRequest.getBytes(StandardCharsets.UTF_8)), request);
+
+    assertThat(
+        postLoginResponse.getEntity().toString(), containsString("\"RelayState\":\"relaystate\""));
+    assertThat(
+        getLoginResponse.getEntity().toString(), containsString("\"RelayState\":\"relaystate\""));
+
+    assertThat(soapLoginResponse.getEntity().toString(), containsString("<ecp:RelayState"));
+    assertThat(soapLoginResponse.getEntity().toString(), containsString("relaystate"));
   }
 
   private Document readDocument(String name)


### PR DESCRIPTION
Forward port of https://github.com/codice/ddf/pull/2889
#### What does this PR do?

1. DDF-3571 Changed DDF so it doesn't require a relayState but if one is provided it should include it in its response
2. DDF-3556 Changed LogoutResponse issuer for post and redirect binding
3. DDF-3574 Check the accepted binding and send a correctly formatted response - adding template type

#### Who is reviewing it? 
@brjeter @Lambeaux @bakejeyner 

#### Choose 2 committers to review/merge the PR. 
@coyotesqrl 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Test by connecting DDF to Spring (which doesn't provide a relay state by default). This should be done without changing DDF's metadata.

#### What are the relevant tickets?
[DDF-3571](https://codice.atlassian.net/browse/DDF-3571)
[DDF-3556](https://codice.atlassian.net/browse/DDF-3556)
[DDF-3574](https://codice.atlassian.net/browse/DDF-3574)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
