### PR TITLE
DDF 3702 - Pre-populated Query Templates in the UI

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -34,35 +34,8 @@ define([
              MultivalueView, metacardDefinitions, PropertyModel, DropdownModel, DropdownView,
             InputWithParam, ValueModel, CQLUtils, properties, Common) {
 
-    const generatePropertyJSON = (value, type, comparator) => {
-        const propertyJSON = _.extend({},
-            metacardDefinitions.metacardTypes[type],
-            {
-                value: value,
-                multivalued: false,
-                enumFiltering: true,
-                enumCustom: true,
-                matchcase: ['MATCHCASE', '='].indexOf(comparator) !== -1 ? true : false,
-                enum: metacardDefinitions.enums[type],
-                showValidationIssues: false
-            });
-            
-        if (propertyJSON.type === 'GEOMETRY'){
-            propertyJSON.type = 'LOCATION';
-        }
 
-        propertyJSON.placeholder = propertyJSON.type === 'DATE' ? 'DD MMM YYYY HH:mm:ss.SSS' : 'Use * for wildcard.';
-
-        if (comparator === 'NEAR') {
-            propertyJSON.type = 'NEAR';
-            propertyJSON.param = 'within';
-            propertyJSON.help =  'The distance (number of words) within which search terms must be found in order to match';
-            delete propertyJSON.enum;
-        }
-        return propertyJSON;
-    }
-
-    return Marionette.LayoutView.extend({
+       return Marionette.LayoutView.extend({
         template: template,
         tagName: CustomElements.register('filter'),
         events: {
@@ -124,9 +97,6 @@ define([
                    }
                    break;
             }
-            return value;
-        },
-        transformValue: function (value, defaultValue, comparator) {
             return value;
         },
         comparatorToCQL: function() {
@@ -322,6 +292,33 @@ define([
                 ? this.filterInput.currentView.model.get('property')
                 : this.filterInput.currentView.model;
             property.set('isEditing', false);
+        },
+        generatePropertyJSON: function(value, type, comparator) {
+            const propertyJSON = _.extend({},
+                metacardDefinitions.metacardTypes[type],
+                {
+                    value: value,
+                    multivalued: false,
+                    enumFiltering: true,
+                    enumCustom: true,
+                    matchcase: ['MATCHCASE', '='].indexOf(comparator) !== -1 ? true : false,
+                    enum: metacardDefinitions.enums[type],
+                    showValidationIssues: false
+                });
+                
+            if (propertyJSON.type === 'GEOMETRY'){
+                propertyJSON.type = 'LOCATION';
+            }
+    
+            propertyJSON.placeholder = propertyJSON.type === 'DATE' ? 'DD MMM YYYY HH:mm:ss.SSS' : 'Use * for wildcard.';
+    
+            if (comparator === 'NEAR') {
+                propertyJSON.type = 'NEAR';
+                propertyJSON.param = 'within';
+                propertyJSON.help =  'The distance (number of words) within which search terms must be found in order to match';
+                delete propertyJSON.enum;
+            }
+            return propertyJSON;
         }
     });
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -126,6 +126,9 @@ define([
             }
             return value;
         },
+        transformValue: function (value, defaultValue, comparator) {
+            return value;
+        },
         comparatorToCQL: function() {
             return {
                 BEFORE: 'BEFORE',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -179,7 +179,7 @@ define([
             let value = Common.duplicate(this.model.get('value'));
             const currentComparator = this.model.get('comparator');
             value = this.transformValue(value, currentComparator);
-            const propertyJSON = generatePropertyJSON(value, this.model.get('type'), currentComparator);
+            const propertyJSON = this.generatePropertyJSON(value, this.model.get('type'), currentComparator);
 
             this.filterInput.show(new MultivalueView({
                 model: new PropertyModel(propertyJSON)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/search-form/filter.search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/search-form/filter.search-form.view.js
@@ -105,6 +105,27 @@ define([
                 : this.filterInput.currentView.model;
             property.set('isEditing', true);
         },
+        setFilter: function(filter){
+            setTimeout(function(){
+                if (CQLUtils.isGeoFilter(filter.type)){
+                    filter.value = _.clone(filter);
+                }
+                if (_.isObject(filter.property)) {
+                    // if the filter is something like NEAR (which maps to a CQL filter function such as 'proximity'),
+                    // there is an enclosing filter that creates the necessary '= TRUE' predicate, and the 'property'
+                    // attribute is what actually contains that proximity() call.
+                    this.setFilterFromFilterFunction(filter.property);
+                } else {
+                    this.model.set({
+                        value: [filter.value],
+                        type: filter.property.split('"').join(''),
+                        comparator: this.CQLtoComparator()[filter.type],
+                        defaultValue: [filter.defaultValue]
+                    });
+                }
+
+            }.bind(this),0);
+        },
         turnOffEditing: function(){
             this.$el.removeClass('is-editing');
             this.filterComparator.currentView.turnOffEditing();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/search-form/filter.search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/search-form/filter.search-form.view.js
@@ -73,17 +73,13 @@ define([
         determineInput: function(){
             this.updateValueFromInput();
             let value = Common.duplicate(this.model.get('value'));
-            var defaultValue;
+            var defaultValue = "";
             if(typeof this.model.get('defaultValue') !== 'undefined'){
                 defaultValue = Common.duplicate(this.model.get('defaultValue'));
             }
-            else{
-                defaultValue = "";
-            }
             const currentComparator = this.model.get('comparator');
             value = this.transformValue(value, defaultValue, currentComparator);
-            FilterView.propertyJSON = FilterView.generatePropertyJSON(value, this.model.get('type'), currentComparator);
-
+            FilterView.propertyJSON = FilterView.prototype.generatePropertyJSON(value, this.model.get('type'), currentComparator);
             this.filterInput.show(new MultivalueView({
                 model: new PropertyModel(FilterView.propertyJSON)
             }));

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/search-form/filter.search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/search-form/filter.search-form.view.js
@@ -45,7 +45,7 @@ define([
             FilterView.prototype.onBeforeShow.call(this);
             this.filterAttribute.currentView.turnOffEditing();
         },
-        transformValue: function (value, comparator) {
+        transformValue: function (value, defaultValue, comparator) {
             switch (comparator) {
                 case 'NEAR':
                     if (value[0].constructor !== Object) {
@@ -59,14 +59,42 @@ define([
                 case 'DWITHIN':
                     break;
                 default:
-                   if (value[0] == null) {
-                        value[0] = "";
-                   } else if (value[0].constructor === Object) {
-                        value[0] = value[0].value;
-                   }
-                   break;
+					if (value[0] != null && value[0].constructor === Object) {
+						value[0] = value[0].value;
+					} else if(defaultValue != "") {
+						value[0] = defaultValue;
+					} else if (value == null) {
+						value[0] = "";     
+					} 
+					break;
             }
             return value;
+        },
+        determineInput: function(){
+            this.updateValueFromInput();
+            let value = Common.duplicate(this.model.get('value'));
+            var defaultValue;
+            if(typeof this.model.get('defaultValue') !== 'undefined'){
+                defaultValue = Common.duplicate(this.model.get('defaultValue'));
+            }
+            else{
+                defaultValue = "";
+            }
+            const currentComparator = this.model.get('comparator');
+            value = this.transformValue(value, defaultValue, currentComparator);
+            FilterView.propertyJSON = FilterView.generatePropertyJSON(value, this.model.get('type'), currentComparator);
+
+            this.filterInput.show(new MultivalueView({
+                model: new PropertyModel(FilterView.propertyJSON)
+            }));
+
+            var isEditing = this.$el.hasClass('is-editing');
+            if (isEditing){
+                this.turnOnEditing();
+            } else {
+                this.turnOffEditing();
+            }
+            this.setDefaultComparator(FilterView.propertyJSON);
         },
         turnOnEditing: function(){
             this.$el.addClass('is-editing');


### PR DESCRIPTION
#### What does this PR do?
Implements the default values for templates on the UI
#### Who is reviewing it? 
@Schachte @adimka 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@jlcsmith
#### How should this be tested? (List steps with links to updated documentation)
Reinstall DDF instance.  
Prior to initial startup add the etc/forms directory to the DDF instance
Edit the XML files to include a default value
  Default values are loaded into the first Literal Tag after the function Tag.  Ex:
            <fes:Function name="template.value.v1">
                <fes:Literal>Connexta</fes:Literal> (DefaultValue)
Start DDF
Open the template that was modified to include a default
Verify default value is displayed in the valid fields
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3702
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/33610537/38253132-1a3dd3a0-3713-11e8-9ae2-10c62a0e0663.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
