### PR TITLE
DDF-2824 Fixed some typos in IngestCommand and some configurations

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -147,7 +147,7 @@ public class IngestCommand extends CatalogCommands {
   @Argument(
     name = "File path or Directory path",
     description =
-        "Path to a file or a directory of files to be ingested. Paths can be absolute or relative to installation directory."
+        "Path to a file or a directory of file(s) to be ingested. Paths can be absolute or relative to installation directory."
             + " This command can only detect roughly 2 billion files in one directory. Individual operating system limits might also apply.",
     index = 0,
     multiValued = false,
@@ -174,7 +174,7 @@ public class IngestCommand extends CatalogCommands {
     aliases = {"-t", "Transformer"},
     multiValued = false,
     description =
-        "The metacard transformer ID to use to transform data files into metacards. "
+        "The metacard transformer ID to use to transform data file(s) into metacard(s). "
             + "The default metacard transformer is the XML transformer."
   )
   String transformerId = DEFAULT_TRANSFORMER_ID;
@@ -197,7 +197,7 @@ public class IngestCommand extends CatalogCommands {
     aliases = {"-d", "-f", "Ingest Failure Directory"},
     multiValued = false,
     description =
-        "The directory to put files that failed to ingest.  Using this option will force a batch size of 1."
+        "The directory to put file(s) that failed to ingest. Using this option will force a batch size of 1."
   )
   String failedDir = null;
 
@@ -227,7 +227,7 @@ public class IngestCommand extends CatalogCommands {
     aliases = {},
     multiValued = false,
     description =
-        "Ingest a zip file that contains metacards and content using the default transformer.  The specified zip must be signed externally using DDF certificates."
+        "Ingest a zip file that contains metacards and content using the default transformer. The specified zip must be signed externally using DDF certificates."
   )
   boolean includeContent = false;
 
@@ -328,20 +328,20 @@ public class IngestCommand extends CatalogCommands {
             Integer.toString(fileCount.get() - ingestCount.get() - ignoreCount.get());
         console.println();
         printErrorMessage(
-            failedAmount + " file(s) failed to be ingested.  See the ingest log for more details.");
-        INGEST_LOGGER.warn("{} files(s) failed to be ingested.", failedAmount);
+            failedAmount + " file(s) failed to be ingested. See the ingest log for more details.");
+        INGEST_LOGGER.warn("{} file(s) failed to be ingested.", failedAmount);
       }
       if (ignoreList != null) {
         String ignoredAmount = Integer.toString(ignoreCount.get());
         console.println();
         printColor(
             Ansi.Color.YELLOW,
-            ignoredAmount + " file(s) ignored.  See the ingest log for more details.");
-        INGEST_LOGGER.warn("{} files(s) were ignored.", ignoredAmount);
+            ignoredAmount + " file(s) ignored. See the ingest log for more details.");
+        INGEST_LOGGER.warn("{} file(s) were ignored.", ignoredAmount);
       }
     }
     console.println();
-    SecurityLogger.audit("Ingested {} files from {}", ingestCount.get(), filePath);
+    SecurityLogger.audit("Ingested {} file(s) from {}", ingestCount.get(), filePath);
     return null;
   }
 
@@ -445,7 +445,7 @@ public class IngestCommand extends CatalogCommands {
   private void logIngestException(IngestException exception, File inputFile) {
     LOGGER.debug("Failed to ingest file [{}].", inputFile.getAbsolutePath(), exception);
     INGEST_LOGGER.warn(
-        "Failed to ingest file [{}]:  \n{}",
+        "Failed to ingest file [{}]:\n{}",
         inputFile.getAbsolutePath(),
         Exceptions.getFullMessage(exception));
   }
@@ -680,9 +680,9 @@ public class IngestCommand extends CatalogCommands {
         INGEST_LOGGER.warn("Unable to transform zip file into metacard list.", e);
       }
     } else {
-      LOGGER.info("No Zip Transformer found.  Unable to transform zip file into metacard list.");
+      LOGGER.info("No Zip Transformer found. Unable to transform zip file into metacard list.");
       INGEST_LOGGER.warn(
-          "No Zip Transformer found.  Unable to transform zip file into metacard list.");
+          "No Zip Transformer found. Unable to transform zip file into metacard list.");
     }
   }
 

