### PR TITLE
DDF-3677 Upgraded several maven plugins

### DIFF
--- a/catalog/resourcemanagement/resourcemanagement-querymonitor-ui/pom.xml
+++ b/catalog/resourcemanagement/resourcemanagement-querymonitor-ui/pom.xml
@@ -213,15 +213,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>de.saumya.mojo</groupId>
-                <artifactId>gem-maven-plugin</artifactId>
-                <version>1.0.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/catalog/resourcemanagement/resourcemanagement-usage-ui/pom.xml
+++ b/catalog/resourcemanagement/resourcemanagement-usage-ui/pom.xml
@@ -251,15 +251,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>de.saumya.mojo</groupId>
-                <artifactId>gem-maven-plugin</artifactId>
-                <version>1.0.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/catalog/spatial/csw/spatial-csw-schema-bindings/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-schema-bindings/pom.xml
@@ -87,7 +87,6 @@
             <plugin>
                 <groupId>org.jvnet.jaxb2.maven2</groupId>
                 <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.13.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -137,24 +136,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Replaced antrun deletion of directories with compiler excludes.
+             Need to exclude several generated classes from the compile phase -->
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.3</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <delete dir="./target/generated-sources/xjc/net/opengis/ogc"/>
-                                <delete dir="./target/generated-sources/xjc/net/opengis/filter"/>
-                                <delete dir="./target/generated-sources/xjc/net/opengis/ows"/>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/net/opengis/ows/*/*.java</exclude>
+                        <exclude>**/net/opengis/ogc/*.java</exclude>
+                        <exclude>**/net/opengis/filter/*/*.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/catalog/spatial/geocoding/spatial-geocoding-admin-module/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-admin-module/pom.xml
@@ -233,18 +233,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- After the doc directory is more consistent across all repositories
-                 there should not be a need for the gem-maven-plugin and
-                 maven-antrun-plugin in this pom file to generate docs -->
-            <plugin>
-                <groupId>de.saumya.mojo</groupId>
-                <artifactId>gem-maven-plugin</artifactId>
-                <version>1.0.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/catalog/spatial/geowebcache/geowebcache-admin-plugin/pom.xml
+++ b/catalog/spatial/geowebcache/geowebcache-admin-plugin/pom.xml
@@ -173,15 +173,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>de.saumya.mojo</groupId>
-                <artifactId>gem-maven-plugin</artifactId>
-                <version>1.0.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-schema-bindings/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-schema-bindings/pom.xml
@@ -95,23 +95,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Replaced antrun deletion of directories with compiler excludes.
+             Need to exclude several generated classes from the compile phase -->
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.3</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <delete dir="./target/generated-sources/xjc/net/opengis/filter"/>
-                                <delete dir="./target/generated-sources/xjc/net/opengis/ows"/>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/net/opengis/ows/*/*.java</exclude>
+                        <exclude>**/net/opengis/filter/*/*.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/catalog/transformer/catalog-transformer-xml-binding/pom.xml
+++ b/catalog/transformer/catalog-transformer-xml-binding/pom.xml
@@ -81,22 +81,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Replaced antrun deletion of directories with compiler excludes.
+             Need to exclude several generated classes from the compile phase -->
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.3</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <delete dir="./target/generated-sources/xjc/net/opengis/gml"/>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/net/opengis/gml/*/*.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/platform/admin/modules/admin-security-ui/pom.xml
+++ b/platform/admin/modules/admin-security-ui/pom.xml
@@ -265,28 +265,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-            </plugin>
-            <!--<plugin>-->
-            <!--<groupId>org.asciidoctor</groupId>-->
-            <!--<artifactId>asciidoctor-maven-plugin</artifactId>-->
-            <!--<executions>-->
-            <!--<execution>-->
-            <!--<id>output-html</id>-->
-            <!--<phase>generate-resources</phase>-->
-            <!--<goals>-->
-            <!--<goal>process-asciidoc</goal>-->
-            <!--</goals>-->
-            <!--<configuration>-->
-            <!--<sourceDirectory>src/main/doc</sourceDirectory>-->
-            <!--<outputDirectory>target/webapp</outputDirectory>-->
-            <!--<backend>html</backend>-->
-            <!--</configuration>-->
-            <!--</execution>-->
-            <!--</executions>-->
-            <!--</plugin>-->
         </plugins>
     </build>
     <profiles>

