### PR TITLE
DDF-2824 Add CVE suppression for docs related compile-time dependency

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -218,6 +218,7 @@
         <cve>CVE-2014-3567</cve>
         <cve>CVE-2014-8176</cve>
         <cve>CVE-2015-0292</cve>
+        <cve>CVE-2015-8768</cve>
         <cve>CVE-2016-2108</cve>
         <cve>CVE-2016-2109</cve>
     </suppress>


### PR DESCRIPTION
#### What does this PR do?
Suppress jruby CVE for docs in the standard search-ui

This library is only used to generate the docs and does not pose any risk to a running system.

#### Who is reviewing it? 
@coyotesqrl @ricklarsen @stustison

#### How should this be tested? (List steps with links to updated documentation)
CI build to run OWASP

#### Any background context you want to provide?
This CVE was found running owasp locally with the failure message of 
`[ERROR] jruby-complete-9.0.4.0.jar\META-INF/maven/com.boundary/high-scale-lib/pom.xml: CVE-2015-8768`

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
