### PR TITLE
DDF-3570 Made WFS 1.1 support redirect configuration when using certificates

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -378,7 +378,7 @@ public class WfsSource extends AbstractWfsSource {
               initProviders(),
               new MarkableStreamInterceptor(),
               this.disableCnCheck,
-              false,
+              this.allowRedirects,
               null,
               null,
               new ClientKeyInfo(getCertAlias(), getKeystorePath()),


### PR DESCRIPTION
#### What does this PR do?
Made WFS 1.1 support redirect configuration when configured with certificate authentication.
Currently, WFS 1.1 allows the user to specify username/pass, or certificate, or neither.  It also allows the user to specify allowRedirects, but that variable was not used when configured with certificates.  This adds that to the configuration

#### Who is reviewing it? 
@troymohl  
@glenhein 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/io
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@jlcsmith

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
Likely just an oversight as different parts came together.  Unfortunately also overlaps with the specific configuration for a current use-case.
#### What are the relevant tickets?
[DDF-3570](https://codice.atlassian.net/browse/DDF-3570)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
