### PR TITLE
DDF-3621 Upgraded and added new extensions to Spock

### DIFF
--- a/libs/spock-shaded/pom.xml
+++ b/libs/spock-shaded/pom.xml
@@ -29,6 +29,17 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.22.0-GA</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
             <version>5.0.4</version>
@@ -36,17 +47,17 @@
         <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
-            <version>3.2.0</version>
+            <version>3.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
-            <version>2.1</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
+            <version>1.1-groovy-2.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.groovy</groupId>
@@ -77,11 +88,12 @@
                 <configuration>
                     <artifactSet>
                         <includes>
+                            <include>org.javassist:javassist</include>
                             <include>org.ow2.asm:asm</include>
-                            <include>cglib:cglib-nodep:3.2.0</include>
-                            <include>org.objenesis:objensis</include>
+                            <include>cglib:cglib-nodep</include>
+                            <include>org.objenesis:objenesis</include>
                             <include>org.spockframework:spock-core</include>
-                            <include>org.codehaus.groovy:groovy-all:2.4.7</include>
+                            <include>org.codehaus.groovy:groovy-all</include>
                         </includes>
                     </artifactSet>
                     <filters>

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/Supplemental.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/Supplemental.groovy
@@ -30,7 +30,7 @@ import java.lang.annotation.*
  * <ul>
  *   <li><code>Method[] Class.getApiMethods()</code>
  *       <p>Gets all API methods (inherited or not) for the given class filtering away all non public