--- a/catalog/schematron/catalog-schematron-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/schematron/catalog-schematron-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -14,23 +14,23 @@
 -->
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
-  <OCD description="Schematron Validators"
-       name="Schematron Validation Services"
-       id="ddf.services.schematron.SchematronValidationService" >
+    <OCD description="Schematron Validators"
+         name="Schematron Validation Services"
+         id="ddf.services.schematron.SchematronValidationService">
 
-    <AD name="Ruleset Name" id="id" required="true" type="String"
-        description="Give this ruleset a name" />
+        <AD name="Ruleset Name" id="id" type="String" description="Give this ruleset a name"/>
 
-    <AD name="Root Namepsace" id="namespace" required="true" type="String"
-        description="The root namespace of the XML" />
+        <AD name="Root Namespace" id="namespace" type="String"
+            description="The root namespace of the XML"/>
 
-    <AD name="Schematron Files" id="schematronFileNames" required="true" type="String" cardinality="100"
-        description="Schematron files (*.sch) to be validated against" />
+        <AD name="Schematron File Names" id="schematronFileNames" type="String" cardinality="100"
+            description="Names of schematron files (*.sch) against which to validate metadata ingested into the Catalog. Absolute paths or relative paths may be specified. Relative paths are assumed to be relative to `${home_directory}/schematron`."/>
 
-  </OCD>
+    </OCD>
 
-  <Designate pid="ddf.services.schematron.SchematronValidationService" factoryPid="ddf.services.schematron.SchematronValidationService">
-    <Object ocdref="ddf.services.schematron.SchematronValidationService" />
-  </Designate>
+    <Designate pid="ddf.services.schematron.SchematronValidationService"
+               factoryPid="ddf.services.schematron.SchematronValidationService">
+        <Object ocdref="ddf.services.schematron.SchematronValidationService"/>
+    </Designate>
 
 </metatype:MetaData>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -12,26 +12,19 @@
     </suppress>
     <suppress>
         <notes>
-            FasterXML jackson-databind through 2.8.10 and 2.9.x through 2.9.3 allows unauthenticated remote code
-            execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by
-            sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist
-            that is ineffective if the Spring libraries are available in the classpath.
-            We have upgraded to 2.9.4 which fixes the issue but version 2.6.3 is still being used by
+            FasterXML jackson-databind through 2.8.10 and 2.9.x through 2.9.3 allows unauthenticated
+            remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization
+            flaw. This is exploitable by sending maliciously crafted JSON input to the readValue
+            method of the ObjectMapper, bypassing a blacklist that is ineffective if the Spring
+            libraries are available in the classpath. We have upgraded to 2.9.4 which fixes the
+            issue but version 2.6.3 is still being used by
             org.apache.cxf:cxf-rt-rs-security-sso-saml -> ehcache-2.10.4 -> jackson-databind-2.6.3.
-            This suppression can be removed when DDF-3593 has been completed.
+            This suppression can be removed when DDF-3593 has been completed. CVE-2017-15095 extends
+            CVE-2017-7525 by blacklisting more classes.
         </notes>
         <cve>CVE-2017-17485</cve>
-    </suppress>
-    <suppress>
-        <notes>
-            FasterXML jackson-databind through 2.8.10 and 2.9.x through 2.9.3 allows unauthenticated remote code
-            execution. This is exploitable by sending maliciously crafted JSON input to the readValue method of
-            the ObjectMapper, bypassing a blacklist that is ineffective if the Spring libraries are available
-            in the classpath. We have upgraded to 2.9.4 which fixes the issue but version 2.6.3 is still
-            being used by org.apache.cxf:cxf-rt-rs-security-sso-saml/ehcache-2.10.4/jackson-databind-2.6.3.
-            This suppression can be removed when DDF-3593 has been completed.
-        </notes>
         <cve>CVE-2017-7525</cve>
