### PR TITLE
DDF-3802 Make AbstractCswSource CXF client factory overridable

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -320,11 +320,11 @@ public abstract class AbstractCswSource extends MaskableImpl
     configureEventService();
   }
 
-  private void initClientFactory() {
+  protected void initClientFactory() {
     if (StringUtils.isNotBlank(cswSourceConfiguration.getUsername())
         && StringUtils.isNotBlank(cswSourceConfiguration.getPassword())) {
       factory =
-          new SecureCxfClientFactory(
+          new SecureCxfClientFactory<>(
               cswSourceConfiguration.getCswUrl(),
               Csw.class,
               initProviders(cswTransformConverter, cswSourceConfiguration),
@@ -338,7 +338,7 @@ public abstract class AbstractCswSource extends MaskableImpl
     } else if (StringUtils.isNotBlank(cswSourceConfiguration.getCertAlias())
         && StringUtils.isNotBlank(cswSourceConfiguration.getKeystorePath())) {
       factory =
-          new SecureCxfClientFactory(
+          new SecureCxfClientFactory<>(
               cswSourceConfiguration.getCswUrl(),
               Csw.class,
               initProviders(cswTransformConverter, cswSourceConfiguration),
@@ -352,7 +352,7 @@ public abstract class AbstractCswSource extends MaskableImpl
               cswSourceConfiguration.getSslProtocol());
     } else {
       factory =
-          new SecureCxfClientFactory(
+          new SecureCxfClientFactory<>(
               cswSourceConfiguration.getCswUrl(),
               Csw.class,
               initProviders(cswTransformConverter, cswSourceConfiguration),
@@ -368,7 +368,7 @@ public abstract class AbstractCswSource extends MaskableImpl
     if (StringUtils.isNotBlank(cswSourceConfiguration.getUsername())
         && StringUtils.isNotBlank(cswSourceConfiguration.getPassword())) {
       subscribeClientFactory =
-          new SecureCxfClientFactory(
+          new SecureCxfClientFactory<>(
               cswSourceConfiguration.getEventServiceAddress(),
               CswSubscribe.class,
               initProviders(cswTransformConverter, cswSourceConfiguration),
@@ -382,9 +382,9 @@ public abstract class AbstractCswSource extends MaskableImpl
     } else if (StringUtils.isNotBlank(cswSourceConfiguration.getCertAlias())
         && StringUtils.isNotBlank(cswSourceConfiguration.getKeystorePath())) {
       subscribeClientFactory =
-          new SecureCxfClientFactory(
+          new SecureCxfClientFactory<>(
               cswSourceConfiguration.getCswUrl(),
-              Csw.class,
+              CswSubscribe.class,
               initProviders(cswTransformConverter, cswSourceConfiguration),
               null,
               cswSourceConfiguration.getDisableCnCheck(),
@@ -396,7 +396,7 @@ public abstract class AbstractCswSource extends MaskableImpl
               cswSourceConfiguration.getSslProtocol());
     } else {
       subscribeClientFactory =
-          new SecureCxfClientFactory(
+          new SecureCxfClientFactory<>(
               cswSourceConfiguration.getEventServiceAddress(),
               CswSubscribe.class,
               initProviders(cswTransformConverter, cswSourceConfiguration),


### PR DESCRIPTION
#### What does this PR do?
Makes the `initClientFactory()` method of `AbstractCswSource` protected instead of private so child classes can override the CXF client factory creation.

Also fixes a type error in `initSubscribeClientFactory()` that was hidden because we weren't using the diamond operator when instantiating `SecureCxfClientFactory`.

#### Who is reviewing it? 
@Bdthomson 
@glenhein 
@troymohl 

#### Select relevant component teams: 
@codice/ogc 
@codice/io

#### Choose 2 committers to review/merge the PR. 
@bdeining
@jlcsmith

#### How should this be tested? (List steps with links to updated documentation)
Run a full build.

#### What are the relevant tickets?
[DDF-3802](https://codice.atlassian.net/browse/DDF-3802)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
