### PR TITLE
[2.11.x] DDF-3558 Upgrade Felix Fileinstall to 3.6.4

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/startup.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/startup.properties
@@ -10,5 +10,5 @@ mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.10.1 = 8
 # mvn\:org.apache.felix/org.apache.felix.configadmin/1.8.14 = 10
 mvn\:ddf.platform.osgi/platform-osgi-internal-api/${project.version} = 9
 mvn\:ddf.platform.osgi/platform-osgi-configadmin/${project.version} = 10
-mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.0 = 11
+mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.4 = 11
 mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.1.4 = 15

--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -293,16 +293,6 @@
         <include>ddf.platform.osgi:platform-osgi-internal-api:jar:${project.version}</include>
       </includes>
     </dependencySet>
-    <!-- Felix fileinstall version 3.6.4 causes issues with our configurations.
-        DDF-3558 will update the config admin and fileinstall versions-->
-    <dependencySet>
-      <outputDirectory>system/org/apache/felix/org.apache.felix.fileinstall/${felix.fileinstall.version}
-      </outputDirectory>
-      <includes>
-        <include>org.apache.felix:org.apache.felix.fileinstall:jar:${felix.fileinstall.version}
-        </include>
-      </includes>
-    </dependencySet>
   </dependencySets>
 
 </component>

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -92,11 +92,6 @@
             <artifactId>platform-osgi-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.fileinstall</artifactId>
-            <version>${felix.fileinstall.version}</version>
-        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/distribution/kernel/src/main/descriptors/bin.xml
+++ b/distribution/kernel/src/main/descriptors/bin.xml
@@ -42,15 +42,5 @@
                 </include>
             </includes>
         </dependencySet>
-        <!-- Felix fileinstall version 3.6.4 causes issues with our configurations.
-        DDF-3558 will update the config admin and fileinstall versions-->
-        <dependencySet>
-            <outputDirectory>system/org/apache/felix/org.apache.felix.fileinstall/${felix.fileinstall.version}
-            </outputDirectory>
-            <includes>
-                <include>org.apache.felix:org.apache.felix.fileinstall:jar:${felix.fileinstall.version}
-                </include>
-            </includes>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
@@ -373,6 +373,9 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
                     returnValues.add(service);
                     break;
                   }
+                } else if (checkForMetaTypesForService(metatypeInformation, service)) {
+                  returnValues.add(service);
+                  break;
                 }
               }
             } else {

--- a/platform/osgi/platform-osgi-configadmin/src/main/java/org/codice/felix/cm/file/ConfigurationContextImpl.java
+++ b/platform/osgi/platform-osgi-configadmin/src/main/java/org/codice/felix/cm/file/ConfigurationContextImpl.java
@@ -15,6 +15,7 @@ package org.codice.felix.cm.file;
 
 import static java.lang.String.format;
 import static org.osgi.framework.Constants.SERVICE_PID;
+import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_BUNDLELOCATION;
 import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_FACTORYPID;
 
 import java.io.File;
@@ -68,6 +69,7 @@ public class ConfigurationContextImpl implements ConfigurationContext {
           Arrays.asList(
               SERVICE_PID,
               SERVICE_FACTORYPID,
+              SERVICE_BUNDLELOCATION,
               FELIX_FILENAME,
               FELIX_NEW_CONFIG,
               SERVICE_FACTORY_PIDLIST));

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,6 @@
         <!--  ################################################################################  -->
 
         <felix.framework.version>5.6.10</felix.framework.version>
-        <felix.fileinstall.version>3.6.0</felix.fileinstall.version>
         <decanter.version>1.3.0</decanter.version>
         <lux.version>1.2</lux.version>
         <opengis.bundle.version>${org.geotools.version}_1</opengis.bundle.version>


### PR DESCRIPTION
#### What does this PR do?
Upgrades Felix Fileinstall to 3.6.4 and removes the hack to stay on 3.6.0

#### Who is reviewing it? 
@paouelle 
@brjeter 

#### Choose 2 committers to review/merge the PR. 
@clockard 
@shaundmorris

#### How should this be tested?
Ensure that config files in etc do not have strange / unnecessary values. 
Ensure all config fields show up on the admin ui. 

#### Any background context you want to provide?
Fileinstall was upgraded from 3.6.0 to 3.6.4 as part of the Karaf upgrade. Due to some issues (config file pollution, configs missing from ui, etc) we implemented a temporary hack to continue using Fileinstall 3.6.0 in case the issue could not be resolved in time. This PR is to resolve said issues. 

#### What are the relevant tickets?
[DDF-3558](https://codice.atlassian.net/browse/DDF-3558)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
