### PR TITLE
[2.11.x] DDF-3604 Fixed OpenSearch bounding box

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-source/pom.xml
@@ -187,6 +187,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.npathai</groupId>
+            <artifactId>hamcrest-optional</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -246,17 +252,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.76</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.62</minimum>
+                                            <minimum>0.61</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.52</minimum>
+                                            <minimum>0.49</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/opensearch/catalog-opensearch-source/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-source/pom.xml
@@ -181,6 +181,12 @@
             <artifactId>commons-httpclient</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -245,12 +251,12 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.61</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.52</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/opensearch/catalog-opensearch-source/src/test/groovy/ddf/catalog/source/opensearch/impl/OpenSearchParserImplCreateBBoxSpec.groovy
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/groovy/ddf/catalog/source/opensearch/impl/OpenSearchParserImplCreateBBoxSpec.groovy
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.source.opensearch.impl
+
+import ddf.catalog.impl.filter.SpatialDistanceFilter
+import ddf.catalog.impl.filter.SpatialFilter
+import org.apache.cxf.jaxrs.client.WebClient
+import spock.lang.Specification
+
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.not
+
+class OpenSearchParserImplCreateBBoxSpec extends Specification {
+
+    def 'create BBox from point radius'() {
+        given:
+        final double searchRadiusInMeters = 804672 // 500 miles
+
+        expect:
+        OpenSearchParserImpl.createBBoxFromPointRadius(lon, lat, searchRadiusInMeters) == [expectedWest, expectedSouth, expectedEast, expectedNorth]
+
+        where:
+        lon  | lat || expectedWest        | expectedSouth       | expectedEast        | expectedNorth
+        -180 | -90 || -180.0              | -90.0               | 180.0               | -82.76341084722164
+        -180 | 0   || 172.76341084722162  | -7.236589152778366  | -172.76341084722162 | 7.236589152778366
+        -180 | 90  || -180.0              | 82.76341084722164   | 180.0               | 90.0
+        -179 | -89 || -180.0              | -90.0               | 180.0               | -81.76341084722164
+        -179 | 89  || -180.0              | 81.76341084722164   | 180.0               | 90.0
+        -122 | -33 || -130.63841021419668 | -40.236589152778365 | -113.36158978580332 | -25.763410847221635
+        -122 | 33  || -130.63841021419668 | 25.763410847221635  | -113.36158978580332 | 40.236589152778365
+        0    | -90 || -180.0              | -90.0               | 180.0               | -82.76341084722164
+        0    | 0   || -7.236589152778366  | -7.236589152778366  | 7.236589152778366   | 7.236589152778366
+        0    | 90  || -180.0              | 82.76341084722164   | 180.0               | 90.0
+        122  | -33 || 113.36158978580332  | -40.236589152778365 | 130.63841021419668  | -25.763410847221635
+        122  | 33  || 113.36158978580332  | 25.763410847221635  | 130.63841021419668  | 40.236589152778365
+        179  | -89 || -180.0              | -90.0               | 180.0               | -81.76341084722164
+        179  | 89  || -180.0              | 81.76341084722164   | 180.0               | 90.0
+        180  | -90 || -180.0              | -90.0               | 180.0               | -82.76341084722164
+        180  | 0   || 172.76341084722162  | -7.236589152778366  | -172.76341084722162 | 7.236589152778366
+        180  | 90  || -180.0              | 82.76341084722164   | 180.0               | 90.0
+    }
+
+    def 'create BBox from polygon'() {
+        expect:
+        OpenSearchParserImpl.createBBoxFromPolygon(["1", "1", "2", "2", "3", "3", "4", "4", "1", "1"] as String[]) == [1, 1, 4, 4]
+    }
+
+    def 'populate spatial distance filter box'() {
+        given:
+        final OpenSearchParserImpl openSearchParserImpl = new OpenSearchParserImpl()
+        final WebClient webClient = WebClient.create("http://www.example.com")
+
+        when:
+        openSearchParserImpl.populateGeospatial(
+                webClient,
+                spatialFilter,
+                true,
+                Arrays.asList(
+                        "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
+                                .split(",")))
+
+        then:
+        final String urlStr = webClient.getCurrentURI().toString()
+        urlStr containsString(OpenSearchParserImpl.GEO_BBOX)
+
+        where:
+        spatialFilter << [
+                new SpatialDistanceFilter("POINT (1 1)", 1.0),
+                new SpatialDistanceFilter("POINT (122 33)", 1.0),
+                new SpatialFilter("POLYGON ((1 1, 2 2, 3 3, 4 4, 1 1))")]
+    }
+
+    def 'populate spatial distance filter box invalid SpatialFilter'() {
+        given:
+        final OpenSearchParserImpl openSearchParserImpl = new OpenSearchParserImpl()
+        final WebClient webClient = WebClient.create("http://www.example.com")
+
+        when:
+        openSearchParserImpl.populateGeospatial(
+                webClient,
+                spatialFilter,
+                true,
+                Arrays.asList(
+                        "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
+                                .split(",")))
+
+        then:
+        final String urlStr = webClient.getCurrentURI().toString()
+        urlStr not(containsString(OpenSearchParserImpl.GEO_BBOX))
+
+        where:
+        spatialFilter << [
+                new SpatialDistanceFilter("POLYGON (1 1)", 1.0),
+                new SpatialFilter("POINT (1 1)"),
+                null]
+    }
+}

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchFilterVisitorTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchFilterVisitorTest.java
@@ -43,7 +43,7 @@ import org.opengis.filter.temporal.After;
 import org.opengis.filter.temporal.During;
 import org.opengis.filter.temporal.TOverlaps;
 
