### PR TITLE
DDF-3623 Set setUseHttpsURLConnectionDefaultHostnameVerifier to false if disabling CN checks

### DIFF
--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
@@ -435,7 +435,7 @@ public class SecureCxfClientFactory<T> {
 
     tlsParams.setDisableCNCheck(disableCnCheck);
 
-    tlsParams.setUseHttpsURLConnectionDefaultHostnameVerifier(true);
+    tlsParams.setUseHttpsURLConnectionDefaultHostnameVerifier(!disableCnCheck);
     String cipherSuites = System.getProperty("https.cipherSuites");
     if (cipherSuites != null) {
       tlsParams.setCipherSuites(Arrays.asList(cipherSuites.split(",")));


### PR DESCRIPTION
#### What does this PR do?
Changes SecureCxfClientFactory to only set setUseHttpsURLConnectionDefaultHostnameVerifier to true when disableCNChecks is false.

#### Who is reviewing it? 
@mackncheesiest 
@mojogitoverhere 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full build with tests.

#### Any background context you want to provide?
Per the javadoc we shouldn't have been setting that parameter to true when we were setting disableCNChecks to true: https://github.com/apache/cxf/blob/master/core/src/main/java/org/apache/cxf/configuration/jsse/TLSClientParameters.java#L127-L132

#### What are the relevant tickets?
[DDF-3623](https://codice.atlassian.net/browse/DDF-3623)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
