### PR TITLE
DDF-3611 Adds ability to hide upload page on Intrigue

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/component.less
@@ -229,3 +229,4 @@
 @import 'result-add/result-add';
 @import 'list-create/list-create';
 @import 'list-interactions/list-interactions';
+@import 'notfound/notfound';

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation/navigation.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/navigation/navigation.view.js
@@ -43,6 +43,9 @@ module.exports = Marionette.LayoutView.extend({
     },
     showNavigationMiddle: function(){
         //override in extensions
+        if (this.options.navigationMiddleComponent) {
+            this.navigationMiddle.show(new this.options.navigationMiddleComponent());
+        }
     },
     onBeforeShow: function(){
         this.navigationLeft.show(new NavigationLeftView());
@@ -68,5 +71,11 @@ module.exports = Marionette.LayoutView.extend({
     handleLogo: function() {
         var hasLogo = properties.showLogo && properties.ui.vendorImage !== "";
         this.$el.toggleClass('has-logo', hasLogo);
+    },
+    serializeData: function() {
+        return {
+            middleClasses: this.options.navigationMiddleClasses,
+            middleText: this.options.navigationMiddleText
+        };
     }
 });

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/navigator/navigator.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/navigator/navigator.less
@@ -62,6 +62,10 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
+
+    button.navigation-choice.choice-upload {
+        display: none;
+    }
 }
 
 @{customElementNamespace}navigator.is-saved {
@@ -82,4 +86,12 @@
         transform: scale(1);
     }
 
+}
+
+html.is-upload-enabled {
+    @{customElementNamespace}navigator {
+        button.navigation-choice.choice-upload {
+            display: block;
+        }
+    }
 }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/notfound/notfound.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/notfound/notfound.hbs
@@ -11,15 +11,18 @@
  *
  **/
  --}}
-<button class="cancel-drawing is-negative">
-    <span class="fa fa-times"></span>
-    <span>Cancel Drawing</span>
-</button>
-<div class="navigation-left is-button is-img">
+<div class="menu">
 </div>
-<div class="navigation-middle {{middleClasses}}">
-    {{middleText}}
-    <!-- Meant to be used on multiple pages, but the other elements are static -->
+<div class="message">
 </div>
-<div class="navigation-right">
+<div class="content">
+     <div class="message is-large-font is-centered">
+        We can't find the page you requested.
+    </div>
+    <div class="message is-medium-font is-centered">
+        Please check the url or navigate to another page.
+    </div>
+    <div class="navigator">
+
+    </div>
 </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/notfound/notfound.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/notfound/notfound.less
@@ -1,0 +1,26 @@
+@{customElementNamespace}notfound {
+    .customElement;
+    overflow: hidden;
+    .changeBackground(@backgroundContent);
+
+    .content .navigator {
+      margin-top: @minimumSpacing;
+    }
+
+    .content {
+        margin: auto;
+        max-width: 1200px;
+        padding: @minimumSpacing 100px;
+        overflow: auto;
+        height: ~'calc(100% - 2*@{minimumLineSize})';
+    }
+}
+
+.is-small-screen, .is-mobile-screen {
+    @{customElementNamespace}notfound {
+      .content {
+        max-width: 100%;
+        padding: @minimumSpacing;
+      }
+    }
+  }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/notfound/notfound.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/notfound/notfound.view.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global require*/
+const Marionette = require('marionette');
+const template = require('./notfound.hbs');
+const CustomElements = require('js/CustomElements');
+const router = require('component/router/router');
+const NavigationView = require('component/navigation/navigation.view');
+const NavigatorView = require('component/navigator/navigator.view');
+
+module.exports = Marionette.LayoutView.extend({
+    template: template,
+    tagName: CustomElements.register('notfound'),
+    modelEvents: {},
+    events: {},
+    ui: {},
+    regions: {
+        content: '> .content > .navigator',
+        menu: '> .menu'
+    },
+    initialize: function() {
+        this.listenTo(router, 'change', this.handleRoute);
+        this.handleRoute();
+    },
+    handleRoute: function() {
+        if (router.toJSON().name === 'notFound') {
+            this.$el.removeClass('is-hidden');
+        } else {
+            this.$el.addClass('is-hidden');
+        }
+    },
+    onBeforeShow: function() {
+        this.menu.show(new NavigationView({
+            navigationMiddleText: 'Page Not Found',
+            navigationMiddleClasses: 'is-bold'
+        }));
+        this.content.show(new NavigatorView({}));
+    },
+    serializeData: function() {
+        return {
+            route: window.location.hash.substring(1)
+        };
+    }
+});

--- a/catalog/ui/catalog-ui-search/src/main/webapp/index.html
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/index.html
@@ -72,6 +72,9 @@
         <div id="workspaces">
 
         </div>
