### PR TITLE
DDF-3758 Prevents configuration edit modals from displaying in the wrong tab

### DIFF
--- a/ui/packages/ui/src/main/webapp/components/configuration-item/configuration-item.hbs
+++ b/ui/packages/ui/src/main/webapp/components/configuration-item/configuration-item.hbs
@@ -12,11 +12,11 @@
  **/
  --}}
 <div>
-    <a href='#{{uuid}}' class='editLink' data-toggle="modal" data-backdrop="static" data-keyboard="false">
+    <a href='#{{cid}}' class='editLink' data-toggle="modal" data-backdrop="static" data-keyboard="false">
         {{displayName}}
     </a>
     <div class="config-modal-container">
-        <div id="{{uuid}}" class="config-modal modal" tabindex="-1" role="dialog" aria-hidden="true">
+        <div id="{{cid}}" class="config-modal modal" tabindex="-1" role="dialog" aria-hidden="true">
 
         </div>
     </div>

--- a/ui/packages/ui/src/main/webapp/components/configuration-item/configuration-item.view.js
+++ b/ui/packages/ui/src/main/webapp/components/configuration-item/configuration-item.view.js
@@ -52,7 +52,10 @@ define([
             }
         },
         serializeData: function () {
-            return _.extend(this.model.toJSON(), {displayName: this.model.getConfigurationDisplayName()}, {hasFactory: this.model.get('fpid')});
+            return _.extend(this.model.toJSON(), {displayName: this.model.getConfigurationDisplayName()}, {
+            hasFactory: this.model.get('fpid'),
+            cid: this.cid
+            });
         }
     });
 

--- a/ui/packages/ui/src/main/webapp/components/service-item/service-item.hbs
+++ b/ui/packages/ui/src/main/webapp/components/service-item/service-item.hbs
@@ -11,13 +11,13 @@
  *
  **/
  --}}
-<a href='#{{uuid}}service' class='newLink' data-toggle="modal" data-backdrop="static" data-keyboard="false">
+<a href='#{{cid}}' class='newLink' data-toggle="modal" data-backdrop="static" data-keyboard="false">
     {{name}}
 </a>
 <hr class="service-divider"/>
 <div id="configurationRegion"></div>
 <div class="service-modal-container">
-    <div id="{{uuid}}service" class="service-modal modal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div id="{{cid}}" class="service-modal modal" tabindex="-1" role="dialog" aria-hidden="true">
 
     </div>
 </div>

--- a/ui/packages/ui/src/main/webapp/components/service-item/service-item.view.js
+++ b/ui/packages/ui/src/main/webapp/components/service-item/service-item.view.js
@@ -59,7 +59,14 @@ define([
             }
 
             this.editModal.show(new ConfigurationEdit.View({model: configuration, service: model}));
+        },
+
+        serializeData: function () {
+            return _.extend(this.model.toJSON(), {
+            cid: this.cid
+            });
         }
+
     });
 
 });


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where configuration edit modals could display in the wrong tab after clicking between them, causing the UI to become unusable until a user refreshes. 
Notes on how to reproduce this issue here: https://codice.atlassian.net/browse/DDF-3758

#### Who is reviewing it? 
@djblue 
@adimka 

#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
For factory and non-factory configurations: 
1. Open any application's menu.
2. Navigate to that app's Configuration tab.
3. Choose (don't click, just make a mental note) any name from the list.
4. Click the System tab.
5. Click the name you chose on this tab.
6. Observe the modal pops up and is editable and able to be saved. 

#### What are the relevant tickets?
[DDF-3758](https://codice.atlassian.net/browse/DDF-3758)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
