### PR TITLE
DDF-3743 Updates dev server to handle ws

### DIFF
--- a/ui/packages/ace/bin.js
+++ b/ui/packages/ace/bin.js
@@ -76,6 +76,7 @@ program
 program
   .command('start')
   .description('start the dev server')
+  .option('-a, --auth <auth>', 'auth <username:password> (default: admin:admin)')
   .option('-e, --env <env>', 'build environment <development|test|production>')
   .option('-o, --open', 'open default browser')
   .option('--port <port>', 'dev server port (default: 8080)')

--- a/ui/packages/ace/lib/start.js
+++ b/ui/packages/ace/lib/start.js
@@ -1,6 +1,7 @@
 const open = require('opn')
 const webpack = require('webpack')
 const WebpackDevServer = require('webpack-dev-server')
+const chalk = require('chalk')
 
 const webpackConfig = require('./webpack.config')
 
@@ -8,7 +9,10 @@ module.exports = ({ args, pkg }) => {
   const config = webpackConfig({
     env: process.env.NODE_ENV || args.env || 'development',
     main: pkg.main,
-    alias: pkg.alias
+    alias: pkg.alias,
+    auth: args.auth ||
+      console.log(chalk.yellow('WARNING: using default basic auth (admin:admin)! See options for how to override this.')) ||
+      'admin:admin'
   })
 
   WebpackDevServer.addDevServerEntrypoints(config, config.devServer)

--- a/ui/packages/ace/lib/webpack.config.js
+++ b/ui/packages/ace/lib/webpack.config.js
@@ -187,15 +187,16 @@ const handleProxyRes = (proxyRes, req, res) => {
   }
 }
 
-const proxyConfig = (target) => ({
+const proxyConfig = ({target = 'https://localhost:8993', auth}) => ({
   target,
   ws: true,
   secure: false,
   changeOrigin: true,
-  onProxyRes: handleProxyRes
+  onProxyRes: handleProxyRes,
+  auth
 })
 
-const dev = (base, { main }) => merge.smart(base, {
+const dev = (base, { main, auth }) => merge.smart(base, {
   mode: 'development',
   devtool: 'cheap-module-eval-source-map',
   entry: [
@@ -210,10 +211,10 @@ const dev = (base, { main }) => merge.smart(base, {
     historyApiFallback: true,
     contentBase: resolve('src/main/resources/'),
     proxy: {
-      '/admin/**': proxyConfig('https://localhost:8993'),
-      '/search/catalog/**': proxyConfig('https://localhost:8993'),
-      '/services/**': proxyConfig('https://localhost:8993'),
-      '/webjars/**': proxyConfig('https://localhost:8993')
+      '/admin/**': proxyConfig({auth}),
+      '/search/catalog/**': proxyConfig({auth}),
+      '/services/**': proxyConfig({auth}),
+      '/webjars/**': proxyConfig({auth})
     }
   },
   plugins: [
@@ -286,13 +287,13 @@ const prod = (base, { main }) => merge.smart(base, {
 })
 
 module.exports = (opts) => {
-  const { env = 'development', main, alias } = opts
+  const { env = 'development', main, alias, auth } = opts
   const b = base({ env, alias })
 
   switch (env) {
     case 'production': return prod(b, { main })
     case 'test': return test(b, { main })
     case 'development':
-    default: return dev(b, { main })
+    default: return dev(b, { main, auth })
   }
 }

--- a/ui/packages/ace/package.json
+++ b/ui/packages/ace/package.json
@@ -24,6 +24,7 @@
     "babel-preset-latest": "6.24.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
+    "chalk": "2.3.2",
     "cheerio": "0.22.0",
     "commander": "2.15.1",
     "console-polyfill": "0.3.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2863,7 +2863,7 @@ chalk@0.5.0:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
-chalk@2.3.x, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2:
+chalk@2.3.2, chalk@2.3.x, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
   dependencies:


### PR DESCRIPTION
#### What does this PR do?
 - The websockets were failing in certain browsers (Firefox, Edge, not Chrome though) when auth wasn't passed.

#### Who is reviewing it? 
@brendan-hofmann
@djblue 
@mackncheesiest 
@Variadicism 

#### How should this be tested? (List steps with links to updated documentation)
Run the dev server and verify it defaults to admin:admin for the basic auth.  Verify you can also pass your own auth through the auth variable.

#### Any background context you want to provide?
Looks like this issue was introduced when we upgraded to the latest webpack, so it's possible it's a bug in one of the newer versions of the webpack dev server or the http-proxy-middleware, etc.  Or they've simply updated how they expect it to be used.

#### What are the relevant tickets?
[DDF-3743](https://codice.atlassian.net/browse/DDF-3743)