### PR TITLE
DDF 3512 Add quick switch actions for forms, user preference for form type

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.hbs
@@ -13,6 +13,21 @@
  --}}
 <div class="interaction interaction-type is-active" title="Change the form used to construct the search." data-help="Change the form used to construct the search.">
 </div>
+<div class="interaction interaction-type-text interaction-form" title="Change the form used to construct the search to the text form." data-help="Change the form used to construct the search to the text form.">
+    <div class="interaction-text">
+        <span class="fa fa-level-up"></span> Text
+    </div>
+</div>
+<div class="interaction interaction-type-basic interaction-form" title="Change the form used to construct the search to the text form." data-help="Change the form used to construct the search to the text form.">
+    <div class="interaction-text">
+        <span class="fa fa-level-up"></span> Basic
+    </div>
+</div>
+<div class="interaction interaction-type-advanced interaction-form" title="Change the form used to construct the search to the text form." data-help="Change the form used to construct the search to the text form.">
+    <div class="interaction-text">
+        <span class="fa fa-level-up"></span> Advanced
+    </div>
+</div>
 <div class="interaction interaction-reset" title="Resets the search form." data-help="Resets the search form.">
     <div class="interaction-icon fa fa-undo">
     </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.less
@@ -28,16 +28,45 @@
   .interaction-icon,
   .interaction-text {
     display: inline-block;
+    vertical-align: top;
   }
 
   .interaction-revert {
     display: none;
   }
 