+        <cve>CVE-2017-15095</cve>
     </suppress>
     <suppress>
         <notes>

--- a/distribution/docs/src/main/resources/content/_securityServices/expansion-service.adoc
+++ b/distribution/docs/src/main/resources/content/_securityServices/expansion-service.adoc
@@ -41,9 +41,10 @@ The following table lists the two pre-defined instances used by ${ddf-branding} 
 
 Each instance of the expansion service can be configured using a configuration file.
 The configuration file can have three different types of lines:
-comments:: any line prefixed with the `#` character is ignored as a comment (for readability, blank lines are also ignored)
-attribute separator:: a line starting with `separator=` defines the attribute separator string.
-rule:: all other lines are assumed to be rules defined in a string format `<key>:<original value>:<new value>`
+
+* comments: any line prefixed with the `#` character is ignored as a comment (for readability, blank lines are also ignored)
+* attribute separator: a line starting with `separator=` defines the attribute separator string.
+* rule: all other lines are assumed to be rules defined in a string format `<key>:<original value>:<new value>`
 
 The following configuration file defines the rules shown above in the example table (using the space as a separator):
 
@@ -119,9 +120,9 @@ Title : VP-Engineering : VP-Engineering VP Engineering
 
 ====== security:expand
 
-The security:expand command runs the expansion service on the provided data.
+The `security:expand` command runs the expansion service on the provided data.
 It takes an attribute and an original value, expands the original value using the current expansion service and ruleset and dumps the results.
-For the ruleset shown above, the expand command produces the following results:
+For the ruleset shown above, the `security:expand` command produces the following results:
 
 [source]
 ----

--- a/distribution/docs/src/main/resources/content/_tables/SchematronValidationService.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/SchematronValidationService.adoc
@@ -23,17 +23,19 @@
 |null
 |true
 
-|Root Namepsace
+|Root Namespace
 |namespace
 |String
 |The root namespace of the XML
 |null
 |true
 
-|Schematron Files
+|Schematron File Names
 |schematronFileNames
 |String
-|Schematron files (*.sch) to be validated against
+|Names of schematron files (*.sch) against which to validate metadata ingested into the Catalog.
+Absolute paths or relative paths may be specified.
+Relative paths are assumed to be relative to `${home_directory}/schematron`.
 |null
 |true
 

--- a/platform/security/expansion/security-expansion-metacardattr-map/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/expansion/security-expansion-metacardattr-map/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,14 +18,13 @@
     <OCD description="Expansion Service for Metacard Attributes"
          name="Security Metacard Attribute Mapping"
          id="ddf.security.metacard.attribute.mapping">
-        <AD description="Attribute separator - used to separate attributes in replacement strings - defaults to space (specified by no value)."
-            name="Attribute Separator" id="attributeSeparator" required="false"
-            type="String" default=" "/>
+        <AD description="Used to separate attributes in replacement strings. Defaults to space (specified by no value)."
+            name="Attribute Separator" id="attributeSeparator" required="false" type="String"
+            default=" "/>
 
         <AD description="Location of the file containing the attribute expansion rules."
-            name="Expansion Rules Configuration File Location" id="expansionFileName"
-            required="true"
-            type="String" default="${ddf.home}/etc/pdp/ddf-metacard-attribute-ruleset.cfg"/>
+            name="Expansion Rules Configuration File Location" id="expansionFileName" type="String"
+            default="${ddf.home}/etc/pdp/ddf-metacard-attribute-ruleset.cfg"/>
     </OCD>
 
     <Designate pid="ddf.security.metacard.attribute.mapping">

