### PR TITLE
[2.11.x] DDF-3614 Modified config admin migratable to export config files in addition to objects

### DIFF
--- a/distribution/docs/src/main/resources/content/_architectures/migration-api.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/migration-api.adoc
@@ -105,10 +105,12 @@ while processing an export migration operation. It defines the following methods
 - `ExportMigrationEntry getEntry(Path path)`
 - `Stream<ExportMigrationEntry> entries(Path path)`
 - `Stream<ExportMigrationEntry> entries(Path path, PathMatcher filter)`
+- `Stream<ExportMigrationEntry> entries(Path path, boolean recurse)`
+- `Stream<ExportMigrationEntry> entries(Path path, boolean recurse, PathMatcher filter)`
 
 The `getSystemPropertyReferencedEntry()` methods create a migration entry to track a file referenced by a given system property value. +
 The `getEntry()` method creates a migration entry given the path for a specific file or directory. +
-The `entries()` methods create multiple entries corresponding to all files recursively located underneath a given path with an optional path matcher to filter which files to create entries for.
+The `entries()` methods create multiple entries corresponding to all files recursively (or not) located underneath a given path with an optional path matcher to filter which files to create entries for.
 
 Once an entry is created, it is not stored with the exported data. It is the migratable's responsibility to store the data using one of the entry's provided methods.
 Entries are uniquely identified using a relative path and are specific to each migratable meaning that an entry with the same path in two migratables will not conflict with each other. Each migratable is given its own context (a.k.a. sandbox) to work with.

--- a/platform/migration/platform-migratable-api/src/main/java/org/codice/ddf/migration/ExportMigrationContext.java
+++ b/platform/migration/platform-migratable-api/src/main/java/org/codice/ddf/migration/ExportMigrationContext.java
@@ -165,7 +165,9 @@ public interface ExportMigrationContext extends MigrationContext {
    * @throws SecurityException if a security manager exists and its <code>checkRead()</code> method
    *     doesn't allow read access to the specified path
    */
-  public Stream<ExportMigrationEntry> entries(Path path);
+  public default Stream<ExportMigrationEntry> entries(Path path) {
+    return entries(path, true);
+  }
 
   /**
    * Recursively walks the provided path's tree to create or retrieve (if already created) entries
@@ -184,5 +186,46 @@ public interface ExportMigrationContext extends MigrationContext {
    * @throws SecurityException if a security manager exists and its <code>checkRead()</code> method
    *     doesn't allow read access to the specified path
    */
-  public Stream<ExportMigrationEntry> entries(Path path, PathMatcher filter);
+  public default Stream<ExportMigrationEntry> entries(Path path, PathMatcher filter) {
+    return entries(path, true, filter);
+  }
+
+  /**
+   * Recursively walks (or not) the provided path's tree to create or retrieve (if already created)
+   * entries for all files found and returns existing or new migration entries for each one of them.
+   *
+   * <p><i>Note:</i> Files referenced are assumed to be relative to ${ddf.home} if not defined as
+   * absolute. All paths will automatically be relativized from ${ddf.home} if located underneath.
+   *
+   * @param path the path to the directory to recursively walk
+   * @param recurse <code>true</code> to recurse the specified path's tree; <code>false</code> to
+   *     only list the files located in the specified path
+   * @return a stream of all created or retrieved entries corresponding to all files recursively
+   *     found under <code>path</code>
+   * @throws IllegalArgumentException if <code>path</code> is <code>null</code>
+   * @throws SecurityException if a security manager exists and its <code>checkRead()</code> method
+   *     doesn't allow read access to the specified path
+   */
+  public Stream<ExportMigrationEntry> entries(Path path, boolean recurse);
+
+  /**
+   * Recursively walks (or not) the provided path's tree to create or retrieve (if already created)
+   * entries for all files found that match the provided path filter and returns existing or new
+   * migration entries for each one of them.
+   *
+   * <p><i>Note:</i> Files referenced are assumed to be relative to ${ddf.home} if not defined as
+   * absolute. All paths will automatically be relativized from ${ddf.home} if located underneath.
+   *
+   * @param path the path to the directory to recursively walk
+   * @param recurse <code>true</code> to recurse the specified path's tree; <code>false</code> to
+   *     only list the files located in the specified path
+   * @param filter the path filter to use
+   * @return a stream of all created or retrieved entries corresponding to all files recursively
+   *     found under <code>path</code> which matches the given filter
+   * @throws IllegalArgumentException if <code>path</code> or <code>filter</code> is <code>null
+   * </code>
+   * @throws SecurityException if a security manager exists and its <code>checkRead()</code> method
+   *     doesn't allow read access to the specified path
+   */
+  public Stream<ExportMigrationEntry> entries(Path path, boolean recurse, PathMatcher filter);
 }

