### PR TITLE
DDF-3566 Updated OpenSearchFilterVisitor for handling changes to wild…

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchFilterVisitorTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/ddf/catalog/source/opensearch/impl/OpenSearchFilterVisitorTest.java
@@ -25,6 +25,7 @@ import ddf.catalog.impl.filter.TemporalFilter;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import org.geotools.filter.FilterFactoryImpl;
 import org.geotools.filter.temporal.TOverlapsImpl;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
@@ -32,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opengis.filter.And;
 import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.Not;
 import org.opengis.filter.Or;
 import org.opengis.filter.PropertyIsEqualTo;
@@ -57,6 +59,10 @@ public class OpenSearchFilterVisitorTest {
   private static final String CQL_INTERSECTS = "(INTERSECTS(anyGeo, " + WKT_POLYGON + "))";
 
   private static final String TEST_STRING = "test";
+
+  private static final String UI_WILDCARD = "%";
+
+  private static final String WILDCARD = "*";
 
   private static final Date START_DATE = new Date(10000);
 
@@ -432,6 +438,27 @@ public class OpenSearchFilterVisitorTest {
     assertThat(searchPhraseMap.containsKey(OpenSearchParserImpl.SEARCH_TERMS), is(true));
     String contextualSearchTerm = searchPhraseMap.get(OpenSearchParserImpl.SEARCH_TERMS);
     assertThat(contextualSearchTerm, is(TEST_STRING));
+  }
+
+  @Test
+  public void testPropertyLikeWildcard() {
+    FilterFactory2 factory = new FilterFactoryImpl();
+
+    PropertyIsLike textLikeFilter =
+        factory.like(factory.property(Core.TITLE), UI_WILDCARD, UI_WILDCARD, "'", "_", false);
+
+    OpenSearchFilterVisitorObject openSearchFilterVisitorObject =
+        new OpenSearchFilterVisitorObject();
+
+    OpenSearchFilterVisitorObject result =
+        (OpenSearchFilterVisitorObject)
+            openSearchFilterVisitor.visit(textLikeFilter, openSearchFilterVisitorObject);
+
+    ContextualSearch contextualSearch = result.getContextualSearch();
+    Map<String, String> searchPhraseMap = contextualSearch.getSearchPhraseMap();
+    assertThat(searchPhraseMap.containsKey(OpenSearchParserImpl.SEARCH_TERMS), is(true));
+    String contextualSearchTerm = searchPhraseMap.get(OpenSearchParserImpl.SEARCH_TERMS);
+    assertThat(contextualSearchTerm, is(WILDCARD));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Applies normalization to OpenSearchFilterVisitor for handling the change in UI wildcard characters. This allows for non-escaped `*` searches on Open Search sources.

#### Who is reviewing it? 
@garrettfreibott 
@jlcsmith 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)
1. Create a OpenSearch source. Give it a name, and the default parameters are enough to verify.
2. Enable CXF logging `log:set DEBUG org.apache.cxf`
3. Query the source for `*`
4. Verify a log message similar to the following is output `https://localhost:8993/services/catalog/query?start=1&count=250&mt=300000&dn=admin&q=*&src=local`. Note: `q=*` is the part we are verifying.

#### Any background context you want to provide?
This normalization was already handled by other sources, and this just adds handling for the OpenSearch source.

#### What are the relevant tickets?
[DDF-3566](https://codice.atlassian.net/browse/DDF-3566)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
