### PR TITLE
DDF-3634 Added empty collection check before access in OpenSearchSource

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
@@ -719,7 +719,15 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
       Collection<ServiceReference<InputTransformer>> transformerReference =
           bundleContext.getServiceReferences(
               InputTransformer.class, "(schema=" + namespaceUri + ")");
-      return bundleContext.getService(transformerReference.iterator().next());
+      if (transformerReference.isEmpty()) {
+        LOGGER.trace("Failed to find Input Transformer by schema : {}", namespaceUri);
+      } else {
+        LOGGER.trace(
+            "Found Input Transformer {} by schema {}",
+            transformerReference.iterator().next().getBundle().getSymbolicName(),
+            namespaceUri);
+        return bundleContext.getService(transformerReference.iterator().next());
+      }
     }
     return null;
   }

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/ddf/catalog/source/opensearch/impl/OpenSearchSource.java
@@ -706,6 +706,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
         LOGGER.debug("failed to close namespace reader", e);
       }
     }
+    LOGGER.debug("Unable to find applicable InputTransformer for metacard content from Atom feed.");
     return null;
   }
 
@@ -719,15 +720,15 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
       Collection<ServiceReference<InputTransformer>> transformerReference =
           bundleContext.getServiceReferences(
               InputTransformer.class, "(schema=" + namespaceUri + ")");
-      if (transformerReference.isEmpty()) {
-        LOGGER.trace("Failed to find Input Transformer by schema : {}", namespaceUri);
-      } else {
+      if (!transformerReference.isEmpty()) {
+        ServiceReference<InputTransformer> transformer = transformerReference.iterator().next();
         LOGGER.trace(
             "Found Input Transformer {} by schema {}",
-            transformerReference.iterator().next().getBundle().getSymbolicName(),
+            transformer.getBundle().getSymbolicName(),
             namespaceUri);
-        return bundleContext.getService(transformerReference.iterator().next());
+        return bundleContext.getService(transformer);
       }
+      LOGGER.trace("Failed to find Input Transformer by schema : {}", namespaceUri);
     }
     return null;
   }


### PR DESCRIPTION
#### What does this PR do?
Adds a check for if `transformerReference` is an empty collection before attempting to call `transformerReference.iterator().next()`. Otherwise, we can throw a `NoSuchElementException` if no service ref is found.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@troymohl @mojogitoverhere @brianfelix @adimka 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@brendan-hofmann

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3634](https://codice.atlassian.net/browse/DDF-3634)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
