### PR TITLE
DDF-3552 bug fix related to srs in queries

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -230,7 +230,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.68</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -164,6 +164,8 @@ public class WfsSource extends AbstractWfsSource {
 
   private static final String ALLOW_REDIRECTS_KEY = "allowRedirects";
 
+  private static final String SRS_NAME_KEY = "srsName";
+
   private static final Properties DESCRIBABLE_PROPERTIES = new Properties();
 
   private static final String SOURCE_MSG = " Source '";
@@ -223,6 +225,8 @@ public class WfsSource extends AbstractWfsSource {
   private FeatureCollectionMessageBodyReaderWfs11 featureCollectionReader;
 
   private List<MetacardTypeEnhancer> metacardTypeEnhancers;
+
+  private String srsName;
 
   private boolean allowRedirects;
 
@@ -307,6 +311,7 @@ public class WfsSource extends AbstractWfsSource {
 
     setConnectionTimeout((Integer) configuration.get(CONNECTION_TIMEOUT_KEY));
     setReceiveTimeout((Integer) configuration.get(RECEIVE_TIMEOUT_KEY));
+    setSrsName((String) configuration.get(SRS_NAME_KEY));
 
     this.nonQueryableProperties = (String[]) configuration.get(NON_QUERYABLE_PROPS_KEY);
 
@@ -825,7 +830,9 @@ public class WfsSource extends AbstractWfsSource {
           || isFeatureTypeInQuery(contentTypes, filterDelegateEntry.getKey().getLocalPart())) {
         QueryType wfsQuery = new QueryType();
         wfsQuery.setTypeName(Collections.singletonList(filterDelegateEntry.getKey()));
-        wfsQuery.setSrsName(GeospatialUtil.EPSG_X_4326_URN);
+        if (StringUtils.isNotBlank(srsName)) {
+          wfsQuery.setSrsName(srsName);
+        }
         FilterType filter = filterAdapter.adapt(query, filterDelegateEntry.getValue());
         if (filter != null) {
           if (areAnyFiltersSet(filter)) {
@@ -1035,6 +1042,14 @@ public class WfsSource extends AbstractWfsSource {
 
   public Integer getReceiveTimeout() {
     return this.receiveTimeout;
+  }
+
+  public void setSrsName(String srsName) {
+    this.srsName = srsName;
+  }
+
+  public String getSrsName() {
+    return this.srsName;
   }
 
   public void setFilterAdapter(FilterAdapter filterAdapter) {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -570,7 +570,7 @@ public class WfsSource extends AbstractWfsSource {
 
           this.featureTypeFilters.put(
               featureMetacardType.getFeatureType(),
-              new WfsFilterDelegate(featureMetacardType, supportedGeo, registration.getSrs()));
+              new WfsFilterDelegate(featureMetacardType, supportedGeo));
         }
       } catch (WfsException | IllegalArgumentException wfse) {
         LOGGER.debug(WFS_ERROR_MESSAGE, wfse);

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -59,6 +59,7 @@
             <argument ref="encryptionService"/>
             <property name="coordinateOrder" value="LAT_LON"/>
             <property name="metacardTypeEnhancers" ref="metacardTypeEnhancerList"/>
+            <property name="srsName" value=""/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -59,7 +59,7 @@
             <argument ref="encryptionService"/>
             <property name="coordinateOrder" value="LAT_LON"/>
             <property name="metacardTypeEnhancers" ref="metacardTypeEnhancerList"/>
-            <property name="srsName" value=""/>
+            <property name="srsName" value="EPSG:4326"/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -68,6 +68,9 @@
         <AD description="Amount of time to wait for a response before timing out, in milliseconds."
             name="Receive Timeout" id="receiveTimeout"
             required="true" type="Integer" default="60000"/>
+        <AD description="SRS Name to use in outbound GetFeature requests. The SRS Name parameter is used to assert the specific CRS transformation to be applied to the geometries of the features returned in a response document."
+            name="SRS Name" id="srsName"
+            required="false" type="String" default="EPSG:4326"/>
     </OCD>
 
     <Designate pid="Wfs_v110_Federated_Source" factoryPid="Wfs_v110_Federated_Source">

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -329,7 +329,7 @@ public class WfsFilterDelegateTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testWFSFilterDelegateNullSchema() {
-    new WfsFilterDelegate(null, null, null);
+    new WfsFilterDelegate(null, null);
   }
 
   @Test
@@ -411,7 +411,7 @@ public class WfsFilterDelegateTest {
   @Test(expected = IllegalArgumentException.class)
   public void testPropertyIsEqualToStringStringBooleanAnyTextNullMetacardType() {
 
-    WfsFilterDelegate delegate = new WfsFilterDelegate(null, SUPPORTED_GEO, SRS_NAME);
+    WfsFilterDelegate delegate = new WfsFilterDelegate(null, SUPPORTED_GEO);
     delegate.propertyIsEqualTo(Metacard.ANY_TEXT, LITERAL, true);
   }
 
@@ -1305,7 +1305,7 @@ public class WfsFilterDelegateTest {
     whenGeom(MOCK_GEOM, MOCK_GEOM2, true, true);
 
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue());
-    WfsFilterDelegate delegate = new WfsFilterDelegate(featureMetacardType, supportedGeo, SRS_NAME);
+    WfsFilterDelegate delegate = new WfsFilterDelegate(featureMetacardType, supportedGeo);
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, notNullValue());
@@ -1329,7 +1329,7 @@ public class WfsFilterDelegateTest {
     whenGeom(MOCK_GEOM, MOCK_GEOM2, false, false);
 
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue());
-    WfsFilterDelegate delegate = new WfsFilterDelegate(featureMetacardType, supportedGeo, SRS_NAME);
+    WfsFilterDelegate delegate = new WfsFilterDelegate(featureMetacardType, supportedGeo);
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1356,8 +1356,7 @@ public class WfsFilterDelegateTest {
     WfsFilterDelegate delegate =
         new WfsFilterDelegate(
             featureMetacardType,
-            Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue()),
-            "EPSG:42304");
+            Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue()));
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1367,7 +1366,7 @@ public class WfsFilterDelegateTest {
   public void testGeoFilterNullMetacardType() {
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.BEYOND.getValue());
 
-    WfsFilterDelegate delegate = new WfsFilterDelegate(null, supportedGeo, SRS_NAME);
+    WfsFilterDelegate delegate = new WfsFilterDelegate(null, supportedGeo);
 
     delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
   }
@@ -1508,7 +1507,7 @@ public class WfsFilterDelegateTest {
   }
 
   private String getDWithinAsIntersectsXml() {
-    return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Filter xmlns=\"http://www.opengis.net/ogc\" xmlns:ns5=\"http://www.w3.org/2001/SMIL20/Language\" xmlns:ns2=\"http://www.opengis.net/gml\" xmlns:ns4=\"http://www.w3.org/2001/SMIL20/\" xmlns:ns3=\"http://www.w3.org/1999/xlink\"><Intersects><PropertyName>ground_geom</PropertyName><ns2:Polygon srsName=\"EPSG:4326\"><ns2:exterior><ns2:LinearRing><ns2:coordinates decimal=\".\" cs=\",\" ts=\" \">-10.0,31.79864073552333 -10.350897400284572,31.76408035813492 -10.688310010261736,31.66172736189105 -10.999271252553244,31.495515115037147 -11.271831061006903,31.271831061006903 -11.495515115037145,30.999271252553243 -11.66172736189105,30.688310010261738 -11.764080358134919,30.350897400284573 -11.798640735523328,30.0 -11.764080358134919,29.649102599715427 -11.66172736189105,29.311689989738262 -11.495515115037145,29.000728747446757 -11.271831061006905,28.728168938993097 -10.999271252553244,28.504484884962853 -10.688310010261736,28.33827263810895 -10.350897400284572,28.23591964186508 -9.999999999999998,28.20135926447667 -9.649102599715427,28.23591964186508 -9.311689989738262,28.338272638108954 -9.000728747446754,28.504484884962856 -8.728168938993093,28.728168938993097 -8.504484884962853,29.000728747446757 -8.33827263810895,29.311689989738266 -8.23591964186508,29.649102599715434 -8.201359264476672,30.000000000000004 -8.235919641865081,30.350897400284577 -8.338272638108954,30.68831001026174 -8.504484884962856,30.99927125255325 -8.7281689389931,31.271831061006907 -9.000728747446761,31.49551511503715 -9.31168998973827,31.661727361891053 -9.649102599715436,31.76408035813492 -10.0,31.79864073552333 </ns2:coordinates></ns2:LinearRing></ns2:exterior></ns2:Polygon></Intersects></Filter>";
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Filter xmlns=\"http://www.opengis.net/ogc\" xmlns:ns5=\"http://www.w3.org/2001/SMIL20/Language\" xmlns:ns2=\"http://www.opengis.net/gml\" xmlns:ns4=\"http://www.w3.org/2001/SMIL20/\" xmlns:ns3=\"http://www.w3.org/1999/xlink\"><Intersects><PropertyName>ground_geom</PropertyName><ns2:Polygon><ns2:exterior><ns2:LinearRing><ns2:coordinates decimal=\".\" cs=\",\" ts=\" \">-10.0,31.79864073552333 -10.350897400284572,31.76408035813492 -10.688310010261736,31.66172736189105 -10.999271252553244,31.495515115037147 -11.271831061006903,31.271831061006903 -11.495515115037145,30.999271252553243 -11.66172736189105,30.688310010261738 -11.764080358134919,30.350897400284573 -11.798640735523328,30.0 -11.764080358134919,29.649102599715427 -11.66172736189105,29.311689989738262 -11.495515115037145,29.000728747446757 -11.271831061006905,28.728168938993097 -10.999271252553244,28.504484884962853 -10.688310010261736,28.33827263810895 -10.350897400284572,28.23591964186508 -9.999999999999998,28.20135926447667 -9.649102599715427,28.23591964186508 -9.311689989738262,28.338272638108954 -9.000728747446754,28.504484884962856 -8.728168938993093,28.728168938993097 -8.504484884962853,29.000728747446757 -8.33827263810895,29.311689989738266 -8.23591964186508,29.649102599715434 -8.201359264476672,30.000000000000004 -8.235919641865081,30.350897400284577 -8.338272638108954,30.68831001026174 -8.504484884962856,30.99927125255325 -8.7281689389931,31.271831061006907 -9.000728747446761,31.49551511503715 -9.31168998973827,31.661727361891053 -9.649102599715436,31.76408035813492 -10.0,31.79864073552333 </ns2:coordinates></ns2:LinearRing></ns2:exterior></ns2:Polygon></Intersects></Filter>";
   }
 
   private String marshal(FilterType filter) throws JAXBException {
@@ -1535,7 +1534,7 @@ public class WfsFilterDelegateTest {
   }
 
   private WfsFilterDelegate createDelegate() {
-    return new WfsFilterDelegate(featureMetacardType, SUPPORTED_GEO, SRS_NAME);
+    return new WfsFilterDelegate(featureMetacardType, SUPPORTED_GEO);
   }
 
   private WfsFilterDelegate createIntegerDelegate() {
@@ -1580,7 +1579,7 @@ public class WfsFilterDelegateTest {
                 MOCK_GEOM, MOCK_GEOM, true, false, false, false, BasicTypes.STRING_TYPE));
 
     List<String> supportedGeo = Collections.singletonList(spatialOpType);
-    return new WfsFilterDelegate(featureMetacardType, supportedGeo, SRS_NAME);
+    return new WfsFilterDelegate(featureMetacardType, supportedGeo);
   }
 
   private void whenTextualStringType() {

--- a/distribution/docs/src/main/resources/content/_tables/Wfs_v1_1_0_Federated_Source.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/Wfs_v1_1_0_Federated_Source.adoc
@@ -100,5 +100,12 @@
 |60000
 |true
 
+|SRS Name
+|srsName
+|String
+|SRS Name to use in outbound GetFeature requests. The SRS Name parameter is used to assert the specific CRS transformation to be applied to the geometries of the features returned in a response document.
+|EPSG:4326
+|false
+
 |===
 

--- a/libs/geospatial/src/main/java/org/codice/ddf/libs/geo/util/GeospatialUtil.java
+++ b/libs/geospatial/src/main/java/org/codice/ddf/libs/geo/util/GeospatialUtil.java
@@ -35,8 +35,6 @@ public class GeospatialUtil {
 
   public static final String EPSG_4326_URN = "urn:ogc:def:crs:EPSG::4326";
 
-  public static final String EPSG_X_4326_URN = "urn:x-ogc:def:crs:EPSG:4326";
-
   public static final String LAT_LON_ORDER = "LAT_LON";
 
   public static final String LON_LAT_ORDER = "LON_LAT";


### PR DESCRIPTION
#### What does this PR do?
It was discovered that since the WFS 1.1 code is able to set the desired SRS in the query, that the code no longer needs to restrict geo queries to features that report a 4326 SRS.  The SRS value used in the query is now admin configurable. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@bdeining 
@jlcsmith 
@GabrielFabian 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/IO
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@millerw8
#### How should this be tested? (List steps with links to updated documentation)

Test against GeoServer. When configuring  the source, use "urn:x-ogc:def:crs:EPSG:4326" for the SRS. 

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
