### PR TITLE
DDF-3626: Add timeout to catalog:removeall command in itests

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -125,6 +125,8 @@ public abstract class AbstractIntegrationTest {
 
   public static final String REMOVE_ALL = "catalog:removeall -f -p";
 
+  protected static final long REMOVE_ALL_TIMEOUT = TimeUnit.MINUTES.toMillis(5);
+
   private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
 
   private static final File UNPACK_DIRECTORY = new File("target/exam");
@@ -807,7 +809,8 @@ public abstract class AbstractIntegrationTest {
   }
 
   public void clearCatalog() {
-    console.runCommand(REMOVE_ALL);
+    String output = console.runCommand(REMOVE_ALL, REMOVE_ALL_TIMEOUT);
+    LOGGER.debug("{} output: {}", REMOVE_ALL, output);
   }
 
   public void clearCache() {

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -38,7 +38,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.useOwnExa
 
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.response.ValidatableResponse;
-import com.sun.istack.NotNull;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -60,6 +59,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.io.FileUtils;
@@ -92,12 +92,16 @@ import org.slf4j.LoggerFactory;
 /** Abstract integration test with helper methods and configuration at the container level */
 public abstract class AbstractIntegrationTest {
 
+  @SuppressWarnings({"squid:S1075" /* resource path should use forward slashes */})
   public static final String JSON_RECORD_RESOURCE_PATH = "/json/record";
 
+  @SuppressWarnings({"squid:S1075" /* resource path should use forward slashes */})
   public static final String CSW_RECORD_RESOURCE_PATH = "/csw/record";
 
+  @SuppressWarnings({"squid:S1075" /* resource path should use forward slashes */})
   public static final String XML_RECORD_RESOURCE_PATH = "/xml/record";
 
+  @SuppressWarnings({"squid:S1075" /* resource path should use forward slashes */})
   public static final String CSW_REQUEST_RESOURCE_PATH = "/csw/request";
 
   protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractIntegrationTest.class);
@@ -125,7 +129,7 @@ public abstract class AbstractIntegrationTest {
 
   public static final String REMOVE_ALL = "catalog:removeall -f -p";
 
-  protected static final long REMOVE_ALL_TIMEOUT = TimeUnit.MINUTES.toMillis(5);
+  public static final long REMOVE_ALL_TIMEOUT = TimeUnit.MINUTES.toMillis(5);
 
   private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
 
@@ -160,6 +164,14 @@ public abstract class AbstractIntegrationTest {
   private CatalogBundle catalogBundle;
 
   private UrlResourceReaderConfigurator urlResourceReaderConfigurator;
+
+  private static final String MVN_LOCAL_REPO = "maven.repo.local";
+
+  private static final String PAX_URL_MVN_LOCAL_REPO = "org.ops4j.pax.url.mvn.localRepository";
+
+  private static final String SYSTEM_PROPERTIES_REL_PATH = "etc/system.properties";
+
+  private static final String DDF_ITESTS_GROUP_ID = "ddf.test.itests";
 
   protected static final String[] DEFAULT_REQUIRED_APPS = {
     "catalog-app", "solr-app", "spatial-app", "sdk-app"
@@ -319,12 +331,14 @@ public abstract class AbstractIntegrationTest {
 
   static {
     // Make Pax URL use the maven.repo.local setting if present
-    if (System.getProperty("maven.repo.local") != null) {
-      System.setProperty(
-          "org.ops4j.pax.url.mvn.localRepository", System.getProperty("maven.repo.local"));
+    if (System.getProperty(MVN_LOCAL_REPO) != null) {
+      System.setProperty(PAX_URL_MVN_LOCAL_REPO, System.getProperty(MVN_LOCAL_REPO));
     }
   }
 
+  @SuppressWarnings({
+    "squid:S2696" /* writing to static ddfHome to share state between test methods */
+  })
   @PostTestConstruct
   public void initFacades() {
     ddfHome = System.getProperty(DDF_HOME_PROPERTY);
@@ -344,6 +358,9 @@ public abstract class AbstractIntegrationTest {
     console = new KarafConsole(getServiceManager().getBundleContext(), features, sessionFactory);
   }
 
+  @SuppressWarnings({
+    "squid:S2696" /* writing to static basePort to share state between test methods */
+  })
   public void waitForBaseSystemFeatures() {
     try {
       basePort = getBasePort();
@@ -362,10 +379,10 @@ public abstract class AbstractIntegrationTest {
     }
   }
 
-  public void waitForSystemReady() throws Exception {
+  public void waitForSystemReady() {
     SystemStateManager manager =
         SystemStateManager.getManager(serviceManager, features, adminConfig, console);
-    manager.setSystemBaseState(() -> waitForBaseSystemFeatures(), false);
+    manager.setSystemBaseState(this::waitForBaseSystemFeatures, false);
     manager.waitForSystemBaseState();
   }
 
@@ -374,6 +391,9 @@ public abstract class AbstractIntegrationTest {
    *
    * @return list of pax exam options
    */
+  @SuppressWarnings({
+    "squid:S2696" /* writing to static basePort to share state between test methods */
+  })
   @org.ops4j.pax.exam.Configuration
   public Option[] config() throws URISyntaxException, IOException {
     basePort = findPortNumber(20000);
@@ -455,24 +475,24 @@ public abstract class AbstractIntegrationTest {
             "etc/users.properties",
             SYSTEM_ADMIN_USER,
             SYSTEM_ADMIN_USER_PASSWORD + ",system-admin"),
-        editConfigurationFilePut("etc/system.properties", "ddf.home", "${karaf.home}"),
-        editConfigurationFilePut("etc/system.properties", "maven.home", "${user.home}"),
-        editConfigurationFilePut("etc/system.properties", "M2_HOME", "${user.home}"),
+        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, DDF_HOME_PROPERTY, "${karaf.home}"),
+        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "maven.home", "${user.home}"),
+        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "M2_HOME", "${user.home}"),
         editConfigurationFilePut(
-            "etc/system.properties", HTTP_PORT.getSystemProperty(), HTTP_PORT.getPort()),
+            SYSTEM_PROPERTIES_REL_PATH, HTTP_PORT.getSystemProperty(), HTTP_PORT.getPort()),
         editConfigurationFilePut(
-            "etc/system.properties", HTTPS_PORT.getSystemProperty(), HTTPS_PORT.getPort()),
+            SYSTEM_PROPERTIES_REL_PATH, HTTPS_PORT.getSystemProperty(), HTTPS_PORT.getPort()),
         editConfigurationFilePut(
-            "etc/system.properties", DEFAULT_PORT.getSystemProperty(), DEFAULT_PORT.getPort()),
+            SYSTEM_PROPERTIES_REL_PATH, DEFAULT_PORT.getSystemProperty(), DEFAULT_PORT.getPort()),
         editConfigurationFilePut(
-            "etc/system.properties", BASE_PORT.getSystemProperty(), BASE_PORT.getPort()),
+            SYSTEM_PROPERTIES_REL_PATH, BASE_PORT.getSystemProperty(), BASE_PORT.getPort()),
 
         // DDF-1572: Disables the periodic backups of .bundlefile. In itests, having those
         // backups serves no purpose and it appears that intermittent failures have occurred
         // when the background thread attempts to create the backup before the exam bundle
         // is completely exploded.
         editConfigurationFilePut(
-            "etc/system.properties", "eclipse.enableStateSaver", Boolean.FALSE.toString()),
+            SYSTEM_PROPERTIES_REL_PATH, "eclipse.enableStateSaver", Boolean.FALSE.toString()),
         editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", SSH_PORT.getPort()),
         editConfigurationFilePut(
             "etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port", HTTP_PORT.getPort()),
@@ -513,31 +533,31 @@ public abstract class AbstractIntegrationTest {
                 + "http://repository.springsource.com/maven/bundles/release@id=springsource,"
                 + "http://repository.springsource.com/maven/bundles/external@id=springsourceext,"
                 + "http://oss.sonatype.org/content/repositories/releases/@id=sonatype"),
-        when(System.getProperty("maven.repo.local") != null)
+        when(System.getProperty(MVN_LOCAL_REPO) != null)
             .useOptions(
                 editConfigurationFilePut(
                     "etc/org.ops4j.pax.url.mvn.cfg",
-                    "org.ops4j.pax.url.mvn.localRepository",
-                    System.getProperty("maven.repo.local"))));
+                    PAX_URL_MVN_LOCAL_REPO,
+                    System.getProperty(MVN_LOCAL_REPO))));
   }
 
   protected Option[] configureSystemSettings() {
     return options(
         when(Boolean.getBoolean("isDebugEnabled"))
             .useOptions(vmOption("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005")),
-        when(System.getProperty("maven.repo.local") != null)
+        when(System.getProperty(MVN_LOCAL_REPO) != null)
             .useOptions(
-                systemProperty("org.ops4j.pax.url.mvn.localRepository")
-                    .value(System.getProperty("maven.repo.local", ""))),
+                systemProperty(PAX_URL_MVN_LOCAL_REPO)
+                    .value(System.getProperty(MVN_LOCAL_REPO, ""))),
         editConfigurationFilePut(
-            "etc/system.properties",
+            SYSTEM_PROPERTIES_REL_PATH,
             "org.codice.ddf.system.version",
-            MavenUtils.getArtifactVersion("ddf.test.itests", "test-itests-common")),
+            MavenUtils.getArtifactVersion(DDF_ITESTS_GROUP_ID, "test-itests-common")),
         editConfigurationFilePut(
-            "etc/system.properties",
+            SYSTEM_PROPERTIES_REL_PATH,
             "ddf.version",
-            MavenUtils.getArtifactVersion("ddf.test.itests", "test-itests-common")),
-        editConfigurationFilePut("etc/system.properties", "artemis.diskusage", "100"));
+            MavenUtils.getArtifactVersion(DDF_ITESTS_GROUP_ID, "test-itests-common")),
+        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "artemis.diskusage", "100"));
   }
 
   protected Option[] configureLogLevel() {
@@ -559,7 +579,7 @@ public abstract class AbstractIntegrationTest {
                     createSetLogLevelOption(
                         "ddf.security.service.impl.AbstractAuthorizingRealm", securityLogLevel))),
         editConfigurationFilePut(
-            "etc/org.ops4j.pax.logging.cfg",
+            LOGGER_CONFIGURATION_FILE_PATH,
             "log4j2.logger.org_apache_activemq_artemis.additivity",
             "true"));
   }