--- a/platform/security/expansion/security-expansion-userattr-map/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/expansion/security-expansion-userattr-map/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,14 +18,13 @@
     <OCD description="Expansion Service for User Attributes"
          name="Security User Attribute Mapping"
          id="ddf.security.user.attribute.mapping">
-        <AD description="Attribute separator - used to separate attributes in replacement strings - defaults to space (specified by no value)."
-            name="Attribute Separator" id="attributeSeparator" required="false"
-            type="String" default=" "/>
+        <AD description="Used to separate attributes in replacement strings. Defaults to space (specified by no value)."
+            name="Attribute Separator" id="attributeSeparator" required="false" type="String"
+            default=" "/>
 
         <AD description="Location of the file containing the attribute expansion rules."
-            name="Expansion Rules Configuration File Location" id="expansionFileName"
-            required="true"
-            type="String" default="${ddf.home}/etc/pdp/ddf-user-attribute-ruleset.cfg"/>
+            name="Expansion Rules Configuration File Location" id="expansionFileName" type="String"
+            default="${ddf.home}/etc/pdp/ddf-user-attribute-ruleset.cfg"/>
     </OCD>
 
     <Designate pid="ddf.security.user.attribute.mapping">

--- a/platform/solr/platform-solr-server-standalone/dependency-check-maven-config.xml
+++ b/platform/solr/platform-solr-server-standalone/dependency-check-maven-config.xml
@@ -18,26 +18,19 @@
     </suppress>
     <suppress>
         <notes>
-            FasterXML jackson-databind through 2.8.10 and 2.9.x through 2.9.3 allows unauthenticated remote code
-            execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by
-            sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist
-            that is ineffective if the Spring libraries are available in the classpath.
-            We have upgraded to 2.9.4 which fixes the issue but version 2.6.3 is still being used by
+            FasterXML jackson-databind through 2.8.10 and 2.9.x through 2.9.3 allows unauthenticated
+            remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization
+            flaw. This is exploitable by sending maliciously crafted JSON input to the readValue
+            method of the ObjectMapper, bypassing a blacklist that is ineffective if the Spring
+            libraries are available in the classpath. We have upgraded to 2.9.4 which fixes the
+            issue but version 2.6.3 is still being used by
             org.apache.cxf:cxf-rt-rs-security-sso-saml -> ehcache-2.10.4 -> jackson-databind-2.6.3.
-            This suppression can be removed when DDF-3593 has been completed.
+            This suppression can be removed when DDF-3593 has been completed. CVE-2017-15095 extends
+            CVE-2017-7525 by blacklisting more classes.
         </notes>
         <cve>CVE-2017-17485</cve>
-    </suppress>
-    <suppress>
-        <notes>
-            FasterXML jackson-databind through 2.8.10 and 2.9.x through 2.9.3 allows unauthenticated remote code
-            execution. This is exploitable by sending maliciously crafted JSON input to the readValue method of
-            the ObjectMapper, bypassing a blacklist that is ineffective if the Spring libraries are available
-            in the classpath. We have upgraded to 2.9.4 which fixes the issue but version 2.6.3 is still
-            being used by org.apache.cxf:cxf-rt-rs-security-sso-saml/ehcache-2.10.4/jackson-databind-2.6.3.
-            This suppression can be removed when DDF-3593 has been completed.
-        </notes>
         <cve>CVE-2017-7525</cve>
+        <cve>CVE-2017-15095</cve>
     </suppress>
     <suppress>
         <notes>


### PR DESCRIPTION
#### What does this PR do?
- Fixes some typos in `IngestCommand`
- Fixes some typos in the `Expansion Service` metatypes and docs
- Adds a note about relative file paths to the `Schematron File Names` field in the `Schematron Validators` configuration
#### Who is reviewing it? 
@kcover @peterhuffer
#### Select relevant component teams: 
@codice/docs 
#### Choose 2 committers to review/merge the PR. 
@clockard
@ricklarsen
#### How should this be tested?
Full build. Check that tooltips and docs are formatted correctly.
#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.