### PR TITLE
[2.11.x]DDF-3600 Use all registered attribute desciptors to build filters in the CSW Endpoint

### DIFF
--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswQueryFilterTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswQueryFilterTransformer.java
@@ -14,14 +14,13 @@
 
 package org.codice.ddf.spatial.ogc.csw.catalog.endpoint.transformer;
 
-import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.transform.QueryFilterTransformer;
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 import org.geotools.filter.FilterFactoryImpl;
 import org.opengis.filter.Filter;
@@ -30,8 +29,8 @@ public class CswQueryFilterTransformer implements QueryFilterTransformer {
 
   private CswRecordMapperFilterVisitor filterVisitor;
 
-  public CswQueryFilterTransformer(CswRecordMap recordMap, List<MetacardType> metacardTypes) {
-    filterVisitor = new CswRecordMapperFilterVisitor(recordMap, metacardTypes);
+  public CswQueryFilterTransformer(CswRecordMap recordMap, AttributeRegistry attributeRegistry) {
+    filterVisitor = new CswRecordMapperFilterVisitor(recordMap, attributeRegistry);
   }
 
   @Override

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswQueryFilterTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswQueryFilterTransformer.java
@@ -30,9 +30,8 @@ public class CswQueryFilterTransformer implements QueryFilterTransformer {
 
   private CswRecordMapperFilterVisitor filterVisitor;
 
-  public CswQueryFilterTransformer(
-      CswRecordMap recordMap, MetacardType metacardType, List<MetacardType> metacardTypes) {
-    filterVisitor = new CswRecordMapperFilterVisitor(recordMap, metacardType, metacardTypes);
+  public CswQueryFilterTransformer(CswRecordMap recordMap, List<MetacardType> metacardTypes) {
+    filterVisitor = new CswRecordMapperFilterVisitor(recordMap, metacardTypes);
   }
 
   @Override

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -174,13 +174,6 @@
 
     <reference id="cswMetacardType" interface="ddf.catalog.data.MetacardType" filter="(name=csw:Record)"/>
 
-    <bean id="metacardTypes" class="ddf.catalog.util.impl.SortedServiceList"/>
-    <reference-list id="metacardTypeList"
-                    interface="ddf.catalog.data.MetacardType">
-        <reference-listener bind-method="bindPlugin" unbind-method="unbindPlugin"
-                            ref="metacardTypes"/>
-    </reference-list>
-
     <bean id="cswFilterFactory"
           class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.CswQueryFactory">
         <argument ref="metacardCswRecordMap"/>
@@ -199,7 +192,7 @@
     <bean id="cswQueryFilterTransformer"
           class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.transformer.CswQueryFilterTransformer">
         <argument ref="metacardCswRecordMap"/>
-        <argument ref="metacardTypes"/>
+        <argument ref="attributeRegistry"/>
     </bean>
     <service ref="cswQueryFilterTransformer" interface="ddf.catalog.transform.QueryFilterTransformer">
         <service-properties>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -199,7 +199,6 @@
     <bean id="cswQueryFilterTransformer"
           class="org.codice.ddf.spatial.ogc.csw.catalog.endpoint.transformer.CswQueryFilterTransformer">
         <argument ref="metacardCswRecordMap"/>
-        <argument ref="cswMetacardType"/>
         <argument ref="metacardTypes"/>
     </bean>
     <service ref="cswQueryFilterTransformer" interface="ddf.catalog.transform.QueryFilterTransformer">

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
@@ -266,7 +266,7 @@ public class CswQueryFactoryTest {
     queryFilterTransformerProvider = mock(QueryFilterTransformerProvider.class);
     QueryFilterTransformer cswQueryFilter =
         new CswQueryFilterTransformer(
-            new MetacardCswRecordMap(), getCswMetacardType(), Collections.emptyList());
+            new MetacardCswRecordMap(), Arrays.asList(getCswMetacardType()));
     when(queryFilterTransformerProvider.getTransformer(
             new QName(CswConstants.CSW_OUTPUT_SCHEMA, "Record")))
         .thenReturn(Optional.of(cswQueryFilter));

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactoryTest.java
@@ -29,11 +29,10 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
-import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.AttributeRegistryImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.data.impl.types.AssociationsAttributes;
@@ -254,10 +253,9 @@ public class CswQueryFactoryTest {
 
     queryFactory = new CswQueryFactory(cswRecordMap, filterBuilder, filterAdapter);
 
-    AttributeRegistry mockAttributeRegistry = mock(AttributeRegistry.class);
-    when(mockAttributeRegistry.lookup(TITLE_TEST_ATTRIBUTE))
-        .thenReturn(Optional.of(mock(AttributeDescriptor.class)));
-    queryFactory.setAttributeRegistry(mockAttributeRegistry);
+    AttributeRegistryImpl attributeRegistry = new AttributeRegistryImpl();
+    attributeRegistry.registerMetacardType(getCswMetacardType());
+    queryFactory.setAttributeRegistry(attributeRegistry);
 
     polygon = new WKTReader().read(POLYGON_STR);
     gmlObjectFactory = new net.opengis.gml.v_3_1_1.ObjectFactory();
@@ -265,8 +263,7 @@ public class CswQueryFactoryTest {
 
     queryFilterTransformerProvider = mock(QueryFilterTransformerProvider.class);
     QueryFilterTransformer cswQueryFilter =
-        new CswQueryFilterTransformer(
-            new MetacardCswRecordMap(), Arrays.asList(getCswMetacardType()));
+        new CswQueryFilterTransformer(new MetacardCswRecordMap(), attributeRegistry);
     when(queryFilterTransformerProvider.getTransformer(
             new QName(CswConstants.CSW_OUTPUT_SCHEMA, "Record")))
         .thenReturn(Optional.of(cswQueryFilter));

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFilterTransformerTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFilterTransformerTest.java
@@ -23,7 +23,7 @@ import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.impl.QueryImpl;
-import java.util.Collections;
+import java.util.Arrays;
 import org.codice.ddf.spatial.ogc.csw.catalog.endpoint.mappings.MetacardCswRecordMap;
 import org.codice.ddf.spatial.ogc.csw.catalog.endpoint.transformer.CswQueryFilterTransformer;
 import org.junit.Before;
@@ -38,9 +38,7 @@ public class CswQueryFilterTransformerTest {
   public void setUp() {
     transformer =
         new CswQueryFilterTransformer(
-            new MetacardCswRecordMap(),
-            CswQueryFactoryTest.getCswMetacardType(),
-            Collections.emptyList());
+            new MetacardCswRecordMap(), Arrays.asList(CswQueryFactoryTest.getCswMetacardType()));
   }
 
   @Test

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFilterTransformerTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFilterTransformerTest.java
@@ -19,11 +19,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.impl.QueryImpl;
-import java.util.Arrays;
 import org.codice.ddf.spatial.ogc.csw.catalog.endpoint.mappings.MetacardCswRecordMap;
 import org.codice.ddf.spatial.ogc.csw.catalog.endpoint.transformer.CswQueryFilterTransformer;
 import org.junit.Before;
@@ -37,8 +37,7 @@ public class CswQueryFilterTransformerTest {
   @Before
   public void setUp() {
     transformer =
-        new CswQueryFilterTransformer(
-            new MetacardCswRecordMap(), Arrays.asList(CswQueryFactoryTest.getCswMetacardType()));
+        new CswQueryFilterTransformer(new MetacardCswRecordMap(), mock(AttributeRegistry.class));
   }
 
   @Test

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswRecordMapperFilterVisitorTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswRecordMapperFilterVisitorTest.java
@@ -117,16 +117,13 @@ public class CswRecordMapperFilterVisitorTest {
     mockMetacardTypeList = new ArrayList<>();
     mockMetacardTypeList.add(metacardType);
 
-    visitor =
-        new CswRecordMapperFilterVisitor(
-            DEFAULT_CSW_RECORD_MAP, metacardType, mockMetacardTypeList);
+    visitor = new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
   }
 
   @Test
   public void testVisitWithUnmappedName() {
     CswRecordMapperFilterVisitor visitor =
-        new CswRecordMapperFilterVisitor(
-            DEFAULT_CSW_RECORD_MAP, metacardType, mockMetacardTypeList);
+        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
 
     PropertyName propertyName = (PropertyName) visitor.visit(attrExpr, null);
 
@@ -143,8 +140,7 @@ public class CswRecordMapperFilterVisitorTest {
                     CswConstants.OWS_BOUNDING_BOX,
                     CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX)));
     CswRecordMapperFilterVisitor visitor =
-        new CswRecordMapperFilterVisitor(
-            DEFAULT_CSW_RECORD_MAP, metacardType, mockMetacardTypeList);
+        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
 
     PropertyName propertyName = (PropertyName) visitor.visit(propName, null);
 
@@ -162,8 +158,7 @@ public class CswRecordMapperFilterVisitorTest {
                     CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX)));
 
     CswRecordMapperFilterVisitor visitor =
-        new CswRecordMapperFilterVisitor(
-            DEFAULT_CSW_RECORD_MAP, metacardType, mockMetacardTypeList);
+        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
 
     PropertyName propertyName = (PropertyName) visitor.visit(propName, null);
 
@@ -300,9 +295,7 @@ public class CswRecordMapperFilterVisitorTest {
 
   @Test
   public void testVisitPropertyIsFuzzy() {
-    visitor =
-        new CswRecordMapperFilterVisitor(
-            DEFAULT_CSW_RECORD_MAP, metacardType, mockMetacardTypeList);
+    visitor = new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
     Expression val1 = factory.property("fooProperty");
     Expression val2 = factory.literal("fooLiteral");
 

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswRecordMapperFilterVisitorTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/transformer/CswRecordMapperFilterVisitorTest.java
@@ -25,14 +25,13 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeRegistryImpl;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.impl.filter.FuzzyFunction;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 import javax.xml.namespace.QName;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.ExtendedGeotoolsFunctionFactory;
@@ -91,7 +90,7 @@ public class CswRecordMapperFilterVisitorTest {
 
   private static MetacardType metacardType;
 
-  private static List<MetacardType> mockMetacardTypeList;
+  private static AttributeRegistryImpl attributeRegistry;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
@@ -112,18 +111,17 @@ public class CswRecordMapperFilterVisitorTest {
                     CswConstants.DUBLIN_CORE_SCHEMA,
                     Core.CREATED,
                     CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX)));
-    metacardType = CswQueryFactoryTest.getCswMetacardType();
 
-    mockMetacardTypeList = new ArrayList<>();
-    mockMetacardTypeList.add(metacardType);
+    attributeRegistry = new AttributeRegistryImpl();
+    attributeRegistry.registerMetacardType(CswQueryFactoryTest.getCswMetacardType());
 
-    visitor = new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
+    visitor = new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, attributeRegistry);
   }
 
   @Test
   public void testVisitWithUnmappedName() {
     CswRecordMapperFilterVisitor visitor =
-        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
+        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, attributeRegistry);
 
     PropertyName propertyName = (PropertyName) visitor.visit(attrExpr, null);
 
@@ -140,7 +138,7 @@ public class CswRecordMapperFilterVisitorTest {
                     CswConstants.OWS_BOUNDING_BOX,
                     CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX)));
     CswRecordMapperFilterVisitor visitor =
-        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
+        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, attributeRegistry);
 
     PropertyName propertyName = (PropertyName) visitor.visit(propName, null);
 
