### PR TITLE
DDF-3685: Use maven-bundle-plugin instead of karaf-services-maven-plugin for karaf commands

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -140,20 +140,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
-                <artifactId>karaf-services-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
-                <executions>
-                    <execution>
-                        <id>service-metadata-generate</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>service-metadata-generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
@@ -183,6 +169,7 @@
                             org.osgi.framework;version="[1.5,2)",
                             *
                         </Import-Package>
+                        <Karaf-Commands>*</Karaf-Commands>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/admin/core/admin-core-appservice/pom.xml
+++ b/platform/admin/core/admin-core-appservice/pom.xml
@@ -140,20 +140,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
-                <artifactId>karaf-services-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
-                <executions>
-                    <execution>
-                        <id>service-metadata-generate</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>service-metadata-generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
@@ -182,6 +168,7 @@
                             org.codice.ddf.admin.application.rest.model,
                             org.codice.ddf.admin.application.service.impl
                         </Private-Package>
+                        <Karaf-Commands>*</Karaf-Commands>
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/error/platform-error-servlet/pom.xml
+++ b/platform/error/platform-error-servlet/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>8.1.9.v20130131</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>


### PR DESCRIPTION
#### What does this PR do?
The karaf-services-maven-plugin takes much longer to generate the karaf command manifest info than the maven-bundle-plugin does. This causes bottlenecks in certain points in our build process.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@paouelle 
@emanns95 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@figliold
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Ensure the karaf commands in catalog-core-commands and admin-core-appservice still work

#### Any background context you want to provide? 

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
