### PR TITLE
DDF-3571 Encode relay state when creating SAML signature

### DIFF
--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/binding/redirect/RedirectResponseCreator.java
@@ -20,6 +20,7 @@ import ddf.security.samlp.impl.EntityInformation;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -93,7 +94,9 @@ public class RedirectResponseCreator extends ResponseCreatorImpl implements Resp
             "UTF-8");
     StringBuilder requestToSign = new StringBuilder("SAMLResponse=").append(encodedResponse);
     if (relayState != null) {
-      requestToSign.append("&RelayState=").append(relayState);
+      requestToSign
+          .append("&RelayState=")
+          .append(URLEncoder.encode(relayState, StandardCharsets.UTF_8.name()));
     }
     String assertionConsumerServiceURL = getAssertionConsumerServiceURL(authnRequest);
     UriBuilder uriBuilder = UriBuilder.fromUri(assertionConsumerServiceURL);


### PR DESCRIPTION
#### What does this PR do?
Encodes the RelayState before creating the signature, according to the [SAML Specification Section 3.4.4.1](https://www.oasis-open.org/committees/download.php/56780/sstc-saml-bindings-errata-2.0-wd-06-diff.pdf):
"To construct the signature, a string consisting of the concatenation of the RelayState (if present), SigAlg, and SAMLRequest (or SAMLResponse) query string parameters (each one URLencoded) is constructed"
#### Who is reviewing it? 
@blen-desta 
@kcover
#### Choose 2 committers to review/merge the PR. 
@clockard
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Log into DDF
#### What are the relevant tickets?
[DDF-3571](https://codice.atlassian.net/browse/DDF-3571)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