@@ -158,7 +156,7 @@ public class CswRecordMapperFilterVisitorTest {
                     CswConstants.DUBLIN_CORE_NAMESPACE_PREFIX)));
 
     CswRecordMapperFilterVisitor visitor =
-        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
+        new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, attributeRegistry);
 
     PropertyName propertyName = (PropertyName) visitor.visit(propName, null);
 
@@ -295,7 +293,7 @@ public class CswRecordMapperFilterVisitorTest {
 
   @Test
   public void testVisitPropertyIsFuzzy() {
-    visitor = new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, mockMetacardTypeList);
+    visitor = new CswRecordMapperFilterVisitor(DEFAULT_CSW_RECORD_MAP, attributeRegistry);
     Expression val1 = factory.property("fooProperty");
     Expression val2 = factory.literal("fooLiteral");
 


### PR DESCRIPTION
#### What does this PR do?
- Includes all registered attribute descriptors to determine the datatype of filter literal expressions. Without this, some expressions were being left as String instead of their actual data type and the query fails in Solr.
- No longer passing in the CSW metacard type into the `CswQueryFilterTransformer` and `CswRecordMapperFilterVisitor` since we are using all metacard types instead (already passed in).
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@emmberk @emanns95 @blen-desta 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining 
@clockard 
#### How should this be tested? (List steps with links to updated documentation)
- Setup a loopback CSW Federation Profile source
- Query the CSW source by several different types of attributes and verify they work as expected (specifically query by `effective` and `datetime.start`, which were broken before this change). Also verify there are no exceptions in the logs similar to this
```
ddf.catalog.source.UnsupportedQueryException: propertyIsLessThan(String,String) not supported by org.opengis.filter.Filter Delegate.
```
#### Any background context you want to provide?
The `CswRecordMapperFilterVisitor` uses the CSW metacard type's attribute descriptors to determine a property's data type in some places. In others, **all** registered attribute descriptors are used. As a result some filter literals are left as a String instead of being mapped to their proper data type. This primarily affects any Date attributes that are not in the CSW metacard type.
#### What are the relevant tickets?
[DDF-3600](https://codice.atlassian.net/browse/DDF-3600)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
