### PR TITLE
[2.11.x] DDF-3105 Create Component test for REST endpoint

### DIFF
--- a/catalog/core/catalog-core-api/src/main/resources/feature.xml
+++ b/catalog/core/catalog-core-api/src/main/resources/feature.xml
@@ -16,7 +16,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="catalog-core-api" install="manual" version="${project.version}"
+    <feature name="catalog-core-api-only" install="manual" version="${project.version}"
              description="Catalog API interfaces and simple implementations.">
         <bundle>mvn:org.codice.thirdparty/gt-opengis/${opengis.bundle.version}</bundle>
         <bundle>mvn:ddf.platform.api/platform-api/${project.version}</bundle>

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -116,11 +116,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
-        </dependency>
-        <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>util-uuidgenerator-api</artifactId>
             <version>${project.version}</version>
@@ -213,12 +208,6 @@
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-junit4</artifactId>
             <version>${pax.exam.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointIT.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointIT.java
@@ -56,6 +56,7 @@ import org.codice.ddf.test.common.configurators.ApplicationOptions;
 import org.codice.ddf.test.common.configurators.BundleOptionBuilder.BundleOption;
 import org.codice.ddf.test.common.configurators.DdfComponentOptions;
 import org.codice.ddf.test.common.configurators.FeatureOptionBuilder.FeatureOption;
+import org.codice.ddf.test.common.configurators.PortFinder;
 import org.codice.ddf.test.common.rules.ServiceRegistrationRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -182,8 +183,8 @@ public class RestEndpointIT extends AbstractComponentTest {
   }
 
   @Override
-  protected ApplicationOptions getApplicationOptions() {
-    return new DdfComponentOptions(getPortFinder()) {
+  protected ApplicationOptions getApplicationOptions(PortFinder portFinder) {
+    return new DdfComponentOptions(portFinder) {
 
       @Override
       protected BundleOption getBundleOptions() {
@@ -208,8 +209,9 @@ public class RestEndpointIT extends AbstractComponentTest {
             .addFeatureFrom("ddf.thirdparty", "rest-assured", "feature", "rest-assured")
             .addFeatureFrom(
                 "ddf.platform.util", "util-uuidgenerator-api", "feature", "uuidgenerator-api")
-            .addFeatureFrom("ddf.mime.core", "mime-core-api", "feature", "mime-core-api")
-            .addFeatureFrom("ddf.catalog.core", "catalog-core-api", "feature", "catalog-core-api");
+            .addFeatureFrom("ddf.mime.core", "mime-core-api", "feature", "mime-core-api-only")
+            .addFeatureFrom(
+                "ddf.catalog.core", "catalog-core-api", "feature", "catalog-core-api-only");
       }
     };
   }

--- a/libs/test-common/src/main/filtered-resources/features.xml
+++ b/libs/test-common/src/main/filtered-resources/features.xml
@@ -12,7 +12,7 @@
  **/
  -->
 
-<features name="karaf-standard-features-${project.version}"
+<features name="test-common--${project.version}"
           xmlns="http://karaf.apache.org/xmlns/features/v1.3.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
@@ -24,5 +24,6 @@
         <bundle>mvn:org.awaitility/awaitility/${awaitility.version}</bundle>
         <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
         <bundle>mvn:org.xmlunit/xmlunit-matchers/${xmlunit.version}</bundle>
+        <bundle>mvn:org.ops4j.pax.exam/pax-exam/${pax.exam.version}</bundle>
     </feature>
 </features>

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/AbstractComponentTest.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/AbstractComponentTest.java
@@ -30,13 +30,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Abstract base class for component tests. Extend to provide and implementation for the {@link
- * #getApplicationOptions()} methods and the test methods.
+ * #getApplicationOptions(PortFinder)} methods and the test methods.
  *
  * <p>It is important to remember that the {@link #config()} method and all the methods it calls,
- * i.e., {@link #getContainerOptions()} and {@link #getApplicationOptions()}, are called inside the
- * test runner process and are only used to configure the test container. All the other methods in
- * this class and its sub-classes will be run inside the test container, which is a separate
- * process.
+ * i.e., {@link #getContainerOptions()} and {@link #getApplicationOptions(PortFinder)}, are called
+ * inside the test runner process and are only used to configure the test container. All the other
+ * methods in this class and its sub-classes will be run inside the test container, which is a
+ * separate process.
  *
  * @see ApplicationOptions
  * @see ContainerOptions
@@ -45,6 +45,9 @@ public abstract class AbstractComponentTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractComponentTest.class);
 
+  // This port finder will only be available during Pax Exam's configuration phase, not inside the
+  // test container and during the tests. If ports need to be assigned during testing, a separate
+  // instance should be used.
   private static PortFinder portFinder;
 
   @Rule public TestFailureLogger testFailureLogger = new TestFailureLogger();
@@ -68,11 +71,9 @@ public abstract class AbstractComponentTest {
     portFinder = new PortFinder();
 
     return options(
-        getContainerOptions().get(), getApplicationOptions().get(), getTestBundleOptions().build());
-  }
-
-  public static PortFinder getPortFinder() {
-    return portFinder;
+        getContainerOptions().get(),
+        getApplicationOptions(portFinder).get(),
+        getTestBundleOptions().build());
   }
 
   /**
@@ -89,13 +90,16 @@ public abstract class AbstractComponentTest {
    * Gets the object to use to configure the component or application inside the container.
    *
    * @return object that returns the application's configuration {@link Option}s
+   * @param portFinder reference to the {@link PortFinder} to use during the test container
+   *     configuration
    */
-  protected abstract ApplicationOptions getApplicationOptions();
+  protected abstract ApplicationOptions getApplicationOptions(PortFinder portFinder);
 
   private BundleOption getTestBundleOptions() {
     return BundleOptionBuilder.add("org.mockito", "mockito-core")
         .add("org.objenesis", "objenesis")
         .add("org.awaitility", "awaitility")
+        .add("org.apache.commons", "commons-collections4")
         .add("org.apache.commons", "commons-lang3")
         .add("ddf.lib", "test-common");
   }

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/configurators/ApplicationOptions.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/configurators/ApplicationOptions.java
@@ -19,7 +19,7 @@ import org.ops4j.pax.exam.Option;
 /**
  * Interface implemented by Pax Exam test classes to provide application specific {@link Option}s.
  *
- * @see org.codice.ddf.test.common.AbstractComponentTest#getApplicationOptions()
+ * @see org.codice.ddf.test.common.AbstractComponentTest#getApplicationOptions(PortFinder)
  */
 public interface ApplicationOptions extends Supplier<Option> {
 

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/configurators/PortFinder.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/configurators/PortFinder.java
@@ -21,7 +21,13 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Class used to find and reserve a range of ports and assign ports within that range. */
+/**
+ * Class used to find and reserve a range of ports, and assign ports within that range by name. For
+ * instance, creating a new instance of {@link PortFinder} will reserve a block of ports, calling
+ * {@link #getPort(String)} or {@link #getPortAsString(String)} the first time will assign a
+ * specific port in that range with the name provided, and calling one of those two methods with
+ * that name will return the same port number afterwards.
+ */
 public class PortFinder implements Closeable {
   private static final Logger LOGGER = LoggerFactory.getLogger(PortFinder.class);
 
@@ -49,7 +55,7 @@ public class PortFinder implements Closeable {
    * @return port number associated with the key provided
    */
   public int getPort(String portKey) {
-    registeredPorts.putIfAbsent(portKey, nextPort++);
+    registeredPorts.computeIfAbsent(portKey, k -> nextPort++);
     return registeredPorts.get(portKey);
   }
 

--- a/platform/mime/core/platform-mime-core-api/src/main/resources/feature.xml
+++ b/platform/mime/core/platform-mime-core-api/src/main/resources/feature.xml
@@ -16,7 +16,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="mime-core-api" version="${project.version}"
+    <feature name="mime-core-api-only" version="${project.version}"
              description="Core MIME API interfaces">
         <bundle>mvn:ddf.mime.core/mime-core-api/${project.version}</bundle>
     </feature>


### PR DESCRIPTION
#### What does this PR do?
Changed how the PortFinder is being passed around in the AbstractComponentTest class.
Renamed the catalog core API and mime type API features to avoid conflict with those defined in the platform-app and catalog-app features files, which was causing tests to fail in some circumstances.
Improved some of the comments and removed unneeded dependencies in pom files.

Back-port of https://github.com/codice/ddf/pull/2951.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@tbatie 
@paouelle 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@coyotesqrl

#### How should this be tested? (List steps with links to updated documentation)
CI build successful.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3105](https://codice.atlassian.net/browse/DDF-3105)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
