### PR TITLE
(2.11.x) DDF-3511 Moved WKTReader in AtomTransformer to be a member variable for thread safety

### DIFF
--- a/catalog/transformer/catalog-transformer-service-atom/src/main/java/ddf/catalog/transformer/response/query/atom/AtomTransformer.java
+++ b/catalog/transformer/catalog-transformer-service-atom/src/main/java/ddf/catalog/transformer/response/query/atom/AtomTransformer.java
@@ -14,6 +14,7 @@
 package ddf.catalog.transformer.response.query.atom;
 
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 import ddf.action.Action;
@@ -98,6 +99,8 @@ public class AtomTransformer implements QueryResponseTransformer {
 
   private static final String MIME_TYPE_OCTET_STREAM = "application/octet-stream";
 
+  private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
   // expensive creation, meant to be done once
   private static final Abdera ABDERA = new Abdera();
 
@@ -118,8 +121,6 @@ public class AtomTransformer implements QueryResponseTransformer {
   private ActionProvider resourceActionProvider;
 
   private ActionProvider thumbnailActionProvider;
-
-  private WKTReader reader = new WKTReader();
 
   public void setViewMetacardActionProvider(ActionProvider viewMetacardActionProvider) {
     this.viewMetacardActionProvider = viewMetacardActionProvider;
@@ -454,7 +455,7 @@ public class AtomTransformer implements QueryResponseTransformer {
           if (geo != null) {
 
             try {
-              Geometry geometry = reader.read(geo.toString());
+              Geometry geometry = new WKTReader(GEOMETRY_FACTORY).read(geo.toString());
 
               CompositeGeometry formatter = CompositeGeometry.getCompositeGeometry(geometry);
 


### PR DESCRIPTION
Backported from master

#### What does this PR do?
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@jlcsmith
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3511](https://codice.atlassian.net/browse/DDF-3511)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
