### PR TITLE
DDF-3297 Updated some Security Manager-related methods in AbstractIntegrationTest to be protected

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -880,8 +880,8 @@ public abstract class AbstractIntegrationTest {
    * Helper Option class to allow interpolation of {@code karaf.home} directory based on the
    * provided {@link #UNPACK_DIRECTORY}.
    */
-  static class HomeAwareVmOption extends VMOption {
-    static HomeAwareVmOption homeAwareVmOption(String option) {
+  protected static class HomeAwareVmOption extends VMOption {
+    public static HomeAwareVmOption homeAwareVmOption(String option) {
       return new HomeAwareVmOption(option);
     }
 
@@ -922,8 +922,8 @@ public abstract class AbstractIntegrationTest {
    * Helper Option class to allow interpolation of {@code karaf.home} directory based on the
    * provided {@link #UNPACK_DIRECTORY}.
    */
-  static class HomePolicyVmOption extends VMOption {
-    static HomePolicyVmOption homePolicyVmOption(String option) {
+  protected static class HomePolicyVmOption extends VMOption {
+    public static HomePolicyVmOption homePolicyVmOption(String option) {
       return new HomePolicyVmOption(option);
     }
 
@@ -967,8 +967,8 @@ public abstract class AbstractIntegrationTest {
    * Helper Option class to allow interpolation of {@code karaf.home} directory based on the
    * provided {@link #UNPACK_DIRECTORY}.
    */
-  static class HomePermVmOption extends VMOption {
-    static HomePermVmOption homePermVmOption(String option) {
+  protected static class HomePermVmOption extends VMOption {
+    public static HomePermVmOption homePermVmOption(String option) {
       return new HomePermVmOption(option);
     }
 


### PR DESCRIPTION
#### What does this PR do?
In a downstream project that extends `AbstractIntegrationTest`, we want the Security Manager turned off for itests. Overriding the `configureVmOptions` method should turn off the Security Manager in the itests, but the `homeXxxOption` methods are not visible outside of the AbstractIntegrationTest class:
```java
  @Override
  protected Option[] configureVmOptions() {
    return options(
        vmOption("-Xmx2048M"),
        // avoid integration tests stealing focus on OS X
        vmOption("-Djava.awt.headless=true"),
        vmOption("-Dfile.encoding=UTF8"),
        HomeAwareVmOption.homeAwareVmOption("-Dddf.home={karaf.home}"),
        HomePermVmOption.homePermVmOption("-Dddf.home.perm={karaf.home}"),
        HomePolicyVmOption.homePolicyVmOption("-Dddf.home.policy={karaf.home}"));
  }
```
#### Who is reviewing it? 
@peterhuffer @kcover @figliold @mcalcote @coyotesqrl
#### Select relevant component teams: 
@codice/security
@codice/test 
#### Choose 2 committers to review/merge the PR. 
@stustison
@clockard
#### How should this be tested?

- Full build of itests
- In a downstream project, confirm that
  - the itests can successfully build after overriding the `configureVmOptions` method.
  - the itests succeed.
  - the Security Manager is turned off in the itests.

#### What are the relevant tickets?
[DDF-3297](https://codice.atlassian.net/browse/DDF-3297)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.