### PR TITLE
DDF-3753 Re-enable CDM component tests

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/AbstractComponentTest.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/AbstractComponentTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractComponentTest {
         .until(() -> bundleContext.getServiceReference(registerClass) != null);
   }
 
-  private Option getComponentUnderTestOptions() throws IOException {
+  private Option getComponentUnderTestOptions() {
     String componentArtifactId = System.getProperty("component.artifactId");
     String componentVersion = System.getProperty("component.version");
     String bundleJarName = String.format("%s-%s.jar", componentArtifactId, componentVersion);

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorIT.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorIT.java
@@ -77,6 +77,7 @@ import org.codice.ddf.catalog.content.monitor.features.CamelFeatures;
 import org.codice.ddf.catalog.content.monitor.features.CxfFeatures;
 import org.codice.ddf.catalog.content.monitor.features.KarafSpringFeatures;
 import org.codice.ddf.catalog.content.monitor.util.BundleInfo;
+import org.codice.ddf.test.common.ComponentTestRunner;
 import org.codice.ddf.test.common.annotations.AfterExam;
 import org.codice.ddf.test.common.annotations.BeforeExam;
 import org.codice.ddf.test.common.annotations.PaxExamRule;
@@ -91,12 +92,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 import org.ops4j.io.FileUtils;
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.ops4j.pax.tinybundles.core.TinyBundles;
 
-@RunWith(PaxExam.class)
+@RunWith(ComponentTestRunner.class)
 @ExamReactorStrategy(PerClass.class)
 public class ContentDirectoryMonitorIT extends AbstractComponentTest {
 
@@ -260,8 +260,6 @@ public class ContentDirectoryMonitorIT extends AbstractComponentTest {
 
   private List<BundleInfo> testDependencies() {
     return Arrays.asList(
-        new BundleInfo("org.apache.commons", "commons-collections4"),
-        new BundleInfo("org.apache.commons", "commons-lang3"),
         new BundleInfo("ddf.lib", "test-common"),
         new BundleInfo("ddf.lib", "common-system"),
         new BundleInfo("org.awaitility", "awaitility"),
@@ -293,6 +291,7 @@ public class ContentDirectoryMonitorIT extends AbstractComponentTest {
         new BundleInfo("commons-lang", "commons-lang"),
         new BundleInfo("commons-io", "commons-io"),
         new BundleInfo("commons-collections", "commons-collections"),
+        new BundleInfo("org.apache.commons", "commons-collections4"),
         new BundleInfo("commons-configuration", "commons-configuration"),
         new BundleInfo("com.google.guava", "guava"),
         new BundleInfo("org.apache.tika", "tika-core"),
@@ -316,7 +315,6 @@ public class ContentDirectoryMonitorIT extends AbstractComponentTest {
         new BundleInfo("ddf.mime.core", "mime-core-api"),
         new BundleInfo("ddf.mime.core", "mime-core-impl"),
         new BundleInfo("ddf.catalog.core", "catalog-core-camelcomponent"),
-        new BundleInfo("ddf.catalog.core", "catalog-core-directorymonitor"),
         new BundleInfo("ddf.thirdparty", "restito"),
         new BundleInfo("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.xalan"));
   }

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/configurators/KarafConfigurator.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/configurators/KarafConfigurator.java
@@ -20,6 +20,7 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configure
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.debugConfiguration;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 import java.io.File;
@@ -42,7 +43,8 @@ public class KarafConfigurator {
             .unpackDirectory(new File("target", "exam"))
             .useDeployFolder(false),
         configureConsole().ignoreLocalConsole(),
-        logLevel().logLevel(LogLevelOption.LogLevel.WARN),
+        keepRuntimeFolder(),
+        logLevel().logLevel(LogLevelOption.LogLevel.DEBUG),
         editConfigurationFilePut("etc/system.properties", "ddf.home", "${karaf.home}"),
         editConfigurationFilePut(
             "etc/system.properties", "org.codice.ddf.system.hostname", "localhost"),

--- a/libs/test-common/pom.xml
+++ b/libs/test-common/pom.xml
@@ -43,6 +43,11 @@
             <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
@@ -60,6 +65,11 @@
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam</artifactId>
+            <version>${pax.exam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-junit4</artifactId>
             <version>${pax.exam.version}</version>
         </dependency>
         <dependency>
@@ -98,12 +108,6 @@
             <version>${xmlunit.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-junit4</artifactId>
-            <version>${pax.exam.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-link-mvn</artifactId>

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/AbstractComponentTest.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/AbstractComponentTest.java
@@ -99,6 +99,7 @@ public abstract class AbstractComponentTest {
     return BundleOptionBuilder.add("org.mockito", "mockito-core")
         .add("org.objenesis", "objenesis")
         .add("org.awaitility", "awaitility")
+        .add("commons-io", "commons-io")
         .add("org.apache.commons", "commons-collections4")
         .add("org.apache.commons", "commons-lang3")
         .add("ddf.lib", "test-common")

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/ComponentTestRunner.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/ComponentTestRunner.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.test.common;
+
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+/**
+ * JUnit test runner that dumps extra debug information to the console when a Pax Exam test
+ * container fails to start.
+ */
+public class ComponentTestRunner extends PaxExam {
+  public ComponentTestRunner(Class<?> testClass) throws InitializationError {
+    super(testClass);
+  }
+
+  @Override
+  public void run(RunNotifier notifier) {
+    notifier.addFirstListener(new KarafContainerFailureLogger());
+    super.run(notifier);
+  }
+}

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/KarafContainerFailureLogger.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/KarafContainerFailureLogger.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.test.common;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.commons.io.IOUtils;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JUnit {@link RunListener} class that logs extra information (e.g., content of the karaf.log file)
+ * to the console when a Karaf test container fails to start.
+ */
+class KarafContainerFailureLogger extends RunListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KarafContainerFailureLogger.class);
+
+  private static final PrintStream OUT = System.out;
+
+  private static final Path EXAM_DIR = Paths.get("target", "exam");
+  private static final Path KARAF_LOG_FILE = Paths.get("data", "log", "karaf.log");
+  private static final Path TEST_DEPENDENCIES_FILE = Paths.get("test-dependencies.xml");
+
+  @Override
+  public void testRunFinished(Result result) {
+    if (result.getFailureCount() > 0) {
+      LOGGER.error("Tests failed!");
+      getLatestExamFolder()
+          .ifPresent(
+              p -> {
+                printFileContent(p, KARAF_LOG_FILE);
+                printFileContent(p, TEST_DEPENDENCIES_FILE);
+              });
+    }
+  }
+
+  private Optional<Path> getLatestExamFolder() {
+    try (Stream<Path> files = Files.list(EXAM_DIR)) {
+      return files
+          .filter(Files::isDirectory)
+          .max(Comparator.comparingLong(p -> p.toFile().lastModified()));
+    } catch (IOException e) {
+      LOGGER.error("No exam directory under {}", EXAM_DIR.toAbsolutePath());
+      return Optional.empty();
+    }
+  }
+
+  private void printFileContent(Path rootPath, Path fileRelativePath) {
+    File file = rootPath.resolve(fileRelativePath).toFile();
+
+    try (FileInputStream fileInputStream = new FileInputStream(file)) {
+      LOGGER.error("===== Printing {} content =====", fileRelativePath.toString());
+      IOUtils.lineIterator(fileInputStream, "UTF-8").forEachRemaining(OUT::println);
+    } catch (IOException e) {
+      LOGGER.error("Couldn't find {}", file.getAbsolutePath());
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Added code to log dump the karaf.log and test-dependencies.xml files to the standard out when the test container fails to come up.

Also fixed a problem that prevented the Karaf container from starting when running the ContentDirectoryMonitorIT component tests.

#### Who is reviewing it?
@oconnormi 
@paouelle 

#### Choose 2 committers to review/merge the PR. 
@brendan-hofmann
@clockard

#### How should this be tested? (List steps with links to updated documentation)
Full build on Docker swarm.

#### Any background context you want to provide?
https://github.com/codice/ddf/pull/3207

#### What are the relevant tickets?
[DDF-3753](https://codice.atlassian.net/browse/DDF-3753)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
