### PR TITLE
DDF-3786 Updated filter-builder.less & filter.less

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.less
@@ -52,7 +52,7 @@
       line-height: @minimumButtonSize;
       @{customElementNamespace}dropdown.is-editing .dropdown-text {
         width: auto;
-        max-width: 200px;
+        max-width: 300px;
       }
     }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.less
@@ -7,7 +7,6 @@
 
   @{customElementNamespace}dropdown.is-simpleDropdown.is-editing {
     width: auto;
-    max-width: 200px;
   }
 
   > .filter-header > .contents-buttons .add-filterBuilder {
@@ -49,14 +48,15 @@
     > .filter-operator {
       display: inline-block;
       vertical-align: top;
-    }
-
-    > .filter-operator {
       height: @minimumButtonSize;
       line-height: @minimumButtonSize;
+      @{customElementNamespace}dropdown.is-editing .dropdown-text {
+        width: auto;
+        max-width: 200px;
+      }
     }
 
-      > .contents-buttons > button{
+    > .contents-buttons > button{
       padding: 0px @minimumSpacing;
     }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.less
@@ -27,6 +27,13 @@
   > .filter-input {
     min-width: 12.5*@minimumFontSize;
   }
+
+  > .filter-attribute {
+    @{customElementNamespace}dropdown.is-editing .dropdown-text {
+      width: auto;
+      max-width: 200px;
+    }
+  }
 }
 
 @{customElementNamespace}filter.is-location {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.less
@@ -31,7 +31,7 @@
   > .filter-attribute {
     @{customElementNamespace}dropdown.is-editing .dropdown-text {
       width: auto;
-      max-width: 200px;
+      max-width: 300px;
     }
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Updates the CSS used by `filter-builder` and `filter` to properly size the filter operation (i.e. `AND`, `OR`, `NOT AND`, `NOT OR`) and filter attribute (i.e. `anyText`, `anyGeo`, ...) buttons so that the text doesn't overflow the width of those components. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@adimka @alexaabrd @djblue @Variadicism 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@brendan-hofmann

#### How should this be tested? (List steps with links to updated documentation)
Verify that the CSS looks like how the screenshots look

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3786](https://codice.atlassian.net/browse/DDF-3786)
#### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/8922497/39020850-1ed8ecb0-43e3-11e8-9a6a-54533db4d2f7.png)

After:
![image](https://user-images.githubusercontent.com/8922497/39020798-e7c08fa8-43e2-11e8-8ef7-b26c11dd4e86.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