-public class TestOpenSearchFilterVisitor {
+public class OpenSearchFilterVisitorTest {
 
   private static final String WKT_POINT = "POINT(1.0 2.0)";
 

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchParserImplTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchParserImplTest.java
@@ -58,9 +58,6 @@ public class OpenSearchParserImplTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchParserImplTest.class);
 
-  private static final StringBuilder URL =
-      new StringBuilder("http://localhost:8080/services/catalog/query");
-
   private static final String MAX_RESULTS = "2000";
 
   private static final String TIMEOUT = "30000";
@@ -69,141 +66,16 @@ public class OpenSearchParserImplTest {
 
   private OpenSearchParserImpl openSearchParserImpl;
 
+  private WebClient webClient;
+
   @Before
   public void setUp() {
     openSearchParserImpl = new OpenSearchParserImpl();
-  }
-
-  @Test
-  public void populateSpatialDistanceFilterBbox() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
-    SpatialDistanceFilter spatialFilter = new SpatialDistanceFilter("POINT (1 1)", 1.0);
-    openSearchParserImpl.populateGeospatial(
-        webClient,
-        spatialFilter,
-        true,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-    String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    assertThat(urlStr, containsString(OpenSearchParserImpl.GEO_BBOX));
-  }
-
-  @Test
-  public void populateSpatialDistanceFilterBboxMin() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
-    SpatialDistanceFilter spatialFilter = new SpatialDistanceFilter("POINT (-211 -211)", 1.0);
-    openSearchParserImpl.populateGeospatial(
-        webClient,
-        spatialFilter,
-        true,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-    String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    assertThat(urlStr, containsString(OpenSearchParserImpl.GEO_BBOX));
-  }
-
-  @Test
-  public void populateSpatialDistanceFilterBboxMax() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
-    SpatialDistanceFilter spatialFilter = new SpatialDistanceFilter("POINT (211 211)", 1.0);
-    openSearchParserImpl.populateGeospatial(
-        webClient,
-        spatialFilter,
-        true,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-    String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    assertThat(urlStr, containsString(OpenSearchParserImpl.GEO_BBOX));
-  }
-
-  @Test
-  public void populateSpatialDistanceFilterInvalidWktBbox() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
-    SpatialDistanceFilter spatialFilter = new SpatialDistanceFilter("POLYGON (1 1)", 1.0);
-    openSearchParserImpl.populateGeospatial(
-        webClient,
-        spatialFilter,
-        true,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-    String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    assertThat(urlStr, not(containsString(OpenSearchParserImpl.GEO_BBOX)));
-  }
-
-  @Test
-  public void populateSpatialFilterInvalidWktBbox() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
-    SpatialFilter spatialFilter = new SpatialFilter("POINT (1 1)");
-    openSearchParserImpl.populateGeospatial(
-        webClient,
-        spatialFilter,
-        true,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-    String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    assertThat(urlStr, not(containsString(OpenSearchParserImpl.GEO_BBOX)));
-  }
-
-  @Test
-  public void populateSpatialFilterBbox() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
-    SpatialFilter spatialFilter = new SpatialFilter("POLYGON ((1 1, 2 2, 3 3, 4 4, 1 1))");
-    openSearchParserImpl.populateGeospatial(
-        webClient,
-        spatialFilter,
-        true,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-    String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    assertThat(urlStr, containsString(OpenSearchParserImpl.GEO_BBOX));
-  }
-
-  @Test
-  public void populateNullSpatialFilter() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
-    openSearchParserImpl.populateGeospatial(
-        webClient,
-        (SpatialFilter) null,
-        true,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-    String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    assertThat(urlStr, not(containsString(OpenSearchParserImpl.GEO_BBOX)));
+    webClient = WebClient.create("http://www.example.com");
   }
 
   @Test
   public void populateSpatialFilterCaseInsensitiveParameters() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
     SpatialFilter spatialFilter = new SpatialFilter("POLYGON ((1 1, 2 2, 3 3, 4 4, 1 1))");
     openSearchParserImpl.populateGeospatial(
         webClient,
@@ -213,19 +85,14 @@ public class OpenSearchParserImplTest {
             "q,src,mr,start,count,mt,dn,lat,lon,radius,BBOX,polygon,dtstart,dtend,dateName,filter,sort"
                 .split(",")));
     String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
     assertThat(urlStr, containsString(OpenSearchParserImpl.GEO_BBOX));
   }
 
   @Test
   public void populateSpatialFilterEmptyParameters() throws Exception {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
     SpatialFilter spatialFilter = new SpatialFilter("POLYGON ((1 1, 2 2, 3 3, 4 4, 1 1))");
     openSearchParserImpl.populateGeospatial(webClient, spatialFilter, true, new ArrayList<>());
     String urlStr = webClient.getCurrentURI().toString();
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
     assertThat(urlStr, not(containsString(OpenSearchParserImpl.GEO_BBOX)));
   }
 
@@ -234,9 +101,6 @@ public class OpenSearchParserImplTest {
     Map<String, String> searchPhraseMap = new HashMap<>();
     searchPhraseMap.put("q", "TestQuery123");
 
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateContextual(
         webClient,
         searchPhraseMap,
@@ -259,9 +123,6 @@ public class OpenSearchParserImplTest {
     Map<String, String> searchPhraseMap = new HashMap<>();
     searchPhraseMap.put("z", "TestQuery123");
 
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateContextual(
         webClient,
         searchPhraseMap,
@@ -270,7 +131,6 @@ public class OpenSearchParserImplTest {
                 .split(",")));
     String urlStr = webClient.getCurrentURI().toString();
     assertThat(urlStr, not(containsString(searchPhraseMap.get("z"))));
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
     try {
       new URL(urlStr);
     } catch (MalformedURLException mue) {
@@ -283,9 +143,6 @@ public class OpenSearchParserImplTest {
   public void populateContextualEmptyMap() {
     Map<String, String> searchPhraseMap = new HashMap<>();
 
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateContextual(
         webClient,
         searchPhraseMap,
@@ -294,7 +151,6 @@ public class OpenSearchParserImplTest {
                 .split(",")));
     String urlStr = webClient.getCurrentURI().toString();
     assertThat(urlStr, not(containsString("q=")));
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
     try {
       new URL(urlStr);
     } catch (MalformedURLException mue) {
@@ -305,9 +161,6 @@ public class OpenSearchParserImplTest {
 
   @Test
   public void populateContextualNullMap() {
-    String urlString = URL.toString();
-    assertThat(urlString, containsString(OpenSearchParserImpl.SEARCH_TERMS));
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateContextual(
         webClient,
         null,
@@ -316,7 +169,6 @@ public class OpenSearchParserImplTest {
                 .split(",")));
     String urlStr = webClient.getCurrentURI().toString();
     assertThat(urlStr, not(containsString("q=")));
-    assertThat(urlStr, containsString(OpenSearchParserImpl.SEARCH_TERMS));
     try {
       new URL(urlStr);
     } catch (MalformedURLException mue) {
@@ -328,7 +180,6 @@ public class OpenSearchParserImplTest {
   /** Verify that passing in null will still remove the parameters from the URL. */
   @Test
   public void populateNullContextual() {
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateContextual(
         webClient,
         null,
@@ -344,10 +195,8 @@ public class OpenSearchParserImplTest {
     DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
     Date start = new Date(System.currentTimeMillis() - 10000000);
     Date end = new Date(System.currentTimeMillis());
-    StringBuilder resultStr = new StringBuilder(URL);
     TemporalFilter temporal = new TemporalFilter(start, end);
 
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateTemporal(
         webClient,
         temporal,
@@ -371,11 +220,11 @@ public class OpenSearchParserImplTest {
     assertThat(urlStr, containsString(OpenSearchParserImpl.TIME_END));
     assertThat(urlStr, not(containsString(OpenSearchParserImpl.TIME_NAME)));
     try {
-      new URL(resultStr.toString());
+      new URL(urlStr);
     } catch (MalformedURLException mue) {
       fail("URL is not valid: " + mue.getMessage());
     }
-    LOGGER.info("URL after temporal population: {}", resultStr.toString());
+    LOGGER.info("URL after temporal population: {}", urlStr);
   }
 
   @Test
@@ -384,7 +233,6 @@ public class OpenSearchParserImplTest {
     temporalFilter.setEndDate(null);
     temporalFilter.setStartDate(null);
 
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateTemporal(
         webClient,
         temporalFilter,
@@ -401,7 +249,6 @@ public class OpenSearchParserImplTest {
   @Test
   public void populateNullTemporal() {
 
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateTemporal(
         webClient,
         null,
@@ -420,8 +267,6 @@ public class OpenSearchParserImplTest {
     Filter filter = mock(Filter.class);
     Query query = new QueryImpl(filter, 0, 2000, sortBy, true, 30000);
     QueryRequest queryRequest = new QueryRequestImpl(query);
-
-    WebClient webClient = WebClient.create(URL.toString());
 
     openSearchParserImpl.populateSearchOptions(
         webClient,
@@ -448,8 +293,6 @@ public class OpenSearchParserImplTest {
     Query query = new QueryImpl(filter, 0, 2000, sortBy, true, 30000);
     QueryRequest queryRequest = new QueryRequestImpl(query);
 
-    WebClient webClient = WebClient.create(URL.toString());
-
     openSearchParserImpl.populateSearchOptions(
         webClient,
         queryRequest,
@@ -474,8 +317,6 @@ public class OpenSearchParserImplTest {
     Filter filter = mock(Filter.class);
     Query query = new QueryImpl(filter, 0, 2000, sortBy, true, 30000);
     QueryRequest queryRequest = new QueryRequestImpl(query);
-
-    WebClient webClient = WebClient.create(URL.toString());
 
     openSearchParserImpl.populateSearchOptions(
         webClient,
@@ -502,8 +343,6 @@ public class OpenSearchParserImplTest {
     Query query = new QueryImpl(filter, 0, 2000, sortBy, true, 30000);
     QueryRequest queryRequest = new QueryRequestImpl(query);
 
-    WebClient webClient = WebClient.create(URL.toString());
-
     openSearchParserImpl.populateSearchOptions(
         webClient,
         queryRequest,
@@ -526,8 +365,6 @@ public class OpenSearchParserImplTest {
     Filter filter = mock(Filter.class);
     Query query = new QueryImpl(filter, 0, 2000, null, true, 30000);
     QueryRequest queryRequest = new QueryRequestImpl(query);
-
-    WebClient webClient = WebClient.create(URL.toString());
 
     openSearchParserImpl.populateSearchOptions(
         webClient,
@@ -553,8 +390,6 @@ public class OpenSearchParserImplTest {
     Query query = new QueryImpl(filter, 0, -1000, sortBy, true, 30000);
     QueryRequest queryRequest = new QueryRequestImpl(query);
 
-    WebClient webClient = WebClient.create(URL.toString());
-
     openSearchParserImpl.populateSearchOptions(
         webClient,
         queryRequest,
@@ -578,8 +413,6 @@ public class OpenSearchParserImplTest {
     Filter filter = mock(Filter.class);
     Query query = new QueryImpl(filter, 0, 2000, sortBy, true, 30000);
     QueryRequest queryRequest = new QueryRequestImpl(query);
-
-    WebClient webClient = WebClient.create(URL.toString());
 
     String principalName = "principalName";
     Subject subject = getMockSubject(principalName);
@@ -610,8 +443,6 @@ public class OpenSearchParserImplTest {
     Query query = new QueryImpl(filter, 0, 2000, sortBy, true, 30000);
     QueryRequest queryRequest = new QueryRequestImpl(query);
 
-    WebClient webClient = WebClient.create(URL.toString());
-
     String principalName = "principalName";
     Subject subject = getMockSubject(principalName);
     when(subject.getPrincipals()).thenReturn(null);
@@ -637,7 +468,6 @@ public class OpenSearchParserImplTest {
   /** Verify that passing in null will still remove the parameters from the URL. */
   @Test
   public void populateNullSearchOptions() {
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateSearchOptions(
         webClient,
         null,
@@ -661,7 +491,6 @@ public class OpenSearchParserImplTest {
     String expectedStr = "1,1,1,5,5,5,5,1,1,1";
 
     SpatialFilter spatial = new SpatialFilter(wktPolygon);
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateGeospatial(
         webClient,
         spatial,
@@ -679,10 +508,9 @@ public class OpenSearchParserImplTest {
     String lat = "43.25";
     String lon = "-123.45";
     String radius = "10000";
-    String wktPoint = "POINT(" + lon + " " + lat + ")";
+    String wktPoint = "POINT (" + lon + " " + lat + ")";
 
     SpatialDistanceFilter spatial = new SpatialDistanceFilter(wktPoint, radius);
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateGeospatial(
         webClient,
         spatial,
@@ -709,7 +537,6 @@ public class OpenSearchParserImplTest {
   /** Verify that passing in null will still remove the parameters from the URL. */
   @Test
   public void populateNullGeospatial() throws Exception {
-    WebClient webClient = WebClient.create(URL.toString());
     openSearchParserImpl.populateGeospatial(
         webClient,
         null,

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchParserImplTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchParserImplTest.java
@@ -54,9 +54,9 @@ import org.opengis.filter.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TestOpenSearchParserImpl {
+public class OpenSearchParserImplTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestOpenSearchParserImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchParserImplTest.class);
 
   private static final StringBuilder URL =
       new StringBuilder("http://localhost:8080/services/catalog/query");

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchSourceTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchSourceTest.java
@@ -80,7 +80,7 @@ import org.osgi.framework.InvalidSyntaxException;
  * @author Ashraf Barakat
  * @author ddf.isgs@lmco.com
  */
-public class TestOpenSearchSource {
+public class OpenSearchSourceTest {
 
   private static final String RESOURCE_TAG = "Resource";
 

--- a/catalog/schematron/catalog-schematron-plugin/src/main/resources/iso-schematron/iso_schematron_skeleton_for_saxon.xsl
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/resources/iso-schematron/iso_schematron_skeleton_for_saxon.xsl
@@ -1043,7 +1043,7 @@ which require a preprocess.
 
 
 	<!-- ISO DIAGNOSTIC -->
-	<!-- We use a mode here to maintain backwards compatability, instead of adding it
+	<!-- We use a mode here to maintain backwards compatibility, instead of adding it
 	     to the other mode.
 	-->
 	<xsl:template match="iso:diagnostic" mode="check-diagnostics">
@@ -1524,7 +1524,7 @@ which require a preprocess.
 	
 	
 	<!-- PROPERTY Experiemental -->
-	<!-- We use a mode here to maintain backwards compatability, instead of adding it
+	<!-- We use a mode here to maintain backwards compatibility, instead of adding it
 	     to the other mode.
 	-->
 	<xsl:template match="iso:property" mode="check-property">

--- a/catalog/schematron/catalog-schematron-plugin/src/main/resources/iso-schematron/iso_svrl_for_xslt2.xsl
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/resources/iso-schematron/iso_svrl_for_xslt2.xsl
@@ -65,7 +65,7 @@
     2007-04-03 
     	* Add option generate-fired-rule (RG)
     2007-02-07
-    	* Prefer true|false for parameters. But allow yes|no on some old for compatability
+    	* Prefer true|false for parameters. But allow yes|no on some old for compatibility
     	* DP Diagnostics output to svrl:text. Diagnosis put out after assertion text.
       	* Removed non-SVRL elements and attributes: better handled as an extra layer that invokes this one
       	* Add more formal parameters

--- a/catalog/ui/search-ui/simple/src/main/resources/RecordView.html
+++ b/catalog/ui/search-ui/simple/src/main/resources/RecordView.html
@@ -35,7 +35,7 @@
     <link href="css/recordView.css?bust=${timestamp}" rel="stylesheet">
 
     <!--
-      browser compatability scripts
+      browser compatibility scripts
     -->
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/catalog/ui/search-ui/simple/src/main/webapp/lib/jquery/js/plugin/purl.js
+++ b/catalog/ui/search-ui/simple/src/main/webapp/lib/jquery/js/plugin/purl.js
@@ -35,7 +35,7 @@
 		
 		key = ['source', 'protocol', 'authority', 'userInfo', 'user', 'password', 'host', 'port', 'relative', 'path', 'directory', 'file', 'query', 'fragment'], // keys available to query
 		
-		aliases = { 'anchor' : 'fragment' }, // aliases for backwards compatability
+		aliases = { 'anchor' : 'fragment' }, // aliases for backwards compatibility
 		
 		parser = {
 			strict : /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,  //less intuitive, more accurate to the specs

--- a/distribution/docs/src/main/resources/content/_tables/OpenSearchSource.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/OpenSearchSource.adoc
@@ -61,7 +61,7 @@
 |Convert to BBox
 |shouldConvertToBBox
 |Boolean
-|Converts Polygon and Point-Radius searches to a Bounding Box for compatability with older interfaces. Generated bounding box is a very rough representation of the input geometry.
+|Converts Polygon and Point-Radius searches to a Bounding Box for compatibility with older interfaces. Generated bounding box is a very rough representation of the input geometry.
 |true
 |true
 

--- a/platform/admin/modules/admin-modules-application/src/test/resources/services.json
+++ b/platform/admin/modules/admin-modules-application/src/test/resources/services.json
@@ -2455,7 +2455,7 @@
         {
           "id": "shouldConvertToBBox",
           "optionLabels": [],
-          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatability with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
+          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatibility with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
           "optionValues": [],
           "name": "Convert to BBox",
           "defaultValue": [
@@ -2594,7 +2594,7 @@
         {
           "id": "shouldConvertToBBox",
           "optionLabels": [],
-          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatability with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
+          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatibility with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
           "optionValues": [],
           "name": "Convert to BBox",
           "defaultValue": [

--- a/platform/admin/modules/admin-modules-configuration/src/test/resources/services.json
+++ b/platform/admin/modules/admin-modules-configuration/src/test/resources/services.json
@@ -2455,7 +2455,7 @@
         {
           "id": "shouldConvertToBBox",
           "optionLabels": [],
-          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatability with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
+          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatibility with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
           "optionValues": [],
           "name": "Convert to BBox",
           "defaultValue": [
@@ -2594,7 +2594,7 @@
         {
           "id": "shouldConvertToBBox",
           "optionLabels": [],
-          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatability with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
+          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatibility with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
           "optionValues": [],
           "name": "Convert to BBox",
           "defaultValue": [

--- a/platform/admin/modules/admin-modules-installer/src/test/resources/services.json
+++ b/platform/admin/modules/admin-modules-installer/src/test/resources/services.json
@@ -2455,7 +2455,7 @@
         {
           "id": "shouldConvertToBBox",
           "optionLabels": [],
-          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatability with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
+          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatibility with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
           "optionValues": [],
           "name": "Convert to BBox",
           "defaultValue": [
@@ -2594,7 +2594,7 @@
         {
           "id": "shouldConvertToBBox",
           "optionLabels": [],
-          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatability with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
+          "description": "Converts Polygon and Point-Radius searches to a Bounding Box for compatibility with older interfaces. Generated bounding box is a very rough representation of the input geometry.",
           "optionValues": [],
           "name": "Convert to BBox",
           "defaultValue": [


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the OpenSearch `Convert to BBox` option.
#### Who is reviewing it? 
@AzGoalie @peterhuffer 
#### Select relevant component teams: 
@codice/io 
#### Choose 2 committers to review/merge the PR. 
@bdeining
@clockard
#### How should this be tested?
Execute point radius searches to an OpenSearch source in Intrigue, and confirm that the expected results are returned.
#### Any background context you want to provide?
Specifically, the issue was observed with a record with `location`=`POLYGON ((-122 37.33, -122.05 37.33, -122.05 37.22, -122 37.22, -122 37.33))` and the search "`Latitude`=`33`, `Longitude`=`-122`, `Radius`=`500 miles`" from Intrigue. The `OpenSearchSource`, with `Convert to BBox`=`true`, was incorrectly transforming the spatial search to `bbox=422.42053621382615,25.77186615764653,-666.4205362138262,40.22813384235347`.
#### What are the relevant tickets?
[DDF-3604](https://codice.atlassian.net/browse/DDF-3604)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.