+        <div id="notfound">
+
+        </div>
     </div>
     <iframe name="autocomplete" style="display:none" src="/search/catalog/blank.html"></iframe>
 <footer></footer>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/application.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/application.js
@@ -44,7 +44,8 @@ define([
         ingestRegion: '#ingest',
         uploadRegion: '#upload',
         controlPanelRegion: '#controlPanel',
-        aboutRegion: '#about'
+        aboutRegion: '#about',
+        notFoundRegion: '#notfound'
     });
 
     const BannerView = Marionette.ItemView.extend({

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
@@ -34,18 +34,16 @@ define([
     'component/upload/upload',
     'component/upload/upload.view',
     'component/navigator/navigator.view',
-    'component/singletons/slideout.left.view-instance.js',
     'component/sources/sources.view',
-    'component/about/about.view'
+    'component/about/about.view',
+    'component/notfound/notfound.view',
+    'properties',
+    'component/announcement'
 ], function (wreqr, $, Backbone, Marionette, store, ConfirmationView, Application, ContentView,
              HomeView, MetacardView, metacardInstance, Query, cql, alertInstance, AlertView,
             IngestView, router, user, uploadInstance, UploadView,
-            NavigatorView, SlideoutLeftViewInstance, SourcesView, AboutView) {
-
-    function toggleNavigator() {
-        SlideoutLeftViewInstance.updateContent(new NavigatorView());
-        SlideoutLeftViewInstance.open();
-    }
+            NavigatorView, SourcesView, AboutView, 
+            NotFoundView, properties, announcement) {
 
     function hideViews() {
         Application.App.workspaceRegion.$el.addClass("is-hidden");
@@ -56,6 +54,7 @@ define([
         Application.App.uploadRegion.$el.addClass('is-hidden');
         Application.App.sourcesRegion.$el.addClass('is-hidden');
         Application.App.aboutRegion.$el.addClass('is-hidden');
+        Application.App.notFoundRegion.$el.addClass('is-hidden');
     }
 
     var Router = Marionette.AppRouter.extend({
@@ -86,6 +85,9 @@ define([
             },
             openAbout() {
                 //console.log('route to about');
+            },
+            notFound() {
+                //console.log('route to notfound');
             }
         },
         appRoutes: {
@@ -97,7 +99,8 @@ define([
             'ingest(/)': 'openIngest',
             'uploads/:id': 'openUpload',
             'sources(/)': 'openSources',
-            'about(/)': 'openAbout'
+            'about(/)': 'openAbout',
+            '*path': 'notFound'
         },
         initialize: function(){
             if (window.location.search.indexOf('lowBandwidth') !== -1) {
@@ -135,15 +138,7 @@ define([
                         Application.App.workspaceRegion.$el.removeClass('is-hidden');
                         this.updateRoute(name, path, args);
                     } else {
-                        toggleNavigator();
-                        this.listenTo(ConfirmationView.generateConfirmation({
-                                prompt: 'Either the workspace has been deleted or you no longer have permission to access it.  ' +
-                                'Please use the left navigation to go somewhere else.',
-                                yes: 'Okay'
-                            }),
-                            'change:choice',
-                            function(){
-                            });
+                        this.onRoute('notFound');
                     }
                     break;
                 case 'openMetacard':
@@ -181,14 +176,7 @@ define([
                     var alertId = args[0];
                     var alert = user.get('user').get('preferences').get('alerts').get(alertId);
                     if (!alert) {
-                        toggleNavigator();
-                        self.listenTo(ConfirmationView.generateConfirmation({
-                                prompt: 'Alert unable to be found.  Please use the left navigation to go somewhere else.',
-                                yes: 'Okay'
-                            }),
-                            'change:choice',
-                            function () {
-                            });
+                        this.onRoute('notFound');
                     } else {
                         queryForMetacards = new Query.Model({
                             cql: cql.write({
@@ -228,14 +216,7 @@ define([
                     var uploadId = args[0];
                     var upload = user.get('user').get('preferences').get('uploads').get(uploadId);
                     if (!upload) {
-                        toggleNavigator();
-                        self.listenTo(ConfirmationView.generateConfirmation({
-                                prompt: 'Upload unable to be found.  Please use the left navigation to go somewhere else.',
-                                yes: 'Okay'
-                            }),
-                            'change:choice',
-                            function () {
-                            });
+                        this.onRoute('notFound');
                     } else {
                         queryForMetacards = new Query.Model({
                             cql: cql.write({
@@ -273,6 +254,10 @@ define([
                     }
                     break;
                 case 'openIngest':
+                    if (!properties.isUploadEnabled()) {
+                        this.onRoute('notFound');
+                        return;
+                    }
                     if (Application.App.ingestRegion.currentView === undefined){
                         Application.App.ingestRegion.show(new IngestView());
                     }
@@ -305,6 +290,13 @@ define([
                         Application.App.aboutRegion.show(new AboutView());
                     }
                     Application.App.aboutRegion.$el.removeClass('is-hidden');
+                    this.updateRoute(name, path, args);
+                    break;
+                case 'notFound':
+                    if (Application.App.notFoundRegion.currentview === undefined) {
+                        Application.App.notFoundRegion.show(new NotFoundView());
+                    } 
+                    Application.App.notFoundRegion.$el.removeClass('is-hidden');
                     this.updateRoute(name, path, args);
                     break;
             }

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
@@ -59,36 +59,16 @@ define([
 
     var Router = Marionette.AppRouter.extend({
         controller: {
-            openWorkspace: function(){
-                //console.log('route to specific workspace:'+workspaceId);
-            },
-            home: function(){
-                //console.log('route to workspaces home');
-            },
-            workspaces: function(){
-                //console.log('route to workspaces home');
-            },
-            openMetacard: function(){
-                //console.log('route to specific metacard:'+metacardId);
-            },
-            openAlert: function(){
-                //console.log('route to specific alert:'+alertId);
-            },
-            openIngest: function(){
-                //console.log('route to ingest');
-            },
-            openUpload: function(){
-                //console.log('route to upload');
-            },
-            openSources: function(){
-                //console.log('route to sources');
-            },
-            openAbout() {
-                //console.log('route to about');
-            },
-            notFound() {
-                //console.log('route to notfound');
-            }
+                openWorkspace() {},
+                home() {},
+                workspaces() {},
+                openMetacard() {},
+                openAlert() {},
+                openIngest() {},
+                openUpload() {},
+                openSources() {},
+                openAbout() {},
+                notFound() {}
         },
         appRoutes: {
             'workspaces/:id': 'openWorkspace',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/properties.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/properties.js
@@ -89,7 +89,7 @@ define(function (require) {
             this.handleEditing();
             this.handleFeedback();
             this.handleExperimental();
-
+            this.handleUpload();
             return props;
         },
         handleEditing: function(){
@@ -101,6 +101,9 @@ define(function (require) {
         handleExperimental: function() {
             $('html').toggleClass('is-experimental', this.hasExperimentalEnabled());
         },  
+        handleUpload: function() {
+            $('html').toggleClass('is-upload-enabled', this.isUploadEnabled());
+        },
         isHidden: function(attribute){
           return match(this.hiddenAttributes, attribute);
         },
@@ -130,6 +133,9 @@ define(function (require) {
         },
         isArchiveSearchEnabled: function(){
             return !this.isArchiveSearchDisabled;
+        },
+        isUploadEnabled: function() {
+            return this.showIngest;
         }
     };
 

--- a/catalog/ui/catalog-ui-search/src/main/webapp/styles/components/content.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/styles/components/content.less
@@ -22,7 +22,8 @@ body.has-header.has-footer #content {
 #ingest,
 #upload,
 #sources,
-#about {
+#about,
+#notfound {
   position: absolute;
   left: 0px;
   top: 0px;
@@ -37,7 +38,8 @@ body.has-header.has-footer #content {
 #ingest,
 #upload,
 #sources,
-#about {
+#about,
+#notfound {
   &.is-hidden {
     display: block !important;
     opacity: 0;

--- a/catalog/ui/catalog-ui-search/src/main/webapp/styles/fonts.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/styles/fonts.less
@@ -25,3 +25,7 @@
 .changeFontWeight (@contrastColor) when (@contrastColor = black) {
   font-weight: 400;
 }
+
+.is-centered {
+  text-align: center;
+}


### PR DESCRIPTION
#### What does this PR do?
 - Adds ability to hide the upload page on Intrigue
 - Adds a "not found" page to handle when routing to something that
 doesn't exist.

#### Who is reviewing it? 
@bdeining 
@jlcsmith 
@adimka 
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Go to Intrigue with upload disabled in the configuration.  Verify you cannot reach the upload page (/#ingest).  

#### Any background context you want to provide?
The  configuration already existed for this, it wasn't hooked in however.

#### What are the relevant tickets?
[3611](https://codice.atlassian.net/browse/3611)

#### Screenshots (if appropriate)
![notfound](https://user-images.githubusercontent.com/11984853/36001036-3a336036-0ce2-11e8-8028-70bd6490150c.png)
![notfound2](https://user-images.githubusercontent.com/11984853/36001037-3a4b54ca-0ce2-11e8-810e-3013fcb6017b.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.