### PR TITLE
DDF-3820 Moved PDF generation to the release profile

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -56,6 +56,68 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>attach-omnibus</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/docs/pdf/documentation.pdf</file>
+                                            <type>pdf</type>
+                                            <classifier>Documentation</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <version>${asciidoctor.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>generate-pdf-doc</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <backend>pdf</backend>
+                                    <outputDirectory>${project.build.directory}/docs/pdf
+                                    </outputDirectory>
+                                    <!-- WARNING callout bullets don't yet work with CodeRay -->
+                                    <attributes>
+                                        <pagenums/>
+                                        <toc/>
+                                        <idprefix>_</idprefix>
+                                        <idseparator>_</idseparator>
+                                    </attributes>
+                                    <imagesDir>${project.build.directory}/images</imagesDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <build>
         <plugins>
             <!-- Disable vulnerability checks since this project only contains documentation -->
@@ -263,26 +325,6 @@
                             </attributes>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>generate-pdf-doc</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>process-asciidoc</goal>
-                        </goals>
-                        <configuration>
-                            <backend>pdf</backend>
-                            <outputDirectory>${project.build.directory}/docs/pdf
-                            </outputDirectory>
-                            <!-- WARNING callout bullets don't yet work with CodeRay -->
-                            <attributes>
-                                <pagenums/>
-                                <toc/>
-                                <idprefix>_</idprefix>
-                                <idseparator>_</idseparator>
-                            </attributes>
-                            <imagesDir>${project.build.directory}/images</imagesDir>
-                        </configuration>
-                    </execution>
                 </executions>
                 <configuration>
                     <sourceDirectory>${project.build.directory}/asciidoctor-ready
@@ -362,11 +404,6 @@
                                 <artifact>
                                     <file>${project.build.directory}/docs/html/documentation.html</file>
                                     <type>html</type>
-                                    <classifier>Documentation</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.directory}/docs/pdf/documentation.pdf</file>
-                                    <type>pdf</type>
                                     <classifier>Documentation</classifier>
                                 </artifact>
                             </artifacts>


### PR DESCRIPTION
#### What does this PR do?
Ensure that PDF generation only occurs when using the release profile. HTML docs will still be generated when building the docs module. 

#### Who is reviewing it? 
@ahoffer @austinsteffes @sblackmore 

#### Select relevant component teams: 
@codice/docs 

#### Choose 2 committers to review/merge the PR. 
@clockard @ricklarsen @rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
`mvn clean install` in \distribution\docs to confirm HTML docs are still generated
`mvn clean install -P release` in \distribution\docs to confirm both HTML and PDF docs are generated 

#### Any background context you want to provide?
This change reduced the standard build of the docs module by 3.5 minutes on my machine.

#### What are the relevant tickets?
[DDF-3820](https://codice.atlassian.net/browse/DDF-3820)
#### Screenshots (if appropriate)
![buildsuccess](https://user-images.githubusercontent.com/11355332/39712121-bdbe44b4-51d6-11e8-89eb-2761513c0c57.PNG)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