--- a/platform/migration/platform-migratable-api/src/test/java/org/codice/ddf/migration/ExportMigrationContextTest.java
+++ b/platform/migration/platform-migratable-api/src/test/java/org/codice/ddf/migration/ExportMigrationContextTest.java
@@ -31,6 +31,7 @@ public class ExportMigrationContextTest {
 
   private final MigrationReport report = Mockito.mock(MigrationReport.class);
 
+  // This will create a mock of the interface to test method delegation later
   private final ExportMigrationContext context =
       Mockito.mock(ExportMigrationContext.class, Mockito.CALLS_REAL_METHODS);
 
@@ -106,26 +107,27 @@ public class ExportMigrationContextTest {
 
   @Test
   public void testEntries() throws Exception {
-    final Path p = Mockito.mock(Path.class);
-    final Stream s = Mockito.mock(Stream.class);
+    final Path path = Mockito.mock(Path.class);
+    final Stream stream = Mockito.mock(Stream.class);
 
-    Mockito.when(context.entries(Mockito.any(), Mockito.anyBoolean())).thenReturn(s);
+    Mockito.when(context.entries(Mockito.any(), Mockito.anyBoolean())).thenReturn(stream);
 
-    Assert.assertThat(context.entries(p), Matchers.sameInstance(s));
+    Assert.assertThat(context.entries(path), Matchers.sameInstance(stream));
 
-    Mockito.verify(context).entries(p, true);
+    Mockito.verify(context).entries(path, true);
   }
 
   @Test
   public void testEntriesWithFilter() throws Exception {
-    final PathMatcher m = Mockito.mock(PathMatcher.class);
-    final Path p = Mockito.mock(Path.class);
-    final Stream s = Mockito.mock(Stream.class);
+    final PathMatcher filter = Mockito.mock(PathMatcher.class);
+    final Path path = Mockito.mock(Path.class);
+    final Stream stream = Mockito.mock(Stream.class);
 
-    Mockito.when(context.entries(Mockito.any(), Mockito.anyBoolean(), Mockito.any())).thenReturn(s);
+    Mockito.when(context.entries(Mockito.any(), Mockito.anyBoolean(), Mockito.any()))
+        .thenReturn(stream);
 
-    Assert.assertThat(context.entries(p, m), Matchers.sameInstance(s));
+    Assert.assertThat(context.entries(path, filter), Matchers.sameInstance(stream));
 
-    Mockito.verify(context).entries(p, true, m);
+    Mockito.verify(context).entries(path, true, filter);
   }
 }

--- a/platform/migration/platform-migratable-api/src/test/java/org/codice/ddf/migration/ExportMigrationContextTest.java
+++ b/platform/migration/platform-migratable-api/src/test/java/org/codice/ddf/migration/ExportMigrationContextTest.java
@@ -13,8 +13,11 @@
  */
 package org.codice.ddf.migration;
 
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.Optional;
 import java.util.function.BiPredicate;
+import java.util.stream.Stream;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -99,5 +102,30 @@ public class ExportMigrationContextTest {
 
     Mockito.verify(context)
         .getSystemPropertyReferencedEntry(Mockito.eq(PROPERTY_NAME), Mockito.any());
+  }
+
+  @Test
+  public void testEntries() throws Exception {
+    final Path p = Mockito.mock(Path.class);
+    final Stream s = Mockito.mock(Stream.class);
+
+    Mockito.when(context.entries(Mockito.any(), Mockito.anyBoolean())).thenReturn(s);
+
+    Assert.assertThat(context.entries(p), Matchers.sameInstance(s));
+
+    Mockito.verify(context).entries(p, true);
+  }
+
+  @Test
+  public void testEntriesWithFilter() throws Exception {
+    final PathMatcher m = Mockito.mock(PathMatcher.class);
+    final Path p = Mockito.mock(Path.class);
+    final Stream s = Mockito.mock(Stream.class);
+
+    Mockito.when(context.entries(Mockito.any(), Mockito.anyBoolean(), Mockito.any())).thenReturn(s);
+
+    Assert.assertThat(context.entries(p, m), Matchers.sameInstance(s));
+
+    Mockito.verify(context).entries(p, true, m);
   }
 }

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratable.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratable.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
  * those and exporting {@link Configuration} objects to configuration files.
  */
 public class ConfigurationAdminMigratable implements Migratable {
+
   /**
    * Holds the current export version.
    *

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ExportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ExportMigrationConfigurationAdminContext.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.felix.fileinstall.internal.DirectoryWatcher;
 import org.codice.ddf.migration.ExportMigrationContext;
+import org.codice.ddf.migration.ExportMigrationEntry;
 import org.codice.ddf.migration.MigrationWarning;
 import org.codice.ddf.platform.io.internal.PersistenceStrategy;
 import org.osgi.service.cm.Configuration;
@@ -48,6 +49,7 @@ public class ExportMigrationConfigurationAdminContext {
       LoggerFactory.getLogger(ExportMigrationConfigurationAdminContext.class);
 
   private static final Path ADMIN_PATH = Paths.get("admin");
+  private static final Path ETC_DIR = Paths.get("etc");
 
   private final ExportMigrationContext context;
 
@@ -55,7 +57,9 @@ public class ExportMigrationConfigurationAdminContext {
 
   private final Set<String> warnedExtensions = new HashSet<>(8);
 
-  private final Map<Path, ExportMigrationConfigurationAdminEntry> entries;
+  private final Set<ExportMigrationEntry> fileEntries;
+
+  private final Map<Path, ExportMigrationConfigurationAdminEntry> memoryEntries;
 
   public ExportMigrationConfigurationAdminContext(
       ExportMigrationContext context, ConfigurationAdminMigratable admin, Configuration[] configs) {
@@ -64,7 +68,11 @@ public class ExportMigrationConfigurationAdminContext {
     Validate.notNull(configs, "invalid null configurations");
     this.context = context;
     this.admin = admin;
-    this.entries =
+    this.fileEntries =
+        context
+            .entries(ExportMigrationConfigurationAdminContext.ETC_DIR, false, admin::isConfigFile)
+            .collect(Collectors.toSet());
+    this.memoryEntries =
         Stream.of(configs)
             .filter(this::isValid)
             .map(this::getEntry)
@@ -105,13 +113,18 @@ public class ExportMigrationConfigurationAdminContext {
     return ConfigurationAdminMigratable.isManagedServiceFactory(cfg);
   }
 
-  public Stream<ExportMigrationConfigurationAdminEntry> entries() {
-    return entries.values().stream();
+  public Stream<ExportMigrationEntry> fileEntries() {
+    return fileEntries.stream();
+  }
+
+  public Stream<ExportMigrationConfigurationAdminEntry> memoryEntries() {
+    return memoryEntries.values().stream();
   }
 
   private ExportMigrationConfigurationAdminEntry getEntry(Configuration configuration) {
     Path path = getPathFromConfiguration(configuration);
-    final String extn = FilenameUtils.getExtension(path.toString());
+    final String pathString = path.toString();
+    final String extn = FilenameUtils.getExtension(pathString);
     PersistenceStrategy ps = admin.getPersister(extn);
 
     if (ps == null) {
@@ -125,7 +138,7 @@ public class ExportMigrationConfigurationAdminContext {
                         "Persistence strategy [%s] is not defined; defaulting to [%s]",
                         extn, ps.getExtension())));
       }
-      path = Paths.get(path.toString() + FilenameUtils.EXTENSION_SEPARATOR + ps.getExtension());
+      path = Paths.get(pathString + FilenameUtils.EXTENSION_SEPARATOR + ps.getExtension());
     }
     return new ExportMigrationConfigurationAdminEntry(context.getEntry(path), configuration, ps);
   }

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ExportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ExportMigrationConfigurationAdminContext.java
@@ -49,6 +49,7 @@ public class ExportMigrationConfigurationAdminContext {
       LoggerFactory.getLogger(ExportMigrationConfigurationAdminContext.class);
 
   private static final Path ADMIN_PATH = Paths.get("admin");
+
   private static final Path ETC_DIR = Paths.get("etc");
 
   private final ExportMigrationContext context;

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.configuration.admin;
 
+import com.google.common.io.Closeables;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,7 +34,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.felix.fileinstall.internal.DirectoryWatcher;
 import org.codice.ddf.migration.ImportMigrationContext;
@@ -58,6 +58,7 @@ public class ImportMigrationConfigurationAdminContext {
       LoggerFactory.getLogger(ImportMigrationConfigurationAdminContext.class);
 
   private static final Path ETC_PATH = Paths.get("etc");
+  private static final Path ADMIN_DIR = Paths.get("admin");
 
   private final ImportMigrationContext context;
 
@@ -104,10 +105,10 @@ public class ImportMigrationConfigurationAdminContext {
         Stream.of(memoryConfigs)
             .filter(ConfigurationAdminMigratable::isManagedServiceFactory)
             .collect(Collectors.groupingBy(Configuration::getFactoryPid));
-    // categorize exported configurations
+    // categorize exported admin configurations
     final ImportMigrationConfigurationAdminEntry[] entries =
         context
-            .entries()
+            .entries(ImportMigrationConfigurationAdminContext.ADMIN_DIR)
             .map(this::proxy)
             .filter(Objects::nonNull)
             .toArray(ImportMigrationConfigurationAdminEntry[]::new);
@@ -125,7 +126,7 @@ public class ImportMigrationConfigurationAdminContext {
     context.getReport().doAfterCompletion(this::deleteUnexportedConfigurationsAfterCompletion);
   }
 
-  public Stream<ImportMigrationConfigurationAdminEntry> entries() {
+  public Stream<ImportMigrationConfigurationAdminEntry> memoryEntries() {
     if (!isValid) {
       return Stream.empty();
     }
@@ -273,7 +274,7 @@ public class ImportMigrationConfigurationAdminContext {
         throw new MigrationException(
             "Import error: failed to read configuration [%s]; %s.", path, e);
       } finally {
-        IOUtils.closeQuietly(is);
+        Closeables.closeQuietly(is);
       }
       // note: we also remove bunde location, factory pid, and pid from the dictionary as we do not
       // want to restore those later
@@ -312,7 +313,7 @@ public class ImportMigrationConfigurationAdminContext {
   }
 
   @SuppressWarnings(
-      "PMD.UnusedFormalParameter" /* report parameter is require as this method is used as a functional interface */)
+      "PMD.UnusedFormalParameter" /* report parameter is required as this method is used as a functional interface */)
   private void deleteUnexportedConfigurationsAfterCompletion(MigrationReport report) {
     if (isValid) {
       Stream.concat(

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
@@ -58,6 +58,7 @@ public class ImportMigrationConfigurationAdminContext {
       LoggerFactory.getLogger(ImportMigrationConfigurationAdminContext.class);
 
   private static final Path ETC_PATH = Paths.get("etc");
+
   private static final Path ADMIN_DIR = Paths.get("admin");
 
   private final ImportMigrationContext context;

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ExportMigrationContextImpl.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ExportMigrationContextImpl.java
@@ -137,27 +137,29 @@ public class ExportMigrationContextImpl extends MigrationContextImpl<ExportMigra
   }
 
   @Override
-  public Stream<ExportMigrationEntry> entries(Path path) {
+  public Stream<ExportMigrationEntry> entries(Path path, boolean recurse) {
     final ExportMigrationEntryImpl entry = new ExportMigrationEntryImpl(this, path);
 
     if (!isDirectory(entry)) {
       return Stream.empty();
     }
-    return FileUtils.listFiles(entry.getFile(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE)
+    return FileUtils.listFiles(
+            entry.getFile(), TrueFileFilter.INSTANCE, recurse ? TrueFileFilter.INSTANCE : null)
         .stream()
         .map(File::toPath)
         .map(this::getEntry);
   }
 
   @Override
-  public Stream<ExportMigrationEntry> entries(Path path, PathMatcher filter) {
+  public Stream<ExportMigrationEntry> entries(Path path, boolean recurse, PathMatcher filter) {
     Validate.notNull(filter, "invalid null path filter");
     final ExportMigrationEntryImpl entry = new ExportMigrationEntryImpl(this, path);
 
     if (!isDirectory(entry)) {
       return Stream.empty();
     }
-    return FileUtils.listFiles(entry.getFile(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE)
+    return FileUtils.listFiles(
+            entry.getFile(), TrueFileFilter.INSTANCE, recurse ? TrueFileFilter.INSTANCE : null)
         .stream()
         .map(File::toPath)
         .map(p -> new ExportMigrationEntryImpl(this, p))

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.fileinstall.internal.DirectoryWatcher;
 import org.apache.karaf.system.SystemService;
@@ -75,10 +76,10 @@ import org.osgi.service.cm.ConfigurationAdmin;
  * /private/var/folders/2j/q2gjqn4s2mv53c2q53_m9d_w0000gn/T/junit4916060293677644046, one would see
  * a similar directory structure to the following:
  *
- * <p>// This is the system exported from: ./ddf ./ddf/etc/DDF_Custom_Mime_Type_Resolver-csw.config
- * ./ddf/Version.txt
+ * <p>// This is the system exported from: ./ddf
+ * ./ddf/admin/DDF_Custom_Mime_Type_Resolver-csw.config ./ddf/Version.txt
  *
- * <p>// This is the system imported into: ./ddf ./ddf/etc ./ddf/Version.txt
+ * <p>// This is the system imported into: ./ddf ./ddf/admin ./ddf/Version.txt
  *
  * <p>// The backup from the imported system will look similar to this:
  * ./exported-1.0-20170816T142400.dar
@@ -294,6 +295,7 @@ public class ConfigurationAdminMigratableTest {
   private void setupConfigAdminForExportSystem() throws Exception {
     Configuration[] configurations = getConfigurationsForExportSystem();
     when(configurationAdminForExport.listConfigurations(isNull())).thenReturn(configurations);
+    when(exportMigrationContext.entries(any(), eq(false), any())).thenReturn(Stream.empty());
   }
 
   private void setupConfigAdminForImportSystem() throws Exception {

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
@@ -33,6 +33,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Dictionary;
@@ -47,6 +48,8 @@ import org.apache.felix.fileinstall.internal.DirectoryWatcher;
 import org.apache.karaf.system.SystemService;
 import org.codice.ddf.configuration.migration.ConfigurationMigrationManager;
 import org.codice.ddf.migration.ExportMigrationContext;
+import org.codice.ddf.migration.ImportMigrationContext;
+import org.codice.ddf.migration.ImportMigrationEntry;
 import org.codice.ddf.migration.Migratable;
 import org.codice.ddf.migration.MigrationException;
 import org.codice.ddf.migration.MigrationMessage;
@@ -55,6 +58,7 @@ import org.codice.ddf.migration.MigrationWarning;
 import org.codice.ddf.platform.io.CfgStrategy;
 import org.codice.ddf.platform.io.ConfigStrategy;
 import org.codice.ddf.platform.io.internal.PersistenceStrategy;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -109,6 +113,9 @@ public class ConfigurationAdminMigratableTest {
 
   private static final String DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID =
       "DDF_Custom_Mime_Type_Resolver";
+
+  private static final String DDF_CUSTOM_MIME_TYPE_RESOLVER_FILENAME =
+      String.format("%s-csw.config", DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
 
   private static final List<PersistenceStrategy> STRATEGIES =
       ImmutableList.of(new CfgStrategy(), new ConfigStrategy());
@@ -210,13 +217,30 @@ public class ConfigurationAdminMigratableTest {
   public void testDoExportDoImport() throws Exception {
     // Setup Export
     Path exportDir = tempDir.getRoot().toPath().toRealPath();
+    final String tag = String.format(DDF_EXPORTED_TAG_TEMPLATE, DDF_HOME);
+    final Path configFile = setupConfigFile(tag);
+
+    // override to intercept doImport() and verify exported files from etc. Must be done before zip
+    // file is closed
     ConfigurationAdminMigratable eCam =
-        new ConfigurationAdminMigratable(configurationAdminForExport, STRATEGIES, DEFAULT_FILE_EXT);
+        new ConfigurationAdminMigratable(
+            configurationAdminForExport, STRATEGIES, DEFAULT_FILE_EXT) {
+          @Override
+          public void doImport(ImportMigrationContext context) {
+            super.doImport(context);
+            assertThat(configFile.toFile(), Matchers.equalTo(false));
+            // Verify exported files from etc since we are currently not re-importing them
+            context.entries(Paths.get("etc")).forEach(ImportMigrationEntry::restore);
+            try {
+              verifyConfigFile(configFile, tag);
+            } catch (IOException e) {
+              throw new AssertionError(e);
+            }
+          }
+        };
     List<Migratable> eMigratables = Arrays.asList(eCam);
     ConfigurationMigrationManager eConfigurationMigrationManager =
         new ConfigurationMigrationManager(eMigratables, systemService);
-    String tag = String.format(DDF_EXPORTED_TAG_TEMPLATE, DDF_HOME);
-    setupConfigFile(tag);
 
     // Perform Export
     MigrationReport exportReport = eConfigurationMigrationManager.doExport(exportDir, this::print);
@@ -235,8 +259,10 @@ public class ConfigurationAdminMigratableTest {
     FileUtils.deleteDirectory(ddfHome.toRealPath().toFile());
     setup(DDF_HOME);
 
+    // intercept doImport() to verify exported files from etc
     ConfigurationAdminMigratable iCam =
         new ConfigurationAdminMigratable(configurationAdminForImport, STRATEGIES, DEFAULT_FILE_EXT);
+
     List<Migratable> iMigratables = Arrays.asList(iCam);
     ConfigurationMigrationManager iConfigurationMigrationManager =
         new ConfigurationMigrationManager(iMigratables, systemService);
@@ -380,17 +406,26 @@ public class ConfigurationAdminMigratableTest {
         versionFile.toFile().getCanonicalFile(), version, StandardCharsets.UTF_8);
   }
 
-  private void setupConfigFile(String tag) throws IOException {
+  private Path setupConfigFile(String tag) throws IOException {
     Path configFile =
         ddfHome
             .resolve("etc")
             .toRealPath()
-            .resolve(String.format("%s-csw.config", DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID));
+            .resolve(ConfigurationAdminMigratableTest.DDF_CUSTOM_MIME_TYPE_RESOLVER_FILENAME);
     Files.createFile(configFile);
     List<String> lines = new ArrayList<>(2);
     lines.add(String.format("#%s:%s", configFile.toRealPath().toString(), tag));
     lines.add(String.format("%s=%s", DirectoryWatcher.FILENAME, configFile.toUri().toString()));
     FileUtils.writeLines(
         configFile.toFile(), StandardCharsets.UTF_8.toString(), lines, System.lineSeparator());
+    return configFile;
+  }
+
+  private void verifyConfigFile(Path configFile, String tag) throws IOException {
+    assertThat(
+        FileUtils.readLines(configFile.toFile(), StandardCharsets.UTF_8.toString()),
+        Matchers.contains(
+            String.format("#%s:%s", configFile.toRealPath().toString(), tag),
+            String.format("%s=%s", DirectoryWatcher.FILENAME, configFile.toUri().toString())));
   }
 }

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ExportMigrationContextImplTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ExportMigrationContextImplTest.java
@@ -557,6 +557,7 @@ public class ExportMigrationContextImplTest extends AbstractMigrationSupport {
     final Path other = createDirectory("other");
     final List<Path> paths = createFiles(etc, "test.cfg", "test2.config", "test3.properties");
 
+    createFiles(etc, "another.cfg", "not-exported.properties");
     createFiles(ks, "testServerKeystore.jks");
     createFiles(ks, "serverKeystore.jks", "serverTruststore.jks");
     createFiles(other, "a", "b");

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ExportMigrationContextImplTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ExportMigrationContextImplTest.java
@@ -387,7 +387,7 @@ public class ExportMigrationContextImplTest extends AbstractMigrationSupport {
   }
 
   @Test
-  public void testEntriesWithRelativePath() throws Exception {
+  public void testEntriesWhenRecursingWithRelativePathAndSubDirectories() throws Exception {
     final Path etc = createDirectory("etc");
     final Path ks = createDirectory("etc", "keystores");
     final Path other = createDirectory("other");
@@ -398,6 +398,28 @@ public class ExportMigrationContextImplTest extends AbstractMigrationSupport {
     createDirectory("etc", "keystores", "empty");
 
     final List<ExportMigrationEntry> entries = context.entries(etc).collect(Collectors.toList());
+
+    Assert.assertThat(
+        entries.stream().map(ExportMigrationEntry::getPath).collect(Collectors.toList()),
+        Matchers.containsInAnyOrder(paths.toArray()));
+    // finally make sure no warnings or errors were recorded
+    Assert.assertThat(report.hasErrors(), Matchers.equalTo(false));
+    Assert.assertThat(report.hasWarnings(), Matchers.equalTo(false));
+  }
+
+  @Test
+  public void testEntriesWhenNotRecursingWithRelativePathAndSubDirectories() throws Exception {
+    final Path etc = createDirectory("etc");
+    final Path ks = createDirectory("etc", "keystores");
+    final Path other = createDirectory("other");
+    final List<Path> paths = createFiles(etc, "test.cfg", "test2.config", "test3.properties");
+
+    createFiles(ks, "serverKeystore.jks", "serverTruststore.jks");
+    createFiles(other, "a", "b");
+    createDirectory("etc", "keystores", "empty");
+
+    final List<ExportMigrationEntry> entries =
+        context.entries(etc, false).collect(Collectors.toList());
 
     Assert.assertThat(
         entries.stream().map(ExportMigrationEntry::getPath).collect(Collectors.toList()),
@@ -504,12 +526,13 @@ public class ExportMigrationContextImplTest extends AbstractMigrationSupport {
   }
 
   @Test
-  public void testEntriesWithFilterAndRelativePath() throws Exception {
+  public void testEntriesWhenRecursingWithFilterAndRelativePath() throws Exception {
     final Path etc = createDirectory("etc");
     final Path ks = createDirectory("etc", "keystores");
     final Path other = createDirectory("other");
     final List<Path> paths = createFiles(etc, "test.cfg", "test2.config", "test3.properties");
 
+    createFiles(paths, ks, "testServerKeystore.jks");
     createFiles(ks, "serverKeystore.jks", "serverTruststore.jks");
     createFiles(other, "a", "b");
     createDirectory("etc", "keystores", "empty");
@@ -517,6 +540,31 @@ public class ExportMigrationContextImplTest extends AbstractMigrationSupport {
     final List<ExportMigrationEntry> entries =
         context
             .entries(etc, p -> p.getFileName().toString().startsWith("test"))
+            .collect(Collectors.toList());
+
+    Assert.assertThat(
+        entries.stream().map(ExportMigrationEntry::getPath).collect(Collectors.toList()),
+        Matchers.containsInAnyOrder(paths.toArray()));
+    // finally make sure no warnings or errors were recorded
+    Assert.assertThat(report.hasErrors(), Matchers.equalTo(false));
+    Assert.assertThat(report.hasWarnings(), Matchers.equalTo(false));
+  }
+
+  @Test
+  public void testEntriesWhenNotRecursingWithFilterAndRelativePath() throws Exception {
+    final Path etc = createDirectory("etc");
+    final Path ks = createDirectory("etc", "keystores");
+    final Path other = createDirectory("other");
+    final List<Path> paths = createFiles(etc, "test.cfg", "test2.config", "test3.properties");
+
+    createFiles(ks, "testServerKeystore.jks");
+    createFiles(ks, "serverKeystore.jks", "serverTruststore.jks");
+    createFiles(other, "a", "b");
+    createDirectory("etc", "keystores", "empty");
+
+    final List<ExportMigrationEntry> entries =
+        context
+            .entries(etc, false, p -> p.getFileName().toString().startsWith("test"))
             .collect(Collectors.toList());
 
     Assert.assertThat(


### PR DESCRIPTION
#### What does this PR do?
It modifies the config admin migratable to export the config files under etc in addition to the config objects. Although the import phase will not re-import those files, it eventually might re-import them. Since in order to support it later, we need to make sure the files are available as part of the export DAR file.

#### Who is reviewing it? 
@emanns95 
@tbatie 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic 
@figliold

#### How should this be tested? (List steps with links to updated documentation)
- Install DDF and make changes to config
- Perform a `migration:export` 
- Preserve the 3 files exported
- Re-install DDF
- Perform `migration:import` 
- Verify that the system is reconfigured as it was

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3614](https://codice.atlassian.net/browseDDF-3614/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
