### PR TITLE
[2.11.x] DDF-3566: Update Intrigue to use CQL query syntax

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/cql.spec.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/cql.spec.js
@@ -92,4 +92,35 @@ describe('tokenize', () => {
         });        
     });
 
+    describe('CQL and UserQL translation functions', () => {
+        it('parses a CQL query into a UserQL String', () => {
+            const result = cql.read('anyText ILIKE \'this % is \\% a \\_ test _ \\* \\?\'');
+            expect(result.value).equals('this * is % a _ test ? \\* \\?');
+        });
+
+        it('parses a UserQL string into a CQL query', () => {
+            const filter = {
+                property: 'anyText',
+                type: 'ILIKE',
+                value: 'this * is % a _ test ? \\* \\?'
+            };
+            const result = cql.write(filter);
+            expect(result).equals('anyText ILIKE \'this % is \\% a \\_ test _ \\* \\?\'');
+        });
+
+        it('parses multiple CQL characters in a row into UserQL', () => {
+            const result = cql.read('anyText ILIKE \'%%\\%\\%\\_\\___\\*\\*\\?\\?\'');
+            expect(result.value).equals('**%%__??\\*\\*\\?\\?');
+        });
+
+        it('parses multiple UserQL characters in a row into CQL', () => {
+            const filter = {
+                property: 'anyText',
+                type: 'ILIKE',
+                value: '**%%__??\\*\\*\\?\\?'
+            };
+            const result = cql.write(filter);
+            expect(result).equals('anyText ILIKE \'%%\\%\\%\\_\\___\\*\\*\\?\\?\'');
+        });
+    });
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -20,11 +20,12 @@ define([
         'js/Common',
         'js/ColorGenerator',
         'js/QueryPolling',
+        'js/cql',
         'component/singletons/user-instance',
         'moment',
         'backboneassociations'
     ],
-    function ($, _, wreqr, Backbone, Query, Common, ColorGenerator, QueryPolling, user, moment) {
+    function ($, _, wreqr, Backbone, Query, Common, ColorGenerator, QueryPolling, cql, user, moment) {
 
         var Workspace = {};
 
@@ -208,17 +209,17 @@ define([
                 }).get('queries').first().startSearch();
             },
             createAdhocWorkspace: function(text){
-                var cql;
+                var cqlQuery;
                 var title = text;
                 if (text.length === 0) {
-                    cql = "anyText ILIKE '*'";
+                    cqlQery = "anyText ILIKE '%'";
                     title = '*';
                 } else {
-                    cql = "anyText ILIKE '" + text + "'";
+                    cqlQuery = "anyText ILIKE '" + cql.translateUserqlToCql(text) + "'";
                 }
                 var queryForWorkspace = new Query.Model({
                     title: title,
-                    cql: cql
+                    cql: cqlQuery
                 });
                 this.create({
                     title: title,
@@ -232,7 +233,7 @@ define([
                     title: 'Example Local',
                     federation: 'local',
                     excludeUnnecessaryAttributes: false,
-                    cql: "anyText ILIKE '*'"
+                    cql: "anyText ILIKE '%'"
                 });
                 this.create({
                     title: 'Template Local',
@@ -246,7 +247,7 @@ define([
                     title: 'Example Federated',
                     federation: 'enterprise',
                     excludeUnnecessaryAttributes: false,
-                    cql: "anyText ILIKE '*'"
+                    cql: "anyText ILIKE '%'"
                 });
                 this.create({
                     title: 'Template Federated',
@@ -259,7 +260,7 @@ define([
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Location',
                     excludeUnnecessaryAttributes: false,
-                    cql: "anyText ILIKE '*' AND INTERSECTS(anyGeo, POLYGON((-130.7514 20.6825, -130.7514 44.5780, -65.1230 44.5780, -65.1230 20.6825, -130.7514 20.6825)))"
+                    cql: "anyText ILIKE '%' AND INTERSECTS(anyGeo, POLYGON((-130.7514 20.6825, -130.7514 44.5780, -65.1230 44.5780, -65.1230 20.6825, -130.7514 20.6825)))"
                 });
                 this.create({
                     title: 'Template Location',
@@ -272,7 +273,7 @@ define([
                 var queryForWorkspace = new Query.Model({
                     title: 'Example Temporal',
                     excludeUnnecessaryAttributes: false,
-                    cql: 'anyText ILIKE \'*\' AND ("created" AFTER ' + moment().subtract(1, 'days').toISOString() + ')'
+                    cql: 'anyText ILIKE \'%\' AND ("created" AFTER ' + moment().subtract(1, 'days').toISOString() + ')'
                 });
                 this.create({
                     title: 'Template Temporal',


### PR DESCRIPTION
**Backport of [DDF-3566](https://github.com/codice/ddf/pull/2887)**

#### What does this PR do?
Intrigue now exclusively uses the characters `* ? \` to represent wildcard, single character wildcard, and escape respectively. These characters are translated to their CQL-equivalent syntax before querying the CQL endpoint and workspaces are saved with their queries in CQL format. Any user-inputted CQL special characters are escaped before sending. If a user wants to utilize these CQL characters, they must the `* ? \` syntax mentioned above.

#### Who is reviewing it? 
@djblue 
@vinamartin 
@rzwiefel

#### Select relevant component teams: 
@codice/ui 
@codice/io 

#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@pklinef 

#### How should this be tested?
Install DDF, create a workspace with a query that uses CQL and Intrigue special characters, and ensure that when the query is run and the workspace is created, all outgoing requests have the following character transformations:
`* `=> `%`
`?` => `_`
`%` =>`\%`
`_` => `\_`
And that the queries displayed to the user within Intrigue use the original-inputted search text and not the CQL-translated versions. Also make sure that other searches behave normally.

#### Any background context you want to provide?
Previously, Intrigue would send a CQL query to the CQL endpoint and put the user-inputted search string into the query verbatim. This caused issues when the CQL endpoint tried to incorrectly interpret underscores and percentages. The solution decided on was to exclusively enforce the use of the already-commonly used `* _ \` on the frontend so it can be translated accurately to and from CQL syntax.

#### What are the relevant tickets?
[DDF-3566](https://codice.atlassian.net/browse/DDF-3566)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
