### PR TITLE
DDF-3752 Updates map-context-menu to not show coordinate options when off map, updates openlayers to not show coordinates when off map

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/map-context-menu/map-context-menu.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/map-context-menu/map-context-menu.less
@@ -34,6 +34,14 @@
   }
 }
 
+@{customElementNamespace}map-context-menu.is-off-map {
+  .interaction-copy-coordinates,
+  .interaction-copy-dms,
+  .interaction-copy-wkt {
+    display: none;
+  }
+}
+
 @{customElementNamespace}map-context-menu.has-target {
   .interaction-view-details {
     display: block;
@@ -44,16 +52,5 @@
   .interaction-view-details-selection,
   .interaction-view-histogram-selection {
     display: block;
-  }
-}
-
-html:not(.is-experimental) {
-  @{customElementNamespace}map-context-menu {
-    .interaction-view-histogram,
-    .interaction-view-details,
-    .interaction-view-details-selection,
-    .interaction-view-histogram-selection {
-      display: none;
-    }
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/map-context-menu/map-context-menu.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/map-context-menu/map-context-menu.view.js
@@ -106,6 +106,10 @@ module.exports = Marionette.LayoutView.extend({
         this.handleSelectionChange();
         this.handleResultsChange();
         this.keepHoverMetacardAround();
+        this.handleOffMap();
+    },
+    handleOffMap: function() {
+        this.$el.toggleClass('is-off-map', this.options.mapModel.isOffMap());
     },
     keepHoverMetacardAround: function () {
         this.previousHoverModel = this.options.mapModel.get('targetMetacard') ||

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -33,6 +33,9 @@ module.exports = Backbone.AssociatedModel.extend({
         target: undefined,
         targetMetacard: undefined
     },
+    isOffMap: function() {
+        return this.get('mouseLat') === undefined;
+    },
     clearMouseCoordinates: function() {
         this.set({
             mouseLat: undefined,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -79,6 +79,10 @@ function unconvertPointCoordinate(point) {
     return Openlayers.proj.transform(point, properties.projection, 'EPSG:4326');
 }
 
+function offMap([longitude, latitude]) {
+    return longitude < -180 || longitude > 180 || latitude < -90 || latitude > 90;
+}
+
 module.exports = function OpenlayersMap(insertionElement, selectionInterface, notificationEl, componentElement, mapModel) {
     var overlays = {};
     var shapes = [];
@@ -87,13 +91,17 @@ module.exports = function OpenlayersMap(insertionElement, selectionInterface, no
     setupTooltip(map);
     var drawingTools = setupDrawingTools(map);
   
-    function setupTooltip(map) {        
+    function setupTooltip(map) {     
         map.on('pointermove', function(e){
             var point = unconvertPointCoordinate(e.coordinate);
-            mapModel.updateMouseCoordinates({
-                lat: point[1],
-                lon: point[0]
-            });
+            if (!offMap(point)) {
+                mapModel.updateMouseCoordinates({
+                    lat: point[1],
+                    lon: point[0]
+                });
+            } else {
+                mapModel.clearMouseCoordinates();
+            }
         });
     }
 


### PR DESCRIPTION
#### What does this PR do?
 - Updates openlayers to not show coordinates when off the main map.
 - Updates map context menu to hide coordinate copying options when coordinates are not available.

#### Who is reviewing it? 
@brendan-hofmann 
@jlcsmith
@mackncheesiest 
@adimka 

#### How should this be tested? (List steps with links to updated documentation)
Verify that the coordinate copy options aren't displayed when off the maps.  Verify that the coordinates are now hidden in openlayers when off the main map.  

#### What are the relevant tickets?
[DDF-3752](https://codice.atlassian.net/browse/DDF-3752)