@@ -610,7 +630,7 @@ public abstract class AbstractIntegrationTest {
         junitBundles(),
         features(
             maven()
-                .groupId("ddf.test.itests")
+                .groupId(DDF_ITESTS_GROUP_ID)
                 .artifactId("test-itests-dependencies-app")
                 .type("xml")
                 .classifier("features")
@@ -640,16 +660,16 @@ public abstract class AbstractIntegrationTest {
     } catch (IOException e) {
       LoggingUtils.failWithThrowableStacktrace(e, "Failed to deploy configuration files: ");
     }
-    return null;
+    return new Option[0];
   }
 
   private Option[] configureEmbeddedSolr() {
     return options(
-        editConfigurationFilePut("etc/system.properties", "solr.client", "EmbeddedSolrServer"),
-        editConfigurationFilePut("etc/system.properties", "solr.http.url", ""),
+        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "solr.client", "EmbeddedSolrServer"),
+        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "solr.http.url", ""),
         editConfigurationFilePut(
-            "etc/system.properties", "solr.data.dir", "${karaf.home}/data/solr"),
-        editConfigurationFilePut("etc/system.properties", "solr.cloud.zookeeper", ""));
+            SYSTEM_PROPERTIES_REL_PATH, "solr.data.dir", "${karaf.home}/data/solr"),
+        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "solr.cloud.zookeeper", ""));
   }
 
   /**
@@ -738,6 +758,9 @@ public abstract class AbstractIntegrationTest {
    * @param classRelativeToResource
    * @return
    */
