### PR TITLE
DDF-3561 Make registry identity node initialization required for bundle startup

### DIFF
--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -39,8 +39,6 @@
         <property name="executor" ref="registryPollerThreadPool"/>
     </bean>
 
-    <bean id="identityNodeInitializerExecutor" class="java.util.concurrent.Executors"
-          factory-method="newSingleThreadScheduledExecutor"/>
     <bean id="registryPollerThreadPool" class="java.util.concurrent.Executors"
           factory-method="newScheduledThreadPool">
         <argument value="${org.codice.ddf.system.threadPoolSize}"/>
@@ -55,11 +53,10 @@
 
     <bean id="identityNodeInitialization"
           class="org.codice.ddf.registry.federationadmin.service.impl.IdentityNodeInitialization"
-          init-method="init" destroy-method="destroy">
+          init-method="init">
         <property name="metacardMarshaller" ref="metacardMarshaller"/>
         <property name="registryTransformer" ref="inputTransformer"/>
         <property name="federationAdminService" ref="federationAdminService"/>
-        <property name="executorService" ref="identityNodeInitializerExecutor"/>
     </bean>
 
     <bean id="metacardMarshaller"

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/SystemStateManager.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/SystemStateManager.java
@@ -173,11 +173,6 @@ public class SystemStateManager {
       console.runCommand("catalog:removeall -f -p");
       console.runCommand("catalog:removeall -f -p --cache");
 
-      // Restart bundles that manage dynamic metacards
-      // TODO: 1/19/18 DDF-3561 remove the plugin bundle from this list
-      serviceManager.restartBundles(
-          "registry-identification-plugin", "registry-federation-admin-service-impl");
-
       console.runCommand(
           "catalog:import --provider --force --skip-signature-verification  itest-catalog-entries.zip");
       LOGGER.debug("Reset took {} sec", (System.currentTimeMillis() - start) / 1000.0);
@@ -220,7 +215,7 @@ public class SystemStateManager {
         baseConfigurations.put(config.getPid(), config);
       }
       console.runCommand(
-          "catalog:export --provider --force --skip-signature-verification --delete=false --output \"./itest-catalog-entries.zip\" --cql \"\\\"metacard-tags\\\" like '*'\"");
+          "catalog:export --provider --force --skip-signature-verification --delete=false --output \"./itest-catalog-entries.zip\" --cql \"\\\"metacard-tags\\\" not like 'geonames'\"");
       LOGGER.info("Feature Count: {}", baseFeatures.size());
       LOGGER.info("Configuration Count: {}", baseConfigurations.size());
     } catch (Exception e) {


### PR DESCRIPTION
#### What does this PR do?
DDF-3561 Make registry identity node initialization required for bundle startup
 - Update SystemStateManger to ignore geoname metacards
 - Remove SystemStateManager todo comment and code
#### Who is reviewing it? 
@Lambeaux @mcalcote 

#### Choose 2 committers to review/merge the PR. 
@coyotesqrl 
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
Verify ci build passes. Build downstream projects and verify their itests pass as well.

#### What are the relevant tickets?
[DDF-3561](https://codice.atlassian.net/browse/DDF-3561)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Update / Add Unit Tests
