### PR TITLE
DDF-3784 Enabling Sharing on Result-Set Templates on UI & Backend

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/SearchFormsApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/SearchFormsApplication.java
@@ -35,6 +35,7 @@ import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.security.Subject;
+import ddf.security.SubjectIdentity;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Comparator;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/SearchFormsApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/SearchFormsApplication.java
@@ -35,7 +35,6 @@ import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.security.Subject;
-import ddf.security.SubjectIdentity;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Comparator;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/SearchFormsApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/SearchFormsApplication.java
@@ -26,23 +26,25 @@ import com.google.common.collect.ImmutableMap;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.types.Core;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.CreateRequestImpl;
 import ddf.catalog.operation.impl.DeleteRequestImpl;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
 import ddf.security.Subject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.shiro.SecurityUtils;
@@ -53,6 +55,7 @@ import org.boon.json.ObjectMapper;
 import org.codice.ddf.catalog.ui.forms.model.FilterNodeValueSerializer;
 import org.codice.ddf.catalog.ui.forms.model.pojo.CommonTemplate;
 import org.codice.ddf.catalog.ui.util.EndpointUtil;
+import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
@@ -77,6 +80,8 @@ public class SearchFormsApplication implements SparkApplication {
 
   private final EndpointUtil util;
 
+  private final FilterBuilder filterBuilder;
+
   private final boolean readOnly;
 
   private static final String RESP_MSG = "message";
@@ -86,10 +91,14 @@ public class SearchFormsApplication implements SparkApplication {
   private static final Logger LOGGER = LoggerFactory.getLogger(SearchFormsApplication.class);
 
   public SearchFormsApplication(
-      CatalogFramework catalogFramework, TemplateTransformer transformer, EndpointUtil util) {
+      FilterBuilder filterBuilder,
+      CatalogFramework catalogFramework,
+      TemplateTransformer transformer,
+      EndpointUtil util) {
     this.catalogFramework = catalogFramework;
     this.transformer = transformer;
     this.util = util;
+    this.filterBuilder = filterBuilder;
     this.readOnly = !SearchFormsLoader.enabled();
   }
 
@@ -274,37 +283,43 @@ public class SearchFormsApplication implements SparkApplication {
   }
 
   private Map<String, Object> doCreateOrUpdate(Response response, Metacard metacard)
-      throws IngestException, SourceUnavailableException {
+      throws IngestException, SourceUnavailableException, FederationException,
+          UnsupportedQueryException {
     if (metacard == null) {
       response.status(400);
       return ImmutableMap.of(RESP_MSG, "Could not create, no valid template specified");
     }
 
-    Map<String, Metacard> allTemplateMetacards =
-        Stream.concat(
-                util.getMetacardsByFilter(QUERY_TEMPLATE_TAG)
-                    .values()
-                    .stream()
-                    .map(Result::getMetacard)
-                    .filter(Objects::nonNull),
-                util.getMetacardsByFilter(ATTRIBUTE_GROUP_TAG)
-                    .values()
-                    .stream()
-                    .map(Result::getMetacard)
-                    .filter(Objects::nonNull))
-            .collect(Collectors.toMap(Metacard::getId, Function.identity()));
-
+    // Going to check to see if the metacard exists or not
+    Metacard oldMetacard = null;
     String id = metacard.getId();
-    Metacard oldMetacard = allTemplateMetacards.get(id);
+    oldMetacard = getMetacardIfExistsOrNull(id);
+
     // The UI should not send an ID during a PUT unless the metacard already exists
     if (id != null && oldMetacard != null) {
-      metacard.setAttribute(new AttributeImpl(Core.CREATED, oldMetacard.getCreatedDate()));
-      metacard.setAttribute(new AttributeImpl(Core.MODIFIED, new Date()));
       catalogFramework.update(new UpdateRequestImpl(id, metacard));
       return ImmutableMap.of(RESP_MSG, "Successfully updated");
     }
     catalogFramework.create(new CreateRequestImpl(metacard));
     return ImmutableMap.of(RESP_MSG, "Successfully created");
+  }
+
+  public Metacard getMetacardIfExistsOrNull(String id)
+      throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    Metacard metacard = null;
+    Filter idFilter = filterBuilder.attribute(Metacard.ID).is().equalTo().text(id);
+    Filter tagsFilter = filterBuilder.attribute(Metacard.TAGS).is().like().text("*");
+    Filter filter = filterBuilder.allOf(idFilter, tagsFilter);
+
+    QueryResponse queryResponse =
+        catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter), false));
+
+    if (!queryResponse.getResults().isEmpty()) {
+      Result result = queryResponse.getResults().get(0);
+      metacard = result.getMetacard();
+    }
+
+    return metacard;
   }
 
   @FunctionalInterface

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
@@ -13,9 +13,13 @@
  */
 package org.codice.ddf.catalog.ui.forms;
 