+  @SuppressWarnings({
+    "squid:S00112" /* A generic RuntimeException is perfectly reasonable in this case. */
+  })
   public static String getFileContent(
       String filePath, ImmutableMap<String, String> params, Class classRelativeToResource) {
 

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/KarafConsole.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/KarafConsole.java
@@ -86,4 +86,8 @@ public class KarafConsole extends KarafTestSupport {
   public String runCommand(String command) {
     return executeCommand(command, DEFAULT_ROLES);
   }
+
+  public String runCommand(String command, long timeout) {
+    return executeCommand(command, timeout, false, DEFAULT_ROLES);
+  }
 }

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/KarafConsole.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/KarafConsole.java
@@ -87,6 +87,15 @@ public class KarafConsole extends KarafTestSupport {
     return executeCommand(command, DEFAULT_ROLES);
   }
 
+  /**
+   * Runs a shell command and returns output as a String. The command will timeout after the
+   * supplied timeout (in milliseconds). Uses the DEFAULT_ROLES to execute the command as an
+   * administrator.
+   *
+   * @param command command to execute. Cannot be {@code null}.
+   * @param timeout command timeout in milliseconds.
+   * @return command output. Can be empty but not {@code null}.
+   */
   public String runCommand(String command, long timeout) {
     return executeCommand(command, timeout, false, DEFAULT_ROLES);
   }

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/SystemStateManager.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/SystemStateManager.java
@@ -13,6 +13,9 @@
  */
 package org.codice.ddf.itests.common;
 
+import static org.codice.ddf.itests.common.AbstractIntegrationTest.REMOVE_ALL;
+import static org.codice.ddf.itests.common.AbstractIntegrationTest.REMOVE_ALL_TIMEOUT;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Dictionary;
@@ -170,7 +173,8 @@ public class SystemStateManager {
       serviceManager.waitForAllBundles();
 
       // reset the catalog
-      console.runCommand("catalog:removeall -f -p");
+      String output = console.runCommand(REMOVE_ALL, REMOVE_ALL_TIMEOUT);
+      LOGGER.debug("{} output: {}", REMOVE_ALL, output);
       console.runCommand("catalog:removeall -f -p --cache");
 
       console.runCommand(


### PR DESCRIPTION
#### What does this PR do?
Increases the timeout for the catalog:removeall commad in itests

#### Who is reviewing it? 
@tbatie 
@emanns95 
@paouelle 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard
@rzwiefel 
#### How should this be tested? (List steps with links to updated documentation)
CI build
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3626
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
