### PR TITLE
DDF-3689 Remove binding for 't' key in catalog search ui

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
@@ -51,7 +51,10 @@ define([
         initializeDatepicker: function(){
             this.$el.find('.input-group.date').datetimepicker({
                 format: getDateFormat(),
-                widgetParent: 'body'
+                widgetParent: 'body',
+                keyBinds: {
+                    t: null
+                }
             });
         },
         handleReadOnly: function () {


### PR DESCRIPTION
#### What does this PR do?
Removes binding for 't' key in catalog search ui

#### Who is reviewing it?
@tbatie @emanns95 @figliold 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)

@beyelerb 
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Make sure typing in 't' doesn't wipe out the current date being entered and replace it with the current date and time.
 
#### Any background context you want to provide?
https://github.com/Eonasdan/bootstrap-datetimepicker/issues/1639

#### What are the relevant tickets?
[DDF-3689](https://codice.atlassian.net/browse/DDF-3689)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
