### PR TITLE
[2.11.x] Minor SAML Spec compliance fixes

### DIFF
--- a/platform/security/common/src/main/java/ddf/security/samlp/impl/SamlValidator.java
+++ b/platform/security/common/src/main/java/ddf/security/samlp/impl/SamlValidator.java
@@ -109,16 +109,18 @@ public abstract class SamlValidator {
 
   void checkRedirectSignature(String reqres) throws ValidationException {
     try {
-      String signedParts =
-          String.format(
-              "%s=%s&RelayState=%s&SigAlg=%s",
-              reqres,
-              URLEncoder.encode(builder.samlString, "UTF-8"),
-              builder.relayState,
-              URLEncoder.encode(builder.sigAlgo, "UTF-8"));
+      StringBuilder signedParts =
+          new StringBuilder(reqres)
+              .append("=")
+              .append(URLEncoder.encode(builder.samlString, "UTF-8"));
+      String relayState = builder.relayState;
+      if (relayState != null) {
+        signedParts.append("&RelayState=").append(relayState);
+      }
+      signedParts.append("&SigAlg=").append(URLEncoder.encode(builder.sigAlgo, "UTF-8"));
 
       if (!builder.simpleSign.validateSignature(
-          signedParts, builder.signature, builder.signingCertificate)) {
+          signedParts.toString(), builder.signature, builder.signingCertificate)) {
         throw new ValidationException("Signature verification failed for redirect binding.");
       }
     } catch (SimpleSign.SignatureException | UnsupportedEncodingException e) {

--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
@@ -450,17 +450,20 @@ public class IdpHandler implements AuthenticationHandler {
       if (idpssoDescriptor == null) {
         throw new ServletException("IdP metadata is missing. No IDPSSODescriptor present.");
       }
-      String queryParams =
-          String.format(
-              "SAMLRequest=%s&RelayState=%s",
-              encodeAuthnRequest(
-                  createAndSignAuthnRequest(false, idpssoDescriptor.getWantAuthnRequestsSigned()),
-                  false),
-              URLEncoder.encode(relayState, "UTF-8"));
+      StringBuilder queryParams =
+          new StringBuilder("SAMLRequest=")
+              .append(
+                  encodeAuthnRequest(
+                      createAndSignAuthnRequest(
+                          false, idpssoDescriptor.getWantAuthnRequestsSigned()),
+                      false));
+      if (relayState != null) {
+        queryParams.append("&RelayState=").append(URLEncoder.encode(relayState, "UTF-8"));
+      }
       idpRequest = idpMetadata.getSingleSignOnLocation() + "?" + queryParams;
       UriBuilder idpUri = new UriBuilderImpl(new URI(idpRequest));
 
-      simpleSign.signUriString(queryParams, idpUri);
+      simpleSign.signUriString(queryParams.toString(), idpUri);
 
       redirectUrl = idpUri.build().toString();
     } catch (UnsupportedEncodingException e) {

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/api/impl/ValidatorImpl.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/api/impl/ValidatorImpl.java
@@ -98,10 +98,8 @@ public abstract class ValidatorImpl implements Validator {
   @Override
   public void validateRelayState(String relayState) {
     LOGGER.debug("Validating RelayState");
-    if (relayState == null || relayState.length() < 0 || relayState.length() > 80) {
-      LOGGER.info(
-          "RelayState has invalid size: {}",
-          (relayState == null) ? "no RelayState" : relayState.length());
+    if (relayState != null && relayState.length() > 80) {
+      LOGGER.warn("RelayState has invalid size: {}", relayState.length());
     }
   }
 

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/post/PostResponseCreator.java
@@ -40,6 +40,7 @@ import org.w3c.dom.Document;
 public class PostResponseCreator extends ResponseCreatorImpl implements ResponseCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PostResponseCreator.class);
+  private static final String SURROUND_WITH_TWO_PARENTHESES = "{{%s}}";
 
   public PostResponseCreator(
       SystemCrypto systemCrypto,
@@ -75,11 +76,18 @@ public class PostResponseCreator extends ResponseCreatorImpl implements Response
         Base64.getEncoder().encodeToString(assertionResponse.getBytes(StandardCharsets.UTF_8));
     String assertionConsumerServiceURL = getAssertionConsumerServiceURL(authnRequest);
     String submitFormUpdated =
-        responseTemplate.replace("{{" + Idp.ACS_URL + "}}", assertionConsumerServiceURL);
-    submitFormUpdated = submitFormUpdated.replace("{{" + Idp.SAML_TYPE + "}}", "SAMLResponse");
+        responseTemplate.replace(
+            String.format(SURROUND_WITH_TWO_PARENTHESES, Idp.ACS_URL), assertionConsumerServiceURL);
     submitFormUpdated =
-        submitFormUpdated.replace("{{" + Idp.SAML_RESPONSE + "}}", encodedSamlResponse);
-    submitFormUpdated = submitFormUpdated.replace("{{" + Idp.RELAY_STATE + "}}", relayState);
+        submitFormUpdated.replace(
+            String.format(SURROUND_WITH_TWO_PARENTHESES, Idp.SAML_TYPE), "SAMLResponse");
+    submitFormUpdated =
+        submitFormUpdated.replace(
+            String.format(SURROUND_WITH_TWO_PARENTHESES, Idp.SAML_RESPONSE), encodedSamlResponse);
+    submitFormUpdated =
+        submitFormUpdated.replace(
+            String.format(SURROUND_WITH_TWO_PARENTHESES, Idp.RELAY_STATE),
+            relayState != null ? relayState : "");
     Response.ResponseBuilder ok = Response.ok(submitFormUpdated);
     if (cookie != null) {
       ok = ok.cookie(cookie);

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
@@ -98,7 +98,9 @@ public class RedirectResponseCreator extends ResponseCreatorImpl implements Resp
     String assertionConsumerServiceURL = getAssertionConsumerServiceURL(authnRequest);
     UriBuilder uriBuilder = UriBuilder.fromUri(assertionConsumerServiceURL);
     uriBuilder.queryParam(SSOConstants.SAML_RESPONSE, encodedResponse);
-    uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState != null ? relayState : "");
+    if (relayState != null) {
+      uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState);
+    }
     getSimpleSign().signUriString(requestToSign.toString(), uriBuilder);
     LOGGER.debug("Signing successful.");
     return uriBuilder.build();

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
@@ -91,13 +91,15 @@ public class RedirectResponseCreator extends ResponseCreatorImpl implements Resp
             RestSecurity.deflateAndBase64Encode(
                 DOM2Writer.nodeToString(OpenSAMLUtil.toDom(samlResponse, doc, false))),
             "UTF-8");
-    String requestToSign =
-        String.format("SAMLResponse=%s&RelayState=%s", encodedResponse, relayState);
+    StringBuilder requestToSign = new StringBuilder("SAMLResponse=").append(encodedResponse);
+    if (relayState != null) {
+      requestToSign.append("&RelayState=").append(relayState);
+    }
     String assertionConsumerServiceURL = getAssertionConsumerServiceURL(authnRequest);
     UriBuilder uriBuilder = UriBuilder.fromUri(assertionConsumerServiceURL);
     uriBuilder.queryParam(SSOConstants.SAML_RESPONSE, encodedResponse);
-    uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState);
-    getSimpleSign().signUriString(requestToSign, uriBuilder);
+    uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState != null ? relayState : "");
+    getSimpleSign().signUriString(requestToSign.toString(), uriBuilder);
     LOGGER.debug("Signing successful.");
     return uriBuilder.build();
   }

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectValidator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectValidator.java
@@ -20,6 +20,7 @@ import ddf.security.samlp.impl.EntityInformation;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.security.idp.binding.api.Validator;
@@ -49,14 +50,17 @@ public class RedirectValidator extends ValidatorImpl implements Validator {
     LOGGER.debug("Validating AuthnRequest required attributes and signature");
     if (strictSignature) {
       if (!StringUtils.isEmpty(signature) && !StringUtils.isEmpty(signatureAlgorithm)) {
-        String signedParts;
+        StringBuilder signedParts;
         try {
           signedParts =
-              String.format(
-                  "SAMLRequest=%s&RelayState=%s&SigAlg=%s",
-                  URLEncoder.encode(samlRequest, "UTF-8"),
-                  relayState,
-                  URLEncoder.encode(signatureAlgorithm, "UTF-8"));
+              new StringBuilder("SAMLRequest=")
+                  .append(URLEncoder.encode(samlRequest, StandardCharsets.UTF_8.name()));
+          if (relayState != null) {
+            signedParts.append("&RelayState=").append(relayState);
+          }
+          signedParts
+              .append("&SigAlg=")
+              .append(URLEncoder.encode(signatureAlgorithm, StandardCharsets.UTF_8.name()));
         } catch (UnsupportedEncodingException e) {
           throw new SimpleSign.SignatureException("Unable to construct signed query parts.", e);
         }
@@ -67,14 +71,14 @@ public class RedirectValidator extends ValidatorImpl implements Validator {
               String.format("Unable to find metadata for %s", authnRequest.getIssuer().getValue()));
         }
 
-        String encryptionCertificate = entityInformation.getEncryptionCertificate();
         String signingCertificate = entityInformation.getSigningCertificate();
         if (signingCertificate == null) {
           throw new ValidationException(
               "Unable to find signing certificate in metadata. Please check metadata.");
         }
         boolean result =
-            getSimpleSign().validateSignature(signedParts, signature, signingCertificate);
+            getSimpleSign()
+                .validateSignature(signedParts.toString(), signature, signingCertificate);
         if (!result) {
           throw new ValidationException("Signature verification failed for redirect binding.");
         }
@@ -92,7 +96,7 @@ public class RedirectValidator extends ValidatorImpl implements Validator {
   public void validateRelayState(String relayState) {
     if (relayState != null) {
       try {
-        relayState = URLDecoder.decode(relayState, "UTF-8");
+        relayState = URLDecoder.decode(relayState, StandardCharsets.UTF_8.name());
       } catch (UnsupportedEncodingException e) {
         LOGGER.info("Unable to URL decode relay state, it may already be decoded.", e);
       }

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/soap/SoapResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/soap/SoapResponseCreator.java
@@ -83,7 +83,7 @@ public class SoapResponseCreator extends ResponseCreatorImpl implements Response
         responseTemplate.replace("{{" + Idp.SAML_RESPONSE + "}}", assertionResponse);
 
     String ecpResponse = createEcpResponse(authnRequest);
-    String ecpRelayState = createEcpRelayState(relayState);
+    String ecpRelayState = relayState != null ? createEcpRelayState(relayState) : "";
     String ecpRequestAuthenticated = createEcpRequestAuthenticated(authnRequest);
     submitFormUpdated = submitFormUpdated.replace("{{" + Idp.ECP_RESPONSE + "}}", ecpResponse);
     submitFormUpdated = submitFormUpdated.replace("{{" + Idp.ECP_RELAY_STATE + "}}", ecpRelayState);


### PR DESCRIPTION
#### What does this PR do?

1. DDF-3571 Changed DDF so it doesn't require a relayState but if one is provided it should include it in its response
2. DDF-3556 Changed LogoutResponse issuer for post and redirect binding
3. DDF-3574 Check the accepted binding and send a correctly formatted response - adding template type

#### Who is reviewing it? 
@brjeter @Lambeaux @bakejeyner 

#### Choose 2 committers to review/merge the PR. 
@coyotesqrl 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Test by connecting DDF to Spring (which doesn't provide a relay state by default). This should be done without changing DDF's metadata.

#### What are the relevant tickets?
[DDF-3571](https://codice.atlassian.net/browse/DDF-3571)
[DDF-3556](https://codice.atlassian.net/browse/DDF-3556)
[DDF-3574](https://codice.atlassian.net/browse/DDF-3574)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
