### PR TITLE
DDF-3687 Remove unnecessary itest

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
@@ -32,8 +32,6 @@ import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasXPath;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -42,7 +40,6 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Response;
 import ddf.catalog.data.Metacard;
 import ddf.security.SecurityConstants;
 import java.io.FileInputStream;

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
@@ -1253,53 +1253,6 @@ public class TestSecurity extends AbstractIntegrationTest {
     Files.copy(Paths.get(getBackupFilename()), Paths.get(getKeystoreFilename()), REPLACE_EXISTING);
   }
 
-  // Purpose is to make sure operations of the security certificate generator are accessible
-  // at runtime. The actual functionality of these operations is proved in unit tests.
-  @Test
-  public void testCertificateGeneratorService() throws Exception {
-    String commonName = "myCn";
-    String expectedValue = "CN=" + commonName;
-    String featureName = "security-certificate";
-    String certGenPath =
-        SECURE_ROOT_AND_PORT
-            + "/admin/jolokia/exec/org.codice.ddf.security.certificate.generator.CertificateGenerator:service=certgenerator";
-    getBackupKeystoreFile();
-    try {
-      getServiceManager().startFeature(true, featureName);
-
-      // Test first operation
-      Response response =
-          given()
-              .auth()
-              .preemptive()
-              .basic("admin", "admin")
-              .when()
-              .get(certGenPath + "/configureDemoCert/" + commonName);
-      String actualValue = JsonPath.from(response.getBody().asString()).getString("value");
-      assertThat(actualValue, equalTo(expectedValue));
-
-      // Test second operation
-      response =
-          given()
-              .auth()
-              .preemptive()
-              .basic("admin", "admin")
-              .when()
-              .get(certGenPath + "/configureDemoCertWithDefaultHostname");
-
-      String jsonString = response.getBody().asString();
-      JsonPath jsonPath = JsonPath.from(jsonString);
-      // If the key value exists, the return value is well-formatted (i.e. not a stacktrace)
-      assertThat(jsonPath.getString("value"), notNullValue());
-
-      // Make sure an invalid key would return null
-      assertThat(jsonPath.getString("someinvalidkey"), nullValue());
-    } finally {
-      restoreKeystoreFile();
-      getServiceManager().stopFeature(false, featureName);
-    }
-  }
-
   @Test
   public void testTransportSoapPolicy() {
     // verify that transport policy is observed indirectly by verifying that a security header with


### PR DESCRIPTION
#### What does this PR do?
Remove unnecessary itest.

#### Who is reviewing it? 
@vinamartin @mcalcote @shaundmorris @rzwiefel @garrettfreibott 

#### Choose 2 committers to review/merge the PR. 

@clockard
@rzwiefel
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)
CI build with tests.

#### Any background context you want to provide?

The CertificateGenerator is created by blueprint in one thread, In this thread, the CertificateGenerator is being registered with the MBean server. In another thread, the test is attempting to use the CertificateGenerator. The CertificateGenerator is not being registered fast enough and the Jolokia call return null.

The unit test coverage is solid. The only thing the itest really does is to make sure that MBeans can be registered and exposed via JMX. Is that worth testing? No, because if that doesn’t it means the JVM itself is broken.

Conclusion: Remove unnecessary itest.

#### What are the relevant tickets?
DDF-3687

#### Checklist:
- [ N/A] Documentation Updated
- [N/A ] Update / Add Unit Tests
- [ X] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
