### PR TITLE
[2.11.x] DDF-2824 fixed formatting for sample DDF urls in docs

### DIFF
--- a/distribution/docs/src/main/resources/content/_appReferences/mg-broker-app.adoc
+++ b/distribution/docs/src/main/resources/content/_appReferences/mg-broker-app.adoc
@@ -95,7 +95,7 @@ If LDAP has been configured then the admin user and password for the above comma
 Note the `"value":true` field: if it is false, then the replication is still in progress or the logs should be consulted to see if there was an issue establishing a connection between the live and backup servers.
 ====
 
-Additionally, for more details about the health of the cluster, the following command can be run using curl or a ${secure_url}/admin/jolokia/read/org.apache.activemq.artemis:broker=%22localhost%22,component=cluster-connections,name=%22my-cluster%22/Topology[browser].
+Additionally, for more details about the health of the cluster, the following command can be run using curl or a \${secure_url}/admin/jolokia/read/org.apache.activemq.artemis:broker=%22localhost%22,component=cluster-connections,name=%22my-cluster%22/Topology[browser].
 
 .Server Health Status Command
 [source]

--- a/distribution/docs/src/main/resources/content/_appReferences/mg-geowebcache.adoc
+++ b/distribution/docs/src/main/resources/content/_appReferences/mg-geowebcache.adoc
@@ -16,7 +16,7 @@ The ${ddf-geowebcache} application is currently in an EXPERIMENTAL status and sh
 ${ddf-geowebcache} enables a server providing a tile cache and tile service aggregation.
 See (http://geowebcache.org[GeoWebCache]) for more information.
 This application also provides an administrative plugin for the management of GeoWebCached layers.
-GeoWebCache also provides a user interface for previewing, truncating, or seeding layers at ${secure_url}/geowebcache/.
+GeoWebCache also provides a user interface for previewing, truncating, or seeding layers at \${secure_url}/geowebcache/.
 
 ===  ${ddf-geowebcache} Application Prerequisites
 
@@ -104,7 +104,7 @@ Add layers to the local cache:
 
 Storage usage for a GeoWebCache server is managed by a `diskquota.xml` file with configuration details to prevent image-intensive data from filling the available storage.
 
-To view the disk quota XML representative: ${secure_url}/geowebcache/rest/diskquota.xml
+To view the disk quota XML representative: \${secure_url}/geowebcache/rest/diskquota.xml
 
 To update the disk quota, a client can post a new XML configuration: `curl -v -k -XPUT -H "Content-type: text/xml" -d ${at-symbol}diskquota.xml "${secure_url}/geowebcache/rest/diskquota.xml"`
 

--- a/distribution/docs/src/main/resources/content/_architectures/metrics-reporting.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/metrics-reporting.adoc
@@ -36,7 +36,7 @@ Also note that if ${branding} is uninstalled/re-installed, all existing metrics
 ====
 
 Hyperlinks are provided for each metric and each format in which data can be displayed.
-For example, the PNG hyperlink for 15m for the Catalog Queries metric maps to ${secure_url}/services/internal/metrics/catalogQueries.png?dateOffset=900, where the `dateOffset=900` indicates the previous 900 seconds (15 minutes) to be graphed.
+For example, the PNG hyperlink for 15m for the Catalog Queries metric maps to \${secure_url}/services/internal/metrics/catalogQueries.png?dateOffset=900, where the `dateOffset=900` indicates the previous 900 seconds (15 minutes) to be graphed.
 
 Note that the date format will vary according to the regional/locale settings for the server.
 
@@ -89,7 +89,7 @@ ${secure_url}/services/internal/metrics/report.<format>?startDate=<start_date_va
 where `<format>` is either `xls` or `ppt` and the `<start_date_value>` and `<end_date_value>` specify the custom time range for the report.
 
 These example reports represent custom aggregate reports.
-NOTE: all example URLs begin with "${secure_url}", which is omitted in the table for brevity.
+NOTE: all example URLs begin with \${secure_url}, which is omitted in the table for brevity.
 
 .Example Aggregate Reports
 [cols="2" options="header"]

--- a/distribution/docs/src/main/resources/content/_configuring/admin-console-tutorial.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/admin-console-tutorial.adoc
@@ -9,7 +9,7 @@
 
 The ${admin-console} is the centralized location for administering the system.
 The ${admin-console} allows an administrator to install and remove selected applications and their dependencies and access configuration pages to configure and tailor system services and properties.
-The default address for the ${admin-console} is ${secure_url}/admin.
+The default address for the ${admin-console} is \${secure_url}/admin.
 
 .Managing Applications from ${admin-console}
 The *Manage* button enables activation/deactivation and adding/removing applications.

--- a/distribution/docs/src/main/resources/content/_configuring/global-settings.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/global-settings.adoc
@@ -435,7 +435,7 @@ Thumbs.db
 |===
 
 These properties are available to be used as variable parameters in input url fields within the ${admin-console}.
-For example, the url for the local csw service (${secure_url}/services/csw) could be defined as:
+For example, the url for the local csw service (\${secure_url}/services/csw) could be defined as:
 
 [source]
 ----

--- a/distribution/docs/src/main/resources/content/_configuring/securing-idp-sp.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/securing-idp-sp.adoc
@@ -31,7 +31,7 @@ The IdP client that interacts with the specified Identity Provider.
 .. An HTTPS URL (https://)
 .. A file URL (file:)
 .. An XML block to refer to desired metadata
-... (e.g., ${secure_url}/services/idp/login/metadata)
+... (e.g., \${secure_url}/services/idp/login/metadata)
 
 .IdP Client (SP) example.xml
 [source,xml,linenums]

--- a/distribution/docs/src/main/resources/content/_devComponents/custom-applications.adoc
+++ b/distribution/docs/src/main/resources/content/_devComponents/custom-applications.adoc
@@ -103,11 +103,11 @@ Sub-directories under `src/main/resources` can be used, e.g., `etc/security`.
 When the user downloads an application by clicking on the *Installation* link, the application's KAR file is downloaded.
 To install manually, the KAR file can be placed in the `${home_directory}/deploy` directory of the running ${branding} instance. ${branding} then detects that a file with a `.kar` file extension has been placed in this monitored directory, unzips the KAR file into the `${home_directory}/system` directory, and installs the bundle(s) listed in the KAR file's feature descriptor file.
 To install via the ${admin-console}:
-. Navigate to ${secure_url}/admin
-. Click the *Manage* button in the upper right
-. Click the *Add an Application* tile
-. Upload the KAR file via the popup window
-. Click *Save Changes* to activate
+. Navigate to the *${admin-console}*.
+. Select *Manage* button.
+. Select *Add an Application*,
+. Upload the KAR file via the popup window.
+. Select *Save Changes* to activate,
 The new application can be viewed via the ${admin-console}'s Active Applications list.
 
 ===== Developing Application Configuration Modules

--- a/distribution/docs/src/main/resources/content/_endpoints/application-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/application-endpoint.adoc
@@ -13,7 +13,7 @@ The Application Upload Endpoint is installed by default with a standard installa
 
 ===== Application Upload Endpoint
 
-The Application endpoint is available at <${secure_url}/services/application.
+The Application endpoint is available at \${secure_url}/services/application.
 
 ===== Configuring Application Upload Endpoint
 

--- a/distribution/docs/src/main/resources/content/_endpoints/catalog-rest-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/catalog-rest-endpoint.adoc
@@ -11,7 +11,7 @@ The Catalog REST Endpoint allows clients to perform CRUD operations on the Cata
 
 The Catalog REST Endpoint allows clients to perform CRUD operations on the Catalog using REST, a simple architectural style that performs communication using HTTP. 
 
-The URL exposing the REST functionality is located at ${secure_url}/services/catalog.
+The URL exposing the REST functionality is located at \${secure_url}/services/catalog.
 
 ===== Installing the Catalog REST Endpoint
 
@@ -164,7 +164,7 @@ ${public_url}/services/catalog/<metacardId>?transform=<TRANSFORMER_ID>
 [TIP]
 ====
 Transforms also work on read operations for metacards in federated sources.
-${secure_url}/services/catalog/sources/<sourceId>/<metacardId>?transform=<TRANSFORMER_ID>
+\${secure_url}/services/catalog/sources/<sourceId>/<metacardId>?transform=<TRANSFORMER_ID>
 ====
 
 See <<_metacard_transformers,Metacard Transformers>> for details on metacard transformers.

--- a/distribution/docs/src/main/resources/content/_endpoints/cometd-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/cometd-endpoint.adoc
@@ -295,8 +295,8 @@ Behind the scenes, the ${branding} Search UI invokes the REST endpoint to retrie
 
 In this request, it adds the query parameter "user" with the CometD session ID or the unique User ID as the value.
 This allows the CometD server to know which subscriber is interested in the notification.
-For example, `${secure_url}/services/catalog/sources/${branding-lowercase}.distribution/2f5db9e5131444279a1293c541c106cd?
-  transform=resource&user=1w1qlo79j6tscii19jszwp9s2i55` notifications contain the following information:
+For example, \${secure_url}/services/catalog/sources/${branding-lowercase}.distribution/2f5db9e5131444279a1293c541c106cd?
+  transform=resource&user=1w1qlo79j6tscii19jszwp9s2i55 notifications contain the following information:
 
 .[[_notification_contents]]Notification Contents
 [cols="1m,3,1" options="header"]

--- a/distribution/docs/src/main/resources/content/_endpoints/csw-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/csw-endpoint.adoc
@@ -18,7 +18,7 @@ It can only be installed or uninstalled.
 
 ===== CSW Endpoint URL
 
-The CSW endpoint is accessible from ${secure_url}/services/csw.
+The CSW endpoint is accessible from \${secure_url}/services/csw.
 
 ====== CSW Endpoint Operations
 
@@ -33,7 +33,7 @@ ${secure_url}/services/csw?service=CSW&version=2.0.2&request=GetCapabilities
 ----
 
 .`GetCapabilities` HTTP POST
-The `HTTP POST` form of `GetCapabilities` operates on the root CSW endpoint URL (${secure_url}/services/csw) with an XML message body that is defined by the `GetCapabilities` element of the http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd[CSW-Discovery XML Schema].
+The `HTTP POST` form of `GetCapabilities` operates on the root CSW endpoint URL (\${secure_url}/services/csw) with an XML message body that is defined by the `GetCapabilities` element of the http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd[CSW-Discovery XML Schema].
 
 .`GetCapabilities` XML Request
 [source,xml,linenums]

--- a/distribution/docs/src/main/resources/content/_endpoints/metrics-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/metrics-endpoint.adoc
@@ -88,7 +88,7 @@ The metric's historical data can be displayed in several formats, including PNG 
 The PNG, CSV, and XLS formats are accessed via hyperlinks provided in the Metrics tab web page.
 The PPT, XML, and JSON formats are accessed by specifying the format in the custom URL, e.g., ${public_url}/services/internal/metrics/catalogQueries.json?dateOffset=1800.
 
-The table below describes each of the supported formats, how to access them, and an example where applicable. (NOTE: all example URLs begin with ${secure_url} which is omitted in the table for brevity.)
+The table below describes each of the supported formats, how to access them, and an example where applicable. (NOTE: all example URLs begin with \${secure_url} which is omitted in the table for brevity.)
 
 .Metrics Formats
 [cols="1,2,1,3a" options="header"]

--- a/distribution/docs/src/main/resources/content/_installing/installing-from-admin-console.adoc
+++ b/distribution/docs/src/main/resources/content/_installing/installing-from-admin-console.adoc
@@ -7,7 +7,7 @@
 
 ===== Completing Installation from the ${admin-console}
 
-Upon startup, the installation can be completed by navigating to the ${admin-console} at ${secure_url}/admin.
+Upon startup, the installation can be completed by navigating to the ${admin-console} at \${secure_url}/admin.
 
 .Internet Explorer 10 TLS Warning
 [WARNING]

--- a/distribution/docs/src/main/resources/content/_installing/system-configuration-settings.adoc
+++ b/distribution/docs/src/main/resources/content/_installing/system-configuration-settings.adoc
@@ -11,7 +11,7 @@
 * Contact Info: Contact information for the point-of-contact or administrator for this installation.
 * Certificates: Add PKI certificates for the Keystore and Truststore for this installation.
 ** For a quick (test) installation, if the hostname/ports are not changed from the defaults, ${branding} includes self-signed certificates to use. Do not use in a working installation.
-** For more advanced testing, on initial startup of the *${admin-console}* append the string `?dev=true` to the url (${secure_url}/admin?dev=true) to auto-generate self-signed certificates from a demo Certificate Authority(CA) which will enable change hostname and port settings. Do not use in a working installation.
+** For more advanced testing, on initial startup of the *${admin-console}* append the string `?dev=true` to the url (\${secure_url}/admin?dev=true) to auto-generate self-signed certificates from a demo Certificate Authority(CA) which will enable change hostname and port settings. Do not use in a working installation.
 *** NOTE: `?dev=true` generates certifcates on initial installation only.
 ** For more information about importing certificate from a Certificate Authority, see <<_managing_keystores_and_certificates,Managing Keystores and Certificates>>.
 

--- a/distribution/docs/src/main/resources/content/_quickstart/quickstart-configuring.adoc
+++ b/distribution/docs/src/main/resources/content/_quickstart/quickstart-configuring.adoc
@@ -8,7 +8,7 @@
 
 Set the configurations needed to run ${branding}.
 
-. In a browser, navigate to the ${admin-console} at ${secure_url}/admin.
+. In a browser, navigate to the ${admin-console} at \${secure_url}/admin.
 .. The ${admin-console} may take a few minutes to start up.
 . Enter the default username of `admin` and the password of `admin`.
 . Follow the installer prompts for a standard installation.

--- a/distribution/docs/src/main/resources/content/_quickstart/quickstart-ingesting.adoc
+++ b/distribution/docs/src/main/resources/content/_quickstart/quickstart-ingesting.adoc
@@ -13,7 +13,7 @@ This is one way to ingest into the catalog, for a complete list of the different
 ==== Ingesting Sample Data
 
 . Download a sample valid https://codice.atlassian.net/wiki/download/attachments/1179756/geojson_valid.json?version=1&modificationDate=1368249436010&api=v2[GeoJson file here].
-. Navigate in the browser to ${catalog-ui} at ${secure_url}/search.
+. Navigate in the browser to ${catalog-ui} at \${secure_url}/search.
 . Select the Menu icon (image:navigator-icon.png[navigator icon]) in the upper left corner
 . Select *Upload*.
 . Drag and drop the sample file or click to navigate to it.
@@ -24,7 +24,7 @@ This is one way to ingest into the catalog, for a complete list of the different
 XML metadata for text searching is not automatically generated from GeoJson fields.
 ====
 
-Querying from the Search UI (${secure_url}/search) will return the record for the file ingested:
+Querying from the Search UI (\${secure_url}/search) will return the record for the file ingested:
 
 . Select the Menu icon (image:navigator-icon.png[navigator icon])and return to *Workspaces*.
 . Search for the ingested data.

--- a/distribution/docs/src/main/resources/content/_running/command-scheduler.adoc
+++ b/distribution/docs/src/main/resources/content/_running/command-scheduler.adoc
@@ -27,7 +27,7 @@ See the log for details about failures.
 
 Configure the Command Scheduler to execute a command at specific intervals.
 
-. Navigate to the *${admin-console}* (${secure_url}/admin).
+. Navigate to the *${admin-console}* (\${secure_url}/admin).
 . Select the *${ddf-platform}* application.
 . Click on the *Configuration* tab.
 . Select *Platform Command Scheduler*.

--- a/distribution/docs/src/main/resources/content/_running/monitoring.adoc
+++ b/distribution/docs/src/main/resources/content/_running/monitoring.adoc
@@ -113,7 +113,7 @@ This is the most popular format for access logs and can be parsed by many web se
 
 Monitor system logs with the *LogViewer*, a convenient "viewing portal" for incoming logs.
 
-* Navigate to the LogViewer at ${secure_url}/admin/logviewer
+* Navigate to the LogViewer at \${secure_url}/admin/logviewer
 
 or
 

--- a/distribution/docs/src/main/resources/content/_securityFramework/guest-interceptor.adoc
+++ b/distribution/docs/src/main/resources/content/_securityFramework/guest-interceptor.adoc
@@ -20,7 +20,7 @@ The `GuestInterceptor` is installed by default with ${ddf-security} Application.
 
 Configure the Guest Interceptor from the ${admin-console}:
 
-. Navigate to the *${admin-console}* at ${secure_url}/admin
+. Navigate to the *${admin-console}* at \${secure_url}/admin
 . Select the *${ddf-security}* application.
 . Select the *Configuration* tab.
 . Select the *Security STS Guest Claims Handler* configuration.

--- a/distribution/docs/src/main/resources/content/_tables/Confluence_Federated_Source.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/Confluence_Federated_Source.adoc
@@ -25,7 +25,7 @@
 |Confluence Rest URL
 |endpointUrl
 |String
-|The Confluence Rest API endpoint URL. Example: ${secure_url}/rest/api/content
+|The Confluence Rest API endpoint URL. Example: \${secure_url}/rest/api/content
 |
 |Yes
 

--- a/distribution/docs/src/main/resources/content/_tables/EmailNotifier.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/EmailNotifier.adoc
@@ -27,7 +27,7 @@
 |bodyTemplate
 |String
 |Set the body template.
-|The workspace '%[attribute=title]' contains up to %[hitCount] results. Log in to see results ${secure_url}/search/catalog/#workspaces/% [attribute=id].
+|The workspace '%[attribute=title]' contains up to %[hitCount] results. Log in to see results \${secure_url}/search/catalog/#workspaces/% [attribute=id].
 |true
 
 |Mail Server

--- a/distribution/docs/src/main/resources/content/_tables/OpenSearchSource.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/OpenSearchSource.adoc
@@ -26,7 +26,7 @@
 |OpenSearch service URL
 |endpointUrl
 |String
-|The OpenSearch endpoint URL or DDF's OpenSearch endpoint (${secure_url}/services/catalog/query)
+|The OpenSearch endpoint URL or DDF's OpenSearch endpoint (\${secure_url}/services/catalog/query)
 |${org.codice.ddf.system.protocol}${org.codice.ddf.system.hostname}:${org.codice.ddf.system.port}${org.codice.ddf.system.rootContext}/catalog/query
 |true
 

--- a/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
@@ -16,7 +16,7 @@ To exit this mode, click the `?` again or press `escape`.
 
 === Accessing ${catalog-ui}
 
-The default URL for ${catalog-ui} is ${secure_url}/search/catalog
+The default URL for ${catalog-ui} is \${secure_url}/search/catalog
 
 .Catalog UI Guest Users
 [NOTE]

--- a/distribution/docs/src/main/resources/content/_using/using-landing-page.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-landing-page.adoc
@@ -6,7 +6,7 @@
 :order: 00
 
 The ${branding} Landing Page is the starting point for using ${branding}.
-It is accessible at ${secure_url}.
+It is accessible at \${secure_url}.
 
 === Search ${branding} Button
 

--- a/pom.xml
+++ b/pom.xml
@@ -200,9 +200,9 @@
         <ddf-branding>DDF</ddf-branding>
         <ddf-branding-lowercase>ddf</ddf-branding-lowercase>
         <ddf-branding-expanded>Distributed Data Framework</ddf-branding-expanded>
-        <!--default url substitutions-->
-        <public_url>\http://{FQDN}:{PORT}</public_url>
-        <secure_url>\https://{FQDN}:{PORT}</secure_url>
+        <!--default url substitutions: preface with a \ to disable automatic hyperlinking-->
+        <public_url>http://{FQDN}:{PORT}</public_url>
+        <secure_url>https://{FQDN}:{PORT}</secure_url>
         <home_directory>&lt;DDF_HOME&gt;</home_directory>
         <!--Needed for documentation formatting
             '@' is an escape character for maven filtering. Use this property if '@'


### PR DESCRIPTION
#### What does this PR do?

Fixes sample default/url formatting for documentation. It has been overgeneralizing the formatting caused pre-formatted code sections to display an unnecessary leading `\` character.

#### Who is reviewing it? 

@mcalcote @vinamartin @ahoffer @garrettfreibott 

#### Choose 2 committers to review/merge the PR. 
@clockard
@coyotesqrl
@lessarderic
@ricklarsen - Documentation
@rzwiefel
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

These default urls should not be displayed as links, but they should not have the escape slash at the beginning either

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
