### PR TITLE
DDF-3529 Use Platform Config UI Timeout for UI session timeout

### DIFF
--- a/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/PlatformUiConfiguration.java
+++ b/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/PlatformUiConfiguration.java
@@ -53,6 +53,8 @@ public class PlatformUiConfiguration {
 
   public static final String VENDOR_IMAGE_CONFIG_KEY = "vendorImage";
 
+  public static final String TIMEOUT_CONFIG_KEY = "timeout";
+
   private boolean systemUsageEnabled;
 
   private String systemUsageTitle;
@@ -68,6 +70,8 @@ public class PlatformUiConfiguration {
   private String color;
 
   private String background;
+
+  private int timeout;
 
   private Optional<BrandingRegistry> branding = Optional.empty();
 
@@ -92,6 +96,7 @@ public class PlatformUiConfiguration {
     jsonObject.put(PRODUCT_IMAGE_CONFIG_KEY, getProductImage());
     jsonObject.put(FAV_ICON_CONFIG_KEY, getFavIcon());
     jsonObject.put(VENDOR_IMAGE_CONFIG_KEY, getVendorImage());
+    jsonObject.put(TIMEOUT_CONFIG_KEY, getTimeout());
 
     return jsonObject.toJSONString();
   }
@@ -170,6 +175,14 @@ public class PlatformUiConfiguration {
 
   public void setBackground(String background) {
     this.background = background;
+  }
+
+  public int getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(int timeout) {
+    this.timeout = timeout;
   }
 
   public String getProductImage() {

--- a/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/PlatformUiConfigurationTest.java
+++ b/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/PlatformUiConfigurationTest.java
@@ -32,6 +32,7 @@ public class PlatformUiConfigurationTest {
 
   @Test
   public void testConfig() throws IOException {
+    int timeout = 1234;
     PlatformUiConfiguration configuration = new PlatformUiConfiguration();
     String wsOutput = configuration.getConfig();
     Object obj = JSONValue.parse(wsOutput); // throws JSON Parse exception if not valid json.
@@ -56,6 +57,7 @@ public class PlatformUiConfigurationTest {
     configuration.setFooter("footer");
     configuration.setBackground("background");
     configuration.setColor("color");
+    configuration.setTimeout(timeout);
 
     wsOutput = configuration.getConfig();
     obj = JSONValue.parse(wsOutput); // throws JSON Parse exception if not valid json.
@@ -84,5 +86,6 @@ public class PlatformUiConfigurationTest {
         new String(
             Base64.getMimeDecoder()
                 .decode((String) jsonObject.get(PlatformUiConfiguration.FAV_ICON_CONFIG_KEY))));
+    assertEquals(timeout, jsonObject.get(PlatformUiConfiguration.TIMEOUT_CONFIG_KEY));
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/session-timeout.js
@@ -22,7 +22,7 @@ var invalidateUrl = '/services/internal/session/invalidate?prevurl=';
 var idleNoticeDuration = 60000;
 // Length of inactivity that will trigger user timeout (15 minutes in ms by default)
 // See STIG V-69243
-var idleTimeoutThreshold = parseInt(properties.timeout) > 0 ? parseInt(properties.timeout) : 900000;
+var idleTimeoutThreshold = parseInt(properties.ui.timeout) > 0 ? parseInt(properties.ui.timeout) : 900000;
 
 function getIdleTimeoutDate() {
     return idleTimeoutThreshold + Date.now();


### PR DESCRIPTION
#### What does this PR do?
Fixes previous commit that incorrectly used properties.timeout which was a UI Connection Timeout for the UI session timeout logic. Now it correctly populates and uses the Platform UI Session Timeout property as intended. 

#### Who is reviewing it? 
@adimka 
@brendan-hofmann 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining 
@millerw8 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Full build with tests.
1. Install DDF
2. Update the Platform UI timeout to 120000 (or something reasonable for testing) in
3. Navigate to /search/catalog
4. Wait for the amount of time specified in step 2
5. Verify that the popup for session timeout appears and session logs out if it's not continued.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3529](https://codice.atlassian.net/browse/DDF-3529)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
