### PR TITLE
DDF-3788 Allows Admin UI installer to uninstall

### DIFF
--- a/features/apps/src/main/feature/feature.xml
+++ b/features/apps/src/main/feature/feature.xml
@@ -48,7 +48,6 @@
         <feature>platform-app</feature>
         <feature>security-services-app</feature>
         <feature>admin-app</feature>
-        <feature>admin-modules-installer</feature>
     </feature>
 
     <feature name="platform-app" version="${project.version}"


### PR DESCRIPTION
#### What does this PR do?
Removes the dependency in `ddf-boot-features` on `admin-modules-installer` that was disallowing the uninstall of `admin-modules-installer`.
#### Who is reviewing it? 
@tbatie @garrettfreibott 
#### Select relevant component teams: 
@codice/ui 
#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)
Full build, run through installer, verify that installer module is uninstalled following reboot after install.
#### Any background context you want to provide?
This was causing some inconsistent and funky install behavior, including directing the user to run the installer again following a successful install as the result of a race condition with the `post-install` module.
#### What are the relevant tickets?
[DDF-3788](https://codice.atlassian.net/browse/DDF-3788)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
