### PR TITLE
DDF-3798: Users should be prevented from running DDF under specific when security manager is enabled

### DIFF
--- a/distribution/docs/src/main/resources/content/_installing/installing-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_installing/installing-intro.adoc
@@ -23,6 +23,11 @@ Adding other components does not have any security/hardening implications.
 
 === Installation Prerequisites
 
+[WARNING]
+====
+For security reasons, ${branding} cannot be started from a user's home directory. If attempted, the system will automatically shut down.
+====
+
 These are the system/environment requirements to configure _prior_ to an installation.
 
 [NOTE]

--- a/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc
+++ b/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc
@@ -22,6 +22,11 @@ These steps will demonstrate:
 
 These are the basic requirements to set up the environment to run a ${branding}.
 
+[WARNING]
+====
+For security reasons, ${branding} cannot be started from a user's home directory. If attempted, the system will automatically shut down.
+====
+
 ==== Hardware Requirements (Quick Install)
 
 * At least 4096MB of memory for ${branding}.

--- a/features/apps/pom.xml
+++ b/features/apps/pom.xml
@@ -182,6 +182,11 @@
             <type>xml</type>
             <classifier>features</classifier>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.security</groupId>
+            <artifactId>secure-boot</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!--end feature dependencies-->
 
         <dependency>

--- a/features/apps/pom.xml
+++ b/features/apps/pom.xml
@@ -182,11 +182,6 @@
             <type>xml</type>
             <classifier>features</classifier>
         </dependency>
-        <dependency>
-            <groupId>ddf.platform.security</groupId>
-            <artifactId>secure-boot</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         <!--end feature dependencies-->
 
         <dependency>

--- a/features/apps/src/main/feature/feature.xml
+++ b/features/apps/src/main/feature/feature.xml
@@ -43,7 +43,7 @@
              description="Features that will be started on container startup.">
         <!--Added prerequisite to kernel since it starts up features that must be started before others such as wrap and blueprint -->
         <feature prerequisite="true">kernel</feature>
-        <bundle>mvn:ddf.platform.security/secure-boot/${project.version}</bundle>
+        <feature>secure-boot</feature>
         <feature>ddf-branding</feature>
         <feature>ui</feature>
         <feature>platform-app</feature>

--- a/features/apps/src/main/feature/feature.xml
+++ b/features/apps/src/main/feature/feature.xml
@@ -43,6 +43,7 @@
              description="Features that will be started on container startup.">
         <!--Added prerequisite to kernel since it starts up features that must be started before others such as wrap and blueprint -->
         <feature prerequisite="true">kernel</feature>
+        <bundle>mvn:ddf.platform.security/secure-boot/${project.version}</bundle>
         <feature>ddf-branding</feature>
         <feature>ui</feature>
         <feature>platform-app</feature>

--- a/features/security/pom.xml
+++ b/features/security/pom.xml
@@ -377,6 +377,11 @@
             <artifactId>platform-country-converter-local</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.security</groupId>
+            <artifactId>secure-boot</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!--feature dependencies-->
         <dependency>

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -589,4 +589,9 @@
         <feature>security-servlet-session-expiry</feature>
         <feature>security-sts-realm</feature>
     </feature>
+
+    <feature name="secure-boot" version="${project.version}"
+             description="Verifies that the installation is located in a secure directory.">
+        <bundle>mvn:ddf.platform.security/secure-boot/${project.version}</bundle>
+    </feature>
 </features>

--- a/platform/security/pom.xml
+++ b/platform/security/pom.xml
@@ -236,5 +236,6 @@
         <module>rest</module>
         <module>security-migratable</module>
         <module>command</module>
+        <module>secure-boot</module>
     </modules>
 </project>

--- a/platform/security/secure-boot/pom.xml
+++ b/platform/security/secure-boot/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>security</artifactId>
+        <groupId>ddf.platform.security</groupId>
+        <version>2.12.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>secure-boot</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>DDF :: Security :: Boot</name>
+
+    <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+            </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.system</groupId>
+            <artifactId>org.apache.karaf.system.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.81</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.78</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.78</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/security/secure-boot/pom.xml
+++ b/platform/security/secure-boot/pom.xml
@@ -75,17 +75,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.81</minimum>
+                                            <minimum>0.84</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.78</minimum>
+                                            <minimum>0.81</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.78</minimum>
+                                            <minimum>0.79</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/secure-boot/pom.xml
+++ b/platform/security/secure-boot/pom.xml
@@ -27,10 +27,10 @@
     <name>DDF :: Security :: Boot</name>
 
     <dependencies>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-            </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.karaf.system</groupId>
             <artifactId>org.apache.karaf.system.core</artifactId>