+import static org.codice.ddf.catalog.ui.security.Constants.SYSTEM_TEMPLATE;
+
+import com.google.common.collect.ImmutableMap;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Security;
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
@@ -117,21 +121,8 @@ public class TemplateTransformer {
     QueryTemplateMetacard wrapped = new QueryTemplateMetacard(metacard);
     TransformVisitor<FilterNode> visitor = new TransformVisitor<>(new JsonModelBuilder());
 
-    List<Serializable> accessIndividuals = new ArrayList<>();
-    List<Serializable> accessGroups = new ArrayList<>();
-
-    if (metacard.getAttribute(SecurityAttributes.ACCESS_INDIVIDUALS) != null) {
-      accessIndividuals = metacard.getAttribute(SecurityAttributes.ACCESS_INDIVIDUALS).getValues();
-    }
-
-    if (metacard.getAttribute(SecurityAttributes.ACCESS_GROUPS) != null) {
-      accessGroups = metacard.getAttribute(SecurityAttributes.ACCESS_GROUPS).getValues();
-    }
-
-    String metacardOwner = "system";
-    if (metacard.getAttribute(Core.METACARD_OWNER) != null) {
-      metacardOwner = metacard.getAttribute(Core.METACARD_OWNER).getValue().toString();
-    }
+    String metacardOwner = retrieveOwnerIfPresent(metacard);
+    Map<String, List<Serializable>> securityAttributes = retrieveSecurityIfPresent(metacard);
 
     try {
       FilterReader reader = new FilterReader();
@@ -148,8 +139,7 @@ public class TemplateTransformer {
       return new FormTemplate(
           wrapped,
           visitor.getResult(),
-          accessIndividuals,
-          accessGroups,
+          securityAttributes,
           metacardOwner,
           wrapped.getQuerySettings());
     } catch (JAXBException | UnsupportedEncodingException e) {
@@ -189,11 +179,50 @@ public class TemplateTransformer {
   /** Convert an attribute group metacard into the JSON representation of FieldFilter. */
   @Nullable
   public FieldFilter toFieldFilter(Metacard metacard) {
+
     if (!AttributeGroupMetacard.isAttributeGroupMetacard(metacard)) {
       LOGGER.debug("Metacard {} was not a result template metacard", metacard);
       return null;
     }
+
+    String metacardOwner = retrieveOwnerIfPresent(metacard);
+    Map<String, List<Serializable>> securityAttributes = retrieveSecurityIfPresent(metacard);
+
     AttributeGroupMetacard wrapped = new AttributeGroupMetacard(metacard);
-    return new FieldFilter(wrapped, wrapped.getGroupDescriptors());
+    return new FieldFilter(
+        wrapped, wrapped.getGroupDescriptors(), metacardOwner, securityAttributes);
+  }
+
+  /** Retrieves original creator of metacard if present to determine if system template or not */
+  private static String retrieveOwnerIfPresent(Metacard inputMetacard) {
+
+    String metacardOwner = SYSTEM_TEMPLATE;
+
+    if (inputMetacard.getAttribute(Core.METACARD_OWNER) != null) {
+      metacardOwner = inputMetacard.getAttribute(Core.METACARD_OWNER).getValue().toString();
+    }
+
+    return metacardOwner;
+  }
+
+  /**
+   * Attaches relevant security attributes to metacard is present to be returned on the JSON
+   * response
+   */
+  private static Map<String, List<Serializable>> retrieveSecurityIfPresent(Metacard inputMetacard) {
+    List<Serializable> accessIndividuals = new ArrayList<>();
+    List<Serializable> accessGroups = new ArrayList<>();
+
+    if (inputMetacard.getAttribute(SecurityAttributes.ACCESS_INDIVIDUALS) != null) {
+      accessIndividuals.addAll(
+          inputMetacard.getAttribute(SecurityAttributes.ACCESS_INDIVIDUALS).getValues());
+    }
+
+    if (inputMetacard.getAttribute(SecurityAttributes.ACCESS_GROUPS) != null) {
+      accessGroups.addAll(inputMetacard.getAttribute(SecurityAttributes.ACCESS_GROUPS).getValues());
+    }
+
+    return ImmutableMap.of(
+        Security.ACCESS_INDIVIDUALS, accessIndividuals, Security.ACCESS_GROUPS, accessGroups);
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
@@ -13,29 +13,17 @@
  */
 package org.codice.ddf.catalog.ui.forms;
 
-import static org.codice.ddf.catalog.ui.forms.data.AttributeGroupType.ATTRIBUTE_GROUP_LIST;
-import static org.codice.ddf.catalog.ui.forms.data.QueryTemplateType.QUERY_TEMPLATE_FILTER;
-
 import com.google.common.collect.ImmutableMap;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Security;
-import ddf.catalog.federation.FederationException;
 import ddf.catalog.filter.FilterBuilder;
-import ddf.catalog.operation.QueryResponse;
-import ddf.catalog.operation.impl.QueryImpl;
-import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -56,8 +44,6 @@ import org.codice.ddf.catalog.ui.forms.filter.VisitableXmlElementImpl;
 import org.codice.ddf.catalog.ui.forms.model.FilterNodeMapImpl;
 import org.codice.ddf.catalog.ui.forms.model.pojo.FieldFilter;
 import org.codice.ddf.catalog.ui.forms.model.pojo.FormTemplate;
-import org.codice.ddf.catalog.ui.util.EndpointUtil;
-import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,17 +60,11 @@ public class TemplateTransformer {
 
   private final CatalogFramework catalogFramework;
 
-  private final EndpointUtil util;
-
   private final FilterBuilder filterBuilder;
 
   public TemplateTransformer(
-      FilterBuilder filterBuilder,
-      EndpointUtil util,
-      CatalogFramework catalogFramework,
-      FilterWriter writer) {
+      FilterBuilder filterBuilder, CatalogFramework catalogFramework, FilterWriter writer) {
     this.filterBuilder = filterBuilder;
-    this.util = util;
     this.writer = writer;
     this.catalogFramework = catalogFramework;
   }
@@ -96,16 +76,17 @@ public class TemplateTransformer {
   /** Convert the JSON representation of a FormTemplate to a QueryTemplateMetacard. */
   @Nullable
   public Metacard toQueryTemplateMetacard(Map<String, Object> formTemplate) {
-    Map<String, Object> filterJson = (Map) formTemplate.get("filterTemplate");
-    String title = (String) formTemplate.get("title");
-    String description = (String) formTemplate.get("description");
-
-    if (filterJson == null) {
-      return null;
-    }
-
-    TransformVisitor<JAXBElement> visitor = new TransformVisitor<>(new XmlModelBuilder());
     try {
+      Map<String, Object> filterJson = (Map) formTemplate.get("filterTemplate");
+      String title = (String) formTemplate.get("title");
+      String description = (String) formTemplate.get("description");
+      String id = (String) formTemplate.get("id");
+
+      if (filterJson == null) {
+        return null;
+      }
+
+      TransformVisitor<JAXBElement> visitor = new TransformVisitor<>(new XmlModelBuilder());
       VisitableJsonElementImpl.create(new FilterNodeMapImpl(filterJson)).accept(visitor);
       JAXBElement filter = visitor.getResult();
       if (!filter.getDeclaredType().equals(FilterType.class)) {
@@ -116,7 +97,6 @@ public class TemplateTransformer {
         return null;
       }
 
-      String id = (String) formTemplate.get("id");
       QueryTemplateMetacard metacard =
           (id == null)
               ? new QueryTemplateMetacard(title, description)
@@ -129,29 +109,11 @@ public class TemplateTransformer {
         metacard.setQuerySettings(querySettings);
       }
 
-      Result result = metacardAlreadyExists(id, filterBuilder, catalogFramework);
-
-      // Perform update of old Metacard if already exists
-      if (result != null) {
-        Metacard oldMetacard = null;
-        oldMetacard = result.getMetacard();
-        oldMetacard.setAttribute(new AttributeImpl(Core.MODIFIED, new Date()));
-        oldMetacard.setAttribute(new AttributeImpl(Core.TITLE, title));
-        oldMetacard.setAttribute(new AttributeImpl(Core.DESCRIPTION, description));
-        oldMetacard.setAttribute(new AttributeImpl(QUERY_TEMPLATE_FILTER, filterXml));
-        return oldMetacard;
-      }
       return metacard;
     } catch (JAXBException e) {
       LOGGER.error("XML generation failed for query template metacard's filter", e);
     } catch (FilterProcessingException e) {
       LOGGER.error("Could not use filter JSON for template - {}", e.getMessage());
-    } catch (SourceUnavailableException e) {
-      LOGGER.error("Source unavailable, {}", e.getMessage());
-    } catch (FederationException e) {
-      LOGGER.error("Error during federation, {}", e.getMessage());
-    } catch (UnsupportedQueryException e) {
-      LOGGER.error("Query unsupported, {}", e.getMessage());
     }
     return null;
   }
@@ -219,34 +181,6 @@ public class TemplateTransformer {
             : new AttributeGroupMetacard(fieldFilter.getTitle(), fieldFilter.getDescription(), id);
 
     metacard.setGroupDescriptors(fieldFilter.getDescriptors());
-    Result result = null;
-
-    try {
-      result = metacardAlreadyExists(id, filterBuilder, catalogFramework);
-    } catch (SourceUnavailableException e) {
-      LOGGER.error("Source unavailable, {}", e.getMessage());
-      return null;
-    } catch (FederationException e) {
-      LOGGER.error("Error during federation, {}", e.getMessage());
-      return null;
-    } catch (UnsupportedQueryException e) {
-      LOGGER.error("Query unsupported, {}", e.getMessage());
-      return null;
-    }
-
-    // Perform update of old Metacard if already exists
-    if (result != null) {
-      Metacard oldMetacard = null;
-      oldMetacard = result.getMetacard();
-      oldMetacard.setAttribute(new AttributeImpl(Core.MODIFIED, new Date()));
-      oldMetacard.setAttribute(new AttributeImpl(Core.TITLE, fieldFilter.getTitle()));
-      oldMetacard.setAttribute(new AttributeImpl(Core.DESCRIPTION, fieldFilter.getDescription()));
-      oldMetacard.setAttribute(
-          new AttributeImpl(
-              ATTRIBUTE_GROUP_LIST,
-              (List<Serializable>) new ArrayList<Serializable>(fieldFilter.getDescriptors())));
-      return oldMetacard;
-    }
     return metacard;
   }
 
@@ -298,22 +232,5 @@ public class TemplateTransformer {
 
     return ImmutableMap.of(
         Security.ACCESS_INDIVIDUALS, accessIndividuals, Security.ACCESS_GROUPS, accessGroups);
-  }
-
-  private static Result metacardAlreadyExists(
-      String id, FilterBuilder filterBuilder, CatalogFramework catalogFramework)
-      throws UnsupportedQueryException, SourceUnavailableException, FederationException {
-    Filter idFilter = filterBuilder.attribute(Metacard.ID).is().equalTo().text(id);
-    Filter tagsFilter = filterBuilder.attribute(Metacard.TAGS).is().like().text("*");
-    Filter queryFilter = filterBuilder.allOf(idFilter, tagsFilter);
-
-    QueryResponse queryResponse =
-        catalogFramework.query(new QueryRequestImpl(new QueryImpl(queryFilter), false));
-
-    if (queryResponse.getResults().isEmpty()) {
-      return null;
-    }
-
-    return queryResponse.getResults().get(0);
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
@@ -13,8 +13,6 @@
  */
 package org.codice.ddf.catalog.ui.forms;
 
-import static org.codice.ddf.catalog.ui.security.Constants.SYSTEM_TEMPLATE;
-
 import com.google.common.collect.ImmutableMap;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.types.SecurityAttributes;
@@ -196,7 +194,7 @@ public class TemplateTransformer {
   /** Retrieves original creator of metacard if present to determine if system template or not */
   private static String retrieveOwnerIfPresent(Metacard inputMetacard) {
 
-    String metacardOwner = SYSTEM_TEMPLATE;
+    String metacardOwner = "system";
 
     if (inputMetacard.getAttribute(Core.METACARD_OWNER) != null) {
       metacardOwner = inputMetacard.getAttribute(Core.METACARD_OWNER).getValue().toString();

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
@@ -70,7 +70,8 @@ public class CommonTemplate {
     this.modified = safeGet(metacard, Core.MODIFIED, Date.class);
     this.owner = safeGet(metacard, Core.METACARD_OWNER, String.class);
 
-    this.accessIndividuals = securityAttributes.getOrDefault(Security.ACCESS_INDIVIDUALS, new ArrayList<>());
+    this.accessIndividuals =
+        securityAttributes.getOrDefault(Security.ACCESS_INDIVIDUALS, new ArrayList<>());
     this.accessGroups = securityAttributes.getOrDefault(Security.ACCESS_GROUPS, new ArrayList<>());
   }
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
@@ -14,12 +14,10 @@
 package org.codice.ddf.catalog.ui.forms.model.pojo;
 
 import static org.codice.ddf.catalog.ui.util.AccessUtil.safeGet;
-import static org.codice.ddf.catalog.ui.util.AccessUtil.safeGetList;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Security;
-
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
@@ -62,8 +60,7 @@ public class CommonTemplate {
     this.owner = safeGet(metacard, Core.METACARD_OWNER, String.class);
   }
 
-  public CommonTemplate(
-      Metacard metacard, Map<String, List<Serializable>> securityAttributes) {
+  public CommonTemplate(Metacard metacard, Map<String, List<Serializable>> securityAttributes) {
     this.id = safeGet(metacard, Core.ID, String.class);
     this.title = safeGet(metacard, Core.TITLE, String.class);
     this.description = safeGet(metacard, Core.DESCRIPTION, String.class);

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
@@ -14,10 +14,15 @@
 package org.codice.ddf.catalog.ui.forms.model.pojo;
 
 import static org.codice.ddf.catalog.ui.util.AccessUtil.safeGet;
+import static org.codice.ddf.catalog.ui.util.AccessUtil.safeGetList;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Security;
+
+import java.io.Serializable;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,6 +48,10 @@ public class CommonTemplate {
 
   private final String owner;
 
+  private List<Serializable> accessGroups;
+
+  private List<Serializable> accessIndividuals;
+
   public CommonTemplate(Metacard metacard) {
     this.id = safeGet(metacard, Core.ID, String.class);
     this.title = safeGet(metacard, Core.TITLE, String.class);
@@ -51,6 +60,20 @@ public class CommonTemplate {
     this.created = safeGet(metacard, Core.CREATED, Date.class);
     this.modified = safeGet(metacard, Core.MODIFIED, Date.class);
     this.owner = safeGet(metacard, Core.METACARD_OWNER, String.class);
+  }
+
+  public CommonTemplate(
+      Metacard metacard, Map<String, List<Serializable>> securityAttributes) {
+    this.id = safeGet(metacard, Core.ID, String.class);
+    this.title = safeGet(metacard, Core.TITLE, String.class);
+    this.description = safeGet(metacard, Core.DESCRIPTION, String.class);
+
+    this.created = safeGet(metacard, Core.CREATED, Date.class);
+    this.modified = safeGet(metacard, Core.MODIFIED, Date.class);
+    this.owner = safeGet(metacard, Core.METACARD_OWNER, String.class);
+
+    this.accessIndividuals = securityAttributes.get(Security.ACCESS_INDIVIDUALS);
+    this.accessGroups = securityAttributes.get(Security.ACCESS_GROUPS);
   }
 
   public CommonTemplate(Map<String, Object> input) {
@@ -87,5 +110,13 @@ public class CommonTemplate {
 
   public String getOwner() {
     return owner;
+  }
+
+  public List<Serializable> getAccessGroups() {
+    return accessGroups;
+  }
+
+  public List<Serializable> getAccessIndividuals() {
+    return accessIndividuals;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
@@ -19,6 +19,7 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Security;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -69,8 +70,8 @@ public class CommonTemplate {
     this.modified = safeGet(metacard, Core.MODIFIED, Date.class);
     this.owner = safeGet(metacard, Core.METACARD_OWNER, String.class);
 
-    this.accessIndividuals = securityAttributes.get(Security.ACCESS_INDIVIDUALS);
-    this.accessGroups = securityAttributes.get(Security.ACCESS_GROUPS);
+    this.accessIndividuals = securityAttributes.getOrDefault(Security.ACCESS_INDIVIDUALS, new ArrayList<>());
+    this.accessGroups = securityAttributes.getOrDefault(Security.ACCESS_GROUPS, new ArrayList<>());
   }
 
   public CommonTemplate(Map<String, Object> input) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FieldFilter.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FieldFilter.java
@@ -16,10 +16,13 @@ package org.codice.ddf.catalog.ui.forms.model.pojo;
 import static org.apache.commons.lang.Validate.notEmpty;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Security;
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.boon.json.annotations.JsonProperty;
 
 /**
  * Provides data model pojo that can be annotated and sent to Boon for JSON serialization.
@@ -35,10 +38,26 @@ public class FieldFilter extends CommonTemplate {
   @SuppressWarnings("squid:S1068" /* Needed for serialization */)
   private final Set<String> descriptors;
 
-  public FieldFilter(Metacard metacard, Set<String> descriptors) {
+  @JsonProperty("creator")
+  private String creator;
+
+  @JsonProperty("accessIndividuals")
+  private List<Serializable> accessIndividuals;
+
+  @JsonProperty("accessGroups")
+  private List<Serializable> accessGroups;
+
+  public FieldFilter(
+      Metacard metacard,
+      Set<String> descriptors,
+      String creator,
+      Map<String, List<Serializable>> securityAttributes) {
     super(metacard);
     notEmpty(descriptors);
     this.descriptors = descriptors;
+    this.creator = creator;
+    this.accessIndividuals = securityAttributes.get(Security.ACCESS_INDIVIDUALS);
+    this.accessGroups = securityAttributes.get(Security.ACCESS_GROUPS);
   }
 
   @SuppressWarnings("unchecked")

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FieldFilter.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FieldFilter.java
@@ -16,7 +16,6 @@ package org.codice.ddf.catalog.ui.forms.model.pojo;
 import static org.apache.commons.lang.Validate.notEmpty;
 
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.types.Security;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FieldFilter.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FieldFilter.java
@@ -41,23 +41,15 @@ public class FieldFilter extends CommonTemplate {
   @JsonProperty("creator")
   private String creator;
 
-  @JsonProperty("accessIndividuals")
-  private List<Serializable> accessIndividuals;
-
-  @JsonProperty("accessGroups")
-  private List<Serializable> accessGroups;
-
   public FieldFilter(
       Metacard metacard,
       Set<String> descriptors,
       String creator,
       Map<String, List<Serializable>> securityAttributes) {
-    super(metacard);
+    super(metacard, securityAttributes);
     notEmpty(descriptors);
     this.descriptors = descriptors;
     this.creator = creator;
-    this.accessIndividuals = securityAttributes.get(Security.ACCESS_INDIVIDUALS);
-    this.accessGroups = securityAttributes.get(Security.ACCESS_GROUPS);
   }
 
   @SuppressWarnings("unchecked")

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FormTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FormTemplate.java
@@ -53,12 +53,10 @@ public class FormTemplate extends CommonTemplate {
       Map<String, List<Serializable>> securityAttributes,
       String creator,
       Map<String, Object> querySettings) {
-    super(metacard);
+    super(metacard, securityAttributes);
     this.root = root;
     this.creator = creator;
     this.querySettings = querySettings;
-    this.accessIndividuals = securityAttributes.get(Security.ACCESS_INDIVIDUALS);
-    this.accessGroups = securityAttributes.get(Security.ACCESS_GROUPS);
   }
 
   public FilterNode getRoot() {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FormTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FormTemplate.java
@@ -14,7 +14,6 @@
 package org.codice.ddf.catalog.ui.forms.model.pojo;
 
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.types.Security;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FormTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FormTemplate.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.catalog.ui.forms.model.pojo;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Security;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -49,16 +50,15 @@ public class FormTemplate extends CommonTemplate {
   public FormTemplate(
       Metacard metacard,
       FilterNode root,
-      List<Serializable> accessIndividuals,
-      List<Serializable> accessGroups,
+      Map<String, List<Serializable>> securityAttributes,
       String creator,
       Map<String, Object> querySettings) {
     super(metacard);
     this.root = root;
-    this.accessIndividuals = accessIndividuals;
-    this.accessGroups = accessGroups;
     this.creator = creator;
     this.querySettings = querySettings;
+    this.accessIndividuals = securityAttributes.get(Security.ACCESS_INDIVIDUALS);
+    this.accessGroups = securityAttributes.get(Security.ACCESS_GROUPS);
   }
 
   public FilterNode getRoot() {

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -413,11 +413,15 @@
 
     <bean id="templateTransformer"
           class="org.codice.ddf.catalog.ui.forms.TemplateTransformer">
+        <argument ref="filterBuilder"/>
+        <argument ref="endpointUtil"/>
+        <argument ref="catalogFramework"/>
         <argument ref="filterWriter"/>
     </bean>
 
     <bean id="searchFormsApplication" class="org.codice.ddf.catalog.ui.forms.SearchFormsApplication"
           init-method="setup">
+        <argument ref="filterBuilder"/>
         <argument ref="catalogFramework"/>
         <argument ref="templateTransformer"/>
         <argument ref="endpointUtil"/>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -414,7 +414,6 @@
     <bean id="templateTransformer"
           class="org.codice.ddf.catalog.ui.forms.TemplateTransformer">
         <argument ref="filterBuilder"/>
-        <argument ref="endpointUtil"/>
         <argument ref="catalogFramework"/>
         <argument ref="filterWriter"/>
     </bean>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -154,7 +154,6 @@ module.exports = Marionette.LayoutView.extend({
         this.onBeforeShow();
     },
     save: function () {
-        //A new form is not necessarily a finished query, so skip saving the rest of the normal stuff
         this.queryContent.currentView.save();
         this.queryTitle.currentView.save();
         if (this.$el.hasClass('is-form-builder')) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -70,9 +70,6 @@ module.exports = Marionette.LayoutView.extend({
             case 'advanced':
                 this.showAdvanced();
                 break;
-            case 'result':
-                this.showResult();
-                break;
             case 'custom':
                 this.showCustom();
                 break;

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -256,11 +256,6 @@ module.exports = Marionette.LayoutView.extend({
             customErrorHandling: true
         })
         .done((data, textStatus, jqxhr) => {
-            announcement.announce({
-                title: 'Saved!',
-                message: 'Search form has been saved.',
-                type: 'success'
-            });
 
             let queryTemplate = _this.getQueryAsQueryTemplate();
             let sorts = queryTemplate['querySettings'] && queryTemplate['querySettings'].sorts;

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.less
@@ -2,7 +2,6 @@
     .customElement;
     overflow: hidden;
     @{customElementNamespace}query-basic,
-    @{customElementNamespace}query-custom,
     @{customElementNamespace}query-advanced {
         .editor-footer {
             display: none;

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-template-sharing/query-template-sharing.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-template-sharing/query-template-sharing.view.js
@@ -123,8 +123,8 @@ module.exports = Marionette.LayoutView.extend({
         }
     },
     getSharingByEmail: function () {
-        return this.options.permissions.accessIndividuals != undefined ? 
-            this.options.permissions.accessIndividuals
+        return this.model.get('accessIndividuals') != undefined ? 
+            this.model.get('accessIndividuals')
             .map(function (email) {
                 return { value: email }
             }) : [];
@@ -132,8 +132,8 @@ module.exports = Marionette.LayoutView.extend({
     getSharingByRole: function () {
         let view = this;
 
-        let roles = this.options.permissions.accessGroups != undefined ? 
-            this.options.permissions.accessGroups
+        let roles = this.model.get('accessGroups') != undefined ? 
+            this.model.get('accessGroups')
             .map(function (group) {
                 return group;
             }) : [];
@@ -183,7 +183,8 @@ module.exports = Marionette.LayoutView.extend({
         this.updateSharingPermissions(templatePerms)
     },
     updateSharingPermissions: function(templatePerms) {
-        let sharingEndpoint = `/search/catalog/internal/sharing/${this.model.id}`
+        let sharingEndpoint = `/search/catalog/internal/sharing/${this.model.get('id')}`
+        this.updateUserPermissions(templatePerms);
         $.ajax({
             url: sharingEndpoint,
             contentType: "application/json; charset=utf-8",
@@ -192,17 +193,13 @@ module.exports = Marionette.LayoutView.extend({
             data: JSON.stringify(templatePerms),
             context: this,
             success: function(data) {
-                this.message('Success!', 'Sharing Settings Saved for Query Template', 'success');
                 this.cleanup();
             }
         });
     },
-    message: function(title, message, type) {
-        announcement.announce({
-            title: title,
-            message: message,
-            type: type
-        });
+    updateUserPermissions: function(templatePerms) {
+        this.model.set('accessIndividuals', templatePerms['security.access-individuals']);
+        this.model.set('accessGroups', templatePerms['security.access-groups']);
     },
     cleanup: function () {
         this.$el.trigger(CustomElements.getNamespace() + 'close-lightbox');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
@@ -117,7 +117,7 @@
    checkIfOwnerOrSystem: function (template) {
      let myEmail = user.get('user').get('email')
      let templateCreator = template.creator
-     return myEmail === templateCreator || templateCreator === 'System Template'
+     return myEmail === templateCreator || templateCreator === 'system-template'
    },
    addResultForm: function (newForm) {
      this.get('resultForms').add(newForm)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
@@ -117,7 +117,7 @@
    checkIfOwnerOrSystem: function (template) {
      let myEmail = user.get('user').get('email')
      let templateCreator = template.creator
-     return myEmail === templateCreator || templateCreator === 'system-template'
+     return myEmail === templateCreator || templateCreator === 'system'
    },
    addResultForm: function (newForm) {
      this.get('resultForms').add(newForm)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
@@ -27,19 +27,7 @@
      url: '/search/catalog/internal/forms/result',
      contentType: 'application/json',
      success: function(data) {
-         //Find templates with the same id but different property maps (because we should trust the server)
-         let updatedTemplates = data.filter(
-             incomingTemplate => _.any(resultTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id && !_.isEqual(cachedTemplate, incomingTemplate))
-         );
-         //Find templates that are new
-         let newTemplates = data.filter(
-             incomingTemplate => resultTemplates.length === 0 || !_.any(resultTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id)
-         );
-         //Replace updated templates in their corresponding indices
-         _.each(updatedTemplates, 
-             updatedTemplate => resultTemplates[_.findIndex(resultTemplates, (cachedTemplate) => cachedTemplate.id === updatedTemplate.id)] = updatedTemplate
-         );
-         resultTemplates = resultTemplates.concat(newTemplates);
+         resultTemplates = data;
          promiseIsResolved = true;
      }
  });
@@ -84,7 +72,7 @@
                   description: resultForm.description,
                   created: resultForm.created,
                   creator: resultForm.creator,
-                  createdBy: resultForm.owner,
+                  createdBy: resultForm.creator,
                   accessGroups: resultForm.accessGroups,
                   accessIndividuals: resultForm.accessIndividuals
               };
@@ -113,11 +101,6 @@
             this.doneLoading();
         });
       }
-   },
-   checkIfOwnerOrSystem: function (template) {
-     let myEmail = user.get('user').get('email')
-     let templateCreator = template.creator
-     return myEmail === templateCreator || templateCreator === 'system'
    },
    addResultForm: function (newForm) {
      this.get('resultForms').add(newForm)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
@@ -109,7 +109,7 @@ module.exports = Marionette.LayoutView.extend({
   save: function () {
     let view = this
     Loading.beginLoading(view)
-    let descriptors = this.basicAttributeSpecific.currentView.model.get('value')
+    let descriptors = this.basicAttributeSpecific.currentView.model.get('value')[0]
     let title = this.basicTitle.currentView.model.getValue()[0]
     if(title === '')
     {
@@ -121,39 +121,43 @@ module.exports = Marionette.LayoutView.extend({
     }
     let description = this.basicDescription.currentView.model.getValue()[0]
     let id = this.model.get('id')
-    let templatePerms = {
+
+    this.model.set({
       'descriptors': descriptors.flatten(),
       'title': title,
-      'description': description,
-      'id' : id
-    }
-    this.updateResults(templatePerms)
+      'description': description
+    })
+
+    this.updateResults()
   },
-  updateResults: function (templatePerms) {
+  updateResults: function () {
     let resultEndpoint = `/search/catalog/internal/forms/result`
+    var _this = this;
     $.ajax({
       url: resultEndpoint,
       contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       type: 'PUT',
-      data: JSON.stringify(templatePerms),
+      data: JSON.stringify(_this.model.toJSON()),
       context: this,
       success: function (data) {
         ResultFormCollection.getResultCollection().filteredList = _.filter(ResultFormCollection.getResultCollection().filteredList, function(template) {
-          return template.id !== templatePerms.id
+          return template.id !== _this.model.get('id')
         })
         ResultFormCollection.getResultCollection().filteredList.push({
-            id: templatePerms.id,
-            label: templatePerms.title,
-            value: templatePerms.title,
+            id: _this.model.get('id'),
+            label: _this.model.get('title'),
+            value: _this.model.get('title'),
             type: 'result',
-            descriptors: templatePerms.descriptors,
-            description: templatePerms.description
+            descriptors: _this.model.get('descriptors'),
+            description: _this.model.get('description'),
+            accessGroups: _this.model.get('accessGroups'),
+            accessIndividuals: _this.model.get('accessIndividual')
           })
           ResultFormCollection.getResultCollection().toggleUpdate()
-          this.cleanup()
+          _this.cleanup()
       },
-      error: this.cleanup()
+      error: _this.cleanup()
     })
   },
   message: function(title, message, type) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
@@ -76,7 +76,7 @@ module.exports = Marionette.LayoutView.extend({
     }))
   },
   setupTitleInput: function () {
-    let currentValue = this.model.get('resultTitle') ? this.model.get('resultTitle') : ''
+    let currentValue = this.model.get('name') ? this.model.get('name') : ''
     this.basicTitle.show(new PropertyView({
       model: new Property({
         value: [currentValue],
@@ -120,7 +120,7 @@ module.exports = Marionette.LayoutView.extend({
       return 
     }
     let description = this.basicDescription.currentView.model.getValue()[0]
-    let id = this.model.get('formId')
+    let id = this.model.get('id')
     let templatePerms = {
       'descriptors': descriptors.flatten(),
       'title': title,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-forms.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-forms.view.js
@@ -14,40 +14,24 @@
  **/
 /* global setTimeout */
 const SearchFormViews = require('component/search-form/search-form.view')
+const properties = require('properties')
+const lightboxResultInstance = require('component/lightbox/result/lightbox.result.view');
+const lightboxInstance = lightboxResultInstance.generateNewLightbox();
+const QueryResult = properties.hasExperimentalEnabled() ? require('component/result-form/result-form.view') : {}
+const SearchFormModel = require('component/search-form/search-form.js')
 
 module.exports = SearchFormViews.extend({
   initialize: function () {
     SearchFormViews.prototype.initialize.call(this)
   },
   changeView: function () {
-    let oldType = this.options.queryModel.get('type')
-    switch (this.model.get('type')) {
-      case 'new-result':
-        this.options.queryModel.set({
-          type: 'new-result',
-          resultTitle: '',
-          formId: this.model.get('id'),
-          accessGroups: [],
-          accessIndividuals: [],
-          descriptors: [],
-          description: ''
-        })
-        break
-      case 'result':
-        this.options.queryModel.set({
-          type: 'result',
-          resultTitle: this.model.get('name'),
-          formId: this.model.get('id'),
-          accessGroups: this.model.get('accessGroups'),
-          accessIndividuals: this.model.get('accessIndividuals'),
-          descriptors: this.model.get('descriptors'),
-          description: this.model.get('description')
-        })
-        break
+    if (properties.hasExperimentalEnabled()) {
+      this.triggerCloseDropdown();
+      lightboxInstance.model.updateTitle(this.model.get('type') === 'new-result' ? '' : this.model.get('name'));
+      lightboxInstance.model.open();
+      lightboxInstance.lightboxContent.show(new QueryResult({
+        model: this.model.get('type') === 'new-result' ? new SearchFormModel({name: ''}) : this.model,
+      }));
     }
-    if (oldType === this.model.get('type')) {
-      this.options.queryModel.trigger('change:type')
-    }
-    this.triggerCloseDropdown()
   }
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-forms.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-forms.view.js
@@ -19,6 +19,7 @@ const lightboxResultInstance = require('component/lightbox/result/lightbox.resul
 const lightboxInstance = lightboxResultInstance.generateNewLightbox();
 const QueryResult = properties.hasExperimentalEnabled() ? require('component/result-form/result-form.view') : {}
 const SearchFormModel = require('component/search-form/search-form.js')
+const CustomElements = require('js/CustomElements')
 
 module.exports = SearchFormViews.extend({
   initialize: function () {
@@ -33,5 +34,9 @@ module.exports = SearchFormViews.extend({
         model: this.model.get('type') === 'new-result' ? new SearchFormModel({name: ''}) : this.model,
       }));
     }
+  },
+  triggerCloseDropdown: function() {
+    this.$el.trigger('closeDropdown.' + CustomElements.getNamespace());
+    this.options.queryModel.trigger('closeDropdown');
   }
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -141,7 +141,7 @@ module.exports =  Marionette.ItemView.extend({
             this.handleClick();
         },
         isSystemTemplate: function() {
-            this.$el.toggleClass('is-system-template', this.model.get('createdBy') === 'system-template');
+            this.$el.toggleClass('is-system-template', this.model.get('createdBy') === 'system');
         },
         handleEdit: function() {
             if(this.model.get('type') === 'custom')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -27,9 +27,9 @@ module.exports =  Marionette.ItemView.extend({
         template: template,
         tagName: CustomElements.register('search-form-interactions'),
         className: 'composed-menu',
-        modelEvents: {
-            'change': 'render'
-        },
+        modelEvents: { 
+            'change': 'render' 
+        }, 
         events: {
             'click .interaction-default': 'handleMakeDefault',
             'click .interaction-clear': 'handleClearDefault',
@@ -133,19 +133,15 @@ module.exports =  Marionette.ItemView.extend({
             });
         },
         handleShare: function() {
-            lightboxInstance.model.updateTitle('Query Template Sharing');
+            lightboxInstance.model.updateTitle(this.options.sharingLightboxTitle);
             lightboxInstance.model.open();
             lightboxInstance.lightboxContent.show(new QueryTemplateSharing({
-                model: this.model,
-                permissions: {
-                    'accessIndividuals': this.model.get('accessIndividuals'),
-                    'accessGroups': this.model.get('accessGroups')
-                }
+                model: this.options.modelForComponent
             }));
             this.handleClick();
         },
         isSystemTemplate: function() {
-            this.$el.toggleClass('is-system-template', this.model.get('createdBy') === 'System Template');
+            this.$el.toggleClass('is-system-template', this.model.get('createdBy') === 'system-template');
         },
         handleEdit: function() {
             if(this.model.get('type') === 'custom')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing-tab-container.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing-tab-container.view.js
@@ -17,7 +17,9 @@
  const $ = require('jquery');
  const template = require('../search-form.collection.hbs');
  const SearchFormCollectionView = require('./search-form-sharing.collection.view');
+ const SearchFormSharingCollection = require('./search-form-sharing.collection');
  const CustomElements = require('js/CustomElements');
+ const LoadingCompanionView = require("component/loading-companion/loading-companion.view")
 
  module.exports = Marionette.LayoutView.extend({
     template: template,
@@ -25,16 +27,26 @@
     regions: {
         collection: '.collection'
     },
+    initialize: function () {
+        this.searchFormSharingCollection = new SearchFormSharingCollection();
+        this.listenTo(this.searchFormSharingCollection, 'change:doneLoading', this.handleLoadingSpinner);
+    },
     onRender: function () {
         this.collection.show(new SearchFormCollectionView({
+            collection: this.searchFormSharingCollection.getCollection(),
             model: this.model
         }));
-        this.$el.find('.loading').show();
-        this.listenTo(this.collection.currentView.searchFormSharingCollection, "change:doneLoading", this.showCollection);
+        LoadingCompanionView.beginLoading(this, this.$el);
+        this.handleLoadingSpinner();
     },
     showCollection: function() {
         if(this.collection.currentView.searchFormSharingCollection.getDoneLoading()) {
             this.$el.find('.loading').hide();
+        }
+    },
+    handleLoadingSpinner: function() {
+        if(this.searchFormSharingCollection.getDoneLoading()) {
+            LoadingCompanionView.endLoading(this);
         }
     }
  });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
@@ -36,7 +36,7 @@
         let newTemplates = data.filter(
             incomingTemplate => sharedTemplates.length === 0 || !_.any(sharedTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id)
         );
-        //Replace updated templates in their corresponding indices (//TODO: Should this just be a backbone collection instead of an array?)
+        //Replace updated templates in their corresponding indices 
         _.each(updatedTemplates, 
             updatedTemplate => sharedTemplates[_.findIndex(sharedTemplates, (cachedTemplate) => cachedTemplate.id === updatedTemplate.id)] = updatedTemplate
         );

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
@@ -28,20 +28,7 @@
     url: '/search/catalog/internal/forms/query',
     contentType: 'application/json',
     success: function (data) {
-        //Find templates with the same id but different property maps (because we should trust the server)
-        let updatedTemplates = data.filter(
-            incomingTemplate => _.any(sharedTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id && !_.isEqual(cachedTemplate, incomingTemplate))
-        );
-        //Find templates that are new
-        let newTemplates = data.filter(
-            incomingTemplate => sharedTemplates.length === 0 || !_.any(sharedTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id)
-        );
-        //Replace updated templates in their corresponding indices 
-        _.each(updatedTemplates, 
-            updatedTemplate => sharedTemplates[_.findIndex(sharedTemplates, (cachedTemplate) => cachedTemplate.id === updatedTemplate.id)] = updatedTemplate
-        );
-
-        sharedTemplates = sharedTemplates.concat(newTemplates);
+        sharedTemplates = data;
         promiseIsResolved = true;
     }
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
@@ -21,15 +21,32 @@
  const user = require('component/singletons/user-instance');
 
  let sharedTemplates = [];
- const templatePromise = $.ajax({
+ let promiseIsResolved = false;
+ const sharedSearchFormPromise = () => $.ajax({
     type: 'GET',
     context: this,
     url: '/search/catalog/internal/forms/query',
     contentType: 'application/json',
     success: function (data) {
-        sharedTemplates = data;
+        //Find templates with the same id but different property maps (because we should trust the server)
+        let updatedTemplates = data.filter(
+            incomingTemplate => _.any(sharedTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id && !_.isEqual(cachedTemplate, incomingTemplate))
+        );
+        //Find templates that are new
+        let newTemplates = data.filter(
+            incomingTemplate => sharedTemplates.length === 0 || !_.any(sharedTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id)
+        );
+        //Replace updated templates in their corresponding indices (//TODO: Should this just be a backbone collection instead of an array?)
+        _.each(updatedTemplates, 
+            updatedTemplate => sharedTemplates[_.findIndex(sharedTemplates, (cachedTemplate) => cachedTemplate.id === updatedTemplate.id)] = updatedTemplate
+        );
+
+        sharedTemplates = sharedTemplates.concat(newTemplates);
+        promiseIsResolved = true;
     }
 });
+
+let bootstrapPromise = sharedSearchFormPromise();
 
  module.exports = Backbone.AssociatedModel.extend({
    model: SearchForm,
@@ -49,31 +66,35 @@
         })
     }],
    addMySharedForms: function() {
-       templatePromise.then(() => {
-            if (!this.isDestroyed){
-                sharedTemplates.forEach((value, index) => {
-                    if (this.checkIfShareable(value)) {
-                        let utcSeconds = value.created / 1000;
-                        let d = new Date(0);
-                        d.setUTCSeconds(utcSeconds);
-                        this.addSearchForm(new SearchForm({
-                            createdOn: Common.getHumanReadableDate(d),
-                            id: value.id,
-                            name: value.title,
-                            description: value.description,
-                            type: 'custom',
-                            filterTemplate: JSON.stringify(value.filterTemplate),
-                            accessIndividuals: value.accessIndividuals,
-                            accessGroups: value.accessGroups,
-                            createdBy: value.creator,
-                            owner: value.owner,
-                            querySettings: value.querySettings
-                        }));
-                    }
-                });
-                this.doneLoading();
-            }
-       });
+    if (!this.isDestroyed){
+        if (promiseIsResolved === true) {
+            promiseIsResolved = false;
+            bootstrapPromise = new sharedSearchFormPromise();
+        }
+        bootstrapPromise.then(() => {
+            $.each(sharedTemplates, (index, value) => {
+                if (this.checkIfShareable(value)) {
+                    let utcSeconds = value.created / 1000;
+                    let d = new Date(0);
+                    d.setUTCSeconds(utcSeconds);
+                    this.addSearchForm(new SearchForm({
+                        createdOn: Common.getHumanReadableDate(d),
+                        id: value.id,
+                        name: value.title,
+                        description: value.description,
+                        type: 'custom',
+                        filterTemplate: JSON.stringify(value.filterTemplate),
+                        accessIndividuals: value.accessIndividuals,
+                        accessGroups: value.accessGroups,
+                        createdBy: value.creator,
+                        owner: value.owner,
+                        querySettings: value.querySettings
+                    }));
+                }
+            });
+            this.doneLoading();
+        })
+    };
    },
    checkIfShareable: function(template) {
        if (this.checkIfInGroup(template) || this.checkIfInIndividiuals(template)) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.view.js
@@ -31,7 +31,8 @@
      },
      childViewOptions: function() {
         return {
-            queryModel: this.options.model
+            queryModel: this.options.model,
+            sharingLightboxTitle: 'Query Form Sharing'
         };
      },
  });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.view.js
@@ -32,7 +32,7 @@
      childViewOptions: function() {
         return {
             queryModel: this.options.model,
-            sharingLightboxTitle: 'Query Form Sharing'
+            sharingLightboxTitle: 'Search Form Sharing'
         };
      },
  });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
@@ -46,19 +46,7 @@ const templatePromiseSupplier = () => properties.hasExperimentalEnabled() ? $.aj
         contentType: 'application/json',
         success: function(data) {
             fixTemplates(data);
-            //Find templates with the same id but different property maps (because we should trust the server)
-            let updatedTemplates = data.filter(
-                incomingTemplate => _.any(cachedTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id && !_.isEqual(cachedTemplate, incomingTemplate))
-            );
-            //Find templates that are new
-            let newTemplates = data.filter(
-                incomingTemplate => cachedTemplates.length === 0 || !_.any(cachedTemplates, (cachedTemplate) => cachedTemplate.id === incomingTemplate.id)
-            );
-            //Replace updated templates in their corresponding indices
-            _.each(updatedTemplates, 
-                updatedTemplate => cachedTemplates[_.findIndex(cachedTemplates, (cachedTemplate) => cachedTemplate.id === updatedTemplate.id)] = updatedTemplate
-            );
-            cachedTemplates = cachedTemplates.concat(newTemplates);
+            cachedTemplates = data;
             promiseIsResolved = true;
         }
     }) : Promise.resolve();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
@@ -12,12 +12,13 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
- /*global require*/
- var Marionette = require('marionette');
- var _ = require('underscore');
- var $ = require('jquery');
- var SearchFormView = require('./search-form.view');
- var CustomElements = require('js/CustomElements');
+/*global require*/
+const Marionette = require('marionette');
+const _ = require('underscore');
+const $ = require('jquery');
+const SearchFormView = require('./search-form.view');
+const SearchFormCollection = require('./search-form.collection');
+const CustomElements = require('js/CustomElements');
 
  module.exports = Marionette.CollectionView.extend({
     childView: SearchFormView,
@@ -28,6 +29,7 @@
     childViewOptions: function() {
         return {
             queryModel: this.options.queryModel,
+            sharingLightboxTitle: 'Query Form Sharing',
             collectionWrapperModel: this.options.collectionWrapperModel
         };
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
@@ -29,7 +29,7 @@ const CustomElements = require('js/CustomElements');
     childViewOptions: function() {
         return {
             queryModel: this.options.queryModel,
-            sharingLightboxTitle: 'Query Form Sharing',
+            sharingLightboxTitle: 'Search Form Sharing',
             collectionWrapperModel: this.options.collectionWrapperModel
         };
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
@@ -23,6 +23,7 @@
         type: "custom",
         id: undefined,
         filterTemplate: "{\"property\":\"anyText\",\"value\":\"\",\"type\":\"ILIKE\"}",
+        descriptors: '{}',
         accessIndividuals: [],
         accessGroups: [],
         querySettings: {}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
@@ -23,7 +23,8 @@
         type: "custom",
         id: undefined,
         filterTemplate: "{\"property\":\"anyText\",\"value\":\"\",\"type\":\"ILIKE\"}",
-        descriptors: '{}',
+        //TODO: Check that nowhere else (i.e. backend) expects this to be a String
+        descriptors: [],
         accessIndividuals: [],
         accessGroups: [],
         querySettings: {}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
@@ -23,7 +23,6 @@
         type: "custom",
         id: undefined,
         filterTemplate: "{\"property\":\"anyText\",\"value\":\"\",\"type\":\"ILIKE\"}",
-        //TODO: Check that nowhere else (i.e. backend) expects this to be a String
         descriptors: [],
         accessIndividuals: [],
         accessGroups: [],

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -59,9 +59,7 @@ module.exports = Marionette.LayoutView.extend({
                     type: 'new-form',
                     associatedFormModel: this.model,
                     title: this.model.get('name'),
-                    filterTree: this.model.get('filterTemplate'),
-                    accessGroups: this.model.get('accessGroups'),
-                    accessIndividuals: this.model.get('accessIndividuals')
+                    filterTree: this.model.get('filterTemplate')
                 });
                 if (oldType === 'new-form') {
                     this.options.queryModel.trigger('change:type');
@@ -94,9 +92,7 @@ module.exports = Marionette.LayoutView.extend({
                     src: (this.model.get('querySettings') && this.model.get('querySettings').src) || '',
                     federation: (this.model.get('querySettings') && this.model.get('querySettings').federation) || 'enterprise',
                     sorts: sorts,
-                    'detail-level': (this.model.get('querySettings') && this.model.get('querySettings')['detail-level']) || 'allFields',
-                    accessGroups: this.model.get('accessGroups'),
-                    accessIndividuals: this.model.get('accessIndividuals')
+                    'detail-level': (this.model.get('querySettings') && this.model.get('querySettings')['detail-level']) || 'allFields'
                 });
                 if (oldType  === 'custom') {
                     this.options.queryModel.trigger('change:type');
@@ -110,6 +106,6 @@ module.exports = Marionette.LayoutView.extend({
     },
     triggerCloseDropdown: function() {
         this.$el.trigger('closeDropdown.' + CustomElements.getNamespace());
-        this.options.queryModel.trigger('closeDropDown');
+        this.options.queryModel.trigger('closeDropdown');
     }
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -106,6 +106,5 @@ module.exports = Marionette.LayoutView.extend({
     },
     triggerCloseDropdown: function() {
         this.$el.trigger('closeDropdown.' + CustomElements.getNamespace());
-        this.options.queryModel.trigger('closeDropdown');
     }
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
@@ -43,7 +43,7 @@ module.exports = Marionette.LayoutView.extend({
         'click > .interaction-type-advanced': 'triggerTypeAdvanced'
     },
     onRender: function(){
-        this.listenTo(this.model, 'change:type', this.triggerCloseDropdown);
+        this.listenTo(this.model, 'change:type closeDropdown', this.triggerCloseDropdown);
         this.generateSearchFormSelector();
         if(properties.hasExperimentalEnabled()) { 
             this.generateResultFormSelector() 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.js
@@ -15,7 +15,7 @@
  const MySearchSharingFormCollectionView = require('component/search-form/forms-sharing/search-form-sharing-tab-container.view');
  const properties = require('properties');
 
- module.exports = Tabs.extend({
+module.exports = Tabs.extend({
     defaults: {
         tabs: properties.hasExperimentalEnabled() ? {
             'My Search Forms': MySearchFormCollectionView,


### PR DESCRIPTION
#### What does this PR do?
Enables sharing on result-set templates:
- Populate shared result-set templates onto users search form in the result-set linker dropdown
- Enable ability to share custom result-set templates from new tab view to other:
   - users
   - groups

#### Screenshots:

![screen shot 2018-04-25 at 4 29 53 pm](https://user-images.githubusercontent.com/7055226/39278044-e8dea696-48a5-11e8-9bae-053e915f42b2.png)

![screen shot 2018-04-25 at 3 50 36 pm](https://user-images.githubusercontent.com/7055226/39277448-9dcf55c2-48a2-11e8-8c83-a9339b7dac4d.png)

![screen shot 2018-04-25 at 3 50 46 pm](https://user-images.githubusercontent.com/7055226/39277449-9f4d85e0-48a2-11e8-9ccc-34b80209f180.png)



#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@middlets719 
@bdeining 
@andrewkfiedler 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@bdeining 
@millerw8 

#### How should this be tested? (List steps with links to updated documentation)
- Quickbuild after pulling down PR
- Unzip distributon and navigate to `/etc` directory `/ddf/distribution/ddf/target/ddf-2.12.0-SNAPSHOT/etc`
- Also ensure that some forms are loaded in the `forms directory`
- Modify the `user.properties` file to have the following contents:

```
admin=admin,group,admin,manager,viewer,system-admin,systembundles
localhost=localhost,group,admin,manager,viewer,system-admin,system-history,systembundles
dummyUser=dummyPassword,group,admin,manager,viewer,system-admin,system-history,systembundles
dummyUser2=dummyPassword,group,manager,viewer,system-history,systembundles
```

- Modify the `user.attributes` to have the following contents:

```
{
    "admin" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"admin@localhost.local"
    },
    "localhost" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"system@localhost.local"
    },
    "dummyUser" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"dummyUser@gmail.com"
    },
    "dummyUser2" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"dummyUser2@gmail.com"
    }
}
```

You now have two users to play with:

- dummyUser, dummyUser@gmail.com/dummyPassword
- dummyUser2, dummyUser2@gmail.com/dummyPassword

##### Note:
> All loaded templates (since technically system templates), need to be shared by the `dummyUser`. This is because `dummyUser` is considered the original metacard owner and the metacard owner is the only one who can share their template. 


- Open the dropdown for a particular query template and share it to the `email address` of dummyUser2, also add some changes to the groups to verify those changes appear in the other account.

- Login to the `dummyUser2` account to ensure that the `Shared Templates` tab has the shared template.

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
