### PR TITLE
DDF-3719 Explicitly shares handlebars dependency

### DIFF
--- a/ui/packages/ace/handlebars/index.js
+++ b/ui/packages/ace/handlebars/index.js
@@ -1,0 +1,1 @@
+module.exports = require('handlebars/dist/handlebars')

--- a/ui/packages/ace/handlebars/runtime.js
+++ b/ui/packages/ace/handlebars/runtime.js
@@ -1,0 +1,1 @@
+module.exports = require('handlebars/runtime')

--- a/ui/packages/ace/lib/webpack.config.js
+++ b/ui/packages/ace/lib/webpack.config.js
@@ -118,12 +118,7 @@ const base = ({ alias = {}, env }) => ({
       {
         test: /\.(hbs|handlebars)$/,
         use: {
-          loader: nodeResolve('handlebars-loader'),
-          options: {
-            runtime: require.resolve('handlebars/runtime', {
-              paths: [path.join(process.cwd(), 'node_modules')]
-            })
-          }
+          loader: nodeResolve('handlebars-loader')
         }
       },
       {

--- a/ui/packages/ace/package.json
+++ b/ui/packages/ace/package.json
@@ -11,9 +11,6 @@
     "test": "standard",
     "format": "standard --fix"
   },
-  "peerDependencies": {
-    "handlebars": "4.0.5"
-  },
   "dependencies": {
     "archiver": "2.1.1",
     "babel-core": "6.26.0",
@@ -34,6 +31,7 @@
     "file-loader": "1.1.11",
     "find-up": "2.1.0",
     "glob": "7.1.2",
+    "handlebars": "4.0.5",
     "handlebars-loader": "1.7.0",
     "html-webpack-plugin": "3.1.0",
     "imports-loader": "0.8.0",

--- a/ui/packages/catalog-ui-search/package.json
+++ b/ui/packages/catalog-ui-search/package.json
@@ -21,9 +21,6 @@
   "engines": {
     "node": ">=0.10.5"
   },
-  "peerDependencies": {
-    "handlebars": "4.0.5"
-  },
   "devDependencies": {
     "@types/backbone": "1.3.41",
     "@types/backbone-associations": "0.6.31",
@@ -53,7 +50,6 @@
     "font-awesome": "4.7",
     "geo-convex-hull": "1.2.0",
     "golden-layout": "1.5.8",
-    "handlebars": "4.0.5",
     "jquery": "3.2.1",
     "jquery-ui": "1.12.1",
     "less-vars-to-js": "1.1.2",

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
@@ -30,7 +30,7 @@ require([
     'backbone',
     'marionette',
     'properties',
-    'handlebars/dist/handlebars',
+    'ace/handlebars',
     'component/announcement',
     'js/Marionette.Region',
     'js/requestAnimationFramePolyfill',

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/HandlebarsHelpers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/HandlebarsHelpers.js
@@ -13,7 +13,7 @@
 define([
     'underscore',
     'moment',
-    'handlebars/runtime',
+    'ace/handlebars/runtime',
     'js/Common',
     'component/singletons/metacard-definitions',
     'lodash/get',


### PR DESCRIPTION
#### What does this PR do?

Ace has a dependency on handlebars at build time to compile templates
while catalog-ui-search has one at runtime. If they don't resolve the
exact same version of handlebars, it can cause issues with missing
helpers at runtime. This can be fixed by ace exposing its version so
`catalog-ui-search` can use it directly.

#### Who is reviewing it? 

@mackncheesiest 
@adimka 
@glenhein 

#### Select relevant component teams: 

@codice/ui 

#### Choose 2 committers to review/merge the PR. 

@andrewkfiedler
@bdeining

#### How should this be tested?

- `mvn clean install` ui directory
- ensure no ui regressions in `/search/catalog`

#### What are the relevant tickets?

[DDF-3719](https://codice.atlassian.net/browse/DDF-3719)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
