### PR TITLE
DDF-3701 Change SAML redirect form submission from "post" to "POST"

### DIFF
--- a/platform/security/common/src/main/resources/templates/submitFormTemplate.html
+++ b/platform/security/common/src/main/resources/templates/submitFormTemplate.html
@@ -19,7 +19,7 @@
     <title>Form Submit</title>
 </head>
 <body>
- <form id="postform" method="post" action="%s">
+ <form id="postform" method="POST" action="%s">
      <input class="idp-form-submit" type="submit" style="display:none;" />
      <input type="hidden" name="%s" value="%s" />
      <input type="hidden" name="RelayState" value="%s" />

--- a/platform/security/idp/security-idp-client/src/main/resources/post-binding.html
+++ b/platform/security/idp/security-idp-client/src/main/resources/post-binding.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <h2>Redirecting...</h2>
-<form id="sso" method="post" action="%s">
+<form id="sso" method="POST" action="%s">
   <input type="hidden" name="SAMLRequest" value="%s">
   <input type="hidden" name="RelayState" value="%s">
   <input type="submit" value="Submit" style="display:none;">

--- a/platform/security/idp/security-idp-client/src/main/resources/templates/submitForm.handlebars
+++ b/platform/security/idp/security-idp-client/src/main/resources/templates/submitForm.handlebars
@@ -17,7 +17,7 @@
     <title>Form Submit</title>
 </head>
 <body>
-<form id="postform" method="post" action="%s">
+<form id="postform" method="POST" action="%s">
     <input class="idp-form-submit" type="submit" style="display:none;"/>
     <input type="hidden" name="%s" value="%s"/>
     <input type="hidden" name="RelayState" value="%s"/>

--- a/platform/security/idp/security-idp-server/src/main/resources/templates/submitForm.handlebars
+++ b/platform/security/idp/security-idp-server/src/main/resources/templates/submitForm.handlebars
@@ -18,7 +18,7 @@
     <title>Form Submit</title>
 </head>
 <body>
-<form id="postform" method="post" action="{{ACSURL}}">
+<form id="postform" method="POST" action="{{ACSURL}}">
     <input class="idp-form-submit" type="submit" style="display:none;"/>
     <input type="hidden" name="{{SAML_TYPE}}" value="{{SAMLResponse}}"/>
     <input type="hidden" name="RelayState" value="{{RelayState}}"/>

--- a/platform/solr/platform-solr-server-standalone/src/main/webapp/tpl/documents.html
+++ b/platform/solr/platform-solr-server-standalone/src/main/webapp/tpl/documents.html
@@ -19,7 +19,7 @@
 
 <div id="documents" class="clearfix">
   <div id="form">
-    <form action="#" method="post">
+    <form action="#" method="POST">
       <label for="qt">
         <a rel="help">Request-Handler (qt)</a>
       </label>

--- a/ui/packages/security-idp-server/src/main/resources/templates/submitForm.handlebars
+++ b/ui/packages/security-idp-server/src/main/resources/templates/submitForm.handlebars
@@ -18,7 +18,7 @@
     <title>Form Submit</title>
 </head>
 <body>
-<form id="postform" method="post" action="{{ACSURL}}">
+<form id="postform" method="POST" action="{{ACSURL}}">
     <input class="idp-form-submit" type="submit" style="display:none;"/>
     <input type="hidden" name="{{SAML_TYPE}}" value="{{SAMLResponse}}"/>
     <input type="hidden" name="RelayState" value="{{RelayState}}"/>


### PR DESCRIPTION
#### What does this PR do?
Changes SAML redirect form submission from "post" to "POST" as stated by section 3.5.4 of the SAML Binding spec:
`The action attribute of the form MUST be the recipient's HTTP endpoint for the protocol or profile using this binding to which the SAML message is to be delivered. The method attribute MUST be "POST".`

#### Who is reviewing it? 
@blen-desta 
@brjeter 
@djblue 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard 
@coyotesqrl 

#### How should this be tested? (List steps with links to updated documentation)
Sign in to DDF.

#### What are the relevant tickets?
[DDF-3701](https://codice.atlassian.net/browse/DDF-3701)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
