### PR TITLE
WIP: DDF-3809 Adding Backend Filtering to SearchFormsApplication, Tests, Removing UI Filtering

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
         </dependency>
@@ -280,6 +285,24 @@
             <groupId>ddf.action.core</groupId>
             <artifactId>action-core-impl</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.7.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.7.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
+            <version>1.7.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/TemplateTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/TemplateTransformer.java
@@ -45,47 +45,6 @@ import org.slf4j.LoggerFactory;
 public class TemplateTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(TemplateTransformer.class);
 
-  //  private Predicate<Metacard> isOwner(Subject subject) {
-  //    return metacard ->
-  //        metacard
-  //            .getAttribute(Core.METACARD_OWNER)
-  //            .getValue()
-  //            .toString()
-  //            .equals(getSubjectEmail(subject));
-  //  }
-  //
-  //  private Predicate<Metacard> isSystem(Subject subject) {
-  //    return metacard ->
-  //        metacard
-  //            .getAttribute(Core.METACARD_OWNER)
-  //            .getValue()
-  //            .toString()
-  //            .equals(SYSTEM_TEMPLATE_ALIAS);
-  //  }
-  //
-  //  private Predicate<requesterHasAccess>(Subject subject, Predicate<Metacard> metacard) {
-  //    return true;
-  //  }
-  //
-  //  @SuppressWarnings("unchecked")
-  //  private String getSubjectEmail(Subject subject) {
-  //    return Optional.ofNullable(subject)
-  //        .map(SubjectUtils::getEmailAddress)
-  //        .orElseThrow(() -> new NullPointerException("Subject doesn't exist"));
-  //  }
-  //
-  //  /** Retrieve map of user groups */
-  //  private Map<String, List<String>> getSubjectPermissions() {
-  //    return new ImmutableMap.Builder<String, List<String>>()
-  //            SecurityUtils.getSubject().getPrincipals().
-  //
-  // .put(SecurityAttributes.ACCESS_GROUPS,SubjectUtils.getAttribute(SecurityUtils.getSubject(),
-  // SecurityAttributes.ACCESS_GROUPS))
-  //
-  // .put(SecurityAttributes.ACCESS_INDIVIDUALS,SubjectUtils.getAttribute(SecurityUtils.getSubject(), SecurityAttributes.ACCESS_INDIVIDUALS))
-  //            .build();
-  //  }
-
   public static boolean invalidFormTemplate(Metacard metacard) {
     return new TemplateTransformer().toFormTemplate(metacard) == null;
   }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/TemplateTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/TemplateTransformer.java
@@ -45,6 +45,47 @@ import org.slf4j.LoggerFactory;
 public class TemplateTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(TemplateTransformer.class);
 
+  //  private Predicate<Metacard> isOwner(Subject subject) {
+  //    return metacard ->
+  //        metacard
+  //            .getAttribute(Core.METACARD_OWNER)
+  //            .getValue()
+  //            .toString()
+  //            .equals(getSubjectEmail(subject));
+  //  }
+  //
+  //  private Predicate<Metacard> isSystem(Subject subject) {
+  //    return metacard ->
+  //        metacard
+  //            .getAttribute(Core.METACARD_OWNER)
+  //            .getValue()
+  //            .toString()
+  //            .equals(SYSTEM_TEMPLATE_ALIAS);
+  //  }
+  //
+  //  private Predicate<requesterHasAccess>(Subject subject, Predicate<Metacard> metacard) {
+  //    return true;
+  //  }
+  //
+  //  @SuppressWarnings("unchecked")
+  //  private String getSubjectEmail(Subject subject) {
+  //    return Optional.ofNullable(subject)
+  //        .map(SubjectUtils::getEmailAddress)
+  //        .orElseThrow(() -> new NullPointerException("Subject doesn't exist"));
+  //  }
+  //
+  //  /** Retrieve map of user groups */
+  //  private Map<String, List<String>> getSubjectPermissions() {
+  //    return new ImmutableMap.Builder<String, List<String>>()
+  //            SecurityUtils.getSubject().getPrincipals().
+  //
+  // .put(SecurityAttributes.ACCESS_GROUPS,SubjectUtils.getAttribute(SecurityUtils.getSubject(),
+  // SecurityAttributes.ACCESS_GROUPS))
+  //
+  // .put(SecurityAttributes.ACCESS_INDIVIDUALS,SubjectUtils.getAttribute(SecurityUtils.getSubject(), SecurityAttributes.ACCESS_INDIVIDUALS))
+  //            .build();
+  //  }
+
   public static boolean invalidFormTemplate(Metacard metacard) {
     return new TemplateTransformer().toFormTemplate(metacard) == null;
   }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/Constants.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/Constants.java
