### PR TITLE
DDF-3693 Updates map-context-menu to use existing conversion library

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -15,7 +15,7 @@
 /*global require*/
 var Backbone = require('backbone');
 var MetacardModel = require('js/model/Metacard');
-var ol = require('openlayers');
+const mtgeo = require('mt-geo');
 
 module.exports = Backbone.AssociatedModel.extend({
     relations: [{
@@ -29,14 +29,13 @@ module.exports = Backbone.AssociatedModel.extend({
         mouseLon: undefined,
         clickLat: undefined,
         clickLon: undefined,
-        clickDms: undefined,
         target: undefined,
         targetMetacard: undefined
     },
     updateClickCoordinates: function () {
         const lat = this.get('mouseLat');
         const lon = this.get('mouseLon');
-        const dms = ol.coordinate.toStringHDMS([lon, lat]);
+        const dms =  `${mtgeo.toLat(lat)} ${mtgeo.toLon(lon)}`;
 
         this.set({
             clickLat: lat,


### PR DESCRIPTION
#### What does this PR do?
 - Updates map-context-menu to use the existing conversion library rather than openlayers.  Depending on openlayers here is a bit heavy handed since it will pull in the entire openlayers library, which would be strange (especially if you're on the cesium map).  In the future we could update it to pull in exactly the conversion portion of openlayers if we want, but we would need to be using the es2015 modules version of openlayers.
 - Removes `clickDms` from the map model since it's unused.

#### Who is reviewing it? 
@Schachte 
@Variadicism 
@jlcsmith 
@bdeining 
@glenhein 

#### How should this be tested? (List steps with links to updated documentation)
1. Right click map.
2. Copy DMS coordinates (verify value in popup matches DMS coordinates in bottom left-hand corner).

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3693](https://codice.atlassian.net/browse/DDF-3693)

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
