### PR TITLE
DDF-3748 Updates how cesium coordinates are retrieved

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -161,30 +161,15 @@ module.exports = function CesiumMap(insertionElement, selectionInterface, notifi
     setupTooltip(map, selectionInterface);
 
     function updateCoordinatesTooltip(position) {
-        if (map.scene.pickPositionSupported) {
-            var cartesian = map.scene.pickPosition(position);
-            if (Cesium.defined(cartesian)){
-                let cartographic = Cesium.Cartographic.fromCartesian(cartesian);
-                mapModel.updateMouseCoordinates({
-                    lat: cartographic.latitude * Cesium.Math.DEGREES_PER_RADIAN,
-                    lon: cartographic.longitude * Cesium.Math.DEGREES_PER_RADIAN
-                });
-            } else {
-                mapModel.clearMouseCoordinates();
-            }
-        }
-    }
-
-    function getCartographicCoordinatesFromEvent(e, boundingRect){
-        if (map.scene.pickPositionSupported){
-            let cartesian = map.scene.pickPosition({
-                x: e.clientX - boundingRect.left,
-                y: e.clientY - boundingRect.top
+        var cartesian = map.camera.pickEllipsoid(position, map.scene.globe.ellipsoid);
+        if (Cesium.defined(cartesian)){
+            let cartographic = Cesium.Cartographic.fromCartesian(cartesian);
+            mapModel.updateMouseCoordinates({
+                lat: cartographic.latitude * Cesium.Math.DEGREES_PER_RADIAN,
+                lon: cartographic.longitude * Cesium.Math.DEGREES_PER_RADIAN
             });
-            if (Cesium.defined(cartesian)){
-                let cartographic = Cesium.Cartographic.fromCartesian(cartesian);
-                return cartographic;
-            }
+        } else {
+            mapModel.clearMouseCoordinates();
         }
     }
 


### PR DESCRIPTION
#### What does this PR do?
- The previous method did not work in IE11.
- Based on https://groups.google.com/forum/#!topic/cesium-dev/p-Rcg0JeH7Y it would
appear using pickEllipsoid is better and will result in more accurate
positions.

#### Who is reviewing it? 
@jlcsmith
@brendan-hofmann 
@mackncheesiest 
@adimka 

#### How should this be tested? (List steps with links to updated documentation)
Verify that coordinates are displayed when mousing over the map in IE11.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3748](https://codice.atlassian.net/browse/DDF-3748)
