### PR TITLE
DDF-3785 Improve codice-icons compatibility with downstream Intrigue modifications

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,1 +1,2 @@
 src/main/resources/webapp
+packages/codice-icons/icons

--- a/ui/packages.xml
+++ b/ui/packages.xml
@@ -20,7 +20,14 @@
         <format>zip</format>
     </formats>
     <fileSets>
-        <fileSet>
+       <fileSet>
+            <directory>${project.basedir}/packages/codice-icons/</directory>
+            <excludes>
+                <exclude>**/node_modules/**</exclude>
+            </excludes>
+            <outputDirectory>codice-icons</outputDirectory>
+       </fileSet>
+       <fileSet>
             <directory>${project.basedir}/packages/catalog-ui-search/</directory>
             <excludes>
                 <exclude>**/target/**</exclude>

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
@@ -153,5 +153,5 @@ require([
     };
 
     require('js/ApplicationStart');
-    require('codice-icons/target/codice.font');
+    require('codice-icons/icons/codice.font');
 });

--- a/ui/packages/codice-icons/package.json
+++ b/ui/packages/codice-icons/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "license": "LGPL-3.0",
   "scripts": {
-    "build": "webpack && ace package"
+    "build": "webpack"
   },
   "dependencies": {
     "css-loader": "0.28.11",
@@ -15,9 +15,8 @@
     "webpack-cli": "2.0.15"
   },
   "files": [
-    "target/"
+    "icons/"
   ],
-  "context-path": "/codice/icons",
   "main": "codice.font.config.js",
   "devDependencies": {}
 }

--- a/ui/packages/codice-icons/webpack.config.js
+++ b/ui/packages/codice-icons/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
         './codice.font.css'
     ],
     output: {
-        path: path.resolve(__dirname, 'target'),
+        path: path.resolve(__dirname, 'icons'),
         publicPath: '/',
         filename: 'codice.font.js'
     },

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -413,11 +413,6 @@
                                     <classifier>cesium-assets</classifier>
                                 </artifact>
                                 <artifact>
-                                    <file>packages/codice-icons/target/codice-icons.jar</file>
-                                    <type>jar</type>
-                                    <classifier>codice-icons</classifier>
-                                </artifact>
-                                <artifact>
                                     <file>packages/geowebcache-admin-plugin/target/geowebcache-admin-plugin.jar</file>
                                     <type>jar</type>
                                     <classifier>geowebcache-admin-plugin</classifier>


### PR DESCRIPTION
#### What does this PR do?
Updates the codice-webfonts package to better support downstream modifications of the `catalog-ui-search` package using the sources artifacts.

This PR:
- Adds the `codice-icons` files to our configuration in `ui/packages.xml` that is then used as [our maven-assembly-plugin](https://github.com/codice/ddf/blob/3d3703bab8972b41a9ace67658d96bc829777fa2/ui/pom.xml#L279-L282) configuration on what things to include for downstream modification and reuse.
- Changes the output directory of the finalized font from `target` to `icons` to avoid tricky issues with build tooling clearing `target` directories at inopportune times
- Removes the `ace package` build step for `codice-icons` since I don't believe we actually need the `codice-icons.jar` artifact when we bundle things with the maven-assembly-plugin

#### Who is reviewing it? 
@alexaabrd @djblue @adimka @Schachte 

#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@bdeining

#### How should this be tested? (List steps with links to updated documentation)
Same hero steps as #3194 as well as verify that downstream projects that rebuild `catalog-ui-search` are able to properly resolve the `codice-icons` dependency.

#### What are the relevant tickets?
[DDF-3785](https://codice.atlassian.net/browse/DDF-3785)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
