### PR TITLE
DDF-3636 Fix logging regression where no error is logged when features fail to start

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanMBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanMBean.java
@@ -24,12 +24,20 @@ import java.util.Map;
 public interface ApplicationServiceBeanMBean {
 
   /**
-   * Starts the installation process for the selected profile.
+   * Installs the specified feature
    *
-   * @param profileName name or key of the profile to install.
-   * @param noRefresh ensures bundles already installed do not refresh.
+   * @param feature name to install.
    */
-  void installProfile(String profileName, boolean noRefresh);
+  @Deprecated
+  void installFeature(String feature);
+
+  /**
+   * Uninstalls the specified feature
+   *
+   * @param feature name to install.
+   */
+  @Deprecated
+  void uninstallFeature(String feature);
 
   /**
    * Creates an application list that has two attributes that describes relationships between

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanMBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanMBean.java
@@ -24,6 +24,14 @@ import java.util.Map;
 public interface ApplicationServiceBeanMBean {
 
   /**
+   * Starts the installation process for the selected profile.
+   *
+   * @param profileName name or key of the profile to install.
+   * @param noRefresh ensures bundles already installed do not refresh.
+   */
+  void installProfile(String profileName, boolean noRefresh);
+
+  /**
    * Creates an application list that has two attributes that describes relationships between
    * applications (parent and children dependencies).
    *

--- a/platform/admin/core/admin-core-appservice/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/core/admin-core-appservice/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -42,6 +42,7 @@
         <argument ref="appService"/>
         <argument ref="configurationAdmin"/>
         <argument ref="mBeanServer"/>
+        <argument ref="featuresService"/>
         <property name="applicationPlugins" ref="applicationPluginList"/>
     </bean>
 

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
@@ -13,9 +13,13 @@
  */
 package org.codice.ddf.admin.application.service.impl;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doThrow;
@@ -27,6 +31,7 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.core.Appender;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +46,7 @@ import org.apache.commons.collections.ListUtils;
 import org.apache.karaf.features.BundleInfo;
 import org.apache.karaf.features.Dependency;
 import org.apache.karaf.features.Feature;
+import org.apache.karaf.features.FeaturesService;
 import org.codice.ddf.admin.application.plugin.ApplicationPlugin;
 import org.codice.ddf.admin.application.rest.model.FeatureDetails;
 import org.codice.ddf.admin.application.service.Application;
@@ -51,6 +57,7 @@ import org.codice.ddf.admin.core.api.Service;
 import org.codice.ddf.admin.core.impl.ServiceImpl;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -86,6 +93,8 @@ public class ApplicationServiceBeanTest {
 
   private Application testApp;
 
+  private FeaturesService mockFeaturesService;
+
   private BundleContext bundleContext;
 
   private MBeanServer mBeanServer;
@@ -97,6 +106,7 @@ public class ApplicationServiceBeanTest {
     testAppService = mock(ApplicationServiceImpl.class);
     testConfigAdminExt = mock(ConfigurationAdmin.class);
     testApp = mock(ApplicationImpl.class);
+    mockFeaturesService = mock(FeaturesService.class);
 
     when(testApp.getName()).thenReturn(TEST_APP_NAME);
     when(testApp.getDescription()).thenReturn(TEST_APP_DESCRIP);
@@ -114,7 +124,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testInit() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
     serviceBean.init();
 
     verify(mBeanServer).registerMBean(serviceBean, objectName);
@@ -129,7 +140,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testInitTwice() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
     when(mBeanServer.registerMBean(any(Object.class), any(ObjectName.class)))
         .thenThrow(new InstanceAlreadyExistsException())
         .thenReturn(null);
@@ -149,7 +161,8 @@ public class ApplicationServiceBeanTest {
   @Test(expected = ApplicationServiceException.class)
   public void testInitWhenRegisterMBeanThrowsInstanceAlreadyExistsException() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
 
     when(mBeanServer.registerMBean(any(Object.class), any(ObjectName.class)))
         .thenThrow(new NullPointerException());
@@ -165,7 +178,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testDestroy() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
 
     serviceBean.destroy();
 
@@ -181,7 +195,8 @@ public class ApplicationServiceBeanTest {
   @Test(expected = ApplicationServiceException.class)
   public void testDestroyWhenUnregisterMBeanThrowsInstanceNotFoundException() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
 
     doThrow(new InstanceNotFoundException()).when(mBeanServer).unregisterMBean(objectName);
 
@@ -197,13 +212,41 @@ public class ApplicationServiceBeanTest {
   @Test(expected = ApplicationServiceException.class)
   public void testDestroyWhenUnregisterMBeanThrowsMBeanRegistrationException() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
 
     doThrow(new MBeanRegistrationException(new Exception()))
         .when(mBeanServer)
         .unregisterMBean(any(ObjectName.class));
 
     serviceBean.destroy();
+  }
+
+  @Test
+  public void testInstallProfileNoRefreshFalse() throws Exception {
+    ApplicationServiceBean serviceBean =
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+    serviceBean.installProfile("profile-name", false);
+
+    ArgumentCaptor<EnumSet<FeaturesService.Option>> captor = ArgumentCaptor.forClass(EnumSet.class);
+    verify(mockFeaturesService).installFeature(eq("profile-name"), captor.capture());
+    assertThat(captor.getValue(), is(empty()));
+  }
+
+  @Test
+  public void testInstallProfileNoRefreshTrue() throws Exception {
+    ApplicationServiceBean serviceBean =
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+    serviceBean.installProfile("profile-name", true);
+
+    ArgumentCaptor<EnumSet<FeaturesService.Option>> captor = ArgumentCaptor.forClass(EnumSet.class);
+    verify(mockFeaturesService).installFeature(eq("profile-name"), captor.capture());
+
+    EnumSet<FeaturesService.Option> options = captor.getValue();
+    assertThat(options, hasSize(1));
+    assertThat(options, hasItem(FeaturesService.Option.NoAutoRefreshBundles));
   }
 
   /**
@@ -239,7 +282,8 @@ public class ApplicationServiceBeanTest {
     when(testAppService.getInstallationProfiles()).thenReturn(featureList);
 
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
 
     List<Map<String, Object>> result = serviceBean.getInstallationProfiles();
 
@@ -258,7 +302,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testGetServices() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer) {
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService) {
           @Override
           protected BundleContext getContext() {
             return bundleContext;
@@ -302,7 +347,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testGetServicesNotContainsKey() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer) {
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService) {
           @Override
           protected BundleContext getContext() {
             return bundleContext;
@@ -348,7 +394,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testGetServicesMetatypeInfo() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer) {
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService) {
           @Override
           protected BundleContext getContext() {
             return bundleContext;
@@ -425,7 +472,8 @@ public class ApplicationServiceBeanTest {
     root.setLevel(Level.ALL);
 
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer) {
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService) {
           @Override
           protected BundleContext getContext() {
             return bundleContext;
@@ -455,7 +503,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testGetSetApplicationPlugins() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
     ApplicationPlugin testPlugin1 = mock(ApplicationPlugin.class);
     ApplicationPlugin testPlugin2 = mock(ApplicationPlugin.class);
     List<ApplicationPlugin> pluginList = new ArrayList<>();
@@ -475,7 +524,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testGetAllFeatures() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
     List<FeatureDetails> testFeatureDetailsList = new ArrayList<>();
     FeatureDetails testFeatureDetails1 = mock(FeatureDetails.class);
     testFeatureDetailsList.add(testFeatureDetails1);
@@ -501,7 +551,8 @@ public class ApplicationServiceBeanTest {
   @Test
   public void testGetPluginsForApplication() throws Exception {
     ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(testAppService, testConfigAdminExt, mBeanServer);
+        new ApplicationServiceBean(
+            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
     ApplicationPlugin testPlugin1 = mock(ApplicationPlugin.class);
     ApplicationPlugin testPlugin2 = mock(ApplicationPlugin.class);
     List<ApplicationPlugin> pluginList = new ArrayList<>();

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
@@ -15,7 +15,6 @@ package org.codice.ddf.admin.application.service.impl;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -223,23 +222,11 @@ public class ApplicationServiceBeanTest {
   }
 
   @Test
-  public void testInstallProfileNoRefreshFalse() throws Exception {
+  public void testInstallProfile() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
             testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
-    serviceBean.installProfile("profile-name", false);
-
-    ArgumentCaptor<EnumSet<FeaturesService.Option>> captor = ArgumentCaptor.forClass(EnumSet.class);
-    verify(mockFeaturesService).installFeature(eq("profile-name"), captor.capture());
-    assertThat(captor.getValue(), is(empty()));
-  }
-
-  @Test
-  public void testInstallProfileNoRefreshTrue() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
-    serviceBean.installProfile("profile-name", true);
+    serviceBean.installFeature("profile-name");
 
     ArgumentCaptor<EnumSet<FeaturesService.Option>> captor = ArgumentCaptor.forClass(EnumSet.class);
     verify(mockFeaturesService).installFeature(eq("profile-name"), captor.capture());

--- a/ui/packages/ui/src/main/webapp/js/models/Installer.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Installer.js
@@ -131,12 +131,12 @@ define([
       wreqr.vent.trigger('modulePoller:stop');
       return $.ajax({
         type: 'GET',
-        url: that.uninstallUrl + 'admin-modules-installer/true',
+        url: that.uninstallUrl + 'admin-modules-installer',
         dataType: 'JSON'
       }).then(function () {
         return $.ajax({
           type: 'GET',
-          url: that.installUrl + 'admin-post-install-modules/true',
+          url: that.installUrl + 'admin-post-install-modules',
           dataType: 'JSON'
         }).then(function () {
           if (restart) {

--- a/ui/packages/ui/src/main/webapp/js/models/Installer.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Installer.js
@@ -47,8 +47,8 @@ define([
   };
 
   Installer.Model = Backbone.Model.extend({
-    installUrl: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installProfile(java.lang.String,boolean)/',
-    uninstallUrl: '/admin/jolokia/exec/org.apache.karaf:type=feature,name=root/uninstallFeature(java.lang.String,boolean)/',
+    installUrl: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/',
+    uninstallUrl: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/',
     shutdownUrl: '/admin/jolokia/exec/org.apache.karaf:type=system,name=root/halt()',
     propertiesUrl: '/admin/jolokia/exec/org.apache.karaf:type=system,name=root/setProperty(java.lang.String,java.lang.String,boolean)/karaf.restart.jvm/true/false',
     restartUrl: '/admin/jolokia/exec/org.apache.karaf:type=system,name=root/reboot()',

--- a/ui/packages/ui/src/main/webapp/js/models/Installer.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Installer.js
@@ -47,7 +47,7 @@ define([
   };
 
   Installer.Model = Backbone.Model.extend({
-    installUrl: '/admin/jolokia/exec/org.apache.karaf:type=feature,name=root/installFeature(java.lang.String,boolean)/',
+    installUrl: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installProfile(java.lang.String,boolean)/',
     uninstallUrl: '/admin/jolokia/exec/org.apache.karaf:type=feature,name=root/uninstallFeature(java.lang.String,boolean)/',
     shutdownUrl: '/admin/jolokia/exec/org.apache.karaf:type=system,name=root/halt()',
     propertiesUrl: '/admin/jolokia/exec/org.apache.karaf:type=system,name=root/setProperty(java.lang.String,java.lang.String,boolean)/karaf.restart.jvm/true/false',

--- a/ui/packages/ui/src/main/webapp/js/models/features/feature.js
+++ b/ui/packages/ui/src/main/webapp/js/models/features/feature.js
@@ -18,10 +18,8 @@ define(['backbone','jquery','underscore'], function (Backbone,$,_) {
     var Feature = {};
 
     var featureUrl = '/admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/AllFeatures';
-    var installUrl = '/admin/jolokia/exec/org.apache.karaf:type=feature,name=root/installFeature(java.lang.String,boolean)/';
+    var installUrl = '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installProfile(java.lang.String,boolean)/';
     var uninstallUrl = '/admin/jolokia/exec/org.apache.karaf:type=feature,name=root/uninstallFeature(java.lang.String,boolean)/';
-
-
 
     Feature.Model = Backbone.Model.extend({
         initialize: function(options) {

--- a/ui/packages/ui/src/main/webapp/js/models/features/feature.js
+++ b/ui/packages/ui/src/main/webapp/js/models/features/feature.js
@@ -18,8 +18,8 @@ define(['backbone','jquery','underscore'], function (Backbone,$,_) {
     var Feature = {};
 
     var featureUrl = '/admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/AllFeatures';
-    var installUrl = '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installProfile(java.lang.String,boolean)/';
-    var uninstallUrl = '/admin/jolokia/exec/org.apache.karaf:type=feature,name=root/uninstallFeature(java.lang.String,boolean)/';
+    var installUrl = '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/';
+    var uninstallUrl = '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/',
 
     Feature.Model = Backbone.Model.extend({
         initialize: function(options) {

--- a/ui/packages/ui/src/main/webapp/js/models/features/feature.js
+++ b/ui/packages/ui/src/main/webapp/js/models/features/feature.js
@@ -19,7 +19,7 @@ define(['backbone','jquery','underscore'], function (Backbone,$,_) {
 
     var featureUrl = '/admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/AllFeatures';
     var installUrl = '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/';
-    var uninstallUrl = '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/',
+    var uninstallUrl = '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/';
 
     Feature.Model = Backbone.Model.extend({
         initialize: function(options) {
@@ -32,14 +32,14 @@ define(['backbone','jquery','underscore'], function (Backbone,$,_) {
         install: function(){
             return $.ajax({
                 type: 'GET',
-                url: installUrl + this.name + "/true",
+                url: installUrl + this.name,
                 dataType: 'JSON'
             });
         },
         uninstall: function(){
             return $.ajax({
                 type: 'GET',
-                url: uninstallUrl + this.name + "/true",
+                url: uninstallUrl + this.name,
                 dataType: 'JSON'
             });
         }

--- a/ui/packages/ui/src/main/webapp/js/views/installer/Profile.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/installer/Profile.view.js
@@ -79,7 +79,7 @@ define([
             installProfile: function (profile, view) {
                 $.ajax({
                     type: 'GET',
-                    url: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installProfile(java.lang.String,boolean)/' + profile + "/true",
+                    url: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String,boolean)/' + profile,
                     dataType: 'JSON',
                     success: function (data) {
                         if(data.status === 200) {

--- a/ui/packages/ui/src/main/webapp/js/views/installer/Profile.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/installer/Profile.view.js
@@ -79,7 +79,7 @@ define([
             installProfile: function (profile, view) {
                 $.ajax({
                     type: 'GET',
-                    url: '/admin/jolokia/exec/org.apache.karaf:type=feature,name=root/installFeature(java.lang.String,boolean)/' + profile + "/true",
+                    url: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installProfile(java.lang.String,boolean)/' + profile + "/true",
                     dataType: 'JSON',
                     success: function (data) {
                         if(data.status === 200) {

--- a/ui/packages/ui/src/main/webapp/js/views/installer/Profile.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/installer/Profile.view.js
@@ -79,7 +79,7 @@ define([
             installProfile: function (profile, view) {
                 $.ajax({
                     type: 'GET',
-                    url: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String,boolean)/' + profile,
+                    url: '/admin/jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/' + profile,
                     dataType: 'JSON',
                     success: function (data) {
                         if(data.status === 200) {


### PR DESCRIPTION
#### What does this PR do?
Adds error logging for the Jolokia servlet. 
This addresses lack of logging when feature resolution has an error. 

#### Who is reviewing it? 
@tbatie 
@GabrielFabian 

#### Choose 2 committers to review/merge the PR. 
@stustison 
@lessarderic

#### How should this be tested?
Install DDF. Ensure everything works as expected for a correct case. 

Remove the `!com.sun.management` statement from the pom of `catalog-ui-search` and ensure that the install process fails with an exception in the backend error logs. The stacktrace returned by Jolokia to the frontend should be redacted (use network tab in Chrome dev tools). 

#### Any background context you want to provide?
App decoupling has hid the Karaf features service from being exposed. Starting features is now done through Karaf's MBean directly, but it does not log the info we need, and this leaves no location in our code to catch exceptions that might occur. 

#### What are the relevant tickets?
[DDF-3636](https://codice.atlassian.net/browse/DDF-3636)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
