### PR TITLE
DDF-3642 Filters out Fragment bundles from logging on itest failures

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerImpl.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerImpl.java
@@ -665,8 +665,12 @@ public class ServiceManagerImpl implements ServiceManager {
 
     for (Bundle bundle : getBundleContext().getBundles()) {
       if (bundle.getState() != Bundle.ACTIVE) {
-        StringBuilder headerString = new StringBuilder("[ ");
         Dictionary<String, String> headers = bundle.getHeaders();
+        if (headers.get("Fragment-Host") != null) {
+          continue;
+        }
+
+        StringBuilder headerString = new StringBuilder("[ ");
         Enumeration<String> keys = headers.keys();
 
         while (keys.hasMoreElements()) {


### PR DESCRIPTION
#### What does this PR do?
Filters out Fragment bundles from the log messages that are displayed for bundles that are not ACTIVE when itests fail to start.

#### Who is reviewing it? 
@emanns95 @tbatie 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@lessarderic
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
This is an itest change and will only show up on a failure to start. CI should be sufficient, but could be more thoroughly heroed by making a feature/bundle un-deployable for an itest (by depending on something unavailable, for example) and then confirming that the log contains none of the Fragment bundles after the `Listing inactive bundles` log message.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-3642](https://codice.atlassian.net/browse/DDF-3642)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
