### PR TITLE
DDF-3615 Removed Consumes from Csw javax RS interface

### DIFF
--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/Csw.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/Csw.java
@@ -41,7 +41,6 @@ public interface Csw {
    * @return
    */
   @GET
-  @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
   @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
   CapabilitiesType getCapabilities(@QueryParam("") GetCapabilitiesRequest request)
       throws CswException;
@@ -64,7 +63,6 @@ public interface Csw {
    * @return
    */
   @GET
-  @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
   @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
   DescribeRecordResponseType describeRecord(@QueryParam("") DescribeRecordRequest request)
       throws CswException;
@@ -108,7 +106,6 @@ public interface Csw {
    * @return
    */
   @GET
-  @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
   @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
   CswRecordCollection getRecordById(
       @QueryParam("") GetRecordByIdRequest request,


### PR DESCRIPTION


#### What does this PR do?
Removed javax.ws.rs.Consumes from CSW GET actions so that the requests don't expect an explicit content type
#### Who is reviewing it? 
@mackncheesiest 
@jrnorth 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/io
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@jlcsmith

#### How should this be tested? (List steps with links to updated documentation)
Hook up to wiremock or any other service that will accept CSW connections.  Confirm the outbound request for getCapabilities (or any GET request) does not include the Content-Type header
#### Any background context you want to provide?
CSW JAX-RS Interface shouldn't impose a Content-Type header on GET methods.

Requiring application/xml or text/xml (as it currently does) implies a payload being sent along the GET requests.  These requests do not include a payload, and it is typically recommended that get requests do not include payloads.  Further, tables 52 and 54 of the CSW 2.0.2 specification highlight that these GET requests should be done with query parameters for key-value pairs.

#### What are the relevant tickets?
[DDF-3615](https://codice.atlassian.net/browse/DDF-3615)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
