### PR TITLE
DDF-3739 Removed the hard dependencies on persistence strategies at initialization time for the config admin migratable

### DIFF
--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratable.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratable.java
@@ -52,7 +52,7 @@ public class ConfigurationAdminMigratable implements Migratable {
 
   private final List<PersistenceStrategy> strategies;
 
-  private final PersistenceStrategy defaultStrategy;
+  private final String defaultFileExtension;
 
   public ConfigurationAdminMigratable(
       ConfigurationAdmin configurationAdmin,
@@ -62,9 +62,7 @@ public class ConfigurationAdminMigratable implements Migratable {
     Validate.notNull(defaultFileExtension, "invalid null default file extension");
     this.configurationAdmin = configurationAdmin;
     this.strategies = strategies;
-    this.defaultStrategy = getPersister(defaultFileExtension);
-    Validate.notNull(
-        defaultStrategy, "unknown persistence strategy extension: " + defaultFileExtension);
+    this.defaultFileExtension = defaultFileExtension;
   }
 
   @SuppressWarnings(
@@ -107,7 +105,8 @@ public class ConfigurationAdminMigratable implements Migratable {
   @Override
   public void doExport(ExportMigrationContext context) {
     final ExportMigrationConfigurationAdminContext adminContext =
-        new ExportMigrationConfigurationAdminContext(context, this, getConfigurations(context));
+        new ExportMigrationConfigurationAdminContext(
+            context, defaultFileExtension, this, getConfigurations(context));
 
     adminContext.fileEntries().forEach(ExportMigrationEntry::store);
     adminContext.memoryEntries().forEach(ExportMigrationConfigurationAdminEntry::store);
@@ -120,12 +119,6 @@ public class ConfigurationAdminMigratable implements Migratable {
             context, this, configurationAdmin, getConfigurations(context));
 
     adminContext.memoryEntries().forEach(ImportMigrationConfigurationAdminEntry::restore);
-  }
-
-  @SuppressWarnings(
-      "PMD.DefaultPackage" /* designed to be called from ExportMigrationConfigurationAdminContext in this package */)
-  PersistenceStrategy getDefaultPersister() {
-    return defaultStrategy;
   }
 
   @SuppressWarnings(

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
@@ -165,14 +165,6 @@ public class ConfigurationAdminMigratableTest {
   }
 
   @Test
-  public void testGetDefaultPersister() {
-    ConfigurationAdminMigratable cam =
-        new ConfigurationAdminMigratable(configurationAdmin, STRATEGIES, DEFAULT_FILE_EXT);
-    PersistenceStrategy strategy = cam.getDefaultPersister();
-    assertThat(strategy, instanceOf(ConfigStrategy.class));
-  }
-
-  @Test
   public void testDoExportConfigAdminThrowsIOException() throws Exception {
     // Setup
     when(exportMigrationContext.getReport()).thenReturn(migrationReport);


### PR DESCRIPTION
## This PR is designed to address one of the issue found in itests right now

#### What does this PR do?
Fixes a race condition that occurs because the config admin migratable has a dependency on the persistence strategy services at init time. This problem surfaces now because of the platform-app split which requires the features to be completely independent from one another or at least to not require each other at initialization time.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@tbatie 
@oconnormi 
@emanns95 
@austinsteffes 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@clockard
@figliold

#### How should this be tested? (List steps with links to updated documentation)
- Unzip and install the distribution.
- Perform a migration export
- Unzip the distribution but do not install it
- Perform a migration import with the --profile option
- Verify the system is restored to its state before the export

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3739](https://codice.atlassian.net/browse/DDF-3739)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