- *          methods and all all methods defined by the {@link Object} class (e.g.
+ *          methods and all methods defined by the {@link Object} class (e.g.
  * {@link Object#equals}, {@link Object#toString}, {@link Object#clone} ...).</li>
  *
  *   <li><code>Method[] Class.getProxyableMethods()</code>

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/Supplemental.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/Supplemental.groovy
@@ -28,15 +28,20 @@ import java.lang.annotation.*
  *
  * <p>The following methods are added:
  * <ul>
+ *   <li><code>Method[] Class.getApiMethods()</code>
+ *       <p>Gets all API methods (inherited or not) for the given class filtering away all non public
+ *          methods and all all methods defined by the {@link Object} class (e.g.
+ * {@link Object#equals}, {@link Object#toString}, {@link Object#clone} ...).</li>
+ *
  *   <li><code>Method[] Class.getProxyableMethods()</code>
  *       <p>Gets all public proxy-able methods (inherited or not) for the class filtering away all
  *          final methods and all methods defined by the {@link Object} class (e.g.
  * {@link Object#equals}, {@link Object#toString}, {@link Object#clone} ...).</li>
- * 
+ *
  *   <li><code>Method Class.getMethodBySimplePrototype(String prototype) throws NoSuchMethodException</code>
  *       <p>Returns a {@code Method} object that reflects the specified public member method of the
  *          underlying class or interface that matches the given simple prototype.
- *          
+ *
  *   <li><code>String Class.getNoSpockSimpleName()</code>
  *       <p>Returns the simple name of the underlying class as given in the source code stripping
  *       away any references to Spock mocks, stubs, or spies.</li>

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/Supplemental.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/Supplemental.groovy
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.spock.extension
+
+import org.codice.spock.extension.builtin.SupplementalExtension
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.*
+
+@Inherited
+@ExtensionAnnotation(SupplementalExtension)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+/**
+ * The <code>Supplemental</code> annotation can be added to any Spock specification class in order
+ * to get additional methods added to specific classes while testing the specification.
+ *
+ * <p>The following methods are added:
+ * <ul>
+ *   <li><code>Method[] Class.getProxyableMethods()</code>
+ *       <p>Gets all public proxy-able methods (inherited or not) for the class filtering away all
+ *          final methods and all methods defined by the {@link Object} class (e.g.
+ * {@link Object#equals}, {@link Object#toString}, {@link Object#clone} ...).</li>
+ * 
+ *   <li><code>Method Class.getMethodBySimplePrototype(String prototype) throws NoSuchMethodException</code>
+ *       <p>Returns a {@code Method} object that reflects the specified public member method of the
+ *          underlying class or interface that matches the given simple prototype.
+ *          
+ *   <li><code>String Class.getNoSpockSimpleName()</code>
+ *       <p>Returns the simple name of the underlying class as given in the source code stripping
+ *       away any references to Spock mocks, stubs, or spies.</li>
+ *
+ *   <li><code>String Method.getSimplePrototype()</code>
+ *       <p>Gets a simple prototype string to represent the method.</li>
+ *
+ *   <li><code>void Method.verifyInvocation(MockInvocation delegate, Object... parameters)</code>
+ *       <p>Asserts if the mock invocation matches the specified method. Only the method name and
+ *          parameter types/values are verified.
+ *       <p>This method is meant to be invoked from within a closure associated with a stubbed
+ *          interaction by passing it a reference to the closure's delegate and the expected
+ *          parameters used when calling the method. Parameters are verified using identity check
+ *          and not equality. No verification of parameters will occur if no expected parameters are
+ *          specified.</li>
+ *
+ *   <li><code>System.setPropertyIfNotNull(String name, String value)</code>
+ *       <p>Sets the system property indicated by the specified key only if the specified value is
+ *          not <code>null</code> otherwise remove any mappings to the specified key.
+ *
+ *   <li><code>&lt;T&gt; T MockingApi.Dummy(Class<T> type)</code>
+ *       <p>Creates a dummy value or stub for the specified type.</li>
+ *
+ *   <li><code>Object[] MockingApi.Dummies(Class<?>... types)</code>
+ *       <p>Creates dummy values or stubs for the specified types.</li>
+ * </ul>
+ */
+public @interface Supplemental {}

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/ClearInterruptions.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/ClearInterruptions.groovy
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.spock.extension;
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Inherited
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+import org.codice.spock.extension.builtin.ClearInterruptionsExtension
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+/**
+ * The <code>ClearInterruptions</code> annotation can be used to clear any interruption states from
+ * the current thread after testing.
+ *
+ * <p>Applying this annotation to a Spock specification class has the same effect as applying it to all
+ * its feature methods.
+ */
+@Inherited
+@ExtensionAnnotation(ClearInterruptionsExtension.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.METHOD])
+@interface ClearInterruptions {}

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/ClearInterruptionsExtension.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/ClearInterruptionsExtension.groovy
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.spock.extension.builtin
+
+import org.codice.spock.extension.ClearInterruptions
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.SpecInfo
+
+/**
+ * Provides the extension point for the {@link ClearInterruptions} annotation.
+ */
+public class ClearInterruptionsExtension extends AbstractAnnotationDrivenExtension<ClearInterruptions> {
+  private static def LISTENER = new IMethodInterceptor() {
+    @Override
+    void intercept(IMethodInvocation invocation) throws Throwable {
+      try {
+        invocation.proceed()
+      } finally {
+        Thread.interrupted()
+      }
+    }
+  }
+
+  @Override
+  void visitSpecAnnotation(ClearInterruptions annotation, SpecInfo spec) {
+    spec.features.each {
+      it.addInterceptor(LISTENER)
+      it.addIterationInterceptor(LISTENER)
+    }
+  }
+
+  @Override
+  void visitFeatureAnnotation(ClearInterruptions annotation, FeatureInfo feature) {
+    feature.addInterceptor(LISTENER);
+    feature.addIterationInterceptor(LISTENER)
+  }
+}

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/SupplementalExtension.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/SupplementalExtension.groovy
@@ -147,10 +147,10 @@ class SupplementalExtension extends AbstractAnnotationDrivenExtension<Supplement
    */
   private def getMethodBySimplePrototype(Class<?> type, String prototype) {
     def p = prototype?.replaceAll("\\s", "")
-    def methods = type.methods.findAll { getSimplePrototype(it) == p }
+    def method = type.methods.find { getSimplePrototype(it) == p }
 
-    if (methods) {
-      return methods[0]
+    if (method) {
+      return method
     }
     throw new NoSuchMethodException(prototype)
   }

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/SupplementalExtension.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/SupplementalExtension.groovy
@@ -112,7 +112,7 @@ class SupplementalExtension extends AbstractAnnotationDrivenExtension<Supplement
 
   /**
    * Gets all API methods (inherited or not) for the given class filtering away all non public
-   * methods and all all methods defined by the {@link Object} class (e.g. {@link Object#equals},
+   * methods and all methods defined by the {@link Object} class (e.g. {@link Object#equals},
    * {@link Object#toString}, {@link Object#clone} ...).
    *
    * @param type the type for which to retrieve all api methods
@@ -126,7 +126,7 @@ class SupplementalExtension extends AbstractAnnotationDrivenExtension<Supplement
 
   /**
    * Gets all proxy-able public methods (inherited or not) for the given class filtering away all
-   * final methods and all all methods defined by the {@link Object} class (e.g. {@link Object#equals},
+   * final methods and all methods defined by the {@link Object} class (e.g. {@link Object#equals},
    * {@link Object#toString}, {@link Object#clone} ...).
    *
    * @param type the type for which to retrieve all proxy-able methods

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/SupplementalExtension.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/SupplementalExtension.groovy
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.spock.extension.builtin
+
+import org.codice.spock.extension.Supplemental
+import org.spockframework.mock.IMockMethod
+import org.spockframework.mock.runtime.MockInvocation
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.extension.builtin.ConfineMetaClassChangesInterceptor
+import org.spockframework.runtime.model.SpecInfo
+import org.spockframework.util.Nullable
+import spock.mock.DetachedMockFactory
+import spock.mock.MockingApi
+
+import java.lang.reflect.Array
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+/**
+ * Provides the extension point for the {@link Supplemental} annotation.
+ */
+class SupplementalExtension extends AbstractAnnotationDrivenExtension<Supplemental> {
+  private static
+  def DEFAULT_VALUES = [
+      (null): null,
+      (void): null,
+      (Void): null,
+      (boolean): false,
+      (Boolean): false,
+      (int): 0,
+      (Integer): 0,
+      (long): 0L,
+      (Long): 0L,
+      (float): 0.0f,
+      (Float): 0.0f,
+      (double): 0.0D,
+      (Double): 0.0D,
+      (char): ('\u0000' as char),
+      (Character): ('\u0000' as char),
+      (short): (short) 0,
+      (Short): (short) 0,
+      (byte): (byte) 0,
+      (Byte): (byte) 0,
+      (String): '',
+      (CharSequence): '',
+      (StringBuilder): { new StringBuilder() },
+      (StringBuffer): { new StringBuffer() },
+      (GString): GString.EMPTY,
+      (Iterable): { new ArrayList<>() },
+      (Collection): { new ArrayList<>() },
+      (List): { new ArrayList<>() },
+      (Set): { new HashSet<>() },
+      (SortedSet): { new TreeSet<>() },
+      (NavigableSet): { new TreeSet<>() },
+      (Map): { new HashMap<>() },
+      (SortedMap): { new TreeMap<>() },
+      (NavigableMap): { new TreeMap<>() },
+      (Optional): Optional.empty(),
+      (BigInteger): BigInteger.ZERO,
+      (BigDecimal): BigDecimal.ZERO
+  ]
+
+  private def mockFactory = new DetachedMockFactory()
+
+  @Override
+  void visitSpecAnnotation(Supplemental annotation, SpecInfo spec) {
+    // register the {@link ConfineMetaClassChanges} interceptor first to restore all metaclass changes
+    // done by our own interceptor
+    spec.bottomSpec.addInterceptor(new ConfineMetaClassChangesInterceptor([Class, Method, System, MockingApi]))
+
+    spec.bottomSpec.addInterceptor(new IMethodInterceptor() {
+      @Override
+      void intercept(IMethodInvocation invocation) throws Throwable {
+        def ext = SupplementalExtension.this
+
+        // supplement the Class class
+        Class.metaClass {
+          getProxyableMethods { ext.getProxyableMethods(delegate) }
+          getMethodBySimplePrototype { String p -> ext.getMethodBySimplePrototype(delegate, p) }
+          getNoSpockSimpleName { ext.getNoSpockSimpleName(delegate) }
+        }
+        // supplement the Method class
+        Method.metaClass {
+          getSimplePrototype { ext.getSimplePrototype(delegate) }
+          verifyInvocation { MockInvocation i, Object... p -> ext.verifyInvocation(delegate, i, p) }
+        }
+        // supplement the System class
+        System.metaClass.static.setPropertyIfNotNull = ext.&setPropertyIfNotNull
+        // supplement specification class to allow creating dummies
+        invocation.instance.class.metaClass {
+          Dummy = ext.&createDummy
+          Dummies = ext.&createDummies
+        }
+        invocation.proceed()
+      }
+    })
+  }
+
+  /**
+   * Gets all proxy-able public methods (inherited or not) for the given class filtering away all
+   * final methods and all all methods defined by the {@link Object} class (e.g. {@link Object#equals},
+   * {@link Object#toString}, {@link Object#clone} ...).
+   *
+   * @param type the type for which to retrieve all proxy-able methods
+   * @return a list of all proxy-able methods for the given class
+   */
+  private def getProxyableMethods(Class<?> type) {
+    type.methods.findAll {
+      Modifier.isPublic(it.modifiers) && !Modifier.isFinal(it.modifiers) && (it.declaringClass != Object.class)
+    }
+  }
+
+  /**
+   * Returns a {@code Method} object that reflects the specified public member method of the class
+   * or interface represented by the specified class that matches the given simple prototype.
+   *
+   * @param type the type for which to retrieve a method matching the given prototype
+   * @param prototype the prototype to match
+   * @return the corresponding method
+   * @throws NoSuchMethodException if a matching method is not found
+   */
+  private def getMethodBySimplePrototype(Class<?> type, String prototype) {
+    def methods = type.methods.findAll { getSimplePrototype(it) == prototype }
+
+    if (methods) {
+      return methods[0]
+    }
+    throw new NoSuchMethodException(prototype)
+  }
+
+  /**
+   * Returns the simple name of the specified class as given in the source code stripping away any
+   * references to Spock mocks, stubs, or spies. Returns an empty string if the class is anonymous.
+   *
+   * @param type the class for which to get its simple name
+   * @return the simple name of the specified class without any references to Spock mocks, stubs, or
+   * spies
+   */
+  private def getNoSpockSimpleName(Class<?> type) {
+    type.simpleName.replaceFirst('\\$Spock.*\\$.*$', '')
+  }
+
+  /**
+   * Gets a simple prototype string to represent the specified method.
+   *
+   * @param method the method for which to get a simple prototype
+   * @return a corresponding simple prototype
+   */
+  private def getSimplePrototype(Method method) {
+    method.name + '(' + method.parameterTypes*.simpleName.join(',') + ')'
+  }
+
+  /**
+   * Gets a simple prototype string to represent the specified method.
+   *
+   * @param method the method for which to get a simple prototype
+   * @return a corresponding simple prototype
+   */
+  private def getSimplePrototype(IMockMethod method) {
+    method.name + '(' + method.parameterTypes*.simpleName.join(',') + ')'
+  }
+
+  /**
+   * Asserts if the mock invocation matches the specified method. Only the method name and
+   * parameter types/values are verified.
+   *
+   * <p>This method is meant to be invoked from within a closure associated with a stubbed
+   * interaction by passing it a reference to the closure's delegate and the expected parameters
+   * used when calling the method. Parameters are verified using identity check and not equality.
+   * No verification of parameters will occur if no expected parameters are specified.
+   *
+   * @param method the method expected to be called
+   * @param delegate the mock invocation to be verified
+   * @param the expected parameters
+   * @throws AssertionError if the method name or parameter types or values do not match
+   */
+  private def verifyInvocation(Method method, MockInvocation delegate, Object... parameters) {
+    def methodPrototype = getSimplePrototype(method)
+    def delegatePrototype = getSimplePrototype(delegate.method)
+
+    assert methodPrototype == delegatePrototype: "expecting $methodPrototype to be invoked instead of $delegatePrototype"
+    assert method.name == delegate.method.name
+    assert method.parameterTypes == delegate.method.parameterTypes
+    if (parameters.length) {
+      def delegate_arguments = delegate.arguments
+
+      for (def i = 0; i < method.parameters.length; i++) {
+        assert delegate_arguments[i].is(parameters[i])
+      }
+    }
+  }
+
+  /**
+   * Sets the system property indicated by the specified key only if the specified value is
+   * not <code>null</code> otherwise clear any mappings to the specified key.
+   *
+   * @param name the name of the system property to be set or removed
+   * @param value the new value for the system property or <code>null</code> to clear the mapping
+   * @return the previous value of the system property, or <code>null</code> if it did not have one
+   */
+  private def setPropertyIfNotNull(String name, @Nullable String value) {
+    (value != null) ? System.setProperty(name, value) : System.clearProperty(name)
+  }
+
+  /**
+   * Creates a dummy value or stub for the specified type.
+   *
+   * @param type the type for which to create a dummy value or stub
+   * @return a corresponding default value or stub
+   */
+  private def <T> T createDummy(Class<T> type) {
+    // see org.spockframework.mock.EmptyOrDummyResponse
+    def val = DEFAULT_VALUES.getOrDefault(type, type)
+
+    if (val instanceof Closure) {
+      val.call()
+    } else if (!val.is(type)) {
+      // if not the default value; it was defined in DEFAULT_VALUES
+      val
+    } else if (type.array) {
+      Array.newInstance(type.componentType, 0)
+    } else if (type.enum) {
+      def constants = type.enumConstants
+
+      (constants.length > 0) ? constants[0] : null
+    } else {
+      try {
+        type.newInstance()
+      } catch (Exception e) {
+        // if we cannot instantiate it, then fallback to stubbing the class
+        mockFactory.Stub(type)
+      }
+    }
+  }
+
+  /**
+   * Creates dummy default values or stubs for the specified types.
+   *
+   * @param types the types for which to create dummy default values or stubs
+   * @return a corresponding array of dummy default values or stubs corresponding to the provided types
+   */
+  private def createDummies(Class<?>... types) {
+    types.collect this.&createDummy
+  }
+}

--- a/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/SupplementalExtension.groovy
+++ b/libs/spock-shaded/src/main/groovy/org/codice/spock/extension/builtin/SupplementalExtension.groovy
@@ -133,7 +133,8 @@ class SupplementalExtension extends AbstractAnnotationDrivenExtension<Supplement
    * @throws NoSuchMethodException if a matching method is not found
    */
   private def getMethodBySimplePrototype(Class<?> type, String prototype) {
-    def methods = type.methods.findAll { getSimplePrototype(it) == prototype }
+    def p = protoype?.replaceAll("\\s", "")
+    def methods = type.methods.findAll { getSimplePrototype(it) == p }
 
     if (methods) {
       return methods[0]

--- a/libs/spock-shaded/src/main/java/org/codice/spock/extension/DeFinalize.java
+++ b/libs/spock-shaded/src/main/java/org/codice/spock/extension/DeFinalize.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.spock.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DeFinalize {
+  /**
+   * Specifies the classes to de-finalize.
+   *
+   * @return the classes to de-finalize
+   */
+  public Class<?>[] value() default {};
+
+  /**
+   * Specifies the packages to de-finalize.
+   *
+   * @return the fully qualified names for the packages to de-finalize
+   */
+  public String[] packages() default {};
+}

--- a/libs/spock-shaded/src/main/java/org/codice/spock/extension/DeFinalizeWith.java
+++ b/libs/spock-shaded/src/main/java/org/codice/spock/extension/DeFinalizeWith.java
@@ -18,27 +18,21 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.runner.Runner;
 
 /**
- * This annotation is used to indicate to the {@link org.codice.spock.extension.builtin.DeFinalizer}
- * test runner, which classes or packages should be definalized.
+ * This annotation is used to indicate the actual test runner that should be used to run the tests
+ * whenever a class uses the {@link org.codice.spock.extension.builtin.DeFinalizer} test runner.
+ *
+ * <p>The standard JUnit's {@link org.junit.runners.JUnit4} test runner or Spock's {@link
+ * org.spockframework.runtime.Sputnik} test runner will be used if the class or the Spock's
+ * specification is not annotated with this annotation.
  */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface DeFinalize {
+public @interface DeFinalizeWith {
 
-  /**
-   * Specifies the classes to de-finalize.
-   *
-   * @return the classes to de-finalize
-   */
-  public Class<?>[] value() default {};
-
-  /**
-   * Specifies the packages to de-finalize.
-   *
-   * @return the fully qualified names for the packages to de-finalize
-   */
-  public String[] packages() default {};
+  /** @return a runner class (must have a constructor that takes a single class to run) */
+  public Class<? extends Runner> value();
 }

--- a/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeClassLoader.java
+++ b/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeClassLoader.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.spock.extension.builtin;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javassist.CannotCompileException;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.LoaderClassPath;
+import javassist.Modifier;
+import javassist.NotFoundException;
+import org.codice.spock.extension.DeFinalize;
+
+/**
+ * Defines the classloader used by the {@link DeFinalizeSputnik} test runner. This classloader is
+ * designed with an aggressive strategy where it will load all classes first before delegating to
+ * its parent. This classloader will therefore reload all classes while definalizing those that are
+ * requested except for all classes in the following packages:
+ *
+ * <ul>
+ *   <li>java
+ *   <li>javax
+ *   <li>sun
+ *   <li>org.xml
+ *   <li>org.junit
+ * </ul>
+ *
+ * These packages are not being reloaded as they are required by the {@link DeFinalizeSputnik} test
+ * runner to delegate to the real {@link org.spockframework.runtime.Sputnik} test runner.
+ *
+ * <p>All loaded classes will be done so with the same protection domain used if they had been
+ * loaded by the parent classloader.
+ */
+public class DeFinalizeClassLoader extends ClassLoader {
+  private final ClassPool pool;
+  private final Set<String> filters;
+
+  /**
+   * Constructs a new classloader for the specified Spock test specification class. The class is
+   * used to retrieve the {@link DeFinalize} annotations in order to identify which classes or
+   * packages should be definalized as they are being loaded.
+   *
+   * <p>The classloader used to load this classloader class will be defined as its parent
+   * classloader.
+   *
+   * @param specClass the Spock test specification class
+   */
+  public DeFinalizeClassLoader(Class<?> specClass) {
+    super(DeFinalizeClassLoader.class.getClassLoader());
+    this.pool = new ClassPool(false);
+    this.pool.appendClassPath(new LoaderClassPath(getParent()));
+    this.pool.appendSystemPath();
+    this.filters =
+        Stream.concat(
+                Stream.of(specClass.getAnnotationsByType(DeFinalize.class))
+                    .map(DeFinalize::value)
+                    .flatMap(Stream::of)
+                    .map(Class::getName),
+                Stream.of(specClass.getAnnotationsByType(DeFinalize.class))
+                    .map(DeFinalize::packages)
+                    .flatMap(Stream::of))
+            .collect(Collectors.toSet());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Loads the class with the specified <a href="#name">binary name</a>.
+   *
+   * <p>The class will always be loaded first from its parent classloader. It will be returned as is
+   * if the class is from one of the reserved packages (see above). Otherwise, the class will be
+   * reloaded and optionally definalize if the class match a requested class or package from one of
+   * the {@link DeFinalize} annotations of the Spock test specification class. The protection domain
+   * from the version of the class loaded by the parent classloader will be re-used when defining
+   * the reloaded class.
+   *
+   * @param name the binary name of the class to load
+   * @param resolve <code>true</code> to resolve the class; <code>false</code> otherwise
+   * @return the resulting class object
+   * @throws ClassNotFoundException if the class could not be found
+   */
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    synchronized (getClassLoadingLock(name)) {
+      Class<?> clazz = findLoadedClass(name);
+
+      if (clazz == null) {
+        clazz = super.loadClass(name, resolve); // always load it from our parent first
+        if (!name.startsWith("java.")
+            && !name.startsWith("javax.")
+            && !name.startsWith("sun.")
+            && !name.startsWith("org.xml.")
+            && !name.startsWith("org.junit.")) {
+          try {
+            boolean definalize = filters.contains(name);
+
+            if (!definalize) {
+              for (int i = name.indexOf('.'); i > 0; i = name.indexOf('.', ++i)) {
+                if (filters.contains(name.substring(0, i))) {
+                  definalize = true;
+                  break;
+                }
+              }
+            }
+            clazz = reloadClass(clazz, definalize);
+          } catch (NotFoundException e) {
+            throw new ClassNotFoundException(e.getMessage(), e);
+          } catch (CannotCompileException e) {
+            throw (ClassFormatError) new ClassFormatError(e.getMessage()).initCause(e);
+          }
+        }
+      }
+      if (resolve) {
+        resolveClass(clazz);
+      }
+      return clazz;
+    }
+  }
+
+  private Class<?> reloadClass(Class<?> clazz, boolean definalize)
+      throws NotFoundException, CannotCompileException {
+    final CtClass ctClass = pool.get(clazz.getName());
+
+    if (definalize) {
+      final CtClass parentClass = ctClass.getDeclaringClass();
+
+      if (parentClass != null) { // must process the parent for inner classes but leave it unfrozen
+        definalizeClass(parentClass);
+      }
+      definalizeClass(ctClass);
+    }
+    ctClass.stopPruning(true);
+    // use the same protection domain as the original class loaded from our parent
+    return ctClass.toClass(this, clazz.getProtectionDomain());
+  }
+
+  private void definalizeClass(CtClass ctClass) {
+    ctClass.defrost();
+    final int modifiers = ctClass.getModifiers();
+
+    if (Modifier.isFinal(modifiers)) {
+      ctClass.setModifiers(Modifier.clear(modifiers, Modifier.FINAL));
+    }
+    Stream.of(ctClass.getDeclaredMethods()).forEach(this::definalizeMethod);
+  }
+
+  private void definalizeMethod(CtMethod ctMethod) {
+    final int modifiers = ctMethod.getModifiers();
+
+    if (Modifier.isFinal(modifiers) && !Modifier.isPrivate(modifiers)) {
+      ctMethod.setModifiers(Modifier.clear(modifiers, Modifier.FINAL));
+    }
+  }
+}

--- a/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeClassLoader.java
+++ b/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeClassLoader.java
@@ -32,11 +32,11 @@ import org.codice.spock.extension.DeFinalize;
  * requested except for all classes in the following packages:
  *
  * <ul>
- *   <li>java
- *   <li>javax
- *   <li>sun
- *   <li>org.xml
- *   <li>org.junit
+ * <li>java
+ * <li>javax
+ * <li>sun
+ * <li>org.xml
+ * <li>org.junit
  * </ul>
  *
  * These packages are not being reloaded as they are required by the {@link DeFinalizeSputnik} test
@@ -46,6 +46,7 @@ import org.codice.spock.extension.DeFinalize;
  * loaded by the parent classloader.
  */
 public class DeFinalizeClassLoader extends ClassLoader {
+
   private final ClassPool pool;
   private final Set<String> filters;
 
@@ -66,13 +67,13 @@ public class DeFinalizeClassLoader extends ClassLoader {
     this.pool.appendSystemPath();
     this.filters =
         Stream.concat(
-                Stream.of(specClass.getAnnotationsByType(DeFinalize.class))
-                    .map(DeFinalize::value)
-                    .flatMap(Stream::of)
-                    .map(Class::getName),
-                Stream.of(specClass.getAnnotationsByType(DeFinalize.class))
-                    .map(DeFinalize::packages)
-                    .flatMap(Stream::of))
+            Stream.of(specClass.getAnnotationsByType(DeFinalize.class))
+                .map(DeFinalize::value)
+                .flatMap(Stream::of)
+                .map(Class::getName),
+            Stream.of(specClass.getAnnotationsByType(DeFinalize.class))
+                .map(DeFinalize::packages)
+                .flatMap(Stream::of))
             .collect(Collectors.toSet());
   }
 
@@ -109,6 +110,9 @@ public class DeFinalizeClassLoader extends ClassLoader {
             boolean definalize = filters.contains(name);
 
             if (!definalize) {
+              // the following loop will check all parent packages and classes all the way to but
+              // excluding the class itself (e.g. for foo.util.SomeList, the loop would be for foo
+              // and foo.util)
               for (int i = name.indexOf('.'); i > 0; i = name.indexOf('.', ++i)) {
                 if (filters.contains(name.substring(0, i))) {
                   definalize = true;

--- a/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeClassLoader.java
+++ b/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeClassLoader.java
@@ -26,10 +26,10 @@ import javassist.NotFoundException;
 import org.codice.spock.extension.DeFinalize;
 
 /**
- * Defines the classloader used by the {@link DeFinalizeSputnik} test runner. This classloader is
- * designed with an aggressive strategy where it will load all classes first before delegating to
- * its parent. This classloader will therefore reload all classes while definalizing those that are
- * requested except for all classes in the following packages:
+ * Defines the classloader used by the {@link DeFinalizer} test runner. This classloader is designed
+ * with an aggressive strategy where it will load all classes first before delegating to its parent.
+ * This classloader will therefore reload all classes while definalizing those that are requested
+ * except for all classes in the following packages:
  *
  * <ul>
  *   <li>java
@@ -39,8 +39,8 @@ import org.codice.spock.extension.DeFinalize;
  *   <li>org.junit
  * </ul>
  *
- * These packages are not being reloaded as they are required by the {@link DeFinalizeSputnik} test
- * runner to delegate to the real {@link org.spockframework.runtime.Sputnik} test runner.
+ * These packages are not being reloaded as they are required by the {@link DeFinalizer} test runner
+ * to delegate to the real test runner.
  *
  * <p>All loaded classes will be done so with the same protection domain used if they had been
  * loaded by the parent classloader.
@@ -58,20 +58,20 @@ public class DeFinalizeClassLoader extends ClassLoader {
    * <p>The classloader used to load this classloader class will be defined as its parent
    * classloader.
    *
-   * @param specClass the Spock test specification class
+   * @param testClass the test class
    */
-  public DeFinalizeClassLoader(Class<?> specClass) {
+  public DeFinalizeClassLoader(Class<?> testClass) {
     super(DeFinalizeClassLoader.class.getClassLoader());
     this.pool = new ClassPool(false);
     this.pool.appendClassPath(new LoaderClassPath(getParent()));
     this.pool.appendSystemPath();
     this.filters =
         Stream.concat(
-                Stream.of(specClass.getAnnotationsByType(DeFinalize.class))
+                Stream.of(testClass.getAnnotationsByType(DeFinalize.class))
                     .map(DeFinalize::value)
                     .flatMap(Stream::of)
                     .map(Class::getName),
-                Stream.of(specClass.getAnnotationsByType(DeFinalize.class))
+                Stream.of(testClass.getAnnotationsByType(DeFinalize.class))
                     .map(DeFinalize::packages)
                     .flatMap(Stream::of))
             .collect(Collectors.toSet());

--- a/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeSputnik.java
+++ b/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeSputnik.java
@@ -58,6 +58,7 @@ import org.spockframework.runtime.Sputnik;
  * required.
  */
 public class DeFinalizeSputnik extends Sputnik {
+
   private static final List<Class<?>> SUPPORTED_INTERFACES =
       Arrays.asList(Describable.class, Filterable.class, Sortable.class);
 
@@ -89,17 +90,14 @@ public class DeFinalizeSputnik extends Sputnik {
       this.filterable =
           new Filterable() {
             @Override
-            public void filter(Filter filter) throws NoTestsRemainException {}
+            public void filter(Filter filter) throws NoTestsRemainException { // nothing to filter
+            }
           };
     }
     if (sputnik instanceof Sortable) {
       this.sortable = (Sortable) sputnik;
     } else {
-      this.sortable =
-          new Sortable() {
-            @Override
-            public void sort(Sorter sorter) {}
-          };
+      this.sortable = sorter -> {};
     }
   }
 

--- a/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeSputnik.java
+++ b/libs/spock-shaded/src/main/java/org/codice/spock/extension/builtin/DeFinalizeSputnik.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.spock.extension.builtin;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.runner.Describable;
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.Filterable;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.manipulation.Sortable;
+import org.junit.runner.manipulation.Sorter;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.spockframework.runtime.Sputnik;
+
+/**
+ * The <code>DefinalizeSputnik</code> test runner is designed to extend the {@link Sputnik} test
+ * runner indirectly in order to add support for de-finalizing (i.e. removing the final constraint)
+ * 3rd party Java classes that needs to be mocked or stubbed during testing. It does so by creating
+ * a classloader designed with an aggressive strategy where it will load all classes first before
+ * delegating to its parent. This classloader will therefore reload all classes while definalizing
+ * those that are requested except for all classes in the following packages:
+ *
+ * <ul>
+ *   <li>java
+ *   <li>javax
+ *   <li>sun
+ *   <li>org.xml
+ *   <li>org.junit
+ * </ul>
+ *
+ * These packages are not being reloaded as they are required for this test runner to delegate to
+ * the real {@link Sputnik} test runner. Even the Spock test specification class will be reloaded in
+ * this internal classloader.
+ *
+ * <p>The indirect extension is done by means of delegation as the real Sputnik test runner is
+ * instantiated from within the classloader that is created internally. This is to ensure that
+ * everything Groovy and Spock and everything they indirectly reference are loaded from within the
+ * classloader.
+ *
+ * <p>See <a href="https://github.com/spockframework/spock/issues/735"/>for a Spock enhancement
+ * request to support mocking final classes/methods at which point, this class will no longer be
+ * required.
+ */
+public class DeFinalizeSputnik extends Sputnik {
+  private static final List<Class<?>> SUPPORTED_INTERFACES =
+      Arrays.asList(Describable.class, Filterable.class, Sortable.class);
+
+  private final DeFinalizeClassLoader classloader;
+  private final Class<?> specClass;
+  private final Runner sputnik;
+  private final Filterable filterable;
+  private final Sortable sortable;
+
+  /**
+   * Creates an instance of this test runner for the specified Spock test specification class.
+   *
+   * @param specClass the Spock test specification class
+   * @throws InitializationError if unable to initialize the test runner
+   */
+  public DeFinalizeSputnik(Class<?> specClass) throws InitializationError {
+    super(specClass);
+    this.classloader = new DeFinalizeClassLoader(specClass);
+    try {
+      // reload the specification class using the new classloader
+      this.specClass = classloader.loadClass(specClass.getName());
+    } catch (ClassNotFoundException e) {
+      throw new InitializationError(e);
+    }
+    this.sputnik = newSputnik();
+    if (sputnik instanceof Filterable) {
+      this.filterable = (Filterable) sputnik;
+    } else {
+      this.filterable =
+          new Filterable() {
+            @Override
+            public void filter(Filter filter) throws NoTestsRemainException {}
+          };
+    }
+    if (sputnik instanceof Sortable) {
+      this.sortable = (Sortable) sputnik;
+    } else {
+      this.sortable =
+          new Sortable() {
+            @Override
+            public void sort(Sorter sorter) {}
+          };
+    }
+  }
+
+  @Override
+  public int testCount() {
+    return sputnik.testCount();
+  }
+
+  @Override
+  public Description getDescription() {
+    return sputnik.getDescription();
+  }
+
+  @Override
+  public void run(RunNotifier notifier) {
+    sputnik.run(notifier);
+  }
+
+  @Override
+  public void filter(Filter filter) throws NoTestsRemainException {
+    filterable.filter(filter);
+  }
+
+  @Override
+  public void sort(Sorter sorter) {
+    sortable.sort(sorter);
+  }
+
+  private Runner newSputnik() throws InitializationError {
+    // verify Sputnik only implements the same interfaces as us
+    // this is so we can catch new interfaces for which we would have to introduce delegate methods
+    Class<?> clazz = Sputnik.class;
+
+    while (clazz != null) {
+      for (final Class<?> i : clazz.getInterfaces()) {
+        if (!DeFinalizeSputnik.SUPPORTED_INTERFACES.contains(i)) {
+          throw new InitializationError(
+              "Sputnik implements new interface: "
+                  + i.getName()
+                  + "; DeFinalizeSputnik needs to be updated");
+        }
+      }
+      clazz = clazz.getSuperclass();
+    }
+    try {
+      return Runner.class.cast(
+          classloader
+              .loadClass(Sputnik.class.getName())
+              .getDeclaredConstructor(Class.class)
+              .newInstance(specClass));
+    } catch (InstantiationException
+        | IllegalAccessException
+        | NoSuchMethodException
+        | ClassNotFoundException
+        | ClassFormatError e) {
+      throw new InitializationError(e);
+    } catch (InvocationTargetException e) {
+      final Throwable t = e.getTargetException();
+
+      if (t instanceof Error) {
+        throw (Error) t;
+      } else if (t instanceof RuntimeException) {
+        throw (RuntimeException) t;
+      }
+      throw new InitializationError(t);
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
- Upgrades Spock to the latest version.
- Fixes the spock-shaded project which not properly shading cglib-nodep, objenesis, and groovy-all
- Adds an extension to Spock's test runner that can properly definalize 3rd party classes to allow mocking them. This new test runner works much like the Kotlin test runner without the quirks
- Adds a Spock extension capable of clearing any left over interruptions on the test thread after a test case
- Adds a Spock extension which supplements some classes with new methods to simplify building test cases

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@jhunzik 
@emanns95 
@figliold 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Running the build will re-validate that all Spock test cases still works.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3621](https://codice.atlassian.net/browse/DDF-3621)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
