### PR TITLE
DDF-3643 Updates search color palette

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/js/ColorGenerator.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/js/ColorGenerator.js
@@ -25,17 +25,21 @@ define([
     return {
         getNewGenerator: function(){
             var colors = [
-                // http://colorbrewer2.org/?type=qualitative&scheme=Paired&n=10
-                '#cab2d6',
-                '#6a3d9a',
-                '#fdbf6f',
-                '#ff7f00',
-                '#fb9a99',
-                '#e31a1c',
-                '#b2df8a',
-                '#33a02c',
-                '#a6cee3',
-                '#1f78b4'
+                // 10 best taken from here: https://ux.stackexchange.com/questions/94696/color-palette-for-all-types-of-color-blindness
+                // http://mkweb.bcgsc.ca/colorblind/
+                '#004949',  //dark turquoise
+                '#009292',  //turquoise
+                '#ff6db6',  //pink
+              //  '#ffb677',  //lightpink 
+                '#490092', //darkpurple
+                '#006ddb',  //darkblue
+                '#b66dff',  //purple
+                '#6db6ff',  //blue
+                '#b6dbff', //lightblue
+                '#924900',  //brown
+               // '#dbd100',  //orange
+                '#24ff24',  //green
+               // '#ffff6d'  //yellow
             ];
             var idToColor = {};
 


### PR DESCRIPTION
#### What does this PR do?
 - Removes colors that typically indicate warnings or errors.
 - Uses the 10 best colors from this palette (https://ux.stackexchange.com/questions/94696/color-palette-for-all-types-of-color-blindness).  These were chosen to avoid warning colors for color blindness as well, so colors that appear fine to normal vision don't appear alarming in others.

#### Who is reviewing it? 
@lcrosenbu 
@jlcsmith 
@pklinef 
@GabrielFabian 
@mackncheesiest 

#### How should this be tested? (List steps with links to updated documentation)
Make ten different searches and examine the colors.

#### Any background context you want to provide?
Users had confusion around thinking certain colors meant the search had issues (red, orange).  This should remove confusion and provide a better color palette for colorblind users.

#### What are the relevant tickets?
[DDF-3643](https://codice.atlassian.net/browse/DDF-3643)

#### Screenshots (if appropriate)
![screen shot 2018-03-06 at 3 42 50 pm](https://user-images.githubusercontent.com/11984853/37065705-2c0d5dd6-215f-11e8-8a7a-fbdb33369559.png)
![screen shot 2018-03-06 at 3 42 24 pm](https://user-images.githubusercontent.com/11984853/37065707-2c46af5a-215f-11e8-98a6-abf728e1fa20.png)


#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
