### PR TITLE
DDF-3674 Fix conflicting attribute descriptor definitions

### DIFF
--- a/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
+++ b/catalog/transformer/catalog-transformer-streaming-lib/src/main/java/org/codice/ddf/transformer/xml/streaming/lib/SaxEventHandlerDelegate.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.input.TeeInputStream;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.platform.util.XMLUtils;
@@ -167,7 +166,8 @@ public class SaxEventHandlerDelegate extends DefaultHandler {
          */
         if (metacard.getAttribute(attribute.getName()) == null) {
           metacard.setAttribute(attribute);
-        } else if (MapUtils.getBoolean(multiValuedMap, attribute.getName(), false)) {
+        } else if (multiValuedMap.getOrDefault(attribute.getName(), false)) {
+          metacard.getAttribute(attribute.getName()).getValues().removeAll(attribute.getValues());
           metacard.getAttribute(attribute.getName()).getValues().addAll(attribute.getValues());
         }
       }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteAttributes.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/notes/NoteAttributes.java
@@ -17,6 +17,7 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,14 +30,7 @@ public class NoteAttributes implements MetacardType {
 
   static {
     Set<AttributeDescriptor> descriptors = new HashSet<>();
-    descriptors.add(
-        new AttributeDescriptorImpl(
-            NoteConstants.PARENT_ID,
-            true /* indexed */,
-            true /* stored */,
-            true /* tokenized */,
-            false /* multivalued */,
-            BasicTypes.STRING_TYPE));
+    descriptors.add(new AssociationsAttributes().getAttributeDescriptor(NoteConstants.PARENT_ID));
     descriptors.add(
         new AttributeDescriptorImpl(
             NoteConstants.COMMENT,

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/ListMetacardTypeImpl.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/ListMetacardTypeImpl.java
@@ -14,10 +14,11 @@
 package org.codice.ddf.catalog.ui.metacard.workspace;
 
 import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.types.Core;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -38,23 +39,9 @@ public class ListMetacardTypeImpl extends MetacardTypeImpl {
   static {
     LIST_DESCRIPTORS = new HashSet<>();
 
-    LIST_DESCRIPTORS.add(
-        new AttributeDescriptorImpl(
-            Metacard.ID,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            BasicTypes.STRING_TYPE));
+    LIST_DESCRIPTORS.add(MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Core.ID));
 
-    LIST_DESCRIPTORS.add(
-        new AttributeDescriptorImpl(
-            Metacard.TITLE,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            BasicTypes.STRING_TYPE));
+    LIST_DESCRIPTORS.add(MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Core.TITLE));
 
     LIST_DESCRIPTORS.add(
         new AttributeDescriptorImpl(

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/QueryMetacardTypeImpl.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/QueryMetacardTypeImpl.java
@@ -14,10 +14,11 @@
 package org.codice.ddf.catalog.ui.metacard.workspace;
 
 import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.types.Core;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -48,23 +49,9 @@ public class QueryMetacardTypeImpl extends MetacardTypeImpl {
   static {
     QUERY_DESCRIPTORS = new HashSet<>();
 
-    QUERY_DESCRIPTORS.add(
-        new AttributeDescriptorImpl(
-            Metacard.ID,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            BasicTypes.STRING_TYPE));
+    QUERY_DESCRIPTORS.add(MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Core.ID));
 
-    QUERY_DESCRIPTORS.add(
-        new AttributeDescriptorImpl(
-            Metacard.TITLE,
-            true /* indexed */,
-            true /* stored */,
-            false /* tokenized */,
-            false /* multivalued */,
-            BasicTypes.STRING_TYPE));
+    QUERY_DESCRIPTORS.add(MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Core.TITLE));
 
     QUERY_DESCRIPTORS.add(
         new AttributeDescriptorImpl(


### PR DESCRIPTION
#### What does this PR do?
 Fix conflicting attribute descriptor definitions. 
Also adds a check that will log a warning every time a MetacardType is created that has conflicting definitions to help prevent new redefinitions.

#### Who is reviewing it? 
@emmberk @peterhuffer @kcover 
#### Choose 2 committers to review/merge the PR. 
@figliold
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Install DDF and go to Intrigue. 
Verify there are no warnings in the log for `Conflicting attribute definitions`

#### What are the relevant tickets?
[DDF-3674](https://codice.atlassian.net/browse/DDF-3674)
