### PR TITLE
DDF-3297 Admin UI permission check performance

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
@@ -1396,7 +1396,9 @@ public class TestSecurity extends AbstractIntegrationTest {
         JsonPath.given(getAllFeaturesResponsePermitted).getString("value.AllFeatures.name");
 
     for (String app : getDefaultRequiredApps()) {
-      assertThat(filteredApplications, containsString(app));
+      if (!"sdk-app".equals(app)) {
+        assertThat(filteredApplications, containsString(app));
+      }
     }
 
     for (String feature : FEATURES_TO_FILTER) {

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationImpl.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationImpl.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.karaf.features.BundleInfo;
@@ -35,6 +36,8 @@ import org.slf4j.LoggerFactory;
 public class ApplicationImpl implements Application {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationImpl.class);
+
+  private static final Map<Long, String> BUNDLE_LOCATIONS = new ConcurrentHashMap<>();
 
   private String name;
 
@@ -99,6 +102,10 @@ public class ApplicationImpl implements Application {
   private Map<String, Bundle> bundlesByLocation() {
     return Arrays.stream(
             FrameworkUtil.getBundle(ApplicationImpl.class).getBundleContext().getBundles())
-        .collect(Collectors.toMap(Bundle::getLocation, Function.identity()));
+        .collect(Collectors.toMap(ApplicationImpl::computeLocation, Function.identity()));
+  }
+
+  private static String computeLocation(Bundle bundle) {
+    return BUNDLE_LOCATIONS.computeIfAbsent(bundle.getBundleId(), id -> bundle.getLocation());
   }
 }

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
@@ -195,6 +195,10 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
     return appService
         .getApplications()
         .stream()
+        .filter(
+            app ->
+                !getPluginsForApplication(app.getName()).isEmpty()
+                    || !getServices(app.getName()).isEmpty())
         .map(this::convertApplicationEntries)
         .collect(Collectors.toList());
   }

--- a/ui/packages/ui/src/main/webapp/js/models/ApplicationsLayout.js
+++ b/ui/packages/ui/src/main/webapp/js/models/ApplicationsLayout.js
@@ -172,46 +172,10 @@ define([
                 applicationsResponseCache = $.ajax({
                     type: 'GET',
                     url: '/admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/Applications/',
-                    dataType: 'JSON'}).then(function(appsResp) {
-                        var apps = appsResp.value;
-    
-                        //Only display apps that have either configurations or plugins
-                        var appPluginReqs = apps.map(function (app) {
-                            return {
-                                type: "EXEC",
-                                mbean: "org.codice.ddf.admin.application.service.ApplicationService:service=application-service",
-                                operation: "getPluginsForApplication",
-                                arguments: [app.name]
-                            };
-                        });
-    
-                        var appConfigsReqs = apps.map(function (app) {
-                            return {
-                                type: "EXEC",
-                                mbean: "org.codice.ddf.admin.application.service.ApplicationService:service=application-service",
-                                operation: "getServices",
-                                arguments: [app.name]
-                            };
-                        });
-    
-                        return $.ajax({
-                            type: 'POST',
-                            url: '/admin/jolokia',
-                            dataType: 'JSON',
-                            data: JSON.stringify(appPluginReqs.concat(appConfigsReqs))
-                        }).then(function (batchedResponses) {
-                            var appsToShow = batchedResponses
-                                .filter(function (resp) {
-                                    return resp.value && resp.value.length !== 0;
-                                })
-                                .map(function (resp) {
-                                    return resp.request.arguments[0];
-                                });
-                            return apps.filter(function (app) {
-                                return appsToShow.indexOf(app.name) !== -1;
-                            });
-                        });
-                    });
+                    dataType: 'JSON'
+                }).then(function (appsResp) {
+                    return appsResp.value;
+                });
             }
             return applicationsResponseCache;
         }


### PR DESCRIPTION
#### What does this PR do?
Admin UI operations have slowed down with the security manager due to permission checks related to different OSGi operations such as looking up the bundle location and getting metatype information.  Caching this information improves Admin UI responsiveness. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@tbatie 
@vinamartin 

#### Select relevant component teams: 
@codice/security 

#### Choose 2 committers to review/merge the PR. 
@coyotesqrl
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Verify the response type to show applications in the Admin UI drops from about 2 seconds to about half a second which is close to pre-security manager response times.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3297](https://codice.atlassian.net/browse/DDF-3297)

#### Screenshots (if appropriate)

#### Checklist:
- [ n/a ] Documentation Updated
- [ n/a ] Update / Add Unit Tests
- [ n/a ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