--- a/platform/osgi/platform-osgi-configadmin/pom.xml
+++ b/platform/osgi/platform-osgi-configadmin/pom.xml
@@ -80,7 +80,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
                     <!--Felix styles don't match ours, even after running the formatter-->
-                    <excludes>src/main/java/org/apache/</excludes>
+                    <excludes>**/org/apache/**</excludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.20.1</version>
                     <configuration>
                         <argLine>${argLine} -Djava.awt.headless=true -noverify</argLine>
                         <includes>
@@ -356,7 +356,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.20.1</version>
                     <executions>
                         <execution>
                             <goals>
@@ -382,7 +382,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.7.0</version>
                     <configuration>
                         <compilerId>javac-with-errorprone</compilerId>
                         <compilerArgs>
@@ -414,11 +414,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                     <configuration>
@@ -428,11 +423,6 @@
                         <arguments>-Prelease ${arguments}</arguments>
                         <useReleaseProfile>false</useReleaseProfile>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -465,17 +455,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.3.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.5.1</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
@@ -486,16 +466,16 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.jaxb2.maven2</groupId>
                     <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>0.13.0</version>
+                    <version>0.13.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
+                    <version>3.0.0</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>
@@ -559,7 +539,7 @@
             <plugin>
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.3.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -590,7 +570,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.9</version>
                 <configuration>
                     <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
@@ -613,7 +593,7 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-checkstyle-plugin</artifactId>
-                            <version>2.17</version>
+                            <version>3.0.0</version>
                             <dependencies>
                                 <dependency>
                                     <groupId>ddf.support</groupId>
@@ -633,8 +613,6 @@
                                         <!-- This configures the plugin for mvn install -->
                                         <configLocation>checkstyle-enforced.xml</configLocation>
                                         <headerLocation>lpgl-header-check.txt</headerLocation>
-                                        <sourceDirectory>${basedir}</sourceDirectory>
-                                        <includes>src/**/*.java</includes>
                                         <consoleOutput>true</consoleOutput>
                                         <failsOnError>true</failsOnError>
                                         <linkXRef>false</linkXRef>
@@ -651,7 +629,7 @@
                                         <!-- This configures the plugin for mvn install -->
                                         <configLocation>checkstyle-enforced-xml.xml</configLocation>
                                         <headerLocation>lpgl-header-check-xml.txt</headerLocation>
-                                        <sourceDirectory>${basedir}</sourceDirectory>
+                                        <sourceDirectories>${basedir}</sourceDirectories>
                                         <includes>src/**/*.xml, pom.xml</includes>
                                         <consoleOutput>true</consoleOutput>
                                         <failsOnError>true</failsOnError>
@@ -664,8 +642,6 @@
                                 <!-- This configures the plugin for mvn checkstyle:checkstyle  -->
                                 <configLocation>checkstyle-enforced.xml</configLocation>
                                 <headerLocation>lpgl-header-check.txt</headerLocation>
-                                <sourceDirectory>${basedir}</sourceDirectory>
-                                <includes>src/**/*.java</includes>
                                 <consoleOutput>true</consoleOutput>
                                 <failsOnError>true</failsOnError>
                                 <linkXRef>false</linkXRef>
@@ -780,7 +756,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
-                        <version>2.17</version>
+                        <version>3.0.0</version>
                     </plugin>
                 </plugins>
             </reporting>


### PR DESCRIPTION
#### What does this PR do?

Upgrades the following plugins

* maven-surefire-plugin
* maven-failsafe-plugin
* maven-compiler-plugin
* maven-jar-plugin
* build-helper-maven-plugin
* maven-jaxb2-plugin
* maven-javadoc-plugin
* fmt-maven-plugin
* maven-project-info-reports-plugin
* maven-checkstyle-plugin

Removes the following plugins from pluginManagement

* maven-deploy-plugin
* maven-clean-plugin
* maven-install-plugin
* cobertura-maven-plugin

Additional
* removes maven-antrun-plugin usages
* removes old/unnecessary gem-maven-plugin usages

#### Who is reviewing it? 

@peterhuffer @emmberk @kcover 

#### Select relevant component teams: 

@codice/build 

#### Choose 2 committers to review/merge the PR. 

@shaundmorris @clockard 

#### How should this be tested? (List steps with links to updated documentation)
Run a full build

#### What are the relevant tickets?

[DDF-3677](https://codice.atlassian.net/browse/DDF-3677)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
