### PR TITLE
DDF-3715 Updates map views to properly clean up their drawing tools when destroyed, refactors the drawing tools by pulling out common methods

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -239,6 +239,12 @@ module.exports = function CesiumMap(insertionElement, selectionInterface, notifi
         drawPolygon: function(model){
             drawingTools.polygon.draw(model);
         },
+        destroyDrawingTools: function() {
+            drawingTools.line.destroy();
+            drawingTools.polygon.destroy();
+            drawingTools.circle.destroy();
+            drawingTools.bbox.destroy();
+        },
         onLeftClick: function(callback) {
             $(map.scene.canvas).on('click', function(e) {
                 var boundingRect = map.scene.canvas.getBoundingClientRect();
@@ -672,6 +678,7 @@ module.exports = function CesiumMap(insertionElement, selectionInterface, notifi
             shapes = [];
         },
         destroy: function() {
+            this.destroyDrawingTools();
             map.destroy();
         }
     });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -143,6 +143,12 @@ module.exports = function OpenlayersMap(insertionElement, selectionInterface, no
         drawPolygon: function(model){
             drawingTools.polygon.draw(model);
         },
+        destroyDrawingTools: function() {
+            drawingTools.line.destroy();
+            drawingTools.polygon.destroy();
+            drawingTools.circle.destroy();
+            drawingTools.bbox.destroy();
+        },
         onLeftClick: function(callback) {
             $(map.getTargetElement()).on('click', function(e) {
                 var boundingRect = map.getTargetElement().getBoundingClientRect();
@@ -572,6 +578,7 @@ module.exports = function OpenlayersMap(insertionElement, selectionInterface, no
             shapes = [];
         },
         destroy: function() {
+            this.destroyDrawingTools();
             unlistenToResize();
         }
     });

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.bbox.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.bbox.js
@@ -18,9 +18,10 @@ define([
         'underscore',
         'wreqr',
         'maptype',
-        './notification.view'
+        './notification.view',
+        './drawing.controller'
     ],
-    function(Marionette, Backbone, Cesium, _, wreqr, maptype, NotificationView) {
+    function(Marionette, Backbone, Cesium, _, wreqr, maptype, NotificationView, DrawingController) {
         "use strict";
         var Draw = {};
 
@@ -334,52 +335,9 @@ define([
 
         });
 
-        Draw.Controller = Marionette.Controller.extend({
-            enabled: true,
-            initialize: function() {
-                this.listenTo(wreqr.vent, 'search:bboxdisplay', function(model) {
-                    this.showBox(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawbbox', function(model) {
-                    this.draw(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawstop', function(model) {
-                    this.stop(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawend', function(model) {
-                    this.destroy(model);
-                });
-                this.listenTo(wreqr.vent, 'search:destroyAllDraw', function(model) {
-                    this.destroyAll(model);
-                });
-            },
-            views: [],
-            isVisible: function() {
-                return this.options.map.scene.canvas.width !== 0;
-            },
-            destroyAll: function() {
-                for (var i = this.views.length - 1; i >= 0; i -= 1) {
-                    this.destroyView(this.views[i]);
-                }
-            },
-            getViewForModel: function(model) {
-                return this.views.filter(function(view) {
-                    return view.model === model && view.options.map === this.options.map;
-                }.bind(this))[0];
-            },
-            removeViewForModel: function(model) {
-                var view = this.getViewForModel(model);
-                if (view) {
-                    this.views.splice(this.views.indexOf(view), 1);
-                }
-            },
-            removeView: function(view) {
-                this.views.splice(this.views.indexOf(view), 1);
-            },
-            addView: function(view) {
-                this.views.push(view);
-            },
-            showBox: function(model) {
+        Draw.Controller = DrawingController.extend({
+            drawingType: 'bbox',
+            show: function(model) {
                 if (this.enabled) {
                     var bboxModel = model || new Draw.BboxModel();
 
@@ -425,32 +383,6 @@ define([
                     });
 
                     return bboxModel;
-                }
-            },
-            stop: function(model) {
-                var view = this.getViewForModel(model);
-                if (view) {
-                    view.stop();
-                }
-                if (this.notificationView) {
-                    this.notificationView.destroy();
-                }
-            },
-            destroyView: function(view) {
-                view.stop();
-                view.destroyPrimitive();
-                this.removeView(view);
-            },
-            destroy: function(model) {
-                this.stop(model);
-                var view = this.getViewForModel(model);
-                if (view) {
-                    view.stop();
-                    view.destroyPrimitive();
-                    this.removeView(view);
-                    if (this.notificationView) {
-                        this.notificationView.destroy();
-                    }
                 }
             }
         });

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.circle.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.circle.js
@@ -21,9 +21,10 @@ define([
         'maptype',
         './notification.view',
         '@turf/turf',
-        '@turf/circle'
+        '@turf/circle',
+        './drawing.controller'
     ],
-    function(Marionette, Backbone, Cesium, _, wreqr, DrawBbox, maptype, NotificationView, Turf, TurfCircle) {
+    function(Marionette, Backbone, Cesium, _, wreqr, DrawBbox, maptype, NotificationView, Turf, TurfCircle, DrawingController) {
         "use strict";
         var DrawCircle = {};
 
@@ -199,59 +200,11 @@ define([
 
         });
 
-        DrawCircle.Controller = Marionette.Controller.extend({
-            enabled: true,
-            initialize: function() {
-                this.listenTo(wreqr.vent, 'search:circledisplay', function(model) {
-                    this.showCircle(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawcircle', function(model) {
-                    this.draw(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawstop', function(model) {
-                    this.stop(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawend', function(model) {
-                    this.destroy(model);
-                });
-                this.listenTo(wreqr.vent, 'search:destroyAllDraw', function(model) {
-                    this.destroyAll(model);
-                });
-            },
-            views: [],
-            isVisible: function() {
-                return this.options.map.scene.canvas.width !== 0;
-            },
-            destroyAll: function() {
-                for (var i = this.views.length - 1; i >= 0; i -= 1) {
-                    this.destroyView(this.views[i]);
-                }
-            },
-            getViewForModel: function(model) {
-                return this.views.filter(function(view) {
-                    return view.model === model && view.options.map === this.options.map;
-                }.bind(this))[0];
-            },
-            removeViewForModel: function(model) {
-                var view = this.getViewForModel(model);
-                if (view) {
-                    this.views.splice(this.views.indexOf(view), 1);
-                }
-            },
-            removeView: function(view) {
-                this.views.splice(this.views.indexOf(view), 1);
-            },
-            addView: function(view) {
-                this.views.push(view);
-            },
-            showCircle: function(model) {
+        DrawCircle.Controller = DrawingController.extend({
+            drawingType: 'circle',
+            show: function(model) {
                 if (this.enabled) {
                     var circleModel = model || new DrawCircle.CircleModel();
-                    /*     view = new DrawCircle.CircleView({
-                             scene: this.scene,
-                             model: circleModel
-                         });*/
-
 
                     var existingView = this.getViewForModel(model);
                     if (existingView) {
@@ -295,34 +248,7 @@ define([
 
                     return circleModel;
                 }
-            },
-            stop: function(model) {
-                var view = this.getViewForModel(model);
-                if (view) {
-                    view.stop();
-                }
-                if (this.notificationView) {
-                    this.notificationView.destroy();
-                }
-            },
-            destroyView: function(view) {
-                view.stop();
-                view.destroyPrimitive();
-                this.removeView(view);
-            },
-            destroy: function(model) {
-                this.stop(model);
-                var view = this.getViewForModel(model);
-                if (view) {
-                    view.stop();
-                    view.destroyPrimitive();
-                    this.removeView(view);
-                    if (this.notificationView) {
-                        this.notificationView.destroy();
-                    }
-                }
             }
-
         });
 
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
@@ -18,9 +18,10 @@ define([
         'wreqr',
         'maptype',
         './notification.view',
-        '@turf/turf'
+        '@turf/turf',
+        './drawing.controller'
     ],
-    function(Marionette, Backbone, Cesium, _, wreqr, maptype, NotificationView, Turf) {
+    function(Marionette, Backbone, Cesium, _, wreqr, maptype, NotificationView, Turf, DrawingController) {
         "use strict";
         var Draw = {};
 
@@ -123,52 +124,9 @@ define([
             }
         });
 
-        Draw.Controller = Marionette.Controller.extend({
-            enabled: true,
-            initialize: function() {
-                this.listenTo(wreqr.vent, 'search:linedisplay', function(model) {
-                    this.showLine(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawline', function(model) {
-                    this.draw(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawstop', function(model) {
-                    this.stop(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawend', function(model) {
-                    this.destroy(model);
-                });
-                this.listenTo(wreqr.vent, 'search:destroyAllDraw', function(model) {
-                    this.destroyAll(model);
-                });
-            },
-            views: [],
-            isVisible: function() {
-                return this.options.map.scene.canvas.width !== 0;
-            },
-            destroyAll: function() {
-                for (var i = this.views.length - 1; i >= 0; i -= 1) {
-                    this.destroyView(this.views[i]);
-                }
-            },
-            getViewForModel: function(model) {
-                return this.views.filter(function(view) {
-                    return view.model === model && view.options.map === this.options.map;
-                }.bind(this))[0];
-            },
-            removeViewForModel: function(model) {
-                var view = this.getViewForModel(model);
-                if (view) {
-                    this.views.splice(this.views.indexOf(view), 1);
-                }
-            },
-            removeView: function(view) {
-                this.views.splice(this.views.indexOf(view), 1);
-            },
-            addView: function(view) {
-                this.views.push(view);
-            },
-            showLine: function(model) {
+        Draw.Controller = DrawingController.extend({
+            drawingType: 'line',
+            show: function(model) {
                 if (this.enabled) {
                     this.options.drawHelper.stopDrawing();
                     // remove old line
@@ -215,31 +173,6 @@ define([
                             wreqr.vent.trigger('search:linedisplay', model);
                         }
                     });
-                }
-            },
-            stop: function() {
-                if (this.enabled) {
-                    // stop drawing
-                    this.options.drawHelper.stopDrawing();
-                }
-                if (this.notificationView) {
-                    this.notificationView.destroy();
-                }
-            },
-            destroyView: function(view) {
-                view.destroy();
-                this.removeView(view);
-            },
-            destroy: function(model) {
-                this.stop();
-                var view = this.getViewForModel(model);
-                // I don't think we need this method.
-                if (this.notificationView) {
-                    this.notificationView.destroy();
-                }
-                if (view) {
-                    view.destroy();
-                    this.removeViewForModel(model);
                 }
             }
         });

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
@@ -17,9 +17,10 @@ define([
         'wreqr',
         'maptype',
         './notification.view',
-        'js/ShapeUtils'
+        'js/ShapeUtils',
+        './drawing.controller'
     ],
-    function(Marionette, Backbone, Cesium, _, wreqr, maptype, NotificationView, ShapeUtils) {
+    function(Marionette, Backbone, Cesium, _, wreqr, maptype, NotificationView, ShapeUtils, DrawingController) {
         "use strict";
         var Draw = {};
 
@@ -77,52 +78,9 @@ define([
             }
         });
 
-        Draw.Controller = Marionette.Controller.extend({
-            enabled: true,
-            initialize: function() {
-                this.listenTo(wreqr.vent, 'search:polydisplay', function(model) {
-                    this.showPolygon(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawpoly', function(model) {
-                    this.draw(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawstop', function(model) {
-                    this.stop(model);
-                });
-                this.listenTo(wreqr.vent, 'search:drawend', function(model) {
-                    this.destroy(model);
-                });
-                this.listenTo(wreqr.vent, 'search:destroyAllDraw', function(model) {
-                    this.destroyAll(model);
-                });
-            },
-            views: [],
-            isVisible: function() {
-                return this.options.map.scene.canvas.width !== 0;
-            },
-            destroyAll: function() {
-                for (var i = this.views.length - 1; i >= 0; i -= 1) {
-                    this.destroyView(this.views[i]);
-                }
-            },
-            getViewForModel: function(model) {
-                return this.views.filter(function(view) {
-                    return view.model === model && view.options.map === this.options.map;
-                }.bind(this))[0];
-            },
-            removeViewForModel: function(model) {
-                var view = this.getViewForModel(model);
-                if (view) {
-                    this.views.splice(this.views.indexOf(view), 1);
-                }
-            },
-            removeView: function(view) {
-                this.views.splice(this.views.indexOf(view), 1);
-            },
-            addView: function(view) {
-                this.views.push(view);
-            },
-            showPolygon: function(model) {
+        Draw.Controller = DrawingController.extend({
+            drawingType: 'poly',
+            show: function(model) {
                 if (this.enabled) {
                     this.options.drawHelper.stopDrawing();
                     // remove old polygon
@@ -169,31 +127,6 @@ define([
                             wreqr.vent.trigger('search:polydisplay', model);
                         }
                     });
-                }
-            },
-            stop: function() {
-                if (this.enabled) {
-                    // stop drawing
-                    this.options.drawHelper.stopDrawing();
-                }
-                if (this.notificationView) {
-                    this.notificationView.destroy();
-                }
-            },
-            destroyView: function(view) {
-                view.destroy();
-                this.removeView(view);
-            },
-            destroy: function(model) {
-                this.stop();
-                var view = this.getViewForModel(model);
-                // I don't think we need this method.
-                if (this.notificationView) {
-                    this.notificationView.destroy();
-                }
-                if (view) {
-                    view.destroy();
-                    this.removeViewForModel(model);
                 }
             }
         });

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/drawing.controller.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/drawing.controller.js
@@ -18,8 +18,11 @@ var wreqr = require('wreqr');
 
 module.exports = Marionette.Controller.extend({
     enabled: true,
-    drawingType: 'extendme!',
+    drawingType: undefined,
     initialize: function() {
+        if (typeof this.drawingType === "undefined"){
+            throw "drawingType needs to be overwritten";
+        }
         this.listenTo(wreqr.vent, `search:${this.drawingType}display`, function(model) {
             this.show(model);
         });
@@ -59,53 +62,11 @@ module.exports = Marionette.Controller.extend({
     addView: function(view) {
         this.views.push(view);
     },
-    show: function(model) {
-        if (this.enabled) {
-            var bboxModel = model || new Draw.BboxModel();
-
-            var existingView = this.getViewForModel(model);
-            if (existingView) {
-                existingView.drawStop();
-                existingView.destroyPrimitive();
-                existingView.updatePrimitive(model);
-            } else {
-                var view = new Draw.BboxView({
-                    map: this.options.map,
-                    model: bboxModel
-                });
-                view.updatePrimitive(model);
-                this.addView(view);
-            }
-
-            return bboxModel;
-        }
+    show: function() {
+        throw "show needs to be overwritten";
     },
-    draw: function(model) {
-        if (this.enabled) {
-            var bboxModel = model || new Draw.BboxModel();
-            var view = new Draw.BboxView({
-                map: this.options.map,
-                model: bboxModel
-            });
-
-            var existingView = this.getViewForModel(model);
-            if (existingView) {
-                existingView.stop();
-                existingView.destroyPrimitive();
-                this.removeView(existingView);
-            }
-            view.start();
-            this.addView(view);
-            this.notificationView = new NotificationView({
-                el: this.options.notificationEl
-            }).render();
-            bboxModel.trigger('BeginExtent');
-            this.listenToOnce(bboxModel, 'EndExtent', function() {
-                this.notificationView.destroy();
-            });
-
-            return bboxModel;
-        }
+    draw: function() {
+        throw "draw needs to be overwritten";
     },
     stop: function(model) {
         var view = this.getViewForModel(model);

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/drawing.controller.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/drawing.controller.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define, require, module*/
+var Marionette = require('marionette');
+var wreqr = require('wreqr');
+
+module.exports = Marionette.Controller.extend({
+    enabled: true,
+    drawingType: 'extendme!',
+    initialize: function() {
+        this.listenTo(wreqr.vent, `search:${this.drawingType}display`, function(model) {
+            this.show(model);
+        });
+        this.listenTo(wreqr.vent, `search:draw${this.drawingType}`, function(model) {
+            this.draw(model);
+        });
+        this.listenTo(wreqr.vent, 'search:drawstop', function(model) {
+            this.stop(model);
+        });
+        this.listenTo(wreqr.vent, 'search:drawend', function(model) {
+            this.destroyByModel(model);
+        });
+        this.listenTo(wreqr.vent, 'search:destroyAllDraw', function(model) {
+            this.destroyAll(model);
+        });
+    },
+    views: [],
+    destroyAll: function() {
+        for (var i = this.views.length - 1; i >= 0; i -= 1) {
+            this.destroyView(this.views[i]);
+        }
+    },
+    getViewForModel: function(model) {
+        return this.views.filter(function(view) {
+            return view.model === model && view.options.map === this.options.map;
+        }.bind(this))[0];
+    },
+    removeViewForModel: function(model) {
+        var view = this.getViewForModel(model);
+        if (view) {
+            this.views.splice(this.views.indexOf(view), 1);
+        }
+    },
+    removeView: function(view) {
+        this.views.splice(this.views.indexOf(view), 1);
+    },
+    addView: function(view) {
+        this.views.push(view);
+    },
+    show: function(model) {
+        if (this.enabled) {
+            var bboxModel = model || new Draw.BboxModel();
+
+            var existingView = this.getViewForModel(model);
+            if (existingView) {
+                existingView.drawStop();
+                existingView.destroyPrimitive();
+                existingView.updatePrimitive(model);
+            } else {
+                var view = new Draw.BboxView({
+                    map: this.options.map,
+                    model: bboxModel
+                });
+                view.updatePrimitive(model);
+                this.addView(view);
+            }
+
+            return bboxModel;
+        }
+    },
+    draw: function(model) {
+        if (this.enabled) {
+            var bboxModel = model || new Draw.BboxModel();
+            var view = new Draw.BboxView({
+                map: this.options.map,
+                model: bboxModel
+            });
+
+            var existingView = this.getViewForModel(model);
+            if (existingView) {
+                existingView.stop();
+                existingView.destroyPrimitive();
+                this.removeView(existingView);
+            }
+            view.start();
+            this.addView(view);
+            this.notificationView = new NotificationView({
+                el: this.options.notificationEl
+            }).render();
+            bboxModel.trigger('BeginExtent');
+            this.listenToOnce(bboxModel, 'EndExtent', function() {
+                this.notificationView.destroy();
+            });
+
+            return bboxModel;
+        }
+    },
+    stop: function(model) {
+        var view = this.getViewForModel(model);
+        if (view && view.stop) {
+            view.stop();
+        }
+        if (this.enabled && this.options.drawHelper) {
+            this.options.drawHelper.stopDrawing();
+        }
+        if (this.notificationView) {
+            this.notificationView.destroy();
+        }
+    },
+    destroyView: function(view) {
+        if (view.stop) {
+            view.stop();
+        }
+        if (view.destroyPrimitive) {
+            view.destroyPrimitive();
+        }
+        if (view.destroy) {
+            view.destroy();
+        }
+        this.removeView(view);
+    },
+    destroyByModel: function(model) {
+        this.stop(model);
+        var view = this.getViewForModel(model);
+        if (view) {
+            this.destroyView(view);
+            if (this.notificationView) {
+                this.notificationView.destroy();
+            }
+        }
+    },
+    onBeforeDestroy: function() {
+        this.destroyAll();
+    }
+});


### PR DESCRIPTION
#### What does this PR do?
 - Updates the map views to properly clean up their drawing tools when destroyed.
 - Starts the process of pulling out common drawing tool functionality, starting with the controllers.  Now there is a base drawing controller that each can extend as necessary.

#### Who is reviewing it? 
@adimka 
@mackncheesiest 
@jlcsmith
@rzwiefel 

#### How should this be tested? (List steps with links to updated documentation)
Test out each of the drawing methods and verify they work as expected.  Make sure to have both types of map open (2d and 3d), and test closing each and reopening each and then drawing with each type.  Verify no errors are thrown.

#### Any background context you want to provide?
It looks like this started being an issue when we updated cesium to destroy itself properly, but regardless both maps should be disposing of their drawing tools when they get destroyed.

#### What are the relevant tickets?
[DDF-3715](https://codice.atlassian.net/browse/DDF-3715)

#### Screenshots (if appropriate)
![Before fix when 3d map is closed and drawing is attempted](https://user-images.githubusercontent.com/11984853/38158700-7cad4dbc-344e-11e8-86bb-9b56da584ab6.png)
