### PR TITLE
DDF-3681 updated pax maven settings

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.url.mvn.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.url.mvn.cfg
@@ -45,7 +45,7 @@
 # Properties prefixed with "org.ops4j.pax.url.mvn." have
 # higher priority except <proxies> element. HTTP proxies should be configured in
 # settings file
-#org.ops4j.pax.url.mvn.settings=
+org.ops4j.pax.url.mvn.settings = ${user.home}/.m2/settings.xml
 
 #
 # Path to the local Maven repository which is used to avoid downloading


### PR DESCRIPTION
#### What does this PR do?

Updates pax mvn settings to only look for a maven settings file under the users home directory

#### Who is reviewing it? 
@peterhuffer @blen-desta @coyotesqrl 
#### Select relevant component teams: 
@codice/security 
#### Choose 2 committers to review/merge the PR. 
@clockard @pklinef 
#### What are the relevant tickets?
[DDF-3681](https://codice.atlassian.net/browse/DDF-3681)
#### Screenshots (if appropriate)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
