### PR TITLE
DDF-3572: Add support to org.codice.ddf.transformer.xml.streaming.lib.SaxEventHandlerDelegate for endDocument()

### DIFF
--- a/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
@@ -190,6 +190,17 @@ public class SaxEventHandlerDelegate extends DefaultHandler {
   /**
    * Takes in a sax event from {@link SaxEventHandlerDelegate#parser} and passes it to the {@link
    * SaxEventHandlerDelegate#eventHandlers}
+   */
+  @Override
+  public void endDocument() throws SAXException {
+    for (SaxEventHandler transformer : eventHandlers) {
+      transformer.endDocument();
+    }
+  }
+
+  /**
+   * Takes in a sax event from {@link SaxEventHandlerDelegate#parser} and passes it to the {@link
+   * SaxEventHandlerDelegate#eventHandlers}
    *
    * @param uri the URI that is passed in by {@link SaxEventHandlerDelegate}
    * @param localName the localName that is passed in by {@link SaxEventHandlerDelegate}


### PR DESCRIPTION
Forward port of [PR 2884](https://github.com/codice/ddf/pull/2884)

#### What does this PR do?

See https://github.com/codice/ddf/pull/2884

#### Who is reviewing it? 
@emanns95
@peterhuffer

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
CI build

#### Any background context you want to provide?

#### What are the relevant tickets?

https://codice.atlassian.net/browse/DDF-3572

[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
