### PR TITLE
DDF-3790 Updates alert settings component to use property components

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/add-attribute/add-attribute.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/add-attribute/add-attribute.view.js
@@ -65,7 +65,6 @@ module.exports = Marionette.LayoutView.extend({
             })
         }));
         this.attributeSelector.currentView.turnOnEditing();
-        this.attributeSelector.currentView.turnOnLimitedWidth();
         this.listenTo(this.attributeSelector.currentView.model, 'change:value', this.addAttribute);
     }
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert-settings/alert-settings.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert-settings/alert-settings.hbs
@@ -13,16 +13,8 @@
  --}}
 <div class="editor-properties">
     <div class="property-persistance">
-        <div class="property-label">
-            Keep notifications after logging out
-        </div>
-        <div class="property-region"/>
     </div>
 
     <div class="property-expiration">
-        <div class="property-label">
-            Expire After
-        </div>
-        <div class="property-region"/>
     </div>
 </div>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert-settings/alert-settings.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert-settings/alert-settings.less
@@ -8,21 +8,10 @@
   .editor-properties {
     overflow: auto;
     max-height: ~"calc(100% - @{minimumButtonSize} - 2*@{minimumSpacing})";
-    text-align: left;
-
-    .property-label {
-      .is-bold();
-    }
   }
 
   .property-expiration {
     display: none;
-  }
-
-  .property-persistance {
-    > .property-region {
-      margin: -10px 0 20px 0;
-    }
   }
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert-settings/alert-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert-settings/alert-settings.view.js
@@ -21,11 +21,8 @@ define([
     'js/CustomElements',
     'component/singletons/user-instance',
     'component/property/property.view',
-    'component/property/property',
-    'component/dropdown/dropdown.view',
-    'component/radio/radio.view'
-], function (Marionette, _, $, template, CustomElements, user, PropertyView, Property,
-             DropdownView, RadioView) {
+    'component/property/property'
+], function (Marionette, _, $, template, CustomElements, user, PropertyView, Property) {
 
     return Marionette.LayoutView.extend({
         template: template,
@@ -37,8 +34,8 @@ define([
             'click .editor-save': 'save'
         },
         regions: {
-            propertyPersistance: '.property-persistance .property-region',
-            propertyExpiration: '.property-expiration .property-region'
+            propertyPersistance: '.property-persistance',
+            propertyExpiration: '.property-expiration'
         },
         ui: {},
         onBeforeShow: function () {
@@ -57,28 +54,32 @@ define([
             this.stopListening(this.propertyPersistance.currentView.model);
         },
         handlePeristance: function () {
-            var persistance = this.propertyPersistance.currentView.model.get('value');
+            var persistance = this.propertyPersistance.currentView.model.getValue()[0];
             this.$el.toggleClass('is-persisted', persistance);
         },
         setupPersistance: function () {
             var persistance = user.get('user').get('preferences').get('alertPersistance');
-            this.propertyPersistance.show(RadioView.createRadio({
-                options: [{
-                    label: 'Yes',
-                    value: true
-                }, {
-                    label: 'No',
-                    value: false
-                }],
-                defaultValue: persistance
+            this.propertyPersistance.show(new PropertyView({
+                model: new Property({
+                    id: 'Keep notifications after logging out',
+                    enum: [{
+                        label: 'Yes',
+                        value: true
+                    }, {
+                        label: 'No',
+                        value: false
+                    }],
+                    value: [persistance]
+                })
             }));
         },
         setupExpiration: function () {
             var expiration = user.get('user').get('preferences').get('alertExpiration');
             var millisecondsInDay = 24 * 60 * 60 * 1000;
-            this.propertyExpiration.show(DropdownView.createSimpleDropdown(
-                {
-                    list: [
+            this.propertyExpiration.show(new PropertyView({
+                model: new Property({
+                    id: 'Expire After',
+                    enum: [
                         {
                             label: '1 Day',
                             value: 1 * millisecondsInDay
@@ -111,9 +112,9 @@ define([
                             value: 365 * millisecondsInDay
                         }
                     ],
-                    defaultSelection: [expiration]
-                }
-            ));
+                    value: [expiration]
+                })
+            }));
         },
         turnOnEditing: function () {
             this.$el.addClass('is-editing');
@@ -126,7 +127,7 @@ define([
         save: function () {
             var preferences = user.get('user').get('preferences');
             preferences.set({
-                alertPersistance: this.propertyPersistance.currentView.model.get('value'),
+                alertPersistance: this.propertyPersistance.currentView.model.get('value')[0],
                 alertExpiration: this.propertyExpiration.currentView.model.get('value')[0]
             });
             preferences.savePreferences();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/details-filter/details-filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/details-filter/details-filter.view.js
@@ -46,7 +46,6 @@ define([
                 })
             }));
             this.editorProperties.currentView.turnOnEditing();
-            this.editorProperties.currentView.turnOnLimitedWidth();
             this.listenTo(this.editorProperties.currentView.model, 'change', this.handleFilterValue);
             this.handleFilterValue();
         },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/editor/editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/editor/editor.view.js
@@ -222,7 +222,6 @@ define([
             });
         },
         handleNewProperties: function(){
-            this.editorProperties.currentView.turnOnLimitedWidth();
             this.$el.addClass('is-editing');
             this.editorProperties.currentView.turnOnEditing();
         },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/editor/metacard-advanced/metacard-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/editor/metacard-advanced/metacard-advanced.view.js
@@ -41,7 +41,6 @@ define([
         onBeforeShow: function() {
             this.editorProperties.show(PropertyCollectionView.generatePropertyCollectionView(
                 [this.model.first().get('metacard>properties').toJSON()]));
-            this.editorProperties.currentView.turnOnLimitedWidth();
             this.editorProperties.currentView.$el.addClass("is-list");
             this.getValidation();
             EditorView.prototype.onBeforeShow.call(this);

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/editor/metacard-basic/metacard-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/editor/metacard-basic/metacard-basic.view.js
@@ -41,7 +41,6 @@ define([
         onBeforeShow: function() {
             this.editorProperties.show(PropertyCollectionView.generateSummaryPropertyCollectionView(
                 [this.model.first().get('metacard>properties').toJSON()]));
-            this.editorProperties.currentView.turnOnLimitedWidth();
             this.editorProperties.currentView.$el.addClass("is-list");
             this.getValidation();
             EditorView.prototype.onBeforeShow.call(this);

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/editor/metacards-basic/metacards-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/editor/metacards-basic/metacards-basic.view.js
@@ -43,7 +43,6 @@ define([
                 return result.get('metacard>properties').toJSON();
             });
             this.editorProperties.show(PropertyCollectionView.generatePropertyCollectionView(metacards));
-            this.editorProperties.currentView.turnOnLimitedWidth();
             this.editorProperties.currentView.$el.addClass("is-list");
             this.getValidation();
             EditorView.prototype.onBeforeShow.call(this);

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/hide-attribute/hide-attribute.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/hide-attribute/hide-attribute.view.js
@@ -85,7 +85,6 @@ module.exports = Marionette.LayoutView.extend({
             })
         }));
         this.attributeSelector.currentView.turnOnEditing();
-        this.attributeSelector.currentView.turnOnLimitedWidth();
         this.listenTo(this.attributeSelector.currentView.model, 'change:value', this.handleSave);
     },
     handleSave: function () {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.view.js
@@ -44,7 +44,6 @@ module.exports = Marionette.LayoutView.extend({
     this.showCQLSwitch();
     this.showCQL();
     this.showIcon();
-    this.turnOnLimitedWidth();
     this.edit();
   },
   showListTitle: function() {
@@ -98,13 +97,6 @@ module.exports = Marionette.LayoutView.extend({
         enum: List.getIconMappingForSelect()
       })
     );
-  },
-  turnOnLimitedWidth: function() {
-    this.regionManager.forEach(function(region) {
-      if (region.currentView && region.currentView.turnOnLimitedWidth) {
-        region.currentView.turnOnLimitedWidth();
-      }
-    });
   },
   edit: function() {
     this.$el.addClass('is-editing');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -472,7 +472,6 @@ define([
             this.listenTo(keywordProperty, 'change:value', this.handleGetKeyword);
             var PropertyView = require('component/property/property.view');
             var keywordPropertyView = new PropertyView({ model: keywordProperty });
-            keywordPropertyView.turnOnLimitedWidth();
             this.keyword.show(keywordPropertyView);
         },
         handleGetKeyword: function(model, values) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/map-settings/map-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/map-settings/map-settings.view.js
@@ -54,7 +54,6 @@ module.exports = Marionette.LayoutView.extend({
                 type: 'STRING'
             })
         }));
-        this.coordinateFormatExample.currentView.turnOnLimitedWidth();
     },
     setupResultCount: function () {
         var coordinateFormat = user.get('user').get('preferences').get('coordinateFormat');
@@ -73,7 +72,6 @@ module.exports = Marionette.LayoutView.extend({
             })
         }));
 
-        this.coordinateFormat.currentView.turnOnLimitedWidth();
         this.coordinateFormat.currentView.turnOnEditing();
         this.listenTo(this.coordinateFormat.currentView.model, 'change:value', this.save);
     },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.collection.view.js
@@ -70,11 +70,6 @@ define([
         removeProperties: function(attributes){
             this.collection.remove(attributes);
         },
-        turnOnLimitedWidth: function() {
-            this.children.forEach(function(childView) {
-                childView.turnOnLimitedWidth();
-            });
-        },
         turnOnEditing: function() {
             this.children.forEach(function(childView) {
                 childView.turnOnEditing();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.hbs
@@ -23,11 +23,12 @@
         <span class="if-editing fa fa-undo property-revert is-button"></span>
         <span class="property-validation fa fa-exclamation-triangle is-hidden"></span>
     </div>
-    <label for="{{cid}}">
-        {{label}}
-        {{#unless label}}
+    <label for="{{cid}}" title="{{#if label}}{{label}}{{else}}{{id}}{{/if}}">
+        {{#if label}}
+            {{label}}
+        {{else}}
             {{id}}
-        {{/unless}}
+        {{/if}}
     </label>
     <div class="if-block">
         <span class="if-editing fa fa-undo property-revert is-button"></span>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.less
@@ -17,6 +17,10 @@
 
   .property-label {
     text-align: right;
+    > div,
+    > label {
+      vertical-align: middle;
+    }
   }
 
   .property-label label {
@@ -24,8 +28,11 @@
     .is-bold();
     max-width: ~'calc(100% - @{minimumButtonSize})';
     margin: 0px;
-    line-height: @minimumButtonSize;
-    padding-right: @minimumSpacing;
+    line-height: 1.4;
+    padding: @minimumSpacing 0px;
+    min-height: @minimumButtonSize;
+    overflow: hidden;
+    text-overflow: ellipsis;
     word-wrap: normal;
     white-space: normal;
   }
@@ -125,10 +132,6 @@
     text-align: left;
   }
 
-  .property-label label {
-    padding-right: 0px;
-  }
-
   .if-inline {
     display: none;
   }
@@ -150,10 +153,6 @@
 
     .property-label {
       text-align: left;
-    }
-
-    .property-label > label {
-      padding-right: 0px;
     }
 
     .if-inline {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.view.js
@@ -51,6 +51,9 @@ define([
         serializeData: function () {
             return _.extend(this.model.toJSON(), {cid: this.cid});
         },
+        initialize: function() {
+            this.turnOnLimitedWidth();
+        },
         onRender: function () {
             this.handleEdit();
             this.handleReadOnly();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-adhoc/query-adhoc.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-adhoc/query-adhoc.view.js
@@ -73,7 +73,6 @@ define([
                     break;
                 }
             });
-            this.textField.currentView.turnOnLimitedWidth();
             this.listenTo(this.textField.currentView.model, 'change:value', this.saveToModel);
         },
         turnOnEditing: function(){

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-altitude/query-altitude.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-altitude/query-altitude.view.js
@@ -325,13 +325,6 @@ module.exports = Marionette.LayoutView.extend({
                 break;
         }
         return filters;
-    },
-    turnOnLimitedWidth: function () {
-        this.regionManager.forEach(function (region) {
-            if (region.currentView && region.currentView.turnOnLimitedWidth) {
-                region.currentView.turnOnLimitedWidth();
-            }
-        });
     }
 }); 
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -161,7 +161,6 @@ define([
 
             this.handleLocationValue();
             this.handleTypeValue();
-            this.turnOnLimitedWidth();
             this.edit();
         },
         setupSettings: function () {
@@ -297,13 +296,6 @@ define([
                     placeholder: 'Text to search for.  Use "%" or "*" for wildcard.'
                 })
             }));
-        },
-        turnOnLimitedWidth: function () {
-            this.regionManager.forEach(function (region) {
-                if (region.currentView && region.currentView.turnOnLimitedWidth) {
-                    region.currentView.turnOnLimitedWidth();
-                }
-            });
         },
         turnOffEdit: function () {
             this.regionManager.forEach(function (region) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-feedback/query-feedback.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-feedback/query-feedback.view.js
@@ -45,15 +45,7 @@ module.exports = Marionette.LayoutView.extend({
                 type: 'TEXTAREA'
             })
         }));
-        this.turnOnLimitedWidth();
         this.edit();
-    },
-    turnOnLimitedWidth: function(){
-        this.regionManager.forEach(function(region){
-            if (region.currentView && region.currentView.turnOnLimitedWidth){
-                region.currentView.turnOnLimitedWidth();
-            }
-        });
     },
     edit: function(){
         this.$el.addClass('is-editing');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-schedule/query-schedule.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-schedule/query-schedule.view.js
@@ -24,11 +24,10 @@ define([
     'component/property/property.view',
     'component/property/property',
     'component/dropdown/dropdown.view',
-    'component/radio/radio.view',
     'moment',
     'js/Common'
 ], function(Marionette, _, $, template, CustomElements, store, properties, PropertyView, Property,
-    DropdownView, RadioView, Moment, Common) {
+    DropdownView, Moment, Common) {
 
     function getHumanReadableDuration(milliseconds) {
         var duration = Moment.duration(milliseconds);
@@ -87,7 +86,6 @@ define([
                 })
             }));
             this.propertyInterval.currentView.turnOffEditing();
-            this.propertyInterval.currentView.turnOnLimitedWidth();
         },
         turnOnEditing: function() {
             this.$el.addClass('is-editing');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -71,7 +71,6 @@ define([
                 this.resultForm.show(new PropertyView({
                     model: detailLevelProperty
                 }));
-                this.resultForm.currentView.turnOnLimitedWidth();
                 this.resultForm.currentView.turnOnEditing();
             }
         },
@@ -92,7 +91,6 @@ define([
                 
             }));
             this.settingsSortField.currentView.turnOffEditing();
-            this.settingsSortField.currentView.turnOnLimitedWidth();
         },
         setupSrcDropdown: function(){
             var sources = this.model.get('src');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-time/query-time.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-time/query-time.view.js
@@ -121,13 +121,6 @@ module.exports = Marionette.LayoutView.extend({
         }
         return filters;
     },
-    turnOnLimitedWidth: function () {
-        this.regionManager.forEach(function (region) {
-            if (region.currentView && region.currentView.turnOnLimitedWidth) {
-                region.currentView.turnOnLimitedWidth();
-            }
-        });
-    },
     handleTimeRangeValue: function () {
         var timeRange = this.basicTime.currentView.model.getValue()[0];
         this.$el.toggleClass('is-timeRange-any', timeRange === 'any');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/remove-attribute/remove-attribute.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/remove-attribute/remove-attribute.view.js
@@ -65,7 +65,6 @@ module.exports = Marionette.LayoutView.extend({
             })
         }));
         this.attributeSelector.currentView.turnOnEditing();
-        this.attributeSelector.currentView.turnOnLimitedWidth();
         this.listenTo(this.attributeSelector.currentView.model, 'change:value', this.removeAttribute);
     }
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-settings/search-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-settings/search-settings.view.js
@@ -70,7 +70,6 @@ define([
                 })
             }));
 
-            this.propertyResultCount.currentView.turnOnLimitedWidth();
             this.propertyResultCount.currentView.turnOnEditing();
         },
         updateSearchSettings: function() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/show-attribute/show-attribute.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/show-attribute/show-attribute.view.js
@@ -112,7 +112,6 @@ module.exports = Marionette.LayoutView.extend({
             })
         }));
         this.attributeSelector.currentView.turnOnEditing();
-        this.attributeSelector.currentView.turnOnLimitedWidth();
         this.listenTo(this.attributeSelector.currentView.model, 'change:value', this.handleSave);
     },
     handleSave: function () {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/sort-item/sort-item.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/sort-item/sort-item.view.js
@@ -119,7 +119,6 @@ define([
             }));
             this.handleAttribute();
             this.turnOnEditing();
-            this.turnOnLimitedWidth();
 
             this.listenTo(this.sortAttribute.currentView.model, 'change:value', (model, attribute) => {
                 this.model.set('attribute', attribute[0]);
@@ -135,10 +134,6 @@ define([
             if (!this.$el.hasClass('is-non-directional-sort')) {
                 this.sortDirection.currentView.turnOnEditing();
             }
-        },
-        turnOnLimitedWidth: function () {
-            this.sortAttribute.currentView.turnOnLimitedWidth();
-            this.sortDirection.currentView.turnOnLimitedWidth();
         },
         handleAttribute: function () {
             var attribute = this.sortAttribute.currentView.model.getValue()[0];
@@ -171,7 +166,6 @@ define([
                 this.$el.toggleClass('is-non-directional-sort', false);
             }
 
-            this.turnOnLimitedWidth();
             this.listenTo(this.sortDirection.currentView.model, 'change:value', (model, direction) => {
                 this.model.set('direction', direction[0])
             });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/theme-settings/theme-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/theme-settings/theme-settings.view.js
@@ -101,7 +101,6 @@ module.exports = Marionette.LayoutView.extend({
             this[colorVariable].show(new PropertyView({
                 model: propertyModel
             }));
-            this[colorVariable].currentView.turnOnLimitedWidth();
             this[colorVariable].currentView.turnOnEditing();
             this.listenTo(propertyModel, 'change:value', () => {
                 var preferences = getPreferences(user);
@@ -130,7 +129,6 @@ module.exports = Marionette.LayoutView.extend({
         this.animationMode.show(new PropertyView({
             model: animationModel
         }));
-        this.animationMode.currentView.turnOnLimitedWidth();
         this.animationMode.currentView.turnOnEditing();
         this.listenTo(animationModel, 'change:value', this.saveAnimationChanges);
     },
@@ -153,7 +151,6 @@ module.exports = Marionette.LayoutView.extend({
         this.hoverPreview.show(new PropertyView({
             model: hoverPreviewModel
         }));
-        this.hoverPreview.currentView.turnOnLimitedWidth();
         this.hoverPreview.currentView.turnOnEditing();
         this.listenTo(hoverPreviewModel, 'change:value', this.saveHoverPreviewChanges);
     },
@@ -169,7 +166,6 @@ module.exports = Marionette.LayoutView.extend({
         this.fontSize.show(new PropertyView({
             model: fontSizeModel
         }));
-        this.fontSize.currentView.turnOnLimitedWidth();
         this.fontSize.currentView.turnOnEditing();
         this.listenTo(fontSizeModel, 'change:value', this.saveFontChanges);
     },
@@ -195,7 +191,6 @@ module.exports = Marionette.LayoutView.extend({
         this.spacingMode.show(new PropertyView({
             model: spacingModeModel
         }));
-        this.spacingMode.currentView.turnOnLimitedWidth();
         this.spacingMode.currentView.turnOnEditing();
         this.listenTo(spacingModeModel, 'change:value', this.saveSpacingChanges);
     },
@@ -225,7 +220,6 @@ module.exports = Marionette.LayoutView.extend({
         this.theme.show(new PropertyView({
             model: themeModel
         }));
-        this.theme.currentView.turnOnLimitedWidth();
         this.theme.currentView.turnOnEditing();
         this.listenTo(themeModel, 'change:value', this.saveThemeChanges);
     },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/time-settings/time-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/time-settings/time-settings.view.js
@@ -54,7 +54,6 @@ module.exports = Marionette.LayoutView.extend({
                 type: 'DATE'
             })
         }));
-        this.propertyTimeCurrent.currentView.turnOnLimitedWidth();
     },
     setupResultCount: function () {
         var timeFormat = user.get('user').get('preferences').get('timeFormat');
@@ -73,7 +72,6 @@ module.exports = Marionette.LayoutView.extend({
             })
         }));
 
-        this.propertyTimeFormat.currentView.turnOnLimitedWidth();
         this.propertyTimeFormat.currentView.turnOnEditing();
         this.listenTo(this.propertyTimeFormat.currentView.model, 'change:value', this.save);
     },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.view.js
@@ -285,7 +285,6 @@ define([
                 })
             }));
             this.histogramAttribute.currentView.turnOnEditing();
-            this.histogramAttribute.currentView.turnOnLimitedWidth();
             this.listenTo(this.histogramAttribute.currentView.model, 'change:value', this.showHistogram);
         },
         onRender: function(){

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/workspaces-templates/workspaces-templates.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/workspaces-templates/workspaces-templates.view.js
@@ -62,7 +62,6 @@ define([
                 placeholder: 'Search ' + properties.branding + ' ' + properties.product
             }));
             this.adhocSearch.currentView.turnOnEditing();
-            this.adhocSearch.currentView.turnOnLimitedWidth();
             this.listenTo(this.adhocSearch.currentView.model, 'change:value', this.handleValue);
             this.setupAdhocListeners();
         },


### PR DESCRIPTION
#### What does this PR do?
 - Updates the alert settings component to use property components so that the styling is consistent with the rest of the UI.
 - Updates property views to turnOnLimitedWidth by default to make development easier.
 - Updates labels for property views to have a better line height for labels that wrap multiple lines.  Also adds a tooltip for labels.

#### Who is reviewing it? 
@brendan-hofmann
@mackncheesiest 
@adimka 
@rzwiefel 

#### How should this be tested? (List steps with links to updated documentation)
Go to the notification settings view in the user settings and verify things look similar to before.  Verify settings still persist as they should. 

#### What are the relevant tickets?
[DDF-3790](https://codice.atlassian.net/browse/DDF-3790)