--- a/platform/security/secure-boot/src/main/java/org/codice/ddf/security/boot/SecureBoot.java
+++ b/platform/security/secure-boot/src/main/java/org/codice/ddf/security/boot/SecureBoot.java
@@ -47,6 +47,10 @@ public class SecureBoot {
     userHome = getUserHome();
   }
 
+  @SuppressWarnings({
+    "squid:S1192", /* Surpress duplicate string literal warning */
+    "squid:S106" /* System.err.println used to notify admin of error */
+  })
   public void init() {
     if (!shuttingDown && isInsecureInstallation()) {
       String message =
@@ -66,6 +70,10 @@ public class SecureBoot {
     return securityManagerEnabled() && isInstalledInUserHome();
   }
 
+  @SuppressWarnings({
+    "squid:HiddenFieldCheck",
+    "squid:S106" /* System.err.println used to notify admin of error */
+  })
   private Path getDdfHome() {
     Path ddfHome;
     try {
@@ -82,6 +90,10 @@ public class SecureBoot {
     return ddfHome;
   }
 
+  @SuppressWarnings({
+    "squid:HiddenFieldCheck",
+    "squid:S106" /* System.err.println used to notify admin of error */
+  })
   private Path getUserHome() {
     Path userHome;
     try {
@@ -119,6 +131,7 @@ public class SecureBoot {
   }
 
   @VisibleForTesting
+  @SuppressWarnings("squid:S106" /* System.err.println used to notify admin of error */)
   void systemExit(Exception e) {
     String message =
         "ERROR: Exception encountered while shutting system down via SystemService. Terminating JVM...";

--- a/platform/security/secure-boot/src/main/java/org/codice/ddf/security/boot/SecureBoot.java
+++ b/platform/security/secure-boot/src/main/java/org/codice/ddf/security/boot/SecureBoot.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.boot;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.karaf.system.SystemService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SecureBoot {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecureBoot.class);
+
+  private static final String DDF_HOME_SYS_PROP = "ddf.home";
+
+  private static final String USER_HOME_SYS_PROP = "user.home";
+
+  private static final int INSECURE_BOOT_EXIT_CODE = 15;
+
+  private static final String NOW = "0";
+
+  private final SystemService systemService;
+
+  private Path ddfHome;
+
+  private Path userHome;
+
+  private boolean shuttingDown = false;
+
+  public SecureBoot(SystemService systemService) {
+    this.systemService = systemService;
+    try {
+      ddfHome = getDdfHome();
+      userHome = getUserHome();
+    } catch (IOException e) {
+      String message =
+          "Unable to determine if your installation ["
+              + ddfHome
+              + "] is located in an insecure directory. See log for details. Shutting down...";
+      System.err.println("\n" + message + "\n");
+      LOGGER.error(message, e);
+      shutdown();
+    }
+  }
+
+  public void init() {
+    if (isInsecureInstallation()) {
+      String message =
+          "ERROR: Your installation ["
+              + ddfHome
+              + "] is located in an insecure directory. Installations cannot be located in ["
+              + userHome
+              + "]. Shutting down...";
+
+      System.err.println("\n" + message + "\n");
+      LOGGER.error(message);
+      shutdown();
+    }
+  }
+
+  private boolean isInsecureInstallation() {
+    return !shuttingDown && securityManagerEnabled() && isInstalledInUserHome();
+  }
+
+  private Path getDdfHome() throws IOException {
+    return Paths.get(System.getProperty(DDF_HOME_SYS_PROP)).toRealPath();
+  }
+
+  private Path getUserHome() throws IOException {
+    return Paths.get(System.getProperty(USER_HOME_SYS_PROP)).toRealPath();
+  }
+
+  private boolean isInstalledInUserHome() {
+    return ddfHome.startsWith(userHome);
+  }
+
+  private void shutdown() {
+    try {
+      shuttingDown = true;
+      systemService.halt(NOW);
+    } catch (Exception e) {
+      systemExit(e);
+    }
+  }
+
+  @VisibleForTesting
+  boolean securityManagerEnabled() {
+    return System.getSecurityManager() != null;
+  }
+
+  @VisibleForTesting
+  void systemExit(Exception e) {
+    String message =
+        "ERROR: Exception encountered while shutting system down via SystemService. Terminating JVM...";
+    System.err.println("\n" + message + "\n");
+    LOGGER.error(message, e);
+    System.exit(INSECURE_BOOT_EXIT_CODE);
+  }
+}

--- a/platform/security/secure-boot/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/secure-boot/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <reference id="systemService" interface="org.apache.karaf.system.SystemService" availability="mandatory"/>
+
+    <bean id="secureBoot"
+          class="org.codice.ddf.security.boot.SecureBoot" init-method="init" scope="singleton">
+        <argument ref="systemService"/>
+    </bean>
+
+</blueprint>

--- a/platform/security/secure-boot/src/test/groovy/org/codice/ddf/security/boot/SecureBootSpec.groovy
+++ b/platform/security/secure-boot/src/test/groovy/org/codice/ddf/security/boot/SecureBootSpec.groovy
@@ -192,6 +192,60 @@ class SecureBootSpec  extends Specification {
         exitedDueToSystemServiceFailureToExit == false
     }
 
+    def 'System exits normally when attempting to read invalid user.home'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def userHomeSysProp = "/" + System.currentTimeMillis() + "/" + UUID.randomUUID() + "/tomPenny"
+        def ddfHomeSysProp = ddfHome.newFolder("ddf").toString()
+        def systemService = Mock(SystemService)
+        def securityManager = Mock(SecurityManager)
+        System.properties.'ddf.home' = ddfHomeSysProp
+        System.properties.'user.home' = userHomeSysProp
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return securityManager;
+            }
+
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        1 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+
+    def 'System exits normally when attempting to read invalid ddf.home and invalid user.home'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def userHomeSysProp = "/" + System.currentTimeMillis() + "/" + UUID.randomUUID() + "/tomPenny"
+        def ddfHomeSysProp = "/" + System.currentTimeMillis() + "/" + UUID.randomUUID() + "/ddf"
+        def systemService = Mock(SystemService)
+        def securityManager = Mock(SecurityManager)
+        System.properties.'ddf.home' = ddfHomeSysProp
+        System.properties.'user.home' = userHomeSysProp
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return securityManager;
+            }
+
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        1 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+
     /**
      * ie. /opt/ddfHomeSymLink -> /users/tomPenny/ddf
      */

--- a/platform/security/secure-boot/src/test/groovy/org/codice/ddf/security/boot/SecureBootSpec.groovy
+++ b/platform/security/secure-boot/src/test/groovy/org/codice/ddf/security/boot/SecureBootSpec.groovy
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.boot
+
+import java.nio.file.Paths
+import org.apache.karaf.system.SystemService
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+import java.nio.file.Files
+
+@RestoreSystemProperties
+class SecureBootSpec  extends Specification {
+
+    @Rule
+    TemporaryFolder temporaryFolder
+
+    @Rule
+    TemporaryFolder ddfHome
+
+    @Rule
+    TemporaryFolder userHome
+
+    def 'System exits normally when security manager enabled and ddf installed inside of user home dir'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def userHomeSysProp = userHome.getRoot().toString()
+        def ddfHomeSysProp = userHome.newFolder("ddf").toString()
+        def systemService = Mock(SystemService)
+        def securityManager = Mock(SecurityManager)
+        System.properties.'ddf.home' = ddfHomeSysProp
+        System.properties.'user.home' = userHomeSysProp
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return securityManager;
+            }
+
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        1 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+
+    def 'System boots when security manager enabled and ddf installed outside of user home dir'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def userHomeSysProp = userHome.newFolder("tomPenny").toString()
+        def ddfHomeSysProp = ddfHome.newFolder("ddf").toString()
+        def systemService = Mock(SystemService)
+        def securityManager = Mock(SecurityManager)
+        System.properties.'ddf.home' = ddfHomeSysProp
+        System.properties.'user.home' = userHomeSysProp
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return securityManager;
+            }
+
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        0 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+
+    def 'System boots when security manager disabled and ddf installed inside of user home dir'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def userHomeSysProp = userHome.getRoot().toString()
+        def ddfHomeSysProp = userHome.newFolder("ddf").toString()
+        def systemService = Mock(SystemService)
+        System.properties.'ddf.home' = ddfHomeSysProp
+        System.properties.'user.home' = userHomeSysProp
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return null;
+            }
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        0 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+
+    def 'System boots when security manager disabled and ddf installed outside of user home dir'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def userHomeSysProp = userHome.newFolder("tomPenny").toString()
+        def ddfHomeSysProp = ddfHome.newFolder("ddf").toString()
+        def systemService = Mock(SystemService)
+        System.properties.'ddf.home' = ddfHomeSysProp
+        System.properties.'user.home' = userHomeSysProp
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return null;
+            }
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        0 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+
+    def 'SystemService throws exception when asked to halt'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def userHomeSysProp = userHome.getRoot().toString()
+        def ddfHomeSysProp = userHome.newFolder("ddf").toString()
+        def systemService = Mock(SystemService)
+        def securityManager = Mock(SecurityManager)
+        System.properties.'ddf.home' = ddfHomeSysProp
+        System.properties.'user.home' = userHomeSysProp
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return securityManager;
+            }
+
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        1 * systemService.halt("0") >> { throw new Exception("unable to halt")}
+        exitedDueToSystemServiceFailureToExit == true
+    }
+
+    def 'System exits normally when attempting to read invalid ddf.home'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def userHomeSysProp = userHome.getRoot().toString()
+        def ddfHomeSysProp = "/" + System.currentTimeMillis() + "/" + UUID.randomUUID() + "/ddf"
+        def systemService = Mock(SystemService)
+        def securityManager = Mock(SecurityManager)
+        System.properties.'ddf.home' = ddfHomeSysProp
+        System.properties.'user.home' = userHomeSysProp
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return securityManager;
+            }
+
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        1 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+
+    /**
+     * ie. /opt/ddfHomeSymLink -> /users/tomPenny/ddf
+     */
+    def 'System exits normally when security manager enabled and symbolic link outside of user home dir pointing to ddf installation inside of user home dir'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def optDir = temporaryFolder.newFolder("opt").toPath()
+        def tomPennyHomeDir = temporaryFolder.newFolder("tomPenny")
+        def ddfHomeDir = Files.createDirectory(Paths.get(tomPennyHomeDir.toString(), "ddf"))
+        def ddfHomeSymLink = Files.createSymbolicLink(Paths.get(optDir.toString(), "ddfHomeSymLink"), ddfHomeDir)
+        def systemService = Mock(SystemService)
+        def securityManager = Mock(SecurityManager)
+        System.properties.'ddf.home' = ddfHomeSymLink.toString()
+        System.properties.'user.home' = tomPennyHomeDir.toString()
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return securityManager;
+            }
+
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        1 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+
+    /**
+     * ie. /users/tomPenny/ddfHomeSymLink -> /opt/ddf
+     */
+    def 'System boots when security manager enabled and symbolic link inside of user home dir pointing to ddf installation outside of user home dir'() {
+        setup:
+        def exitedDueToSystemServiceFailureToExit = false
+        def optDir = temporaryFolder.newFolder("opt").toPath()
+        def ddfHomeDir = Files.createDirectory(Paths.get(optDir.toString(), "ddf"))
+        def tomPennyHomeDir = temporaryFolder.newFolder("tomPenny")
+        def ddfHomeSymLink = Files.createSymbolicLink(Paths.get(tomPennyHomeDir.toString(), "ddfHomeSymLink"), ddfHomeDir)
+        def systemService = Mock(SystemService)
+        def securityManager = Mock(SecurityManager)
+        System.properties.'ddf.home' = ddfHomeSymLink.toString()
+        System.properties.'user.home' = tomPennyHomeDir.toString()
+
+        when:
+        def secureBoot = new SecureBoot(systemService) {
+            boolean securityManagerEnabled() {
+                return securityManager;
+            }
+
+            void systemExit(Exception e) {
+                exitedDueToSystemServiceFailureToExit = true
+            }
+        }
+        secureBoot.init()
+
+        then:
+        0 * systemService.halt("0")
+        exitedDueToSystemServiceFailureToExit == false
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Prevents users from running DDF under specific directories when security manager is enabled

#### Who is reviewing it? 
@tbatie 
@emanns95 
@paouelle 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
@clockard
@lessarderic 
#### How should this be tested? (List steps with links to updated documentation)
1) Unzip DDF in your user.home directory and verify that it shutsdown automatically with an error message stating that DDF cannot be installed in user.home.
2) Unzip DDF in another directory outside of user.home, and verify that it starts up and runs with no problems.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3798
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
