### PR TITLE
DDF-3620 Move BASIC_METACARD to MetacardImpl

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/BasicTypes.java
@@ -13,19 +13,13 @@
  */
 package ddf.catalog.data.impl;
 
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.AttributeType.AttributeFormat;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.types.Validation;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Constants for basic types, both {@link MetacardType} and {@link AttributeType}
@@ -33,8 +27,6 @@ import java.util.Set;
  * @author ddf.isgs@lmco.com
  */
 public class BasicTypes {
-  /** A Constant for a {@link MetacardType} with the required {@link AttributeType}s. */
-  public static final MetacardType BASIC_METACARD;
 
   /** A Constant for an {@link AttributeType} with {@link AttributeFormat#DATE} . */
   public static final AttributeType<Date> DATE_TYPE;
@@ -72,15 +64,7 @@ public class BasicTypes {
   /** A Constant for an {@link AttributeType} with {@link AttributeFormat#SHORT}. */
   public static final AttributeType<Short> SHORT_TYPE;
 
-  /** Use {@link Validation#VALIDATION_WARNINGS}. */
-  @Deprecated public static final String VALIDATION_WARNINGS = "validation-warnings";
-
-  /** Use {@link Validation#VALIDATION_ERRORS}. */
-  @Deprecated public static final String VALIDATION_ERRORS = "validation-errors";
-
   private static final Map<String, AttributeType> ATTRIBUTE_TYPE_MAP;
-
-  private static final Set<AttributeDescriptor> DESCRIPTORS;
 
   static {
     Map<String, AttributeType> attributeTypeMap = new HashMap<>();
@@ -120,238 +104,9 @@ public class BasicTypes {
         addAttributeType("SHORT_TYPE", AttributeFormat.SHORT, Short.class, attributeTypeMap);
 
     ATTRIBUTE_TYPE_MAP = Collections.unmodifiableMap(attributeTypeMap);
-
-    Set<AttributeDescriptor> descriptors = new HashSet<>();
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.MODIFIED,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            DATE_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.EXPIRATION,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            DATE_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.EFFECTIVE,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            DATE_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.CREATED,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            DATE_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.ID,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.TITLE,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.POINT_OF_CONTACT,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.CONTENT_TYPE,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.CONTENT_TYPE_VERSION,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.TARGET_NAMESPACE,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.METADATA,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            false /* multivalued */,
-            XML_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.RESOURCE_URI,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.RESOURCE_DOWNLOAD_URL,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.RESOURCE_SIZE,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.THUMBNAIL,
-            false /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            BINARY_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.GEOGRAPHY,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            GEO_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.DESCRIPTION,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Validation.VALIDATION_WARNINGS,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Validation.VALIDATION_ERRORS,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.TAGS,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.CHECKSUM_ALGORITHM,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.CHECKSUM,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.DERIVED_RESOURCE_URI,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.DERIVED_RESOURCE_DOWNLOAD_URL,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.DERIVED,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Metacard.RELATED,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Validation.FAILED_VALIDATORS_WARNINGS,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            Validation.FAILED_VALIDATORS_ERRORS,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            true /* multivalued */,
-            STRING_TYPE));
-    DESCRIPTORS = Collections.unmodifiableSet(descriptors);
-
-    BASIC_METACARD =
-        new MetacardTypeImpl(
-            MetacardType.DEFAULT_METACARD_TYPE_NAME, getBasicAttributeDescriptors());
   }
+
+  private BasicTypes() {}
 
   private static <T extends Serializable> AttributeType<T> addAttributeType(
       final String typeName,
@@ -376,10 +131,6 @@ public class BasicTypes {
     map.put(typeName, attributeType);
 
     return attributeType;
-  }
-
-  private static Set<AttributeDescriptor> getBasicAttributeDescriptors() {
-    return DESCRIPTORS;
   }
 
   public static AttributeType getAttributeType(String type) {

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardTypeImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardTypeImpl.java
@@ -32,8 +32,8 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
- * Default implementation of the {@link MetacardType}, used by {@link BasicTypes} to create the
- * {@link BasicTypes#BASIC_METACARD}.
+ * Default implementation of the {@link MetacardType}, used by {@link MetacardImpl} to create the
+ * {@link MetacardImpl#BASIC_METACARD}.
  *
  * <p>This class is {@link java.io.Serializable} and care should be taken with compatibility if
  * changes are made.

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardImplTest.java
@@ -74,7 +74,7 @@ public class MetacardImplTest {
     locWkt = "POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))";
     nsUri = new URI("http://" + MetacardImplTest.class.getName());
     resourceUri = new URI(nsUri.toString() + "/resource.html");
-    mc = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    mc = new MetacardImpl();
     mc.setContentTypeName("testContentType");
     mc.setContentTypeVersion("testContentTypeVersion");
     mc.setAttribute("testAtt", "testAttValue");
@@ -147,7 +147,7 @@ public class MetacardImplTest {
     assertEquals(null, mi.getExpirationDate());
     assertEquals(null, mi.getId());
     assertEquals(null, mi.getLocation());
-    assertEquals(BasicTypes.BASIC_METACARD, mi.getMetacardType());
+    assertEquals(MetacardImpl.BASIC_METACARD, mi.getMetacardType());
     assertEquals(null, mi.getMetadata());
     assertEquals(null, mi.getModifiedDate());
     assertEquals(null, mi.getResourceSize());
@@ -158,7 +158,7 @@ public class MetacardImplTest {
     assertEquals(null, mi.getDescription());
     assertEquals(null, mi.getPointOfContact());
 
-    mi = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    mi = new MetacardImpl();
     assertEquals(null, mi.getContentTypeName());
     assertEquals(null, mi.getContentTypeNamespace());
     assertEquals(null, mi.getContentTypeVersion());
@@ -167,7 +167,7 @@ public class MetacardImplTest {
     assertEquals(null, mi.getExpirationDate());
     assertEquals(null, mi.getId());
     assertEquals(null, mi.getLocation());
-    assertEquals(BasicTypes.BASIC_METACARD, mi.getMetacardType());
+    assertEquals(MetacardImpl.BASIC_METACARD, mi.getMetacardType());
     assertEquals(null, mi.getMetadata());
     assertEquals(null, mi.getModifiedDate());
     assertEquals(null, mi.getResourceSize());
@@ -187,7 +187,7 @@ public class MetacardImplTest {
     assertEquals(mc.getExpirationDate(), mi.getExpirationDate());
     assertEquals(mc.getId(), mi.getId());
     assertEquals(mc.getLocation(), mi.getLocation());
-    assertEquals(BasicTypes.BASIC_METACARD, mi.getMetacardType());
+    assertEquals(MetacardImpl.BASIC_METACARD, mi.getMetacardType());
     assertEquals(mc.getMetacardType(), mi.getMetacardType());
     assertEquals(mc.getMetadata(), mi.getMetadata());
     assertEquals(mc.getModifiedDate(), mi.getModifiedDate());
@@ -355,7 +355,7 @@ public class MetacardImplTest {
 
     Metacard metacard = new MetacardImpl(innerMetacard);
 
-    Serializer<Metacard> serializer = new Serializer<Metacard>();
+    Serializer<Metacard> serializer = new Serializer<>();
 
     serializer.serialize(metacard, DEFAULT_SERIALIZATION_FILE_LOCATION);
 

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardTypeImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardTypeImplTest.java
@@ -13,7 +13,7 @@
  */
 package ddf.catalog.data.impl;
 
-import static ddf.catalog.data.impl.BasicTypes.BASIC_METACARD;
+import static ddf.catalog.data.impl.MetacardImpl.BASIC_METACARD;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;

--- a/catalog/core/catalog-core-defaultvalues/src/test/java/ddf/catalog/data/defaultvalues/DefaultAttributeValueRegistryImplTest.java
+++ b/catalog/core/catalog-core-defaultvalues/src/test/java/ddf/catalog/data/defaultvalues/DefaultAttributeValueRegistryImplTest.java
@@ -15,7 +15,7 @@ package ddf.catalog.data.defaultvalues;
 
 import static ddf.catalog.data.Metacard.POINT_OF_CONTACT;
 import static ddf.catalog.data.Metacard.TITLE;
-import static ddf.catalog.data.impl.BasicTypes.BASIC_METACARD;
+import static ddf.catalog.data.impl.MetacardImpl.BASIC_METACARD;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 

--- a/catalog/core/catalog-core-impl/metacard-type-registry/src/main/java/ddf/catalog/data/metacardtype/MetacardTypeRegistryImpl.java
+++ b/catalog/core/catalog-core-impl/metacard-type-registry/src/main/java/ddf/catalog/data/metacardtype/MetacardTypeRegistryImpl.java
@@ -16,7 +16,7 @@ package ddf.catalog.data.metacardtype;
 import ddf.catalog.data.MetacardTypeRegistry;
 import ddf.catalog.data.MetacardTypeUnregistrationException;
 import ddf.catalog.data.QualifiedMetacardType;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.QualifiedMetacardTypeImpl;
 import java.util.Collections;
 import java.util.HashSet;
@@ -39,7 +39,7 @@ public final class MetacardTypeRegistryImpl implements MetacardTypeRegistry {
 
   private MetacardTypeRegistryImpl() {
     this.registeredMetacardTypes = new CopyOnWriteArraySet<QualifiedMetacardType>();
-    register(new QualifiedMetacardTypeImpl(BasicTypes.BASIC_METACARD));
+    register(new QualifiedMetacardTypeImpl(MetacardImpl.BASIC_METACARD));
   }
 
   public static MetacardTypeRegistry getInstance() {

--- a/catalog/core/catalog-core-injectattribute/src/test/java/ddf/catalog/data/inject/AttributeInjectorImplTest.java
+++ b/catalog/core/catalog-core-injectattribute/src/test/java/ddf/catalog/data/inject/AttributeInjectorImplTest.java
@@ -13,7 +13,7 @@
  */
 package ddf.catalog.data.inject;
 
-import static ddf.catalog.data.impl.BasicTypes.BASIC_METACARD;
+import static ddf.catalog.data.impl.MetacardImpl.BASIC_METACARD;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;

--- a/catalog/core/catalog-core-metacardgroomerplugin/src/test/java/ddf/catalog/plugin/groomer/MetacardGroomerPluginTest.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/test/java/ddf/catalog/plugin/groomer/MetacardGroomerPluginTest.java
@@ -34,7 +34,6 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.data.impl.types.CoreAttributes;
@@ -841,7 +840,7 @@ public class MetacardGroomerPluginTest {
    * @return hybrid metacard type
    */
   private MetacardType getHybridMetacardType() {
-    List<MetacardType> list = Arrays.asList(new CoreAttributes(), BasicTypes.BASIC_METACARD);
+    List<MetacardType> list = Arrays.asList(new CoreAttributes(), MetacardImpl.BASIC_METACARD);
     return new MetacardTypeImpl("HybridAttributes", list);
   }
 }

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
@@ -30,6 +30,7 @@ import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.data.types.Validation;
 import java.io.ByteArrayInputStream;
@@ -165,7 +166,7 @@ public class DynamicSchemaResolver {
 
     anyTextFieldsCache.add(Metacard.METADATA + SchemaFields.TEXT_SUFFIX);
     Set<String> basicTextAttributes =
-        BasicTypes.BASIC_METACARD
+        MetacardImpl.BASIC_METACARD
             .getAttributeDescriptors()
             .stream()
             .filter(descriptor -> BasicTypes.STRING_TYPE.equals(descriptor.getType()))

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/MockMetacard.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/MockMetacard.java
@@ -15,7 +15,6 @@ package ddf.catalog.source.solr;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -55,7 +54,7 @@ public class MockMetacard extends MetacardImpl {
   }
 
   public MockMetacard(String metadata) {
-    this(metadata, BasicTypes.BASIC_METACARD);
+    this(metadata, MetacardImpl.BASIC_METACARD);
   }
 
   public static List<String> toStringList(List<Metacard> cards) {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
@@ -4918,7 +4918,7 @@ public class SolrProviderTest extends SolrProviderTestCase {
               Library.getFlagstaffRecord(),
               new MetacardTypeImpl(
                   "distanceTest",
-                  BasicTypes.BASIC_METACARD,
+                  MetacardImpl.BASIC_METACARD,
                   Sets.newSet(
                       new AttributeDescriptorImpl(
                           attribute, true, true, true, true, BasicTypes.GEO_TYPE))));

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -413,6 +413,7 @@
                             ddf.catalog.content;version="2.0",
                             ddf.catalog.core.versioning;version="2.0",
                             ddf.catalog.data;version="2.0",
+                            ddf.catalog.data.types;version="2.0",
                             ddf.catalog.event;version="2.0",
                             ddf.catalog.federation;version="2.0",
                             ddf.catalog.filter.delegate;version=${project.version},

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/CatalogFrameworkImpl.java
@@ -20,7 +20,7 @@ import ddf.catalog.content.operation.UpdateStorageRequest;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.federation.FederationException;
 import ddf.catalog.federation.FederationStrategy;
 import ddf.catalog.impl.operations.CreateOperations;
@@ -142,10 +142,10 @@ public class CatalogFrameworkImpl extends DescribableImpl implements CatalogFram
     Bundle bundle = FrameworkUtil.getBundle(CatalogFrameworkImpl.class);
     if (bundle != null && bundle.getBundleContext() != null) {
       Dictionary<String, Object> properties = new DictionaryMap<>();
-      properties.put("name", BasicTypes.BASIC_METACARD.getName());
+      properties.put("name", MetacardImpl.BASIC_METACARD.getName());
       bundle
           .getBundleContext()
-          .registerService(MetacardType.class, BasicTypes.BASIC_METACARD, properties);
+          .registerService(MetacardType.class, MetacardImpl.BASIC_METACARD, properties);
     }
   }
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OverrideAttributesSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OverrideAttributesSupport.java
@@ -18,7 +18,6 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import java.io.Serializable;
 import java.nio.charset.Charset;
@@ -56,7 +55,7 @@ public class OverrideAttributesSupport {
       boolean ignoreType,
       boolean onlyFillNull) {
     MetacardType updatedMetacardType = currentMetacard.getMetacardType();
-    if (!ignoreType && !BasicTypes.BASIC_METACARD.equals(overrideMetacard.getMetacardType())) {
+    if (!ignoreType && !MetacardImpl.BASIC_METACARD.equals(overrideMetacard.getMetacardType())) {
       updatedMetacardType = overrideMetacard.getMetacardType();
     }
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/CachedResourceMetacardComparatorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/CachedResourceMetacardComparatorTest.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableSet;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.EmptyMetacardType;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
@@ -248,7 +247,7 @@ public class CachedResourceMetacardComparatorTest {
     securityMap.put("key1", ImmutableList.of("value1"));
     securityMap.put("key2", ImmutableList.of("value1", "value2"));
 
-    MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl metacard = new MetacardImpl();
 
     metacard.setContentTypeName("testContentType");
     metacard.setContentTypeVersion("testContentTypeVersion");

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/event/retrievestatus/DownloadsStatusEventListenerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.mock;
 
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import ddf.catalog.cache.impl.ResourceCacheImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.operation.ResourceRequest;
 import ddf.catalog.resource.ResourceReader;
@@ -91,7 +90,6 @@ public class DownloadsStatusEventListenerTest {
     testMetacard.setId("easyas123");
     testMetacard.setResourceURI(downloadFile.toURI());
     testMetacard.setResourceSize("125");
-    testMetacard.setType(BasicTypes.BASIC_METACARD);
     URLResourceReader testURLResourceReader = new URLResourceReader();
     testURLResourceReader.setRootResourceDirectories(
         new HashSet<String>(Arrays.asList(new String[] {System.getProperty("user.dir")})));

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
@@ -45,7 +45,6 @@ import ddf.catalog.core.versioning.impl.MetacardVersionImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.CreateRequest;
@@ -118,7 +117,7 @@ public class HistorianTest {
 
     historian.setFilterBuilder(new GeotoolsFilterBuilder());
 
-    historian.setMetacardTypes(Collections.singletonList(BasicTypes.BASIC_METACARD));
+    historian.setMetacardTypes(Collections.singletonList(MetacardImpl.BASIC_METACARD));
 
     Security security = mock(Security.class);
     Subject subject = mock(MockSubject.class);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -13,7 +13,6 @@
  */
 package ddf.catalog.impl;
 
-import static ddf.catalog.data.impl.BasicTypes.BASIC_METACARD;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
@@ -528,7 +527,7 @@ public class CatalogFrameworkImplTest {
     final String title = "Create";
     final String injectAttributeName = "new attribute";
     final double injectAttributeValue = 2;
-    final MetacardImpl originalMetacard = new MetacardImpl(BASIC_METACARD);
+    final MetacardImpl originalMetacard = new MetacardImpl();
     originalMetacard.setTitle(title);
     originalMetacard.setAttribute(injectAttributeName, injectAttributeValue);
     final List<Metacard> metacards = Collections.singletonList(originalMetacard);
@@ -568,29 +567,29 @@ public class CatalogFrameworkImplTest {
   private List<Metacard> getMetacards(String title, Date expiration) {
     List<Metacard> metacards = new ArrayList<>();
 
-    MetacardImpl basicMetacardHasBoth = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl basicMetacardHasBoth = new MetacardImpl();
     basicMetacardHasBoth.setId("1");
     basicMetacardHasBoth.setTitle(title);
     basicMetacardHasBoth.setExpirationDate(expiration);
     metacards.add(basicMetacardHasBoth);
 
-    MetacardImpl basicMetacardHasTitle = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl basicMetacardHasTitle = new MetacardImpl();
     basicMetacardHasTitle.setId("2");
     basicMetacardHasTitle.setTitle(title);
     metacards.add(basicMetacardHasTitle);
 
-    MetacardImpl basicMetacardHasExpiration = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl basicMetacardHasExpiration = new MetacardImpl();
     basicMetacardHasExpiration.setId("3");
     basicMetacardHasExpiration.setExpirationDate(expiration);
     metacards.add(basicMetacardHasExpiration);
 
-    MetacardImpl basicMetacardHasNeither = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl basicMetacardHasNeither = new MetacardImpl();
     basicMetacardHasNeither.setId("4");
     metacards.add(basicMetacardHasNeither);
 
     MetacardType customMetacardType =
         new MetacardTypeImpl(
-            CUSTOM_METACARD_TYPE_NAME, BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+            CUSTOM_METACARD_TYPE_NAME, MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
     MetacardImpl customMetacardHasNeither = new MetacardImpl(customMetacardType);
     customMetacardHasNeither.setId("5");
     metacards.add(customMetacardHasNeither);
@@ -2360,7 +2359,7 @@ public class CatalogFrameworkImplTest {
     SourcePoller mockPoller = mock(SourcePoller.class);
     when(mockPoller.getCachedSource(isA(Source.class))).thenReturn(null);
 
-    MetacardImpl metacard = new MetacardImpl(BASIC_METACARD);
+    MetacardImpl metacard = new MetacardImpl();
     metacard.setId(metacardId);
     metacard.setResourceURI(metacardUri);
     Result result = new ResultImpl(metacard);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloadManagerTest.java
@@ -31,7 +31,7 @@ import ddf.catalog.cache.MockInputStream;
 import ddf.catalog.cache.impl.CacheKey;
 import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.event.retrievestatus.DownloadStatusInfo;
 import ddf.catalog.event.retrievestatus.DownloadStatusInfoImpl;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventListener;
@@ -824,7 +824,7 @@ public class ReliableResourceDownloadManagerTest {
 
     when(metacard.getSourceId()).thenReturn(source);
 
-    when(metacard.getMetacardType()).thenReturn(BasicTypes.BASIC_METACARD);
+    when(metacard.getMetacardType()).thenReturn(MetacardImpl.BASIC_METACARD);
 
     return metacard;
   }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
@@ -31,7 +31,7 @@ import com.google.common.io.CountingOutputStream;
 import ddf.catalog.cache.MockInputStream;
 import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.event.retrievestatus.DownloadStatusInfoImpl;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventListener;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventPublisher;
@@ -277,7 +277,7 @@ public class ReliableResourceDownloaderTest {
 
     when(metacard.getSourceId()).thenReturn(source);
 
-    when(metacard.getMetacardType()).thenReturn(BasicTypes.BASIC_METACARD);
+    when(metacard.getMetacardType()).thenReturn(MetacardImpl.BASIC_METACARD);
 
     return metacard;
   }

--- a/catalog/core/catalog-core-validationparser/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
+++ b/catalog/core/catalog-core-validationparser/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
@@ -25,6 +25,7 @@ import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.InjectableAttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.validation.AttributeValidator;
 import ddf.catalog.validation.AttributeValidatorRegistry;
@@ -320,7 +321,7 @@ public class ValidationParser implements ArtifactInstaller {
     BundleContext context = getBundleContext();
     for (Outer.MetacardType metacardType : metacardTypes) {
       Set<AttributeDescriptor> attributeDescriptors =
-          new HashSet<>(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+          new HashSet<>(MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
       Set<String> requiredAttributes = new HashSet<>();
 
       metacardType.attributes.forEach(

--- a/catalog/core/catalog-core-validationparser/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpec.groovy
+++ b/catalog/core/catalog-core-validationparser/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpec.groovy
@@ -8,6 +8,7 @@ import ddf.catalog.data.defaultvalues.DefaultAttributeValueRegistryImpl
 import ddf.catalog.data.impl.AttributeDescriptorImpl
 import ddf.catalog.data.impl.AttributeRegistryImpl
 import ddf.catalog.data.impl.BasicTypes
+import ddf.catalog.data.impl.MetacardImpl
 import ddf.catalog.data.impl.MetacardTypeImpl
 import ddf.catalog.data.impl.types.CoreAttributes
 import ddf.catalog.validation.AttributeValidatorRegistry
@@ -382,10 +383,10 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(valid) }
 
         mockStatic(FrameworkUtil.class)
-        def Bundle mockBundle = Mock(Bundle)
+        Bundle mockBundle = Mock(Bundle)
         when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
 
-        def BundleContext mockBundleContext = Mock(BundleContext)
+        BundleContext mockBundleContext = Mock(BundleContext)
         mockBundle.getBundleContext() >> mockBundleContext
 
         def attribute1Name = "attribute1";
@@ -403,11 +404,11 @@ class ValidationParserSpec extends Specification {
 
         then:
         1 * mockBundleContext.registerService(MetacardType.class, {
-            it == new MetacardTypeImpl(type1Name, BasicTypes.BASIC_METACARD,
+            it == new MetacardTypeImpl(type1Name, MetacardImpl.BASIC_METACARD,
                     [expectedAttribute1, expectedAttribute2] as Set)
         }, { it.get("name") == type1Name })
         1 * mockBundleContext.registerService(MetacardType.class, {
-            it == new MetacardTypeImpl(type2Name, BasicTypes.BASIC_METACARD,
+            it == new MetacardTypeImpl(type2Name, MetacardImpl.BASIC_METACARD,
                     [expectedAttribute1] as Set)
         }, { it.get("name") == type2Name })
     }

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
@@ -35,7 +35,7 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
   private static final MetacardType METACARD_TYPE;
 
   private static final Set<AttributeDescriptor> DESCRIPTORS =
-      new HashSet<>(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+      new HashSet<>(MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
 
   static {
     DESCRIPTORS.add(

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
@@ -65,7 +65,7 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
   private static final MetacardType METACARD_VERSION;
 
   private static final Set<AttributeDescriptor> VERSION_DESCRIPTORS =
-      new HashSet<>(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+      new HashSet<>(MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
 
   private static final Cache<Integer, byte[]> METACARD_TYPE_CACHE =
       CacheBuilder.newBuilder().maximumSize(256).build();
@@ -104,7 +104,12 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
    * @throws IllegalArgumentException
    */
   public MetacardVersionImpl(String id, Metacard sourceMetacard, Action action, Subject subject) {
-    this(id, sourceMetacard, action, subject, Collections.singletonList(BasicTypes.BASIC_METACARD));
+    this(
+        id,
+        sourceMetacard,
+        action,
+        subject,
+        Collections.singletonList(MetacardImpl.BASIC_METACARD));
   }
 
   /**
@@ -235,7 +240,7 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
   private static void sanitizeVersionAttributes(/*Mutable*/ Metacard source) {
     Consumer<String> nullifySourceAttribute =
         (s) -> source.setAttribute(new AttributeImpl(s, (Serializable) null));
-    Sets.difference(VERSION_DESCRIPTORS, BasicTypes.BASIC_METACARD.getAttributeDescriptors())
+    Sets.difference(VERSION_DESCRIPTORS, MetacardImpl.BASIC_METACARD.getAttributeDescriptors())
         .stream()
         .map(AttributeDescriptor::getName)
         .forEach(nullifySourceAttribute);

--- a/catalog/core/catalog-core-versioning/versioning-common/src/test/groovy/ddf/catalog/core/versioning/impl/MetacardVersionImplSpec.groovy
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/test/groovy/ddf/catalog/core/versioning/impl/MetacardVersionImplSpec.groovy
@@ -82,7 +82,7 @@ class MetacardVersionImplSpec extends Specification {
                 SecurityUtils.subject)
 
         when:
-        Metacard metacard = history.getMetacard([BasicTypes.BASIC_METACARD])
+        Metacard metacard = history.getMetacard([MetacardImpl.BASIC_METACARD])
 
         then:
         metacard != null
@@ -102,7 +102,7 @@ class MetacardVersionImplSpec extends Specification {
                 meta.metacard as Metacard,
                 action,
                 SecurityUtils.subject,
-                [BasicTypes.BASIC_METACARD, meta.metacardType])
+                [MetacardImpl.BASIC_METACARD, meta.metacardType])
 
         then: "The metacard type should contain non default attribute descriptors"
         meta.attributeDescriptor in history.metacardType.attributeDescriptors
@@ -110,7 +110,7 @@ class MetacardVersionImplSpec extends Specification {
                 meta.metacard.metacardType.attributeDescriptors)
 
         when:
-        Metacard metacard = history.getMetacard([BasicTypes.BASIC_METACARD, meta.metacardType])
+        Metacard metacard = history.getMetacard([MetacardImpl.BASIC_METACARD, meta.metacardType])
 
         then:
         metacard != null
@@ -138,7 +138,7 @@ class MetacardVersionImplSpec extends Specification {
         history.getAttribute(MetacardVersion.VERSION_TYPE_BINARY)?.value != null
 
         when: "reconstructing metacard with only serialized type available"
-        Metacard metacard = history.getMetacard([BasicTypes.BASIC_METACARD])
+        Metacard metacard = history.getMetacard([MetacardImpl.BASIC_METACARD])
 
         then: "ensure metacard and type are properly restored"
         metacard.metacardType == meta.metacard.metacardType
@@ -152,7 +152,7 @@ class MetacardVersionImplSpec extends Specification {
         res.tags = [Metacard.DEFAULT_TAG]
         res.uri = URI.create("http://google.com")
 
-        MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+        MetacardImpl metacard = new MetacardImpl()
         metacard.id = res.id
         metacard.tags = res.tags
         metacard.metadata = res.metadata
@@ -176,7 +176,7 @@ class MetacardVersionImplSpec extends Specification {
                 BasicTypes.STRING_TYPE)
         res.metacardType = new MetacardTypeImpl(
                 "NonBasicType",
-                BasicTypes.BASIC_METACARD, [res.attributeDescriptor] as Set)
+                MetacardImpl.BASIC_METACARD, [res.attributeDescriptor] as Set)
         res.metacard = new MetacardImpl(res.metacardType)
         res.attributeValue = "My New Attribute Value"
         res.metacard.with {

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointTest.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointTest.java
@@ -34,7 +34,6 @@ import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.ContentTypeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.federation.FederationException;
@@ -262,7 +261,7 @@ public class RestEndpointTest {
     UuidGenerator uuidGenerator = mock(UuidGenerator.class);
     when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID().toString());
     rest.setUuidGenerator(uuidGenerator);
-    rest.setMetacardTypes(Collections.singletonList(BasicTypes.BASIC_METACARD));
+    rest.setMetacardTypes(Collections.singletonList(MetacardImpl.BASIC_METACARD));
     MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
     when(mimeTypeMapper.getMimeTypeForFileExtension("txt")).thenReturn("text/plain");
     when(mimeTypeMapper.getMimeTypeForFileExtension("xml")).thenReturn("text/xml");
@@ -339,7 +338,7 @@ public class RestEndpointTest {
             return bundleContext;
           }
         };
-    rest.setMetacardTypes(Collections.singletonList(BasicTypes.BASIC_METACARD));
+    rest.setMetacardTypes(Collections.singletonList(MetacardImpl.BASIC_METACARD));
     MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
     when(mimeTypeMapper.getMimeTypeForFileExtension("txt")).thenReturn("text/plain");
     when(mimeTypeMapper.getMimeTypeForFileExtension("xml")).thenReturn("text/xml");
@@ -411,7 +410,7 @@ public class RestEndpointTest {
             return bundleContext;
           }
         };
-    rest.setMetacardTypes(Collections.singletonList(BasicTypes.BASIC_METACARD));
+    rest.setMetacardTypes(Collections.singletonList(MetacardImpl.BASIC_METACARD));
     MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
     when(mimeTypeMapper.getMimeTypeForFileExtension("txt")).thenReturn("text/plain");
     when(mimeTypeMapper.getMimeTypeForFileExtension("xml")).thenReturn("text/xml");

--- a/catalog/solr/catalog-solr-provider/pom.xml
+++ b/catalog/solr/catalog-solr-provider/pom.xml
@@ -99,6 +99,7 @@
                             com.vividsolutions.jts.simplify,
                             com.vividsolutions.jts.util,
                             ddf.catalog.data;version="[2.0,3)",
+                            ddf.catalog.data.types;version="[2.0,3)",
                             ddf.catalog.filter;version="[2.0,3)",
                             ddf.catalog.operation;version="[2.0,3)",
                             ddf.catalog.source;version="[2.0,3)",

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/reader/GetRecordsMessageBodyReaderTest.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/reader/GetRecordsMessageBodyReaderTest.java
@@ -30,7 +30,6 @@ import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.resource.Resource;
@@ -115,7 +114,7 @@ public class GetRecordsMessageBodyReaderTest {
   @Test
   public void testFullThread() throws Exception {
     List<Metacard> inputMetacards = new ArrayList<>();
-    MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl metacard = new MetacardImpl();
     metacard.setId("metacard1");
     metacard.setTitle("title1");
     inputMetacards.add(metacard);
@@ -152,7 +151,7 @@ public class GetRecordsMessageBodyReaderTest {
   @Test
   public void testGetMultipleMetacardsWithForeignText() throws Exception {
     List<Metacard> inputMetacards = new ArrayList<>();
-    MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl metacard = new MetacardImpl();
     inputMetacards.add(metacard);
     CswRecordCollection collection = new CswRecordCollection();
     collection.setCswRecords(inputMetacards);

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswMarshallHelper.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswMarshallHelper.java
@@ -23,7 +23,6 @@ import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import java.io.Serializable;
 import java.util.Base64;
@@ -98,7 +97,7 @@ class CswMarshallHelper {
 
         /*  Backwards Compatibility */
         if (ad == null) {
-          ad = BasicTypes.BASIC_METACARD.getAttributeDescriptor(attrName);
+          ad = MetacardImpl.BASIC_METACARD.getAttributeDescriptor(attrName);
         }
         writeAttribute(writer, context, metacard, ad, qName);
       }

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswRecordConverter.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswRecordConverter.java
@@ -31,7 +31,6 @@ import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
@@ -320,8 +319,8 @@ public class CswRecordConverter implements Converter, MetacardTransformer, Input
   private MetacardType getMetacardTypeWithBackwardsCompatibility(MetacardType metacardType) {
     Set<AttributeDescriptor> additionalDescriptors =
         ImmutableSet.of(
-            BasicTypes.BASIC_METACARD.getAttributeDescriptor(Metacard.EFFECTIVE),
-            BasicTypes.BASIC_METACARD.getAttributeDescriptor(Metacard.CONTENT_TYPE));
+            MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Metacard.EFFECTIVE),
+            MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Metacard.CONTENT_TYPE));
     return new MetacardTypeImpl(metacardType.getName(), metacardType, additionalDescriptors);
   }
 

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/GmdConverterTest.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/GmdConverterTest.java
@@ -22,7 +22,6 @@ import com.thoughtworks.xstream.core.TreeMarshaller;
 import com.thoughtworks.xstream.io.naming.NoNameCoder;
 import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Contact;
 import ddf.catalog.data.types.Core;
@@ -138,7 +137,7 @@ public class GmdConverterTest {
   }
 
   private MetacardImpl getSparseMetacard() {
-    MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl metacard = new MetacardImpl();
     metacard.setAttribute(Core.ID, "ID");
     metacard.setAttribute(Core.CREATED, createdDate.getTime());
     metacard.setAttribute(Core.MODIFIED, modifiedDate.getTime());

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/MockMetacardType.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/MockMetacardType.java
@@ -17,6 +17,7 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType.AttributeFormat;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import java.util.Set;
 
@@ -29,7 +30,7 @@ public class MockMetacardType extends MetacardTypeImpl {
   public MockMetacardType() {
     super(NAME, (Set<AttributeDescriptor>) null);
 
-    descriptors.addAll(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+    descriptors.addAll(MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
 
     descriptors.add(
         new AttributeDescriptorImpl(

--- a/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/metacard/RegistryObjectMetacardType.java
+++ b/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/metacard/RegistryObjectMetacardType.java
@@ -18,6 +18,7 @@ import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import java.util.Collections;
 import java.util.HashSet;
@@ -81,7 +82,7 @@ public class RegistryObjectMetacardType extends MetacardTypeImpl {
   }
 
   private void addRegistryAttributes() {
-    descriptors.add(BasicTypes.BASIC_METACARD.getAttributeDescriptor(Metacard.POINT_OF_CONTACT));
+    descriptors.add(MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Metacard.POINT_OF_CONTACT));
     addQueryableBoolean(REGISTRY_IDENTITY_NODE, false);
     addQueryableBoolean(REGISTRY_LOCAL_NODE, false);
     addQueryableDate(LAST_PUBLISHED);

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-converter/src/test/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/converter/impl/GenericFeatureConverterTest.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-converter/src/test/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/converter/impl/GenericFeatureConverterTest.java
@@ -24,7 +24,6 @@ import com.thoughtworks.xstream.io.xml.WstxDriver;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
 import java.io.InputStream;
@@ -264,12 +263,12 @@ public class GenericFeatureConverterTest {
 
           @Override
           public Set<AttributeDescriptor> getAttributeDescriptors() {
-            return BasicTypes.BASIC_METACARD.getAttributeDescriptors();
+            return MetacardImpl.BASIC_METACARD.getAttributeDescriptors();
           }
 
           @Override
           public AttributeDescriptor getAttributeDescriptor(String arg0) {
-            return BasicTypes.BASIC_METACARD.getAttributeDescriptor(arg0);
+            return MetacardImpl.BASIC_METACARD.getAttributeDescriptor(arg0);
           }
         });
     wfc.getFeatureMembers().add(mc2);

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-converter/src/test/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/converter/impl/GenericFeatureConverterTest.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-converter/src/test/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/converter/impl/GenericFeatureConverterTest.java
@@ -24,7 +24,6 @@ import com.thoughtworks.xstream.io.xml.WstxDriver;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -313,12 +312,12 @@ public class GenericFeatureConverterTest {
 
           @Override
           public Set<AttributeDescriptor> getAttributeDescriptors() {
-            return BasicTypes.BASIC_METACARD.getAttributeDescriptors();
+            return MetacardImpl.BASIC_METACARD.getAttributeDescriptors();
           }
 
           @Override
           public AttributeDescriptor getAttributeDescriptor(String arg0) {
-            return BasicTypes.BASIC_METACARD.getAttributeDescriptor(arg0);
+            return MetacardImpl.BASIC_METACARD.getAttributeDescriptor(arg0);
           }
         });
     wfc.getMembers().add(mc2);

--- a/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/FeatureAttributeDescriptor.java
+++ b/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/FeatureAttributeDescriptor.java
@@ -20,8 +20,8 @@ import ddf.catalog.data.impl.AttributeDescriptorImpl;
 /**
  * Extension of the {@link AttributeDescriptorImpl} to allow for mapping of an actual property name,
  * which may collide with a "reserved" attributeDescriptor from {@link
- * ddf.catalog.data.impl.BasicTypes.BASIC_METACARD}, to a name that can be used without over-writing
- * existing attributeDescriptors.
+ * ddf.catalog.data.impl.MetacardImpl.BASIC_METACARD}, to a name that can be used without
+ * over-writing existing attributeDescriptors.
  */
 public class FeatureAttributeDescriptor extends AttributeDescriptorImpl {
 

--- a/catalog/spatial/wfs/spatial-wfs-converter/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/converter/impl/AbstractFeatureConverter.java
+++ b/catalog/spatial/wfs/spatial-wfs-converter/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/converter/impl/AbstractFeatureConverter.java
@@ -392,8 +392,8 @@ public abstract class AbstractFeatureConverter implements FeatureConverter {
 
   private Set<String> getBasicAttributeNames() {
     Set<String> attrNames =
-        new HashSet<String>(BasicTypes.BASIC_METACARD.getAttributeDescriptors().size());
-    for (AttributeDescriptor ad : BasicTypes.BASIC_METACARD.getAttributeDescriptors()) {
+        new HashSet<>(MetacardImpl.BASIC_METACARD.getAttributeDescriptors().size());
+    for (AttributeDescriptor ad : MetacardImpl.BASIC_METACARD.getAttributeDescriptors()) {
       attrNames.add(ad.getName());
     }
     return attrNames;

--- a/catalog/transformer/catalog-transformer-common/src/test/java/ddf/catalog/transformer/common/tika/MetacardCreatorTest.java
+++ b/catalog/transformer/catalog-transformer-common/src/test/java/ddf/catalog/transformer/common/tika/MetacardCreatorTest.java
@@ -23,6 +23,7 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.data.types.Contact;
 import ddf.catalog.data.types.Media;
@@ -45,7 +46,7 @@ public class MetacardCreatorTest {
     final Metadata metadata = new Metadata();
 
     final Metacard metacard =
-        MetacardCreator.createMetacard(metadata, null, null, BasicTypes.BASIC_METACARD);
+        MetacardCreator.createMetacard(metadata, null, null, MetacardImpl.BASIC_METACARD);
 
     assertThat(metacard, notNullValue());
     assertThat(metacard.getTitle(), nullValue());
@@ -60,7 +61,7 @@ public class MetacardCreatorTest {
   @Test
   public void testBasicMetacard() {
     Metacard metacard = createTestMetacard(null);
-    assertThat(metacard.getMetacardType(), is(BasicTypes.BASIC_METACARD));
+    assertThat(metacard.getMetacardType(), is(MetacardImpl.BASIC_METACARD));
   }
 
   @Test
@@ -75,7 +76,7 @@ public class MetacardCreatorTest {
     metadata.add(MetacardCreator.DURATION_METDATA_KEY, durationValue);
     MetacardTypeImpl extendedMetacardType =
         new MetacardTypeImpl(
-            BasicTypes.BASIC_METACARD.getName(), BasicTypes.BASIC_METACARD, extraAttributes);
+            MetacardImpl.BASIC_METACARD.getName(), MetacardImpl.BASIC_METACARD, extraAttributes);
     final String id = "id";
     final String metadataXml = "<xml>test</xml>";
 
@@ -96,7 +97,7 @@ public class MetacardCreatorTest {
     metadata.add(MetacardCreator.COMPRESSION_TYPE_METADATA_KEY, null);
     MetacardTypeImpl extendedMetacardType =
         new MetacardTypeImpl(
-            BasicTypes.BASIC_METACARD.getName(), BasicTypes.BASIC_METACARD, extraAttributes);
+            MetacardImpl.BASIC_METACARD.getName(), MetacardImpl.BASIC_METACARD, extraAttributes);
     final String id = "id";
     final String metadataXml = "<xml>test</xml>";
 
@@ -118,7 +119,7 @@ public class MetacardCreatorTest {
     metadata.add(MetacardCreator.DURATION_METDATA_KEY, durationValue);
     MetacardTypeImpl extendedMetacardType =
         new MetacardTypeImpl(
-            BasicTypes.BASIC_METACARD.getName(), BasicTypes.BASIC_METACARD, extraAttributes);
+            MetacardImpl.BASIC_METACARD.getName(), MetacardImpl.BASIC_METACARD, extraAttributes);
     final String id = "id";
     final String metadataXml = "<xml>test</xml>";
 
@@ -140,7 +141,7 @@ public class MetacardCreatorTest {
     metadata.add(TIFF.IMAGE_LENGTH, imageLength);
     MetacardTypeImpl extendedMetacardType =
         new MetacardTypeImpl(
-            BasicTypes.BASIC_METACARD.getName(), BasicTypes.BASIC_METACARD, extraAttributes);
+            MetacardImpl.BASIC_METACARD.getName(), MetacardImpl.BASIC_METACARD, extraAttributes);
     final String id = "id";
     final String metadataXml = "<xml>test</xml>";
 
@@ -154,7 +155,7 @@ public class MetacardCreatorTest {
   public void testMetacardExtended() {
     Metacard metacard =
         createTestMetacard(ImmutableSet.of(createObjectAttr("attr1"), createObjectAttr("attr2")));
-    assertThat(metacard.getMetacardType().getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacard.getMetacardType().getName(), is(MetacardImpl.BASIC_METACARD.getName()));
 
     ImmutableSet<String> attrNames = ImmutableSet.of("attr1", "attr2");
     int count =
@@ -175,7 +176,7 @@ public class MetacardCreatorTest {
 
     metadata.add(TikaCoreProperties.TITLE, "metadata title");
     final Metacard metacard =
-        MetacardCreator.createMetacard(metadata, null, null, BasicTypes.BASIC_METACARD, false);
+        MetacardCreator.createMetacard(metadata, null, null, MetacardImpl.BASIC_METACARD, false);
 
     assertThat(metacard.getTitle(), nullValue());
   }
@@ -187,7 +188,7 @@ public class MetacardCreatorTest {
     metadata.add(Office.LAST_AUTHOR, "AnotherFirst AnotherLast");
     metadata.add(TikaCoreProperties.CREATOR, "First Last");
     final Metacard metacard =
-        MetacardCreator.createMetacard(metadata, null, null, BasicTypes.BASIC_METACARD, false);
+        MetacardCreator.createMetacard(metadata, null, null, MetacardImpl.BASIC_METACARD, false);
 
     assertThat(
         metacard.getAttribute(Contact.CONTRIBUTOR_NAME).getValue().toString(),
@@ -201,7 +202,7 @@ public class MetacardCreatorTest {
     metadata.add(Office.LAST_AUTHOR, "First Last");
     metadata.add(TikaCoreProperties.CREATOR, "First Last");
     final Metacard metacard =
-        MetacardCreator.createMetacard(metadata, null, null, BasicTypes.BASIC_METACARD, false);
+        MetacardCreator.createMetacard(metadata, null, null, MetacardImpl.BASIC_METACARD, false);
 
     assertThat(metacard.getAttribute(Contact.CONTRIBUTOR_NAME), nullValue());
   }
@@ -211,7 +212,7 @@ public class MetacardCreatorTest {
     final Metadata metadata = new Metadata();
 
     final Metacard metacard =
-        MetacardCreator.createMetacard(metadata, null, null, BasicTypes.BASIC_METACARD, false);
+        MetacardCreator.createMetacard(metadata, null, null, MetacardImpl.BASIC_METACARD, false);
 
     assertThat(metacard.getAttribute(Contact.CONTRIBUTOR_NAME), nullValue());
   }
@@ -243,11 +244,11 @@ public class MetacardCreatorTest {
     final Metacard metacard;
     if (CollectionUtils.isEmpty(extraAttributes)) {
       metacard =
-          MetacardCreator.createMetacard(metadata, id, metadataXml, BasicTypes.BASIC_METACARD);
+          MetacardCreator.createMetacard(metadata, id, metadataXml, MetacardImpl.BASIC_METACARD);
     } else {
       MetacardTypeImpl extendedMetacardType =
           new MetacardTypeImpl(
-              BasicTypes.BASIC_METACARD.getName(), BasicTypes.BASIC_METACARD, extraAttributes);
+              MetacardImpl.BASIC_METACARD.getName(), MetacardImpl.BASIC_METACARD, extraAttributes);
       metacard = MetacardCreator.createMetacard(metadata, id, metadataXml, extendedMetacardType);
     }
 

--- a/catalog/transformer/catalog-transformer-geojson-input/src/main/java/ddf/catalog/transformer/input/geojson/GeoJsonInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-geojson-input/src/main/java/ddf/catalog/transformer/input/geojson/GeoJsonInputTransformer.java
@@ -46,7 +46,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Converts standard GeoJSON (geojson.org) into a Metacard. The limitation on the GeoJSON is that it
- * must conform to the {@link ddf.catalog.data.impl.BasicTypes#BASIC_METACARD} {@link MetacardType}.
+ * must conform to the {@link ddf.catalog.data.impl.MetacardImpl#BASIC_METACARD} {@link
+ * MetacardType}.
  */
 public class GeoJsonInputTransformer implements InputTransformer {
 

--- a/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/GeoJsonExtensibleTest.java
+++ b/catalog/transformer/catalog-transformer-geojson-input/src/test/java/ddf/catalog/transformer/input/geojson/GeoJsonExtensibleTest.java
@@ -13,7 +13,6 @@
  */
 package ddf.catalog.transformer.input.geojson;
 
-import static ddf.catalog.data.impl.BasicTypes.BASIC_METACARD;
 import static ddf.catalog.data.impl.BasicTypes.DOUBLE_TYPE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -33,6 +32,7 @@ import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.AttributeRegistryImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import java.io.ByteArrayInputStream;
@@ -439,12 +439,12 @@ public class GeoJsonExtensibleTest {
     Metacard metacard = transformer.transform(geoJsonInput);
 
     // since no metacard type was specified only the Basic Metacard Type attributes should be
-    // available. These are defined in BasicTypes.BASIC_METACARD
+    // available. These are defined in MetacardImpl.BASIC_METACARD
     // none of the custom attributes defined in SampleMetacardTypeA will be added to the
     // metacard.
     assertEquals(DEFAULT_TITLE, metacard.getTitle());
     assertEquals(DEFAULT_ID, metacard.getId());
-    assertEquals(BASIC_METACARD.getName(), metacard.getMetacardType().getName());
+    assertEquals(MetacardImpl.BASIC_METACARD.getName(), metacard.getMetacardType().getName());
 
     assertEquals(DEFAULT_TEMPERATURE, metacard.getAttribute(TEMPERATURE_KEY).getValue());
 
@@ -482,7 +482,7 @@ public class GeoJsonExtensibleTest {
   }
 
   private List<MetacardType> prepareMetacardTypes() {
-    return Arrays.asList(sampleMetacardTypeA(), sampleMetacardTypeB(), BASIC_METACARD);
+    return Arrays.asList(sampleMetacardTypeA(), sampleMetacardTypeB(), MetacardImpl.BASIC_METACARD);
   }
 
   private void verifyBasics(Metacard metacard) throws ParseException {
@@ -500,7 +500,7 @@ public class GeoJsonExtensibleTest {
     assertEquals(DEFAULT_EFFECTIVE_DATE, dateFormat.format(metacard.getEffectiveDate()));
     assertArrayEquals(DEFAULT_BYTES, metacard.getThumbnail());
     assertEquals(DEFAULT_TEMPERATURE, metacard.getAttribute(TEMPERATURE_KEY).getValue());
-    assertEquals(BASIC_METACARD.getName(), metacard.getMetacardType().getName());
+    assertEquals(MetacardImpl.BASIC_METACARD.getName(), metacard.getMetacardType().getName());
 
     WKTReader reader = new WKTReader();
 

--- a/catalog/transformer/catalog-transformer-geojson-metacard/src/test/java/ddf/catalog/transformer/metacard/geojson/GeoJsonMetacardTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-geojson-metacard/src/test/java/ddf/catalog/transformer/metacard/geojson/GeoJsonMetacardTransformerTest.java
@@ -491,7 +491,7 @@ public class GeoJsonMetacardTransformerTest {
   @Test
   public void testWithMultiValueAttributes() throws Exception {
     Set<AttributeDescriptor> descriptors =
-        new HashSet(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+        new HashSet(MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
     descriptors.add(
         new AttributeDescriptorImpl(
             "multi-string", true, true, false, true, /* multivalued */ BasicTypes.STRING_TYPE));
@@ -593,7 +593,7 @@ public class GeoJsonMetacardTransformerTest {
     assertThat(toString(properties.get(SOURCE_ID_PROPERTY)), is(DEFAULT_SOURCE_ID));
     assertThat(
         toString(properties.get(GeoJsonMetacardTransformer.METACARD_TYPE_PROPERTY_KEY)),
-        is(BasicTypes.BASIC_METACARD.getName()));
+        is(MetacardImpl.BASIC_METACARD.getName()));
   }
 
   private String toString(Object object) {

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
@@ -18,7 +18,6 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Validation;
 import ddf.catalog.transform.CatalogTransformerException;
@@ -120,7 +119,7 @@ public class SaxEventHandlerDelegate extends DefaultHandler {
     MetacardType metacardType = getMetacardType(id);
 
     if (metacardType == null) {
-      metacardType = BasicTypes.BASIC_METACARD;
+      metacardType = MetacardImpl.BASIC_METACARD;
       LOGGER.debug("No metacard type found. Defaulting to Basic Metacard.");
     }
     /*
@@ -291,7 +290,7 @@ public class SaxEventHandlerDelegate extends DefaultHandler {
    */
   public MetacardType getMetacardType(String id) {
     Set<AttributeDescriptor> attributeDescriptors =
-        new HashSet<>(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+        new HashSet<>(MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
 
     attributeDescriptors.addAll(
         eventHandlers

--- a/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/GenericXmlLibTest.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/test/java/org/codice/ddf/transformer/xml/streaming/lib/GenericXmlLibTest.java
@@ -28,6 +28,7 @@ import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Validation;
 import ddf.catalog.transform.CatalogTransformerException;
 import java.io.FileInputStream;
@@ -120,7 +121,7 @@ public class GenericXmlLibTest {
     MetacardType metacardType = delegate.getMetacardType(xmlInputTransformer.getId());
     assertThat(
         metacardType.getAttributeDescriptors(),
-        is(BasicTypes.BASIC_METACARD.getAttributeDescriptors()));
+        is(MetacardImpl.BASIC_METACARD.getAttributeDescriptors()));
   }
 
   @Test
@@ -133,7 +134,7 @@ public class GenericXmlLibTest {
     MetacardType metacardType = delegate.getMetacardType(xmlInputTransformer.getId());
     assertThat(
         metacardType.getAttributeDescriptors(),
-        is(BasicTypes.BASIC_METACARD.getAttributeDescriptors()));
+        is(MetacardImpl.BASIC_METACARD.getAttributeDescriptors()));
   }
 
   @Test

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedMetacard.java
@@ -18,7 +18,6 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.transformer.xml.binding.Base64BinaryElement;
 import ddf.catalog.transformer.xml.binding.BooleanElement;
@@ -77,13 +76,13 @@ public class AdaptedMetacard implements Metacard {
 
   public AdaptedMetacard(Metacard metacard) {
     if (metacard == null) {
-      this.metacardType = BasicTypes.BASIC_METACARD;
+      this.metacardType = MetacardImpl.BASIC_METACARD;
     } else {
       this.sourceId = metacard.getSourceId();
       this.metacardType =
           metacard.getMetacardType() != null
               ? metacard.getMetacardType()
-              : BasicTypes.BASIC_METACARD;
+              : MetacardImpl.BASIC_METACARD;
       for (AttributeDescriptor descriptor : metacardType.getAttributeDescriptors()) {
         if (descriptor != null) {
           this.setAttribute(metacard.getAttribute(descriptor.getName()));

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedSourceResponse.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AdaptedSourceResponse.java
@@ -18,7 +18,7 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceProcessingDetails;
 import ddf.catalog.operation.SourceResponse;
@@ -123,7 +123,7 @@ public class AdaptedSourceResponse implements SourceResponse {
 
       if (metacard.getMetacardType() != null) {
 
-        String metacardTypeName = BasicTypes.BASIC_METACARD.getName();
+        String metacardTypeName = MetacardImpl.BASIC_METACARD.getName();
 
         if (isNotBlank(metacard.getMetacardType().getName())) {
           metacardTypeName = metacard.getMetacardType().getName();

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AttributeAdapter.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/AttributeAdapter.java
@@ -18,7 +18,7 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType.AttributeFormat;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transformer.xml.binding.AbstractAttributeType;
 import ddf.catalog.transformer.xml.binding.Base64BinaryElement;
@@ -43,7 +43,7 @@ public class AttributeAdapter extends XmlAdapter<AbstractAttributeType, Attribut
   private MetacardType metacardType = null;
 
   public AttributeAdapter() {
-    this(BasicTypes.BASIC_METACARD);
+    this(MetacardImpl.BASIC_METACARD);
   }
 
   public AttributeAdapter(MetacardType metacardType) {

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/MetacardTypeAdapter.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/adapter/MetacardTypeAdapter.java
@@ -14,7 +14,7 @@
 package ddf.catalog.transformer.xml.adapter;
 
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import java.util.List;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
@@ -54,8 +54,8 @@ public class MetacardTypeAdapter extends XmlAdapter<String, MetacardType> {
 
     if (StringUtils.isEmpty(typeName)
         || CollectionUtils.isEmpty(types)
-        || typeName.equals(BasicTypes.BASIC_METACARD.getName())) {
-      return BasicTypes.BASIC_METACARD;
+        || typeName.equals(MetacardImpl.BASIC_METACARD.getName())) {
+      return MetacardImpl.BASIC_METACARD;
     }
 
     LOGGER.debug("Searching through registerd metacard types {} for '{}'.", types, typeName);
@@ -68,8 +68,8 @@ public class MetacardTypeAdapter extends XmlAdapter<String, MetacardType> {
     LOGGER.debug(
         "Metacard type '{}' is not registered.  Using metacard type of '{}'.",
         typeName,
-        BasicTypes.BASIC_METACARD.getName());
+        MetacardImpl.BASIC_METACARD.getName());
 
-    return BasicTypes.BASIC_METACARD;
+    return MetacardImpl.BASIC_METACARD;
   }
 }

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/MetacardTypeAdapterTest.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/MetacardTypeAdapterTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertThat;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transformer.xml.adapter.MetacardTypeAdapter;
@@ -32,7 +32,7 @@ public class MetacardTypeAdapterTest {
 
   private static final String EMPTY_TYPE_NAME = "";
 
-  private static final String DDF_METACARD_TYPE_NAME = BasicTypes.BASIC_METACARD.getName();
+  private static final String DDF_METACARD_TYPE_NAME = MetacardImpl.BASIC_METACARD.getName();
 
   private static final String UNKNOWN_TYPE_NAME = "unknownTypeName.metacard";
 
@@ -47,14 +47,14 @@ public class MetacardTypeAdapterTest {
   public void testUnmarshalWithNullTypeName() throws CatalogTransformerException {
     MetacardTypeAdapter metacardTypeAdpater = new MetacardTypeAdapter();
     MetacardType metacardType = metacardTypeAdpater.unmarshal(NULL_TYPE_NAME);
-    assertThat(metacardType.getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacardType.getName(), is(MetacardImpl.BASIC_METACARD.getName()));
   }
 
   @Test
   public void testUnmarshalWithEmptyTypeName() throws CatalogTransformerException {
     MetacardTypeAdapter metacardTypeAdpater = new MetacardTypeAdapter();
     MetacardType metacardType = metacardTypeAdpater.unmarshal(EMPTY_TYPE_NAME);
-    assertThat(metacardType.getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacardType.getName(), is(MetacardImpl.BASIC_METACARD.getName()));
   }
 
   @Test
@@ -65,7 +65,7 @@ public class MetacardTypeAdapterTest {
     metacardTypes.add(unknownMetacardType);
     MetacardTypeAdapter metacardTypeAdpater = new MetacardTypeAdapter(metacardTypes);
     MetacardType metacardType = metacardTypeAdpater.unmarshal(DDF_METACARD_TYPE_NAME);
-    assertThat(metacardType.getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacardType.getName(), is(MetacardImpl.BASIC_METACARD.getName()));
   }
 
   @Test
@@ -76,21 +76,21 @@ public class MetacardTypeAdapterTest {
     metacardTypes.add(unknownMetacardType);
     MetacardTypeAdapter metacardTypeAdpater = new MetacardTypeAdapter(metacardTypes);
     MetacardType metacardType = metacardTypeAdpater.unmarshal(UNKNOWN_TYPE_NAME);
-    assertThat(metacardType.getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacardType.getName(), is(MetacardImpl.BASIC_METACARD.getName()));
   }
 
   @Test
   public void testUnmarshalWithNullRegisteredMetacardTypes() throws CatalogTransformerException {
     MetacardTypeAdapter metacardTypeAdpater = new MetacardTypeAdapter(NULL_METACARD_TYPES_LIST);
     MetacardType metacardType = metacardTypeAdpater.unmarshal(UNKNOWN_TYPE_NAME);
-    assertThat(metacardType.getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacardType.getName(), is(MetacardImpl.BASIC_METACARD.getName()));
   }
 
   @Test
   public void testUnmarshalWithEmptyRegisteredMetacardTypes() throws CatalogTransformerException {
     MetacardTypeAdapter metacardTypeAdpater = new MetacardTypeAdapter(EMPTY_METACARD_TYPES_LIST);
     MetacardType metacardType = metacardTypeAdpater.unmarshal(UNKNOWN_TYPE_NAME);
-    assertThat(metacardType.getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacardType.getName(), is(MetacardImpl.BASIC_METACARD.getName()));
   }
 
   @Test

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/XmlInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/XmlInputTransformerTest.java
@@ -23,7 +23,7 @@ import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transformer.xml.XmlInputTransformer;
@@ -72,7 +72,7 @@ public class XmlInputTransformerTest {
           "\t" + descriptor.getName() + ": " + ((attribute == null) ? null : attribute.getValue()));
     }
 
-    assertThat(metacard.getMetacardType().getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacard.getMetacardType().getName(), is(MetacardImpl.BASIC_METACARD.getName()));
   }
 
   @Test
@@ -81,7 +81,7 @@ public class XmlInputTransformerTest {
     List<MetacardType> metacardTypes = new ArrayList<MetacardType>(1);
     MetacardType extensibleType =
         new MetacardTypeImpl(
-            "extensible.metacard", BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+            "extensible.metacard", MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
     metacardTypes.add(extensibleType);
     xit.setMetacardTypes(metacardTypes);
     Metacard metacard =
@@ -146,7 +146,7 @@ public class XmlInputTransformerTest {
   public void testFallbackToBasicMetacardForUnknowMetacardType()
       throws FileNotFoundException, IOException, CatalogTransformerException, ParseException {
     List<MetacardType> metacardTypes = new ArrayList<MetacardType>(1);
-    metacardTypes.add(BasicTypes.BASIC_METACARD);
+    metacardTypes.add(MetacardImpl.BASIC_METACARD);
     xit.setMetacardTypes(metacardTypes);
 
     Metacard metacard =
@@ -162,7 +162,7 @@ public class XmlInputTransformerTest {
           "\t" + descriptor.getName() + ": " + ((attribute == null) ? null : attribute.getValue()));
     }
 
-    assertThat(metacard.getMetacardType().getName(), is(BasicTypes.BASIC_METACARD.getName()));
+    assertThat(metacard.getMetacardType().getName(), is(MetacardImpl.BASIC_METACARD.getName()));
 
     assertThat("1234567890987654321", is(metacard.getId()));
     assertThat("foobar", is(metacard.getSourceId()));

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/XmlResponseQueueTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/XmlResponseQueueTransformerTest.java
@@ -31,7 +31,6 @@ import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.operation.SourceResponse;
@@ -82,7 +81,7 @@ public class XmlResponseQueueTransformerTest {
 
   private boolean verboseDebug = false;
 
-  private static final String DEFAULT_TYPE_NAME = BasicTypes.BASIC_METACARD.getName();
+  private static final String DEFAULT_TYPE_NAME = MetacardImpl.BASIC_METACARD.getName();
 
   private static final Date DEFAULT_EXPIRATION_DATE = new DateTime(123456789).toDate();
 

--- a/catalog/ui/catalog-ui-enumeration/src/main/java/org/codice/ddf/catalog/ui/enumeration/ExperimentalEnumerationExtractor.java
+++ b/catalog/ui/catalog-ui-enumeration/src/main/java/org/codice/ddf/catalog/ui/enumeration/ExperimentalEnumerationExtractor.java
@@ -20,7 +20,6 @@ import ddf.catalog.data.AttributeInjector;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.validation.AttributeValidatorRegistry;
 import ddf.catalog.validation.violation.ValidationViolation;
@@ -94,7 +93,7 @@ public class ExperimentalEnumerationExtractor {
 
   public Map<String, Set<String>> getEnumerations(@Nullable String metacardType) {
     if (isBlank(metacardType)) {
-      metacardType = BasicTypes.BASIC_METACARD.getName();
+      metacardType = MetacardImpl.BASIC_METACARD.getName();
     }
     MetacardType type = getTypeFromName(metacardType);
 

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/cql/CqlResultTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/cql/CqlResultTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ddf.action.ActionRegistry;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.filter.FilterAdapter;
@@ -55,7 +54,7 @@ public class CqlResultTest {
   }
 
   private void distanceCheck(Double input, Double output) {
-    MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+    MetacardImpl metacard = new MetacardImpl();
     ResultImpl result = new ResultImpl(metacard);
     result.setDistanceInMeters(input);
     ActionRegistry actionRegistry = mock(ActionRegistry.class);

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/monitor/impl/WorkspaceServiceImplTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/monitor/impl/WorkspaceServiceImplTest.java
@@ -26,7 +26,7 @@ import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.federation.FederationException;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.QueryRequest;
@@ -89,7 +89,7 @@ public class WorkspaceServiceImplTest {
     QueryResponse queryResponse = mock(QueryResponse.class);
     Result result = mock(Result.class);
     Metacard metacard = mock(Metacard.class);
-    when(metacard.getMetacardType()).thenReturn(BasicTypes.BASIC_METACARD);
+    when(metacard.getMetacardType()).thenReturn(MetacardImpl.BASIC_METACARD);
     Attribute attribute = mock(Attribute.class);
     when(attribute.getValue()).thenReturn(id);
     when(metacard.getAttribute(Metacard.ID)).thenReturn(attribute);
@@ -231,7 +231,7 @@ public class WorkspaceServiceImplTest {
   public void testGetQueryMetacards() {
 
     Metacard metacard = mock(Metacard.class);
-    when(metacard.getMetacardType()).thenReturn(BasicTypes.BASIC_METACARD);
+    when(metacard.getMetacardType()).thenReturn(MetacardImpl.BASIC_METACARD);
 
     String xml = "<xml/>";
 

--- a/distribution/docs/src/main/resources/content/_data/data-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_data/data-intro.adoc
@@ -51,7 +51,7 @@ For example, an image may have different attributes than a PDF document, so each
 ===== Default Metacard Type and Attributes
 
 Most metacards within the system are created using the default metacard type or a metacard type based on the default type.
-The default metacard type of the system can be programmatically retrieved by calling `ddf.catalog.data.BasicTypes.BASIC_METACARD`.
+The default metacard type of the system can be programmatically retrieved by calling `ddf.catalog.data.impl.MetacardImpl.BASIC_METACARD`.
 The name of the default `MetacardType` can be retrieved from `ddf.catalog.data.MetacardType.DEFAULT_METACARD_TYPE_NAME`.
 
 The default metacard type has the following required attributes.


### PR DESCRIPTION
#### What does this PR do?
Moves the BASIC_METACARD definition to MetacardImpl so BASIC_METACARD can use the common taxonomy attributes instead of redefining them.
Also address some sonarqube findings in MetacardImpl.
#### Who is reviewing it? 
@emmberk @peterhuffer @kcover 

#### Choose 2 committers to review/merge the PR. 
@bdeining
@brendan-hofmann
@coyotesqrl

#### How should this be tested? (List steps with links to updated documentation)
CI Build + manual install
#### What are the relevant tickets?
[DDF-3620](https://codice.atlassian.net/browse/DDF-3620)
