### PR TITLE
DDF-3735 Upgrades Cesium to fix zoom issue

### DIFF
--- a/ui/packages/catalog-ui-search/package.json
+++ b/ui/packages/catalog-ui-search/package.json
@@ -45,7 +45,7 @@
     "backbone.modelbinder": "1.1.0",
     "backbone.paginator": "2.0.5",
     "bootstrap": "3.3.7",
-    "cesium": "1.34",
+    "cesium": "1.44",
     "clipboard": "1.7.1",
     "density-clustering": "1.3.0",
     "dropzone": "4.3.0",

--- a/ui/packages/cesium-assets/package.json
+++ b/ui/packages/cesium-assets/package.json
@@ -9,7 +9,7 @@
     "build": "ace package"
   },
   "dependencies": {
-    "cesium": "1.34",
+    "cesium": "1.44",
     "mkdirp": "0.5.1"
   },
   "files": [

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2801,9 +2801,9 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-cesium@1.34:
-  version "1.34.0"
-  resolved "https://registry.yarnpkg.com/cesium/-/cesium-1.34.0.tgz#e85c5e8027853672b02c101da9415338f0d11392"
+cesium@1.44:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/cesium/-/cesium-1.44.0.tgz#1f56c056e38edeae781ac6fd2b2994162ae953d8"
   dependencies:
     requirejs "^2.3.2"
 


### PR DESCRIPTION
#### What does this PR do?
 - Cesium was having issues maintaining the correct coordinate frame of reference during certain zooms, particularly when the user zoomed too far out.  It appears to be fixed in the latest version.

#### Who is reviewing it? 
@jlcsmith 
@djblue 
@Variadicism 
@bdeining 

#### How should this be tested? (List steps with links to updated documentation)
Before using the version with upgraded cesium, verify that on the old cesium zooming far out will cause results to become unclickable.  Then use the upgraded cesium and verify that this behavior disappears.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3735](https://codice.atlassian.net/browse/DDF-3735)
