### PR TITLE
DDF-3622 Adds admin config for list templates

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -164,6 +164,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   private Map<String, String> attributeDescriptions = Collections.emptyMap();
 
+  private List<String> listTemplates = Collections.emptyList();
+
   private int sourcePollInterval = 60000;
 
   private String uiName;
@@ -238,6 +240,10 @@ public class ConfigurationApplication implements SparkApplication {
     return hiddenAttributes;
   }
 
+  public List<String> getListTemplates() {
+    return listTemplates;
+  }
+
   public List<String> getAttributeDescriptions() {
     return attributeDescriptions
         .entrySet()
@@ -276,6 +282,10 @@ public class ConfigurationApplication implements SparkApplication {
 
   public void setHiddenAttributes(List<String> hiddenAttributes) {
     this.hiddenAttributes = hiddenAttributes;
+  }
+
+  public void setListTemplates(List<String> listTemplates) {
+    this.listTemplates = listTemplates;
   }
 
   public void setAttributeDescriptions(List<String> attributeDescriptions) {
@@ -370,6 +380,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("summaryShow", summaryShow);
     config.put("resultShow", resultShow);
     config.put("hiddenAttributes", hiddenAttributes);
+    config.put("listTemplates", listTemplates);
     config.put("attributeDescriptions", attributeDescriptions);
     config.put("attributeAliases", attributeAliases);
     config.put("sourcePollInterval", sourcePollInterval);

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.config.xml
@@ -42,6 +42,14 @@
             type="String"
             default='[{"type": "stack", "content": [{"type": "component", "component": "cesium", "componentName": "cesium", "title": "3D Map"}, {"type": "component", "component": "inspector", "componentName": "inspector", "title": "Inspector"}]}]'
             required="true"/>
+
+        <AD id="listTemplates"
+            name="List Templates"
+            description='Templates for users to quickly create lists that already specify an icon and a filter. Example: {"id":"Pizza Deliveries", "list.icon": "tasks", "list.cql": "(\"anyText\" ILIKE &apos;pizza&apos;)"} '
+            type="String"
+            cardinality="10000"
+            default=''
+            required="false"/>
             
         <AD id="projection"
             name="Map Projection"

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/list-create/list-create.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/list-create/list-create.view.js
@@ -55,7 +55,8 @@ module.exports = Marionette.LayoutView.extend({
   showListEditor: function() {
     this.listEditor.show(
       new ListEditorView({
-        model: new List()
+        model: new List(),
+        showListTemplates: true
       })
     );
   },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.hbs
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.hbs
@@ -15,6 +15,9 @@
     <div class="list-title">
 
     </div>
+    <div class="list-template">
+
+    </div>
     <div class="list-limiting-switch">
 
     </div>

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.less
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.less
@@ -55,3 +55,11 @@
     display: block;
   }
 }
+
+@{customElementNamespace}list-editor.is-template {
+  .list-limiting-switch,
+  .list-limiting,
+  .list-icon {
+    display: none;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.view.js
@@ -25,6 +25,7 @@ var Property = require('component/property/property');
 var List = require('js/model/List');
 var DropdownView = require('component/dropdown/popout/dropdown.popout.view');
 var ListFilterView = require('component/result-filter/list/result-filter.list.view');
+var properties = require('properties');
 
 module.exports = Marionette.LayoutView.extend({
   tagName: CustomElements.register('list-editor'),
@@ -35,12 +36,15 @@ module.exports = Marionette.LayoutView.extend({
   },
   regions: {
     listTitle: '.list-title',
+    listTemplate: '.list-template',
     listCQLSwitch: '.list-limiting-switch',
     listCQL: '.list-limiting',
     listIcon: '.list-icon'
   },
+  listTemplateId: 'custom',
   onBeforeShow: function() {
     this.showListTitle();
+    this.showListTemplate();
     this.showCQLSwitch();
     this.showCQL();
     this.showIcon();
@@ -55,6 +59,37 @@ module.exports = Marionette.LayoutView.extend({
         type: 'TEXT'
       })
     );
+  },
+  handleListTemplate() {
+    this.$el.toggleClass('is-template', this.listTemplateId !== 'custom');
+  },
+  showListTemplate() {
+    if (this.options.showListTemplates === true) {
+      const propertyModel = new Property({
+          label: 'Template',
+          value: [this.listTemplateId],
+          enum: [{
+            label: 'Custom',
+            value: 'custom'
+          }].concat(properties.listTemplates.map(template =>
+            ({
+              label: template.id,
+              value: template.id,
+              class: List.getIconMapping()[template['list.icon']]
+            })
+          )),
+          id: 'Template'
+      });
+      this.listTemplate.show(new PropertyView({
+          model: propertyModel
+      }));
+      this.listTemplate.currentView.turnOnLimitedWidth();
+      this.listTemplate.currentView.turnOnEditing();
+      this.listenTo(propertyModel, 'change:value', () => {
+        this.listTemplateId = propertyModel.getValue()[0];
+        this.handleListTemplate();
+      });
+    }
   },
   showCQLSwitch: function() {
     this.listCQLSwitch.show(
@@ -128,18 +163,23 @@ module.exports = Marionette.LayoutView.extend({
     this.$el.trigger('closeDropdown.' + CustomElements.getNamespace());
   },
   saveIcon: function() {
-    this.model.set('list.icon', this.listIcon.currentView.model.getValue()[0]);
+    const icon = this.listTemplateId === 'custom' ?
+      this.listIcon.currentView.model.getValue()[0] :
+      properties.listTemplates.filter((template) => template.id === this.listTemplateId)[0]['list.icon'];
+    this.model.set('list.icon', icon);
   },
   saveTitle: function() {
     this.model.set('title', this.listTitle.currentView.model.getValue()[0]);
   },
   saveCQL: function() {
-    var shouldLimit = this.listCQLSwitch.currentView.model.getValue()[0];
-    if (shouldLimit) {
-      this.model.set('list.cql', this.listCQL.currentView.model.getValue());
-    } else {
-      this.model.set('list.cql', '');
+    const shouldLimit = this.listCQLSwitch.currentView.model.getValue()[0];
+    let cql = '';
+    if (this.listTemplateId !== 'custom') {
+      cql = properties.listTemplates.filter((template) => template.id === this.listTemplateId)[0]['list.cql'];
+    } else if (shouldLimit === true) {
+      cql = this.listCQL.currentView.model.getValue();
     }
+    this.model.set('list.cql', cql);
   },
   save: function() {
     this.saveTitle();

--- a/catalog/ui/catalog-ui-search/src/main/webapp/properties.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/properties.js
@@ -90,7 +90,22 @@ define(function (require) {
             this.handleFeedback();
             this.handleExperimental();
             this.handleUpload();
+            this.handleListTemplates();
+
             return props;
+        },
+        handleListTemplates: function() {
+            try {
+                this.listTemplates = this.listTemplates.map(JSON.parse);
+            }
+            catch (error) {
+                /*
+                    would be a good to start reporting errors like this to a log that can alert admins
+                    or update the admin interface to include validation that prevents errors like this
+                    ideally both
+                */
+                this.listTemplates = [];
+            }
         },
         handleEditing: function(){
             $('html').toggleClass('is-editing-restricted', this.isEditingRestricted());


### PR DESCRIPTION
#### What does this PR do?
 - Allows the admin to specify commonly created lists for users to utilize.

#### Who is reviewing it? 
@bdeining
@millerw8
@djblue 
@mackncheesiest 

#### How should this be tested? (List steps with links to updated documentation)
Go to the admin UI and add a new template like:
`{"id":"Pizza Deliveries", "list.icon": "tasks", "list.cql": "(\"anyText\" ILIKE 'pizza')"}`

#### What are the relevant tickets?
[3622](https://codice.atlassian.net/browse/DDF-3622)

#### Screenshots (if appropriate)
![screen shot 2018-02-13 at 4 51 40 pm](https://user-images.githubusercontent.com/11984853/36180735-e202068c-10de-11e8-8ac7-ce39c66b5f5c.png)
![screen shot 2018-02-13 at 4 52 41 pm](https://user-images.githubusercontent.com/11984853/36180734-e1e7b2b4-10de-11e8-8135-1113f59e91a0.png)
![screen shot 2018-02-13 at 4 52 48 pm](https://user-images.githubusercontent.com/11984853/36180733-e1c70eba-10de-11e8-9749-a8d016ebbfa4.png)
![screen shot 2018-02-13 at 4 53 02 pm](https://user-images.githubusercontent.com/11984853/36180732-e1a70cc8-10de-11e8-8253-f943195be42f.png)

