### PR TITLE
 DDF-3670 Added boundary supplier to OverviewMetacardTransformer

### DIFF
--- a/catalog/transformer/catalog-transformer-overlay/src/main/java/ddf/catalog/transformer/ThumbnailBoundarySupplier.java
+++ b/catalog/transformer/catalog-transformer-overlay/src/main/java/ddf/catalog/transformer/ThumbnailBoundarySupplier.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer;
+
+import com.vividsolutions.jts.geom.Geometry;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.transform.CatalogTransformerException;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThumbnailBoundarySupplier
+    implements BiFunction<Metacard, Map<String, Serializable>, Optional<Geometry>> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThumbnailBoundarySupplier.class);
+
+  @Override
+  public Optional<Geometry> apply(
+      Metacard metacard, Map<String, Serializable> stringSerializableMap) {
+    try {
+      Geometry geometry = GeometryUtils.parseGeometry(metacard.getLocation());
+      return Optional.of(geometry);
+    } catch (CatalogTransformerException e) {
+      LOGGER.debug("Unable to parse location", e);
+      return Optional.empty();
+    }
+  }
+}

--- a/catalog/transformer/catalog-transformer-overlay/src/test/java/ddf/catalog/transformer/ThumbnailBoundarySupplierTest.java
+++ b/catalog/transformer/catalog-transformer-overlay/src/test/java/ddf/catalog/transformer/ThumbnailBoundarySupplierTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.vividsolutions.jts.geom.Geometry;
+import ddf.catalog.data.impl.MetacardImpl;
+import java.util.Optional;
+import org.junit.Test;
+
+public class ThumbnailBoundarySupplierTest {
+
+  private ThumbnailBoundarySupplier supplier = new ThumbnailBoundarySupplier();
+
+  @Test
+  public void testValidWkt() {
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setLocation("POLYGON ((0 1, 1 0, 0 -1, -1 0, 0 1))");
+    Optional<Geometry> geometry = supplier.apply(metacard, null);
+    assertThat(geometry.isPresent(), is(true));
+  }
+
+  @Test
+  public void testInvalidWkt() {
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setLocation("INVALID WKT");
+    Optional<Geometry> geometry = supplier.apply(metacard, null);
+    assertThat(geometry.isPresent(), is(false));
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -285,7 +285,7 @@
         <service-properties>
             <entry key="urlPatterns" value="/search/catalog/internal/*"/>
         </service-properties>
-</service>
+    </service>
 
     <bean id="securityService"
           class="org.codice.ddf.catalog.ui.query.monitor.impl.SecurityServiceImpl"/>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -285,7 +285,7 @@
         <service-properties>
             <entry key="urlPatterns" value="/search/catalog/internal/*"/>
         </service-properties>
-    </service>
+</service>
 
     <bean id="securityService"
           class="org.codice.ddf.catalog.ui.query.monitor.impl.SecurityServiceImpl"/>


### PR DESCRIPTION
#### What does this PR do?
Makes the OverviewMetacardTransformer more extensible by enabling the ability to override the logic used to get the bounding polygon of the image.
#### Who is reviewing it? 
@GabrielFabian @jrnorth @troymohl @AzGoalie @dcruver @jlcsmith 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@jlcsmith
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
Full build
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3670](https://codice.atlassian.net/browse/DDF-3670)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
