### PR TITLE
DDF-3570 Allows a SecureCXFClient supporting redirects to the same URL multiple times

### DIFF
--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
@@ -101,6 +101,15 @@ public class SecureCxfClientFactory<T> {
 
   private static final Integer DEFAULT_RECEIVE_TIMEOUT = 60000;
 
+  private static final String AUTO_REDIRECT_ALLOW_REL_URI = "http.redirect.relative.uri";
+
+  private static final String AUTO_REDIRECT_MAX_SAME_URI_COUNT = "http.redirect.max.same.uri.count";
+
+  // a seemingly magic number.  Needs at least 2 so that it can come back with authentication
+  // cookies.  Set one higher for safety.  The trade-off is failing to catch a loop vs cutting
+  // off a server before it is fully authenticated.  Any small number seems to be a safe option
+  private static final int SAME_URI_REDIRECT_MAX = 3;
+
   private boolean basicAuth = false;
 
   private Integer connectionTimeout;
@@ -423,7 +432,8 @@ public class SecureCxfClientFactory<T> {
         clientPolicy.setAutoRedirect(true);
         Bus bus = clientConfig.getBus();
         if (bus != null) {
-          bus.getProperties().put("http.redirect.relative.uri", true);
+          bus.getProperties().put(AUTO_REDIRECT_ALLOW_REL_URI, true);
+          bus.getProperties().put(AUTO_REDIRECT_MAX_SAME_URI_COUNT, SAME_URI_REDIRECT_MAX);
         }
       }
     }

--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/SecureCxfClientFactory.java
@@ -101,14 +101,14 @@ public class SecureCxfClientFactory<T> {
 
   private static final Integer DEFAULT_RECEIVE_TIMEOUT = 60000;
 
+  // A default small value greater than one to handle loopbacks after validation.  Configurable
+  private static final Integer SAME_URI_REDIRECT_MAX = 3;
+
   private static final String AUTO_REDIRECT_ALLOW_REL_URI = "http.redirect.relative.uri";
 
   private static final String AUTO_REDIRECT_MAX_SAME_URI_COUNT = "http.redirect.max.same.uri.count";
 
-  // a seemingly magic number.  Needs at least 2 so that it can come back with authentication
-  // cookies.  Set one higher for safety.  The trade-off is failing to catch a loop vs cutting
-  // off a server before it is fully authenticated.  Any small number seems to be a safe option
-  private static final int SAME_URI_REDIRECT_MAX = 3;
+  private Integer sameUriRedirectMax = SAME_URI_REDIRECT_MAX;
 
   private boolean basicAuth = false;
 
@@ -374,6 +374,18 @@ public class SecureCxfClientFactory<T> {
     return newClient;
   }
 
+  public Integer getSameUriRedirectMax() {
+    return sameUriRedirectMax;
+  }
+
+  public void setSameUriRedirectMax(Integer sameUriRedirectMax) {
+    if (sameUriRedirectMax != null && sameUriRedirectMax > 0) {
+      this.sameUriRedirectMax = sameUriRedirectMax;
+    } else {
+      LOGGER.warn("Cannot set redirect to invalid value: {}", sameUriRedirectMax);
+    }
+  }
+
   private void auditRemoteConnection(String asciiString) {
     try {
       URI uri = new URI(asciiString);
@@ -433,7 +445,7 @@ public class SecureCxfClientFactory<T> {
         Bus bus = clientConfig.getBus();
         if (bus != null) {
           bus.getProperties().put(AUTO_REDIRECT_ALLOW_REL_URI, true);
-          bus.getProperties().put(AUTO_REDIRECT_MAX_SAME_URI_COUNT, SAME_URI_REDIRECT_MAX);
+          bus.getProperties().put(AUTO_REDIRECT_MAX_SAME_URI_COUNT, getSameUriRedirectMax());
         }
       }
     }


### PR DESCRIPTION
Allows a SecureCXFClient supporting redirects the ability to go through the same URL multiple times

#### What does this PR do?
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
@codice/security 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3570](https://codice.atlassian.net/browse/DDF-3570)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
