### PR TITLE
DDF-3719 Updates ace to be more resilient

### DIFF
--- a/ui/packages/ace/lib/ls-packages.js
+++ b/ui/packages/ace/lib/ls-packages.js
@@ -7,9 +7,8 @@ module.exports = (dirs) => {
   return dirs
     .filter((dir) => !dir.match('target'))
     .map((d) => path.resolve(d))
-    .map((d) => glob.sync(d))
+    .map((d) => glob.sync(d + '/package.json'))
     .reduce(flatten, [])
-    .map((d) => path.join(d, 'package.json'))
     .map((d) => {
       const json = require(d)
       json.__path = d


### PR DESCRIPTION
#### What does this PR do?

Sometimes when switching branches, the `ui/packages` directory can
contain empty directories which cause ace to fail. By not assuming that
all directories in `ui/packages` are valid packages (have a
`package.json`), we can prevent build failures.

#### Who is reviewing it? 

 @mojogitoverhere 
@GabrielFabian 

#### Choose 2 committers to review/merge the PR. 

@andrewkfiedler
@bdeining

#### How should this be tested?

- Ensure `ui/packages` contains an empty directory
- `mvn clean install` the ui directory

#### What are the relevant tickets?

[DDF-3719](https://codice.atlassian.net/browse/DDF-3719)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