+  .interaction-form {
+    margin: 0 @minimumButtonSize;
+    padding: 0 @minimumButtonSize;
+  }
+
+  .interaction-form > .interaction-text .fa-level-up {
+    transform: rotate(90deg);
+    font-size: @mediumFontSize;
+    margin-right: @minimumSpacing;
+  }
 }
 
 @{customElementNamespace}search-interactions.allow-revert {
   .interaction-revert {
     display: block;
+  }
+}
+
+@{customElementNamespace}search-interactions.is-text {
+  .interaction-type-text {
+    display: none;
+  }
+}
+
+@{customElementNamespace}search-interactions.is-basic {
+  .interaction-type-basic {
+    display: none;
+  }
+}
+
+@{customElementNamespace}search-interactions.is-advanced {
+  .interaction-type-advanced {
+    display: none;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
@@ -26,6 +26,7 @@ var DropdownModel = require('component/dropdown/dropdown');
 var SearchTypeDropdownView = require('component/dropdown/search-type/dropdown.search-type.view');
 var _merge = require('lodash/merge');
 var ConfirmationView = require('component/confirmation/confirmation.view');
+var user = require('component/singletons/user-instance');
 
 module.exports = Marionette.LayoutView.extend(Decorators.decorate({
     template: template,
@@ -99,13 +100,18 @@ module.exports = Marionette.LayoutView.extend(Decorators.decorate({
             }
         }.bind(this));
     },
+    triggerType: function(type) {
+        this.model.set('type', type);
+        user.getQuerySettings().set('type', type);
+        user.savePreferences();
+    },
     triggerTypeText: function() {
-        this.model.set('type', 'text');
+        this.triggerType('text');
     },
     triggerTypeBasic: function() {
-        this.model.set('type', 'basic');
+        this.triggerType('basic');
     },
     triggerTypeAdvanced: function() {
-        this.model.set('type', 'advanced');
+        this.triggerType('advanced');
     }
 }, MenuNavigationDecorator));

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
@@ -35,7 +35,29 @@ module.exports = Marionette.LayoutView.extend(Decorators.decorate({
         searchSettings: '.interaction-settings'
     },
     events: {
-        'click > .interaction-reset': 'triggerReset'
+        'click > .interaction-reset': 'triggerReset',
+        'click > .interaction-type-text': 'triggerTypeText',
+        'click > .interaction-type-basic': 'triggerTypeBasic',
+        'click > .interaction-type-advanced': 'triggerTypeAdvanced',
+        'click > .interaction-form': 'triggerCloseDropdown'
+    },
+    initialize: function() {
+        this.handleType();
+        this.listenTo(this.model, 'change:type', this.handleType);
+    },
+    handleType: function() {
+        this.$el.removeClass('is-text').removeClass('is-basic').removeClass('is-advanced');
+        switch(this.model.get('type')) {
+            case 'text':
+                this.$el.addClass('is-text');
+            break;
+            case 'basic':
+                this.$el.addClass('is-basic');
+            break;
+            case 'advanced':
+                this.$el.addClass('is-advanced');
+            break;
+        }
     },
     onRender: function(){
         this.generateSearchType();
@@ -60,6 +82,9 @@ module.exports = Marionette.LayoutView.extend(Decorators.decorate({
             replaceElement: true
         });
     },
+    triggerCloseDropdown: function() {
+        this.$el.trigger('closeDropdown.'+CustomElements.getNamespace());
+    },
     triggerReset: function() {
         this.listenTo(ConfirmationView.generateConfirmation({
             prompt: 'Are you sure you want to reset the search?',
@@ -70,11 +95,17 @@ module.exports = Marionette.LayoutView.extend(Decorators.decorate({
         function(confirmation) {
             if (confirmation.get('choice')) {
                 this.model.resetToDefaults();
-                this.handleClick();
+                this.triggerCloseDropdown();
             }
         }.bind(this));
     },
-    handleClick: function(){
-        this.$el.trigger('closeDropdown.'+CustomElements.getNamespace());
+    triggerTypeText: function() {
+        this.model.set('type', 'text');
+    },
+    triggerTypeBasic: function() {
+        this.model.set('type', 'basic');
+    },
+    triggerTypeAdvanced: function() {
+        this.model.set('type', 'advanced');
     }
 }, MenuNavigationDecorator));

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/search-settings/search-settings.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/search-settings/search-settings.view.js
@@ -74,7 +74,7 @@ define([
             user.getPreferences().get('querySettings').set(this.propertySearchSettings.currentView.toJSON());
         },
         updateResultCountSettings: function () {
-            user.getPreferences().get({
+            user.getPreferences().set({
                 resultCount: this.propertyResultCount.currentView.model.getValue()[0]
             });
         },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/search-type/search-type.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/search-type/search-type.view.js
@@ -19,6 +19,7 @@ var Marionette = require('marionette');
 var CustomElements = require('js/CustomElements');
 var PropertyView = require('component/property/property.view');
 var Property = require('component/property/property');
+var user = require('component/singletons/user-instance');
 
 module.exports = Marionette.LayoutView.extend({
     tagName: CustomElements.register('search-type'),
@@ -27,7 +28,10 @@ module.exports = Marionette.LayoutView.extend({
         typeSelector: '> .type-selector'
     },
     updateQueryType: function(){
-        this.model.set('type', this.typeSelector.currentView.model.getValue()[0]);
+        let type = this.typeSelector.currentView.model.getValue()[0];
+        this.model.set('type', type);
+        user.getQuerySettings().set('type', type);
+        user.savePreferences();
     },
     onBeforeShow: function () {
         this.typeSelector.show(new PropertyView({

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -15,6 +15,7 @@ var Backbone = require('backbone');
 module.exports = Backbone.Model.extend({
     defaults: function() {
         return {
+            type: 'text',
             src: undefined,
             federation: 'enterprise',
             sortField: 'modified',


### PR DESCRIPTION
#### What does this PR do?
Incorporates some feedback from https://github.com/codice/ddf/pull/2845

Adds quick switch actions for the basic form types, and stores the type as a preference.

#### Who is reviewing it? 
@bdeining 
@millerw8
@mackncheesiest 
@adimka 

#### How should this be tested? (List steps with links to updated documentation)
Verify the quick switch options work for switching forms.  Verify that after running a search, the form you switched to is the form that appears when searching.

#### What are the relevant tickets?
[DDF-3512](https://codice.atlassian.net/browse/3512)

#### Screenshots (if appropriate)
![screen shot 2018-01-30 at 3 19 15 pm](https://user-images.githubusercontent.com/11984853/35594829-cc5735a4-05d1-11e8-9cb6-529f971e95e9.png)
