### PR TITLE
DDF-3710 remove smart unit conversion for line and radius point search

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -14,8 +14,9 @@
 define([
     'jquery',
     'js/cql',
+    'js/DistanceUtils.js',
     'component/singletons/metacard-definitions'
-], function ($, cql, metacardDefinitions) {
+], function ($, cql, DistanceUtils, metacardDefinitions) {
 
     return {
         sanitizeForCql: function (text) {
@@ -83,7 +84,7 @@ define([
                         property: property,
                         value: 'LINESTRING' +
                         this.sanitizeForCql(JSON.stringify(this.lineToCQLLIne(model.line))),
-                        distance: Number(model.lineWidth)
+                        distance: DistanceUtils.getDistanceInMeters(model.lineWidth, model.lineUnits)
                     };
                 case 'POLYGON':
                     return {
@@ -112,7 +113,7 @@ define([
                         type: 'DWITHIN',
                         property: property,
                         value: 'POINT(' + model.lon + ' ' + model.lat + ')',
-                        distance: Number(model.radius)
+                        distance: DistanceUtils.getDistanceInMeters(model.radius, model.radiusUnits)
                     };
             }
         },


### PR DESCRIPTION
#### What does this PR do?
Remove "smart" rescaling of units from Point Radius and Line. No conversion is executed when switching between unit

Don’t want to convert in units. If user types 1000 with meter selected, then select unit then they want 1000 NM, not 1000 meters converted to NM

#### Who is reviewing it? 
@BernardIgiri 
@AzGoalie 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining   
@millerw8  
#### How should this be tested? (List steps with links to updated documentation)
Open a basic search diaglog
Located -> Some where specific -> Point Radius
Enter a value, change unit. The value shouldn't be converted

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3710
https://jira.di2e.net/browse/GSR-1661

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
