### PR TITLE
[2.11.x] DDF-3614 Modified config admin migratable to export config objects to a separate folder

### DIFF
--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ExportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ExportMigrationConfigurationAdminContext.java
@@ -47,6 +47,8 @@ public class ExportMigrationConfigurationAdminContext {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ExportMigrationConfigurationAdminContext.class);
 
+  private static final Path ADMIN_PATH = Paths.get("admin");
+
   private final ExportMigrationContext context;
 
   private final ConfigurationAdminMigratable admin;
@@ -170,8 +172,8 @@ public class ExportMigrationConfigurationAdminContext {
       path = constructPathForBasename(configuration);
     }
     // ignore the whole path if any (there shouldn't be any other than etc) and force it to be under
-    // etc
-    return Paths.get("etc").resolve(path.getFileName());
+    // admin in the exported file
+    return ExportMigrationConfigurationAdminContext.ADMIN_PATH.resolve(path.getFileName());
   }
 
   private Path constructPathForBasename(Configuration configuration) {

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
@@ -57,6 +57,8 @@ public class ImportMigrationConfigurationAdminContext {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ImportMigrationConfigurationAdminContext.class);
 
+  private static final Path ETC_PATH = Paths.get("etc");
+
   private final ImportMigrationContext context;
 
   private final ConfigurationAdminMigratable admin;
@@ -226,7 +228,7 @@ public class ImportMigrationConfigurationAdminContext {
     }
     // ignore the whole path if any (there shouldn't be any other than etc) and force it to be under
     // etc
-    return Paths.get("etc").resolve(path.getFileName());
+    return ImportMigrationConfigurationAdminContext.ETC_PATH.resolve(path.getFileName());
   }
 
   private Dictionary<String, Object> readProperties(


### PR DESCRIPTION
#### What does this PR do?
It modifies the config admin migratable to export the config objects into a different folder from etc to prevent collision if actual config files from etc are exported.

#### Who is reviewing it? 
@emanns95 
@tbatie 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@figliold

#### How should this be tested? (List steps with links to updated documentation)
- Install DDF and make changes to config
- Perform a `migration:export` 
- Preserve the 3 files exported
- Re-install DDF
- Perform `migration:import` 
- Verify that the system is reconfigured as it was

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3614](https://codice.atlassian.net/browseDDF-3614/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
