### PR TITLE
DDF-3750 Restores constructor to SourceDescriptorImpl

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/source/impl/SourceDescriptorImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/source/impl/SourceDescriptorImpl.java
@@ -41,12 +41,22 @@ public class SourceDescriptorImpl extends DescribableImpl implements SourceDescr
    *
    * @param sourceId the source's id
    * @param catalogedTypes the cataloged types
+   */
+  public SourceDescriptorImpl(String sourceId, Set<ContentType> catalogedTypes) {
+    this.sourceId = sourceId;
+    this.catalogedTypes = catalogedTypes;
+  }
+
+  /**
+   * Instantiates a new SourceDescriptorImpl.
+   *
+   * @param sourceId the source's id
+   * @param catalogedTypes the cataloged types
    * @param actions list of actions
    */
   public SourceDescriptorImpl(
       String sourceId, Set<ContentType> catalogedTypes, List<Action> actions) {
-    this.sourceId = sourceId;
-    this.catalogedTypes = catalogedTypes;
+    this(sourceId, catalogedTypes);
     this.actions = actions;
   }
 
@@ -99,6 +109,9 @@ public class SourceDescriptorImpl extends DescribableImpl implements SourceDescr
 
   @Override
   public List<Action> getActions() {
+    if (actions == null) {
+      return SourceDescriptor.super.getActions();
+    }
     return actions;
   }
 


### PR DESCRIPTION
#### What does this PR do?
Restores a ctor that was inadvertently removed in #3141. This removal might impact downstream projects.

#### Who is reviewing it? 
@glenhein @jlcsmith 

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@pklinef
@stustison

#### How should this be tested? (List steps with links to updated documentation)
CI build should be sufficient.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3750](https://codice.atlassian.net/browse/DDF-3750)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
