### PR TITLE
DDF-3655 Ensuring Backend Exports Only Visibly Selected Attributes

### DIFF
--- a/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformer.java
+++ b/catalog/transformer/catalog-transformer-csv/src/main/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformer.java
@@ -90,8 +90,10 @@ public class CsvQueryResponseTransformer implements QueryResponseTransformer {
         Optional.ofNullable((Map<String, String>) arguments.get(COLUMN_ALIAS_KEY))
             .orElse(Collections.emptyMap());
 
+    Set<String> requestedFields = new HashSet<>(attributeOrder);
+
     Set<AttributeDescriptor> allAttributeDescriptors =
-        getAllRequestedAttributes(upstreamResponse.getResults(), hiddenFields);
+        getAllRequestedAttributes(upstreamResponse.getResults(), hiddenFields, requestedFields);
 
     List<AttributeDescriptor> sortedAttributeDescriptors =
         sortAttributes(allAttributeDescriptors, attributeOrder);
@@ -169,7 +171,9 @@ public class CsvQueryResponseTransformer implements QueryResponseTransformer {
   }
 
   private Set<AttributeDescriptor> getAllRequestedAttributes(
-      final List<Result> results, final Set<String> hiddenFields) {
+      final List<Result> results,
+      final Set<String> hiddenFields,
+      final Set<String> requestedFields) {
 
     Set<AttributeDescriptor> allAttributes = new HashSet<>();
 
@@ -191,6 +195,9 @@ public class CsvQueryResponseTransformer implements QueryResponseTransformer {
                             !AttributeType.AttributeFormat.OBJECT.equals(
                                 desc.getType().getAttributeFormat()))
                     .filter(desc -> !hiddenFields.contains(desc.getName()))
+                    .filter(
+                        desc ->
+                            requestedFields.isEmpty() || requestedFields.contains(desc.getName()))
                     .forEach(allAttributes::add));
 
     return allAttributes;

--- a/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformerTest.java
@@ -86,7 +86,7 @@ public class CsvQueryResponseTransformerTest {
     String[] hiddenFieldsArray = {"attribute3", "attribute5"};
     argumentsMap.put("hiddenFields", buildSet(hiddenFieldsArray));
 
-    String[] columnOrderArray = {"attribute4", "attribute2"};
+    String[] columnOrderArray = {"attribute4", "attribute2", "attribute1"};
     argumentsMap.put("columnOrder", buildList(columnOrderArray));
 
     String[][] aliases = {{"attribute1", "column1"}, {"attribute2", "column2"}};
@@ -98,7 +98,11 @@ public class CsvQueryResponseTransformerTest {
     Scanner scanner = new Scanner(bc.getInputStream());
     scanner.useDelimiter("\\n|\\r|,");
 
-    // OBJECT types, BINARY types and hidden attributes will be filtered out
+    /*
+     * OBJECT types, BINARY types and hidden attributes will be filtered out
+     * We want to ensure that the only output data matches the explicitly requested headers
+     */
+
     String[] expectedHeaders = {"attribute4", "column2", "column1"};
     validate(scanner, expectedHeaders);
 

--- a/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-csv/src/test/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformerTest.java
@@ -86,7 +86,7 @@ public class CsvQueryResponseTransformerTest {
     String[] hiddenFieldsArray = {"attribute3", "attribute5"};
     argumentsMap.put("hiddenFields", buildSet(hiddenFieldsArray));
 
-    String[] columnOrderArray = {"attribute4", "attribute2", "attribute1"};
+    String[] columnOrderArray = {"attribute4", "attribute2"};
     argumentsMap.put("columnOrder", buildList(columnOrderArray));
 
     String[][] aliases = {{"attribute1", "column1"}, {"attribute2", "column2"}};
@@ -103,12 +103,12 @@ public class CsvQueryResponseTransformerTest {
      * We want to ensure that the only output data matches the explicitly requested headers
      */
 
-    String[] expectedHeaders = {"attribute4", "column2", "column1"};
+    String[] expectedHeaders = {"attribute4", "column2"};
     validate(scanner, expectedHeaders);
 
     // The scanner will split "value,4" into two tokens even though the CSVPrinter will
     // handle it correctly.
-    String[] expectedValues = {"", "\"value", "4\"", "101", "value1"};
+    String[] expectedValues = {"", "\"value", "4\"", "101"};
 
     for (int i = 0; i < METACARD_COUNT; i++) {
       validate(scanner, expectedValues);


### PR DESCRIPTION
#### What does this PR do?
Currently from the UI, if a user select a list of items and chooses the "export visible" only option, those attributes along with a whole series of other attributes were added to the output CSV. 

This PR ensures that only the selected attributes from the UI will appear in the output CSV and updates a unit test to reflect this logic adjustment accordingly. 

This is the desired outcome as the UI will only populate columns where data exists and is not null, therefore, the output CSV will not be populated with a series of empty columns with no data. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@GabrielFabian 
@Bdthomson 
@mackncheesiest 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)
1) Ingest some data
2) Do a search in Intrigue
3) Add a "table view" visual from the UI
4) Select only the attribute fields you are interested in
5) Click the "export visible" button
6) Ensure that the CSV ONLY has columns representing the selected attributes from the UI

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3655](https://codice.atlassian.net/projects/DDF/issues/DDF-3665)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ X ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
