### PR TITLE
DDF-3629 Updates instantiations of new Searches to be more specific

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/List.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/List.js
@@ -78,7 +78,8 @@ module.exports = Backbone.AssociatedModel.extend({
     }],
     initialize: function() {
         this.set('query', new Query.Model({
-            cql: generateCql(this.get('list.bookmarks'))
+            cql: generateCql(this.get('list.bookmarks')),
+            federation: 'enterprise'
         }));
         this.listenTo(this, 'update:list.bookmarks change:list.bookmarks', this.updateQuery);
     },

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.collection.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/model/Workspace.collection.js
@@ -81,7 +81,8 @@ module.exports = Backbone.Collection.extend({
         }
         var queryForWorkspace = new Query.Model({
             title: title,
-            cql: cqlQuery
+            cql: cqlQuery,
+            type: 'text'
         });
         this.create({
             title: title,
@@ -95,7 +96,8 @@ module.exports = Backbone.Collection.extend({
             title: 'Example Local',
             federation: 'local',
             excludeUnnecessaryAttributes: false,
-            cql: "anyText ILIKE '%'"
+            cql: "anyText ILIKE '%'",
+            type: 'basic'
         });
         this.create({
             title: 'Template Local',
@@ -109,7 +111,8 @@ module.exports = Backbone.Collection.extend({
             title: 'Example Federated',
             federation: 'enterprise',
             excludeUnnecessaryAttributes: false,
-            cql: "anyText ILIKE '%'"
+            cql: "anyText ILIKE '%'",
+            type: 'basic'
         });
         this.create({
             title: 'Template Federated',
@@ -122,7 +125,8 @@ module.exports = Backbone.Collection.extend({
         var queryForWorkspace = new Query.Model({
             title: 'Example Location',
             excludeUnnecessaryAttributes: false,
-            cql: "anyText ILIKE '%' AND INTERSECTS(anyGeo, POLYGON((-130.7514 20.6825, -130.7514 44.5780, -65.1230 44.5780, -65.1230 20.6825, -130.7514 20.6825)))"
+            cql: "anyText ILIKE '%' AND INTERSECTS(anyGeo, POLYGON((-130.7514 20.6825, -130.7514 44.5780, -65.1230 44.5780, -65.1230 20.6825, -130.7514 20.6825)))",
+            type: 'basic'
         });
         this.create({
             title: 'Template Location',
@@ -135,7 +139,8 @@ module.exports = Backbone.Collection.extend({
         var queryForWorkspace = new Query.Model({
             title: 'Example Temporal',
             excludeUnnecessaryAttributes: false,
-            cql: 'anyText ILIKE \'%\' AND ("created" AFTER ' + moment().subtract(1, 'days').toISOString() + ')'
+            cql: 'anyText ILIKE \'%\' AND ("created" AFTER ' + moment().subtract(1, 'days').toISOString() + ')',
+            type: 'basic'
         });
         this.create({
             title: 'Template Temporal',

--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/router.js
@@ -135,7 +135,8 @@ define([
                               value: '*',
                               property: '"metacard-tags"'
                           }]
-                        })
+                        }),
+                        federation: 'enterprise'
                     });
                     if (metacardInstance.get('currentQuery')){
                         metacardInstance.get('currentQuery').cancelCurrentSearches();
@@ -168,7 +169,8 @@ define([
                                         property: '"id"'
                                     };
                                 })
-                            })
+                            }),
+                            federation: 'enterprise'
                         });
                         if (alertInstance.get('currentQuery')){
                             alertInstance.get('currentQuery').cancelCurrentSearches();
@@ -214,7 +216,8 @@ define([
                                     value: '-1',
                                     property: '"id"'
                                 })
-                            })
+                            }),
+                            federation: 'enterprise'
                         });
                         if (uploadInstance.get('currentQuery')){
                             uploadInstance.get('currentQuery').cancelCurrentSearches();


### PR DESCRIPTION
#### What does this PR do?
 - Previously these areas would get the defaults for the unspecified attributes.  This could possibly cause issues with attributes like federation being left blank.  Whether or not we should do so for the "create search from geo" is hard to determine.
 - It might be worth exploring doing this in alternative ways.  We could go back and make it so user defaults need to be explicitly mixed in rather than having them as part of the Query defaults for all new queries.  Or we could make a method to apply user defaults and use that where we need it.  Or we could have two different query models, with one that extends the other and simply mixes in the user defaults.  There are a lot of options.

#### Who is reviewing it? 
@djblue 
@rzwiefel 
@birda 
@pklinef

[3629](https://codice.atlassian.net/browse/DDF-3629)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
