### PR TITLE
(2.11.x) DDF-3516 Converted coordinates from map projection to EPSG:4326 to display lat/lng to user

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -89,9 +89,10 @@ module.exports = function OpenlayersMap(insertionElement, selectionInterface, no
   
     function setupTooltip(map) {        
         map.on('pointermove', function(e){
+            var point = unconvertPointCoordinate(e.coordinate);
             parentView.updateMouseCoordinates({
-                lat: e.coordinate[1],
-                lon: e.coordinate[0]
+                lat: point[1],
+                lon: point[0]
             });
         });
     }


### PR DESCRIPTION
Lat/Lon show up as degrees when they are actually meters from 0 when using certain projections (EPSG:3857) in the lower corner of the map.  This cleans that up.  

Backport from master

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@beyelerb
@brendan-hofmann
@rzwiefel
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3516](https://codice.atlassian.net/browse/DDF-3516)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
