### PR TITLE
DDF-3678 Enable Functionality for Saving Default Query Templates

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/search-form/filter.search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/search-form/filter.search-form.view.js
@@ -45,7 +45,7 @@ define([
             FilterView.prototype.onBeforeShow.call(this);
             this.filterAttribute.currentView.turnOffEditing();
         },
-        transformValue: function (value, defaultValue, comparator) {
+        transformValue: function (value, comparator) {
             switch (comparator) {
                 case 'NEAR':
                     if (value[0].constructor !== Object) {
@@ -59,38 +59,14 @@ define([
                 case 'DWITHIN':
                     break;
                 default:
-					if (value[0] != null && value[0].constructor === Object) {
-						value[0] = value[0].value;
-					} else if(defaultValue != "") {
-						value[0] = defaultValue;
-					} else if (value == null) {
-						value[0] = "";     
-					} 
-					break;
+                   if (value[0] == null) {
+                        value[0] = "";
+                   } else if (value[0].constructor === Object) {
+                        value[0] = value[0].value;
+                   }
+                   break;
             }
             return value;
-        },
-        determineInput: function(){
-            this.updateValueFromInput();
-            let value = Common.duplicate(this.model.get('value'));
-            var defaultValue = "";
-            if(typeof this.model.get('defaultValue') !== 'undefined'){
-                defaultValue = Common.duplicate(this.model.get('defaultValue'));
-            }
-            const currentComparator = this.model.get('comparator');
-            value = this.transformValue(value, defaultValue, currentComparator);
-            FilterView.propertyJSON = FilterView.prototype.generatePropertyJSON(value, this.model.get('type'), currentComparator);
-            this.filterInput.show(new MultivalueView({
-                model: new PropertyModel(FilterView.propertyJSON)
-            }));
-
-            var isEditing = this.$el.hasClass('is-editing');
-            if (isEditing){
-                this.turnOnEditing();
-            } else {
-                this.turnOffEditing();
-            }
-            this.setDefaultComparator(FilterView.propertyJSON);
         },
         turnOnEditing: function(){
             this.$el.addClass('is-editing');
@@ -100,27 +76,6 @@ define([
                 ? this.filterInput.currentView.model.get('property')
                 : this.filterInput.currentView.model;
             property.set('isEditing', true);
-        },
-        setFilter: function(filter){
-            setTimeout(function(){
-                if (CQLUtils.isGeoFilter(filter.type)){
-                    filter.value = _.clone(filter);
-                }
-                if (_.isObject(filter.property)) {
-                    // if the filter is something like NEAR (which maps to a CQL filter function such as 'proximity'),
-                    // there is an enclosing filter that creates the necessary '= TRUE' predicate, and the 'property'
-                    // attribute is what actually contains that proximity() call.
-                    this.setFilterFromFilterFunction(filter.property);
-                } else {
-                    this.model.set({
-                        value: [filter.value],
-                        type: filter.property.split('"').join(''),
-                        comparator: this.CQLtoComparator()[filter.type],
-                        defaultValue: [filter.defaultValue]
-                    });
-                }
-
-            }.bind(this),0);
         },
         turnOffEditing: function(){
             this.$el.removeClass('is-editing');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -26,8 +26,8 @@ var store = require('js/store');
 var QueryConfirmationView = require('component/confirmation/query/confirmation.query.view');
 var LoadingView = require('component/loading/loading.view');
 var wreqr = require('wreqr');
+var user = require('component/singletons/user-instance');
 const cql = require('js/cql');
-const user = require('component/singletons/user-instance');
 
 module.exports = Marionette.LayoutView.extend({
     template: template,
@@ -105,7 +105,18 @@ module.exports = Marionette.LayoutView.extend({
         }));
     },
     focus: function () {
+        this.loadDefaultTemplate();
         this.queryContent.currentView.focus();
+    },
+    loadDefaultTemplate: function() {
+        var defaultTemplate = user.getQuerySettings().get('defaultTemplate');
+
+        if (defaultTemplate) {
+            this.queryContent.show(new QueryCustom({
+                model: new Query.Model(defaultTemplate.model),
+                filterTemplate: defaultTemplate.filterTemplate
+            }));
+        }
     },
     edit: function () {
         this.$el.addClass('is-editing');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -26,7 +26,7 @@ var store = require('js/store');
 var QueryConfirmationView = require('component/confirmation/query/confirmation.query.view');
 var LoadingView = require('component/loading/loading.view');
 var wreqr = require('wreqr');
-var user = require('component/singletons/user-instance');
+const user = require('component/singletons/user-instance');
 const cql = require('js/cql');
 
 module.exports = Marionette.LayoutView.extend({
@@ -105,18 +105,7 @@ module.exports = Marionette.LayoutView.extend({
         }));
     },
     focus: function () {
-        this.loadDefaultTemplate();
         this.queryContent.currentView.focus();
-    },
-    loadDefaultTemplate: function() {
-        var defaultTemplate = user.getQuerySettings().get('defaultTemplate');
-
-        if (defaultTemplate) {
-            this.queryContent.show(new QueryCustom({
-                model: new Query.Model(defaultTemplate.model),
-                filterTemplate: defaultTemplate.filterTemplate
-            }));
-        }
     },
     edit: function () {
         this.$el.addClass('is-editing');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.hbs
@@ -13,9 +13,6 @@
  --}}
 <form target="autocomplete" action="/search/catalog/blank.html" novalidate>
     <div class="editor-properties">
-        <div class="query-advanced-label">
-            Custom Search Form: <i>{{templateTitle}}</i>
-        </div><br>
         <div class="query-custom-label">
         </div>
         <div class="query-advanced">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.hbs
@@ -14,7 +14,9 @@
 <form target="autocomplete" action="/search/catalog/blank.html" novalidate>
     <div class="editor-properties">
         <div class="query-advanced-label">
-            Search
+            Custom Search Form: <i>{{templateTitle}}</i>
+        </div><br>
+        <div class="query-custom-label">
         </div>
         <div class="query-advanced">
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.view.js
@@ -24,9 +24,11 @@ define([
     'js/cql',
     'js/store',
     'component/query-settings/query-settings.view',
-    'component/query-advanced/query-advanced.view'
+    'component/query-advanced/query-advanced.view',
+    'component/singletons/user-instance',
+    'component/announcement'
 ], function (Marionette, _, $, template, CustomElements, FilterBuilderView, FilterBuilderModel, cql,
-            store, QuerySettingsView, QueryAdvanced) {
+            store, QuerySettingsView, QueryAdvanced, user, announcement) {
 
     return QueryAdvanced.extend({
         template: template,
@@ -65,6 +67,14 @@ define([
             this.model.set({
                 cql: filter
             });
+        },
+        serializeData: function() {
+            var templateTitle = this.options.model.get('title') != null
+                                 ? this.options.model.get('title')
+                                 : "Standard Search";
+            return {
+                templateTitle: templateTitle
+            };
         }
     });
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.view.js
@@ -67,14 +67,6 @@ define([
             this.model.set({
                 cql: filter
             });
-        },
-        serializeData: function() {
-            var templateTitle = this.model.get('name') != null
-                                 ? this.model.get('name')
-                                 : "Standard Search";
-            return {
-                templateTitle: templateTitle
-            };
         }
     });
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-custom/query-custom.view.js
@@ -69,8 +69,8 @@ define([
             });
         },
         serializeData: function() {
-            var templateTitle = this.options.model.get('title') != null
-                                 ? this.options.model.get('title')
+            var templateTitle = this.model.get('name') != null
+                                 ? this.model.get('name')
                                  : "Standard Search";
             return {
                 templateTitle: templateTitle

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.hbs
@@ -11,6 +11,24 @@
  *
  **/
  --}}
+<div class="search-form-interaction interaction-default" data-help="Deletes the search form.
+Anyone who has access to this search-form will subsequently lose access.">
+    <div class="interaction-icon fa fa-star">
+    </div>
+    <div class="interaction-text">
+        Make Default Form
+    </div>
+</div>
+
+<div class="search-form-interaction interaction-clear" data-help="Deletes the search form.
+Anyone who has access to this search-form will subsequently lose access.">
+    <div class="interaction-icon fa fa-eraser">
+    </div>
+    <div class="interaction-text">
+        Clear Default Form
+    </div>
+</div>
+
 <div class="search-form-interaction interaction-trash" data-help="Deletes the search form.
 Anyone who has access to this search-form will subsequently lose access.">
     <div class="interaction-icon fa fa-trash-o">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -24,3 +24,9 @@
     display: inline-block;
   }
 }
+
+@{customElementNamespace}search-form-interactions.is-current-template {
+  > .interaction-default {
+    display: none;
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -26,69 +26,110 @@ var  announcement = require('component/announcement');
 var  ConfirmationView = require('component/confirmation/confirmation.view');
 
 module.exports =  Marionette.ItemView.extend({
-    template: template,
-    tagName: CustomElements.register('search-form-interactions'),
-    className: 'composed-menu',
-    modelEvents: {
-        'change': 'render'
-    },
-    events: {
-        'click .interaction-trash': 'handleTrash',
-        'click .search-form-interaction': 'handleClick'
-    },
-    ui: {},
-    initialize: function() {},
-    onRender: function() {
-        this.checkIfSubscribed();
-    },
-    checkIfSubscribed: function() {
-        this.$el.toggleClass('is-subscribed', Boolean(this.model.get('subscribed')));
-    },
-    handleTrash: function() {
-        var loginUser = user.get('user');
-        if(loginUser.get('username') === this.model.get('createdBy'))
-        {
-            this.listenTo(ConfirmationView.generateConfirmation({
-                prompt: 'This will permanently delete the template. Are you sure? ',
-                no: 'Cancel',
-                yes: 'Delete'
-            }),
-            'change:choice',
-            function(confirmation) {
-                if (confirmation.get('choice')) {
-                    var loadingview = new LoadingView();
-                        this.model.url = '/search/catalog/internal/forms/' + this.model.id;
-                        this.model.destroy({
-                            wait: true,
-                            error: function(model, xhr, options){
-                                announcement.announce({
-                                    title: 'Error!',
-                                    message: "Unable to delete the forms: " + xhr.responseText,
-                                    type: 'error'
-                                });
-                                throw new Error('Error Deleting Template: ' + xhr.responseText);                                  
-                            }
-                        }); 
-                    this.removeCachedTemplate(this.model.id);
-                    loadingview.remove();
-                }
-            }.bind(this));                        
-        }
-        else{
+        template: template,
+        tagName: CustomElements.register('search-form-interactions'),
+        className: 'composed-menu',
+        modelEvents: {
+            'change': 'render'
+        },
+        events: {
+            'click .interaction-default': 'handleMakeDefault',
+            'click .interaction-clear': 'handleClearDefault',
+            'click .interaction-trash': 'handleTrash',
+            'click .search-form-interaction': 'handleClick'
+        },
+        ui: {},
+        initialize: function() {
+            this.checkIfDefaultSearchForm();
+        },
+        onRender: function() {
+            this.checkIfSubscribed();
+        },
+        checkIfSubscribed: function() {
+            this.$el.toggleClass('is-subscribed', Boolean(this.model.get('subscribed')));
+        },
+        handleTrash: function() {
+            var loginUser = user.get('user');
+            if(loginUser.get('username') === this.model.get('createdBy'))
+            {
+                this.listenTo(ConfirmationView.generateConfirmation({
+                    prompt: 'This will permanently delete the template. Are you sure? ',
+                    no: 'Cancel',
+                    yes: 'Delete'
+                }),
+                'change:choice',
+                function(confirmation) {
+                    if (confirmation.get('choice')) {
+                        var loadingview = new LoadingView();
+                            this.model.url = '/search/catalog/internal/forms/' + this.model.id;
+                            this.model.destroy({
+                                wait: true,
+                                error: function(model, xhr, options){
+                                    announcement.announce({
+                                        title: 'Error!',
+                                        message: "Unable to delete the forms: " + xhr.responseText,
+                                        type: 'error'
+                                    });
+                                    throw new Error('Error Deleting Template: ' + xhr.responseText);                                  
+                                }
+                            }); 
+                        this.removeCachedTemplate(this.model.id);
+                        loadingview.remove();
+                    }
+                }.bind(this));                        
+            }
+            else{
+                this.messageNotifier(
+                    'Error!',
+                    'Unable to delete the form: You are not the author',
+                    'error'
+                );
+                throw new Error('Unable to delete the form: You are not the author ');                
+            }
+            this.trigger("doneLoading");
+        },
+        handleMakeDefault: function() {
+            var templateJSON = {
+                filterTemplate: this.model.get('filterTemplate'),
+                model: this.model
+            };
+
+            user.getQuerySettings().set('defaultTemplate', JSON.parse(JSON.stringify(templateJSON)));
+            user.savePreferences();
+            this.messageNotifier(
+                'Success!', 
+                `\"${this.model.get('name')}\" Saved As Default Query Form`, 
+                'success'
+            );
+        },
+        handleClearDefault: function() {
+            user.getQuerySettings().set('defaultTemplate', null);
+            user.savePreferences();
+            this.messageNotifier(
+                'Success!', 
+                `Default Query Form Cleared`, 
+                'success'
+            );
+        },
+        checkIfDefaultSearchForm: function() {
+            var storedTemplate = user.getQuerySettings().toJSON();
+            var currentTemplate = this.model;
+
+            this.$el.find('.interaction-default').toggleClass('is-hidden', storedTemplate['defaultTemplate'] != undefined &&
+                storedTemplate['defaultTemplate'].model.name == currentTemplate.get('name'));
+        },
+        messageNotifier: function(title, message, type) {
             announcement.announce({
-                title: 'Error!',
-                message: "Unable to delete the form: You are not the author",
-                type: 'error'
+                title: title,
+                message: message,
+                type: type
             });
-            throw new Error('Unable to delete the form: You are not the author ');                
-            
+            this.checkIfDefaultSearchForm();
+        },
+        handleClick: function() {
+            this.$el.trigger('closeDropdown.' + CustomElements.getNamespace());
+        },
+        removeCachedTemplate: function(id){
+            wreqr.vent.trigger("deleteTemplateById", id);
         }
-        this.trigger("doneLoading");
-    },
-    handleClick: function() {
-        this.$el.trigger('closeDropdown.' + CustomElements.getNamespace());
-    },
-    removeCachedTemplate: function(id){
-        wreqr.vent.trigger("deleteTemplateById", id);
-    }
-});
+    });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
@@ -20,6 +20,21 @@
  var SearchForm = require('./search-form');
  var Common = require('js/Common');
 
+ const fixFilter = function(filter) {
+    if (filter.filters) {
+        filter.filters.forEach(fixFilter);
+    } else {
+        filter.defaultValue = filter.defaultValue || '';
+        filter.value = filter.value || filter.defaultValue;
+    }
+ }
+
+ const fixTemplates = function(templates) {
+    templates.forEach((template) => {
+        return fixFilter(template.filterTemplate);
+    });
+ };
+ 
  let systemTemplates = [];
  let templatePromise = $.ajax({
     type: 'GET',
@@ -27,6 +42,7 @@
     url: '/search/catalog/internal/forms/query',
     contentType: 'application/json',
     success: function (data) {
+        fixTemplates(data);
         systemTemplates = data;
     }
  });

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -22,5 +22,12 @@ module.exports = Backbone.Model.extend({
             sortOrder: 'descending',
             template: undefined
         };
+    },
+    isTemplate: function(template) {
+        if (this.get('template') !== undefined) {
+            return this.get('template').id === template.id;
+        } else {
+            return false;
+        }
     }
 });


### PR DESCRIPTION
#### What does this PR do?

This tickets adds the preference options to the user to save default query templates when a new search is performed. 

The user is able to do the following:

- Save custom query templates as default templates
- Clear custom query templates
- Persists into user settings

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)

@adimka 
@GabrielFabian 
@mackncheesiest 
@bdeining  

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)

- Load different templates and ensure saving will load the saved template when a new query is performed.

- Likewise, ensure that clearing the saved template doesn't always load the saved template when a new query is performed

- Also ensure the buttons toggle as templates are saved and cleared

#### Any background context you want to provide?
`N\A`
#### What are the relevant tickets?
[DDF-3678](https://codice.atlassian.net/browse/DDF-3678)
#### Screenshots (if appropriate)


![demo](https://user-images.githubusercontent.com/7055226/37420995-767a2626-2775-11e8-8c15-8b0f82986cf2.gif)



#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
