### PR TITLE
DDF-3682 Updates display name for content directory monitors

### DIFF
--- a/ui/packages/ui/src/main/webapp/js/MetatypeRegistry.js
+++ b/ui/packages/ui/src/main/webapp/js/MetatypeRegistry.js
@@ -11,22 +11,26 @@
  **/
 /*global define*/
 define([
-    'js/MetatypeRegistry'
-], function (MetatypeRegistry) {
+], function () {
+
+    var Metatypes = {};
 
     return {
-        getName: function(properties) {
-            switch(properties.get('service.factoryPid')) {
-                case 'org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor':
-                    var processingMechanism = MetatypeRegistry.getRelevantOptionLabel({
-                        metatypeId: properties.get('service.factoryPid'),
-                        property: 'processingMechanism',
-                        value: properties.get('processingMechanism')
-                    });
-                    return processingMechanism + ' | ' + properties.get('monitoredDirectoryPath');
-                default:
-                    return null;
+        add: function(id, metatypeModel) {
+            Metatypes[id] = Metatypes[id] || metatypeModel;
+        },
+        get: function(id) {
+            return Metatypes[id];
+        },
+        getRelevantOptionLabel: function(options) {
+            console.log(Metatypes);
+            if (options.metatypeId === undefined || options.property === undefined || options.value === undefined) {
+                throw "insufficient parameters to determine the relevant label";
             }
+            if (this.get(options.metatypeId) === undefined) {
+                return '';
+            }
+            return this.get(options.metatypeId).get(options.property).get('options')[options.value].label;
         }
     };
 });

--- a/ui/packages/ui/src/main/webapp/js/ServiceFactoryNameRegistry.js
+++ b/ui/packages/ui/src/main/webapp/js/ServiceFactoryNameRegistry.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+], function () {
+
+    return {
+        getName: function(properties) {
+            switch(properties.get('service.factoryPid')) {
+                case 'org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor':
+                    return properties.get('monitoredDirectoryPath');
+                default:
+                    return null;
+            }
+        }
+    };
+});

--- a/ui/packages/ui/src/main/webapp/js/models/Service.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Service.js
@@ -14,7 +14,7 @@
  **/
 /*global define*/
 /* jshint -W024*/
-define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
+define(['backbone', 'jquery', 'js/ServiceFactoryNameRegistry', 'backboneassociations'],function (Backbone, $, ServiceFactoryNameRegistry) {
 
     function isServiceFactory(properties){
         return properties.get('service.factoryPid');
@@ -220,7 +220,7 @@ define(['backbone', 'jquery','backboneassociations'],function (Backbone, $) {
             var displayName = this.get('id');
             var properties = this.get('properties');
             if (isServiceFactory(properties)) {
-                displayName = properties.get('name') || properties.get('shortname') || properties.get('id') || displayName;
+                displayName = ServiceFactoryNameRegistry.getName(properties) || properties.get('name') || properties.get('shortname') || properties.get('id') || displayName;
             } else if (displayName === undefined && properties !== undefined) {
                 displayName = properties.get('service.pid');
             } else if (displayName === undefined) {

--- a/ui/packages/ui/src/main/webapp/js/models/Service.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Service.js
@@ -14,7 +14,7 @@
  **/
 /*global define*/
 /* jshint -W024*/
-define(['backbone', 'jquery', 'js/ServiceFactoryNameRegistry', 'backboneassociations'],function (Backbone, $, ServiceFactoryNameRegistry) {
+define(['backbone', 'jquery', 'js/ServiceFactoryNameRegistry', 'js/MetatypeRegistry', 'backboneassociations'],function (Backbone, $, ServiceFactoryNameRegistry, MetatypeRegistry) {
 
     function isServiceFactory(properties){
         return properties.get('service.factoryPid');
@@ -25,7 +25,22 @@ define(['backbone', 'jquery', 'js/ServiceFactoryNameRegistry', 'backboneassociat
     var Service = {};
 
     Service.Metatype = Backbone.AssociatedModel.extend({
-
+        initialize: function() {
+            this.transformOptions();
+        },
+        transformOptions: function() {
+            var optionLabels = this.get('optionLabels');
+            var optionValues = this.get('optionValues');
+            if (optionValues) {
+                this.set('options', optionValues.reduce(function(blob, value, index) {
+                    blob[value] = {
+                        label: optionLabels[index],
+                        value: value
+                    };
+                    return blob;
+                }, {}));
+            }
+        }
     });
 
     Service.Properties = Backbone.AssociatedModel.extend({
@@ -268,6 +283,7 @@ define(['backbone', 'jquery', 'js/ServiceFactoryNameRegistry', 'backboneassociat
             if(options && options.id) {
                 this.set({"uuid": options.id.replace(/\./g, '')});
             }
+            MetatypeRegistry.add(this.id, this.get('metatype'));
         },
 
         hasConfiguration: function() {


### PR DESCRIPTION
#### What does this PR do?
 - Adds method to determine display name for a service based on its
 fpid and properties.
 - Updates the content directory monitor service to use monitored directory as its display
 name.

#### Who is reviewing it? 
@Lambeaux 
@pklinef
@clockard 
@tbatie 

#### How should this be tested? (List steps with links to updated documentation)
Create a content directory monitor and verify that it uses the monitored directory as the name.

#### What are the relevant tickets?
[DDF-3682](https://codice.atlassian.net/browse/DDF-3682)

#### Screenshots (if appropriate)
![cdm](https://user-images.githubusercontent.com/11984853/38367588-f34ac038-3897-11e8-85c6-1144ba3a8898.png)
