### PR TITLE
DDF-3515 Updates List search federation to always be enterprise

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/List.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/List.js
@@ -78,7 +78,10 @@ module.exports = Backbone.AssociatedModel.extend({
     }],
     initialize: function() {
         this.set('query', new Query.Model({
-            cql: generateCql(this.get('list.bookmarks'))
+            cql: generateCql(this.get('list.bookmarks')),
+            federation: 'enterprise',
+            sortField: 'modified',
+            sortOrder: 'descending'
         }));
         this.listenTo(this, 'update:list.bookmarks change:list.bookmarks', this.updateQuery);
     },


### PR DESCRIPTION
#### What does this PR do?
 - If we don't do this, it would be possible for a list to be created using defaults that might restrict its sources.

#### Who is reviewing it? 
@rzwiefel 
@pklinef
@mackncheesiest 
@adimka 

#### How should this be tested? (List steps with links to updated documentation)
Create a list after setting your defaults to something that doesn't include a particular source.  Verify that you can add a result from that source to your list and still retrieve the result when looking at the list.

#### What are the relevant tickets?
[3515](https://codice.atlassian.net/browse/DDF-3515)
