### PR TITLE
DDF-3580, DDF-3581 Updates workspace collection to appropriately rerender and sort

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.hbs
@@ -15,8 +15,8 @@
     <span class="title-text" title="{{bindAttr attr="title" selector="> .choice-title > .title-text" event="change:title" key=(path "title")}}">{{bind selector="> .choice-title > .title-text" event="change:title" key=(path "title")}}</span>
     <div class="title-indicator"></div>
 </div>
-<div class="choice-date" title="{{bindAttr attr="title" selector="> .choice-date" event="change:modified" key=(path "niceDate")}}" data-help="The date the workspace was last modified">
-    {{bind selector="> .choice-date" event="change:modified" key=(path "niceDate")}}
+<div class="choice-date" title="{{bindAttr attr="title" selector="> .choice-date" event="change:metacard.modified" key=(path "niceDate")}}" data-help="The date the workspace was last modified">
+    {{bind selector="> .choice-date" event="change:metacard.modified" key=(path "niceDate")}}
 </div>
 <div class="choice-owner" title="{{bindAttr attr="title" selector="> .choice-owner" event="change:metacard.owner" key=(path "owner")}}" data-help="The owner of the workspace.">
     {{#if localStorage}} 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-details/workspace-details.view.js
@@ -47,7 +47,7 @@ define([
         },
         serializeData: function() {
             var workspacesJSON = this.model.toJSON();
-            workspacesJSON.niceDate = moment(workspacesJSON.modified).fromNow();
+            workspacesJSON.niceDate = moment(workspacesJSON['metacard.modified']).fromNow();
             workspacesJSON.owner = workspacesJSON['metacard.owner'] || 'Guest';
             return workspacesJSON;
         },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-item/workspace-item.collection.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/workspace-item/workspace-item.collection.view.js
@@ -15,12 +15,12 @@
 /*global define, alert*/
 define([
     'marionette',
-    'underscore',
     'jquery',
     'js/CustomElements',
     './workspace-item.view',
-    'component/singletons/user-instance'
-], function (Marionette, _, $, CustomElements, WorkspaceItemView, user) {
+    'component/singletons/user-instance',
+    'lodash'
+], function (Marionette, $, CustomElements, WorkspaceItemView, user, _) {
 
     var getUser = function () {
          return user.get('user');
@@ -53,15 +53,15 @@ define([
             switch (getPrefs().get('homeSort')) {
                 case 'Title':
                     return workspace.get('title').toLowerCase();
-                case 'Last modified':
                 default:
-                    return workspace.get('modified');
+                    return -workspace.get('metacard.modified');
             }
         },
         initialize: function () {
             this.listenTo(getPrefs(), 'change:homeDisplay', this.switchDisplay);
             this.listenTo(getPrefs(), 'change:homeFilter', this.render);
             this.listenTo(getPrefs(), 'change:homeSort', this.render);
+            this.listenTo(this.collection, 'sync', _.debounce(this.render, 200));
         },
         onRender: function(){
             this.handleGridDisplay();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -87,6 +87,7 @@ module.exports = Backbone.AssociatedModel.extend({
     },
     saveLocal: function (options) {
         this.set('id', this.get('id') || Common.generateUUID());
+        this.set('metacard.modified', Date.now());
         var localWorkspaces = this.collection.getLocalWorkspaces();
         localWorkspaces[this.get('id')] = this.toJSON();
         window.localStorage.setItem('workspaces', JSON.stringify(localWorkspaces));


### PR DESCRIPTION
#### What does this PR do?
 - Previously the workspace collection wouldn't rerender on sync, so newly created workspaces that lacked an owner (till the server returned) would be hidden if the filtering was set to "owned by me".
 - Sorting by modified previously used the static "modified" field.  Now it uses the "metacard.modified" field.  Also, the sorting is reversed to sort newly modified things to the top.

#### Who is reviewing it? 
@adimka 
@mackncheesiest 
@bdeining 
@brendan-hofmann 