### PR TITLE
DDF-3697 Add security manager exceptions for profile:install & wrapper:install commands

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv-windows-wrapper.conf
+++ b/distribution/ddf-common/src/main/resources/bin/setenv-windows-wrapper.conf
@@ -7,7 +7,7 @@ wrapper.on_exit.10 = RESTART
 
 # Defines a command file to be used by the ddf_on_error.sh script when executed following
 # a non-recoverable system error and the JVM should be restarted
-wrapper.commandfile = %KARAF_HOME%/bin/restart.jvm
+wrapper.commandfile = %KARAF_HOME%\bin\restart.jvm
 
 # Additional JVM parameters
 # note that n is the parameter number starting from 11 (1-10 is defined in ddf-wrapper.conf).
@@ -15,21 +15,23 @@ wrapper.commandfile = %KARAF_HOME%/bin/restart.jvm
 # ### Replace any <Number> with the next available number
 wrapper.java.additional.11 = -server
 wrapper.java.additional.12 = -Dfile.encoding=UTF8
-wrapper.java.additional.13 = -Dkaraf.instances=%KARAF_HOME%/instances
+wrapper.java.additional.13 = -Dkaraf.instances=%KARAF_HOME%\instances
 wrapper.java.additional.14 = -Dkaraf.restart.jvm.supported=true
-wrapper.java.additional.15 = -Djava.io.tmpdir=%KARAF_HOME%/data/tmp
-wrapper.java.additional.16 = -Djava.util.logging.config.file=%KARAF_HOME%/etc/java.util.logging.properties
+wrapper.java.additional.15 = -Djava.io.tmpdir=%KARAF_HOME%\data\tmp
+wrapper.java.additional.16 = -Djava.util.logging.config.file=%KARAF_HOME%\etc\java.util.logging.properties
 wrapper.java.additional.17 = -XX:+UnlockDiagnosticVMOptions
 wrapper.java.additional.18 = -XX:+DisableAttachMechanism
 wrapper.java.additional.19 = -XX:+UnsyncloadClass
 wrapper.java.additional.20 = -Djava.awt.headless=true
+wrapper.java.additional.21 = -Dddf.home=%KARAF_HOME%
+wrapper.java.additional.22 = -Dddf.home.perm=%KARAF_HOME%\
 
 # Enables MBean support for the service wrapper; used to trigger restart
-wrapper.java.additional.21 = -Dorg.tanukisoftware.wrapper.WrapperManager.mbean=TRUE
+wrapper.java.additional.23 = -Dorg.tanukisoftware.wrapper.WrapperManager.mbean=TRUE
 
 # Error handling scripts
-wrapper.java.additional.22 = "-XX:OnOutOfMemoryError=%KARAF_HOME%\bin\ddf_on_error.bat wrapper %p"
-wrapper.java.additional.23 = "-XX:OnError=%KARAF_HOME%\bin\ddf_on_error.bat wrapper %p"
+wrapper.java.additional.24 = "-XX:OnOutOfMemoryError=%KARAF_HOME%\bin\ddf_on_error.bat wrapper %p"
+wrapper.java.additional.25 = "-XX:OnError=%KARAF_HOME%\bin\ddf_on_error.bat wrapper %p"
 
 # Uncomment to enable cxf logging interceptors
 # wrapper.java.additional.<Number> = -Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true

--- a/distribution/ddf-common/src/main/resources/bin/setenv-wrapper.conf
+++ b/distribution/ddf-common/src/main/resources/bin/setenv-wrapper.conf
@@ -23,16 +23,18 @@ wrapper.java.additional.17 = -XX:+UnlockDiagnosticVMOptions
 wrapper.java.additional.18 = -XX:+DisableAttachMechanism
 wrapper.java.additional.19 = -XX:+UnsyncloadClass
 wrapper.java.additional.20 = -Djava.awt.headless=true
+wrapper.java.additional.21 = -Dddf.home=%KARAF_HOME%
+wrapper.java.additional.22 = -Dddf.home.perm=%KARAF_HOME%/
 
 # Enables MBean support for the service wrapper; used to trigger restart
-wrapper.java.additional.21 = -Dorg.tanukisoftware.wrapper.WrapperManager.mbean=TRUE
+wrapper.java.additional.23 = -Dorg.tanukisoftware.wrapper.WrapperManager.mbean=TRUE
 
 # Prefer /dev/urandom over /dev/random on Linux systems.
-wrapper.java.additional.22 = -Djava.security.egd=file:/dev/./urandom
+wrapper.java.additional.24 = -Djava.security.egd=file:/dev/./urandom
 
 # Error handling scripts
-wrapper.java.additional.23 = -XX:OnOutOfMemoryError=%KARAF_HOME%/bin/ddf_on_error.sh wrapper %p
-wrapper.java.additional.24 = -XX:OnError=%KARAF_HOME%/bin/ddf_on_error.sh wrapper %p
+wrapper.java.additional.25 = -XX:OnOutOfMemoryError=%KARAF_HOME%/bin/ddf_on_error.sh wrapper %p
+wrapper.java.additional.26 = -XX:OnError=%KARAF_HOME%/bin/ddf_on_error.sh wrapper %p
 
 # Uncomment to enable cxf logging interceptors
 # wrapper.java.additional.<Number> = -Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true

--- a/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.wrapper.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.apache.karaf.command.acl.wrapper.cfg
@@ -1,0 +1,7 @@
+#
+# This configuration file defines the ACLs for commands in the wrapper subshell,
+# which gets installed by the wrapper feature
+#
+
+* = NO_ACCESS
+install = admin

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -359,6 +359,17 @@ grant {
     permission java.io.FilePermission "/jenkins/-", "read";
 }
 
+// Permissions required by the wrapper:install command
+grant codeBase "file:/org.apache.karaf.wrapper.core/org.apache.karaf.shell.core/org.apache.karaf.shell.ssh/org.apache.sshd.core" {
+    permission java.io.FilePermission "<<ALL FILES>>", "execute";
+    permission java.io.FilePermission "${ddf.home.perm}bin${/}*", "read, write";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}*", "read, write";
+    permission java.io.FilePermission "${ddf.home.perm}lib${/}wrapper", "write";
+    permission java.io.FilePermission "${ddf.home.perm}lib${/}wrapper${/}*", "write";
+    permission java.io.FilePermission "/etc/redhat-release", "read";
+    permission java.io.FilePermission "/etc/debian_version", "read";
+}
+
 //
 // Permissions granted to all bundles
 //
@@ -419,6 +430,8 @@ grant {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}scripts${/}-", "read";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}pdp", "read";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}pdp${/}-", "read";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}profiles", "read";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}profiles${/}*", "read";
 
     permission java.io.FilePermission "${ddf.home.perm}wrap:jardir:${ddf.home.perm}etc${/}-", "read";
     permission java.io.FilePermission "${ddf.home.perm}wrap:mvn:org.jvnet.ogc${/}-", "read";


### PR DESCRIPTION
#### What does this PR do?
Adds permissions necessary to run the profile:install and wrapper:install commands, adds a Karaf ACL so that only admin users can run wrapper:install, and fixes the default service wrapper configuration.
#### Who is reviewing it? 
@bakejeyner @blen-desta @brjeter @idperez 
#### Select relevant component teams: 
@codice/security 
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@stustison
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3697](https://codice.atlassian.net/browse/DDF-3697)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
