### PR TITLE
DDF-3719 Reduced CI logs & improved set-env.js

### DIFF
--- a/ui/packages/ace/lib/set-env.js
+++ b/ui/packages/ace/lib/set-env.js
@@ -4,6 +4,6 @@ module.exports = ({ args: [cmd, ...args], pkg }) => {
   spawn(cmd, args, {
     stdio: 'inherit',
     env: Object.assign({}, process.env, { ACE_BUILD: Date.now() })
-  })
+  }).on('exit', process.exit)
 }
 

--- a/ui/packages/ace/lib/webpack.config.js
+++ b/ui/packages/ace/lib/webpack.config.js
@@ -58,9 +58,6 @@ const base = ({ alias = {}, env }) => ({
       filename: 'index.html',
       template: resolve('src/main/webapp/index.html')
     }),
-    new SimpleProgressWebpackPlugin({
-      format: 'compact'
-    }),
     new webpack.ProvidePlugin({
       ReactDOM: 'react-dom',
       React: 'react'
@@ -214,7 +211,10 @@ const dev = (base, { main, auth }) => merge.smart(base, {
   },
   plugins: [
     new webpack.NamedModulesPlugin(),
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new SimpleProgressWebpackPlugin({
+      format: 'compact'
+    })
   ]
 })
 


### PR DESCRIPTION
#### What does this PR do?
Disables the SimpleProgressWebpackPlugin when `webBuildEnv` is set to prod to reduce CI logging noise.

Also improves `set-env.js` so that it returns the exit code of the process that it invokes to fail faster in the build.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@Bdthomson @djblue @Schachte 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler @bdeining

#### How should this be tested? (List steps with links to updated documentation)
Verify build and look at CI logs
 
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3719](https://codice.atlassian.net/browse/DDF-3719)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.