### PR TITLE
DDF-3763 Added fabric-karaf-checks to boot features

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -115,7 +115,7 @@ grant codeBase "file:/registry-federation-admin-impl" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}registry${/}-", "read";
 }
 
-grant codeBase "file:/spatial-csw-source/spatial-csw-endpoint/org.apache.camel.camel-core/com.google.guava/ddf-pubsub/registry-source-configuration-handler/registry-api-impl/org.apache.camel.camel-blueprint" {
+grant codeBase "file:/spatial-csw-source/spatial-csw-endpoint/org.apache.camel.camel-core/com.google.guava/ddf-pubsub/registry-source-configuration-handler/registry-api-impl/org.apache.camel.camel-blueprint/fabric8-karaf-checks" {
     permission java.lang.RuntimePermission "createClassLoader";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}-", "read";

--- a/features/kernel/src/main/feature/feature.xml
+++ b/features/kernel/src/main/feature/feature.xml
@@ -18,6 +18,7 @@
 
     <repository>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</repository>
     <repository>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</repository>
+    <repository>mvn:io.fabric8/fabric8-karaf-features/${fabric8.version}/xml/features</repository>
 
     <feature name="kernel" version="${project.version}"
              description="Minimual set of features and dependencies commonly used.">
@@ -25,6 +26,7 @@
         <feature version="${karaf.version}">eventadmin</feature>
         <feature version="${karaf.version}">jasypt-encryption</feature>
         <feature version="${karaf.version}">http</feature>
+        <feature version="${fabric8.version}">fabric8-karaf-checks</feature>
     </feature>
 
     <feature name="javax-validation" version="${project.version}">

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -58,6 +58,8 @@
                 <value>/logout</value>
                 <value>/error</value>
                 <value>/webjars</value>
+                <value>/health-check</value>
+                <value>/readiness-check</value>
             </array>
         </property>
         <property name="traversalDepth">

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -42,7 +42,7 @@
         <AD description="List of contexts that will not use security. Note that sub-contexts to ones listed here will also skip security, unless authentication types are provided for it. For example: if /foo is listed here, then /foo/bar will also not require any sort of authentication. However, if /foo is listed and /foo/bar has authentication types provided in the 'Authentication Types' field, then that more specific policy will be used."
             name="White Listed Contexts" id="whiteListContexts" required="true" cardinality="100"
             type="String"
-            default="${org.codice.ddf.system.rootContext}/SecurityTokenService,${org.codice.ddf.system.rootContext}/internal/metrics,/proxy,${org.codice.ddf.system.rootContext}/saml,${org.codice.ddf.system.rootContext}/idp,/idp,${org.codice.ddf.system.rootContext}/platform/config/ui,/login,/logout,${org.codice.ddf.system.rootContext}/internal/session,/error,/webjars"/>
+            default="${org.codice.ddf.system.rootContext}/SecurityTokenService,${org.codice.ddf.system.rootContext}/internal/metrics,/proxy,${org.codice.ddf.system.rootContext}/saml,${org.codice.ddf.system.rootContext}/idp,/idp,${org.codice.ddf.system.rootContext}/platform/config/ui,/login,/logout,${org.codice.ddf.system.rootContext}/internal/session,/error,/webjars,/health-check,/readiness-check"/>
 
     </OCD>
 

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,7 @@ are essentially embedding a slightly modified version of felix -->
         <keyczar.version>0.66</keyczar.version>
         <cas.client.version>3.4.1</cas.client.version>
         <javax.inject.version>1</javax.inject.version>
+        <fabric8.version>3.0.11</fabric8.version>
     </properties>
     <!--
     NOTE: The properties ddf.scm.connection.url, snapshots.repository.url and releases.repository.url should be defined


### PR DESCRIPTION
#### What does this PR do?

Adds the health and readiness endpoints from fabric8 to the ddf boot features

 * supports more intelligent load balancing via health monitoring
 * supports readiness checks that help determine when it is ok to interact with the system
 * extensible to support additional health and readiness checks if needed

Not sure if the way I'm adding it is the best way to do this, open to suggestions.

#### Who is reviewing it? 

@tbatie @Lambeaux 

#### Choose 2 committers to review/merge the PR. 

@lessarderic @pklinef 

#### How should this be tested? (List steps with links to updated documentation)

* Start the system, 
ping https://localhost:8993/readiness-check and https://localhost:8993/health-check until they return `200`

#### Any background context you want to provide?

https://fabric8.io/guide/karaf.html#fabric8-karaf-health-checks

#### What are the relevant tickets?
[DDF-3763](https://codice.atlassian.net/browse/DDF-3763)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Add feature to security manager policy

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