@@ -27,7 +27,7 @@ public class Constants {
           WorkspaceAttributes.WORKSPACE_TAG,
           QueryTemplateType.QUERY_TEMPLATE_TAG);
 
-  public static final String SYSTEM_TEMPLATE = "System Template";
+  public static final String SYSTEM_TEMPLATE_ALIAS = "System Template";
 
   public static final String ROLES_CLAIM_URI =
       "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/ShareableMetacardImpl.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/ShareableMetacardImpl.java
@@ -134,7 +134,7 @@ public class ShareableMetacardImpl extends MetacardImpl {
    * @return a {@link ShareableMetacardImpl} with all the attributes of the original.
    */
   @VisibleForTesting
-  static ShareableMetacardImpl clone(Metacard metacard) {
+  public static ShareableMetacardImpl clone(Metacard metacard) {
     ShareableMetacardImpl shareableMetacard = new ShareableMetacardImpl();
     metacard
         .getMetacardType()

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/SearchFormsApplicationTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/SearchFormsApplicationTest.java
@@ -1,0 +1,268 @@
+package org.codice.ddf.catalog.ui.forms;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
+import static org.powermock.api.support.membermodification.MemberModifier.stub;
+import static spark.Spark.awaitInitialization;
+
+import com.google.common.collect.ImmutableMap;
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.ProcessingDetails;
+import ddf.security.SubjectUtils;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.apache.shiro.subject.Subject;
+import org.codice.ddf.catalog.ui.forms.model.TemplateTransformer;
+import org.codice.ddf.catalog.ui.security.ShareableMetacardImpl;
+import org.codice.ddf.catalog.ui.util.EndpointUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import spark.Request;
+import spark.Spark;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SecurityUtils.class, SubjectUtils.class, SearchFormsApplication.class})
+@PowerMockIgnore("javax.net.ssl.*")
+public class SearchFormsApplicationTest {
+
+  private static final String TEST_HOST = "http://localhost";
+
+  private static final int TEST_PORT = 4567;
+
+  // Allotted time to kill the Spark Servlet (milliseconds)
+  private static final int TIME_TO_KILL_SPARK = 100;
+
+  private static final String SPARK_TEST_SERVER = TEST_HOST + ":" + TEST_PORT;
+
+  private static final String TEST_EMAIL_1 = "dummyUser@gmail.com";
+
+  private static final String TEST_EMAIL_2 = "dummyUser2@gmail.com";
+
+  private static final String TEST_EMAIL_3 = "dummyUser3@gmail.com";
+
+  private static final String DELETE_REQ = "delete";
+
+  private static final String POST_REQ = "post";
+
+  private static final String GET_REQ = "get";
+
+  CatalogFramework catalogFramework;
+
+  TemplateTransformer templateTransformer;
+
+  EndpointUtil endpointUtil;
+
+  SearchFormsApplication sfa;
+
+  CloseableHttpClient httpClient;
+
+  List<String> testRoles = new ArrayList<>();
+
+  DeleteResponse deleteResponse = mock(DeleteResponse.class, Mockito.RETURNS_DEEP_STUBS);
+
+  Set<ProcessingDetails> mockedSet = mock(HashSet.class);
+
+  HashSet<String> mockedRoleSet = new HashSet<>();
+
+  HashSet<String> mockedIndividualSet = new HashSet<>();
+
+  @org.mockito.Mock private Subject currentSubject;
+
+  @org.mockito.Mock PrincipalCollection principalCollection;
+
+  @org.mockito.Mock HttpServletRequest servletRequest;
+
+  @org.mockito.Mock HttpSession httpSession;
+
+  @org.mockito.Mock Request request;
+
+  @org.mockito.Mock ShareableMetacardImpl shareableMetacard;
+
+  @Before
+  public void setup() throws Exception {
+
+    // Mock classes
+    catalogFramework = mock(CatalogFramework.class);
+    templateTransformer = mock(TemplateTransformer.class);
+    endpointUtil = mock(EndpointUtil.class);
+    httpClient = HttpClients.custom().build();
+
+    // Mock static classes/methods
+    mockStatic(SecurityUtils.class);
+    mockStatic(SubjectUtils.class);
+
+    // Mock some sample roles
+    testRoles.add("admin");
+    testRoles.add("viewer");
+    testRoles.add("guest");
+
+    // Mock requests
+    when(catalogFramework.delete(any(DeleteRequest.class))).thenReturn(deleteResponse);
+    when(deleteResponse.getProcessingErrors()).thenReturn(mockedSet);
+
+    // Initialize the Spark Server inside SFA controller
+    sfa = spy(new SearchFormsApplication(catalogFramework, templateTransformer, endpointUtil));
+    sfa.init();
+    awaitInitialization();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    Spark.stop();
+    Thread.sleep(TIME_TO_KILL_SPARK);
+  }
+
+  @Test
+  public void testSuccessfulTemplateDeletion() throws Exception {
+    when(sfa.getRequesterEmail()).thenReturn(TEST_EMAIL_1);
+    doReturn(
+            new ImmutableMap.Builder<String, Object>()
+                .put(Core.METACARD_OWNER, TEST_EMAIL_1)
+                .build())
+        .when(sfa, "getOriginalMetacardOwner", any(Request.class));
+    when(deleteResponse.getProcessingErrors().isEmpty()).thenReturn(true);
+    ImmutableMap<String, Object> responseData = makeRequestUtility(DELETE_REQ, "/forms/5");
+    assertEquals(new Integer(200), (Integer) responseData.get("status"));
+    assertThat(
+        responseData.get("response").toString(), containsString("Message=Successfully deleted."));
+  }
+
+  @Test
+  public void testFailedTemplateDeletion() throws Exception {
+    when(sfa.getRequesterEmail()).thenReturn(TEST_EMAIL_1);
+    doReturn(
+            new ImmutableMap.Builder<String, Object>()
+                .put(Core.METACARD_OWNER, TEST_EMAIL_1)
+                .build())
+        .when(sfa, "getOriginalMetacardOwner", any(Request.class));
+    when(deleteResponse.getProcessingErrors().isEmpty()).thenReturn(false);
+    ImmutableMap<String, Object> responseData = makeRequestUtility(DELETE_REQ, "/forms/5");
+    assertEquals(new Integer(500), (Integer) responseData.get("status"));
+    assertThat(
+        responseData.get("response").toString(), containsString("Message=Failed to delete."));
+  }
+
+  @Test
+  public void testGetRequesterGroupsOnSubject() {
+    stub(method(SubjectUtils.class, "getAttribute", Subject.class, String.class))
+        .toReturn(testRoles);
+    assertEquals(testRoles, sfa.getRequesterGroups());
+  }
+
+  @Test
+  public void testRetrievalOfOriginalMetacardOwner() throws IOException {
+    String jsonMap = "{\"metacard.owner\":" + TEST_EMAIL_2 + "}";
+    doReturn(jsonMap).when(endpointUtil).safeGetBody(request);
+    assertEquals(TEST_EMAIL_2, sfa.getOriginalMetacardOwner(request).get(Core.METACARD_OWNER));
+  }
+
+  @Test
+  public void testRetrievalOfRequesterEmail() {
+    when(SecurityUtils.getSubject()).thenReturn(currentSubject);
+    stub(method(SubjectUtils.class, "getEmailAddress", Subject.class)).toReturn(TEST_EMAIL_3);
+    assertEquals(TEST_EMAIL_3, sfa.getRequesterEmail());
+  }
+
+  @Test
+  public void testListIntersectionByRoleIsEmpty() {
+    HashSet<String> testRoleSet = new HashSet<>();
+    testRoleSet.add("viewer");
+    when(sfa.getRequesterGroups()).thenReturn(testRoles);
+    when(shareableMetacard.getAccessGroups()).thenReturn(testRoleSet);
+    assertTrue(sfa.sharedByGroup().test(shareableMetacard));
+  }
+
+  @Test
+  public void testListIntersectionByRoleIsNotEmpty() {
+    when(sfa.getRequesterGroups()).thenReturn(testRoles);
+    when(shareableMetacard.getAccessGroups()).thenReturn(mockedRoleSet);
+    assertFalse(sfa.sharedByGroup().test(shareableMetacard));
+  }
+
+  @Test
+  public void testSubjectExistsWithinMetacardAccessIndividuals() {
+    HashSet<String> testIndividualSet = new HashSet<>();
+    testIndividualSet.add(TEST_EMAIL_2);
+    when(sfa.getRequesterEmail()).thenReturn(TEST_EMAIL_2);
+    when(shareableMetacard.getAccessIndividuals()).thenReturn(testIndividualSet);
+    assertTrue(sfa.sharedByIndividual().test(shareableMetacard));
+  }
+
+  @Test
+  public void testSubjectDoesNotExistsWithinMetacardAccessIndividuals() {
+    when(sfa.getRequesterEmail()).thenReturn(TEST_EMAIL_2);
+    when(shareableMetacard.getAccessIndividuals()).thenReturn(mockedIndividualSet);
+    assertFalse(sfa.sharedByIndividual().test(shareableMetacard));
+  }
+
+  /** Request utility helper method */
+  private ImmutableMap<String, Object> makeRequestUtility(String type, String endpoint)
+      throws IOException {
+
+    HttpRequestBase req;
+    endpoint = SPARK_TEST_SERVER + endpoint;
+
+    switch (type) {
+      case GET_REQ:
+        req = new HttpGet(endpoint);
+        break;
+      case POST_REQ:
+        req = new HttpPost(endpoint);
+        break;
+      case DELETE_REQ:
+        req = new HttpDelete(endpoint);
+        break;
+      default:
+        throw new UnsupportedOperationException("Request Method Unsupported!");
+    }
+
+    CloseableHttpResponse response = httpClient.execute(req);
+
+    int statusCode = response.getStatusLine().getStatusCode();
+    BufferedReader rd =
+        new BufferedReader(new InputStreamReader(response.getEntity().getContent()));
+
+    StringBuffer result = new StringBuffer();
+    String line = "";
+    while ((line = rd.readLine()) != null) {
+      result.append(line);
+    }
+
+    return new ImmutableMap.Builder<String, Object>()
+        .put("response", result)
+        .put("status", statusCode)
+        .build();
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
@@ -24,7 +24,7 @@
  const templatePromise = $.ajax({
     type: 'GET',
     context: this,
-    url: '/search/catalog/internal/forms/query',
+    url: '/search/catalog/internal/forms/query-template/shared',
     contentType: 'application/json',
     success: function (data) {
         sharedTemplates = data;
@@ -52,47 +52,23 @@
        templatePromise.then(() => {
             if (!this.isDestroyed){
                 $.each(sharedTemplates, (index, value) => {
-                    if (this.checkIfShareable(value)) {
-                        let utcSeconds = value.created / 1000;
-                        let d = new Date(0);
-                        d.setUTCSeconds(utcSeconds);
-                        this.addSearchForm(new SearchForm({
-                            createdOn: Common.getHumanReadableDate(d),
-                            id: value.id,
-                            name: value.title,
-                            type: 'custom',
-                            filterTemplate: value.filterTemplate,
-                            accessIndividuals: value.accessIndividuals,
-                            accessGroups: value.accessGroups,
-                            createdBy: value.creator
-                        }));
-                    }
+                    let utcSeconds = value.created / 1000;
+                    let d = new Date(0);
+                    d.setUTCSeconds(utcSeconds);
+                    this.addSearchForm(new SearchForm({
+                        createdOn: Common.getHumanReadableDate(d),
+                        id: value.id,
+                        name: value.title,
+                        type: 'custom',
+                        filterTemplate: value.filterTemplate,
+                        accessIndividuals: value.accessIndividuals,
+                        accessGroups: value.accessGroups,
+                        createdBy: value.creator
+                    }));
                 });
                 this.doneLoading();
             }
        });
-   },
-   checkIfShareable: function(template) {
-       if (this.checkIfInGroup(template) || this.checkIfInIndividiuals(template)) {
-           return true;
-       }
-       return false;
-   },
-   checkIfInGroup: function(template) {
-       let myGroups = user.get('user').get('roles');
-       let roleIntersection = myGroups.filter(function(n) {
-        return template.accessGroups.indexOf(n) !== -1;
-       });
-
-       return !_.isEmpty(roleIntersection);
-   },
-   checkIfInIndividiuals: function(template) {
-       let myEmail = [user.get('user').get('email')];
-       let accessIndividualIntersection = myEmail.filter(function(n) {
-        return template.accessIndividuals.indexOf(n) !== -1;
-       });
-
-       return !_.isEmpty(accessIndividualIntersection);
    },
     addSearchForm: function(searchForm) {
         this.get('sharedSearchForms').add(searchForm);

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
@@ -73,7 +73,6 @@ module.exports = Backbone.AssociatedModel.extend({
         templatePromise.then(() => {
             if (!this.isDestroyed) {
                 $.each(systemTemplates, (index, value) => {
-                    if (this.checkIfOwnerOrSystem(value)) {
                         var utcSeconds = value.created / 1000;
                         var d = new Date(0);
                         d.setUTCSeconds(utcSeconds);
@@ -87,7 +86,6 @@ module.exports = Backbone.AssociatedModel.extend({
                             accessGroups: value.accessGroups,
                             createdBy: value.creator
                         }));
-                    }
                 });
                 this.doneLoading();
             }
@@ -101,11 +99,6 @@ module.exports = Backbone.AssociatedModel.extend({
     },
     getDoneLoading: function() {
         return this.get('doneLoading');
-    },
-    checkIfOwnerOrSystem: function(template) {
-        let myEmail = user.get('user').get('email');
-        let templateCreator = template.creator;
-        return myEmail === templateCreator || templateCreator === "System Template";
     },
     doneLoading: function() {
         this.set('doneLoading', true);


### PR DESCRIPTION
#### What does this PR do?
Previously, there was really odd filtering going on in the UI for query results hitting the `SearchFormsApplication` for result-set templates and search form templates. 

This PR attempts to remove _all_ the UI filtering to keep it strictly on the backend. This PR also adds a layer of testing for the Spark App that runs templates. All queries to the standard template endpoints will only retrieve user owned templates by requested subject and system templates. 

#### Things Left:
- Finish writing more unit tests for the _sharing filtering logic_
- Add system template support

#### Who is reviewing it? 
@bdeining 
@Lambeaux
@middlets719 
@adimka 
@Bdthomson 
@stustison 
@andrewkfiedler 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@stustison
#### How should this be tested? (List steps with links to updated documentation)

- Ensure that templates shared with you -> shared tab
- Templates you created/system templates _ONLY_ show up my Search Forms

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3809](https://codice.atlassian.net/browse/DDF-3809)
#### Checklist:
- [ ] Documentation Updated
- [ x ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
