### PR TITLE
DDF-3825 GeoCoder preingest plugin country code derivation

### DIFF
--- a/catalog/spatial/geocoding/spatial-geocoding-api/src/main/java/org/codice/ddf/spatial/geocoding/GeoEntryQueryable.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-api/src/main/java/org/codice/ddf/spatial/geocoding/GeoEntryQueryable.java
@@ -71,7 +71,7 @@ public interface GeoEntryQueryable {
    *
    * @param wktLocation A WKT location
    * @param radius the radius in kilometers to search from the given {@code wktLocation}
-   * @return a country code in ISO 3166-1 alpha-2 format or null if not found (for example, a
+   * @return a country code in ISO 3166-1 alpha-3 format or null if not found (for example, a
    *     location in the ocean)
    */
   Optional<String> getCountryCode(String wktLocation, int radius)

--- a/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/main/java/org/codice/ddf/spatial/geocoder/GazetteerGeoCoder.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/main/java/org/codice/ddf/spatial/geocoder/GazetteerGeoCoder.java
@@ -73,17 +73,12 @@ public class GazetteerGeoCoder implements GeoCoder {
   @Override
   public Optional<String> getCountryCode(String locationWKT, int radius) {
     try {
-      Optional<String> alpha3CountryCode = geoEntryQueryable.getCountryCode(locationWKT, radius);
-
-      if (alpha3CountryCode.isPresent()) {
-        return alpha3CountryCode;
-      }
+      return geoEntryQueryable.getCountryCode(locationWKT, radius);
     } catch (GeoEntryQueryException e) {
       LOGGER.debug("Error querying GeoNames", e);
     } catch (ParseException e) {
       LOGGER.debug("Error parsing WKT: {} ", locationWKT, e);
     }
-
     return Optional.empty();
   }
 }

--- a/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/main/java/org/codice/ddf/spatial/geocoder/GazetteerGeoCoder.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/main/java/org/codice/ddf/spatial/geocoder/GazetteerGeoCoder.java
@@ -15,8 +15,6 @@ package org.codice.ddf.spatial.geocoder;
 
 import java.text.ParseException;
 import java.util.List;
-import java.util.Locale;
-import java.util.MissingResourceException;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.codice.ddf.spatial.geocoding.GeoEntry;
@@ -75,19 +73,10 @@ public class GazetteerGeoCoder implements GeoCoder {
   @Override
   public Optional<String> getCountryCode(String locationWKT, int radius) {
     try {
-      Optional<String> alpha2CountryCode = geoEntryQueryable.getCountryCode(locationWKT, radius);
+      Optional<String> alpha3CountryCode = geoEntryQueryable.getCountryCode(locationWKT, radius);
 
-      if (alpha2CountryCode.isPresent()) {
-        try {
-          String alpha3CountryCode =
-              new Locale(Locale.ENGLISH.getLanguage(), alpha2CountryCode.get()).getISO3Country();
-          return Optional.of(alpha3CountryCode);
-        } catch (MissingResourceException e) {
-          LOGGER.debug(
-              "Failed to convert country code {} to alpha-3 format. Returning empty value",
-              alpha2CountryCode.get(),
-              e);
-        }
+      if (alpha3CountryCode.isPresent()) {
+        return alpha3CountryCode;
       }
     } catch (GeoEntryQueryException e) {
       LOGGER.debug("Error querying GeoNames", e);

--- a/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/test/java/org/codice/ddf/spatial/geocoder/GazetteerGeoCoderTest.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/test/java/org/codice/ddf/spatial/geocoder/GazetteerGeoCoderTest.java
@@ -147,7 +147,7 @@ public class GazetteerGeoCoderTest {
 
   @Test
   public void testGetCountryCode() throws ParseException, GeoEntryQueryException {
-    when(geoEntryQueryable.getCountryCode(TEST_POINT, 50)).thenReturn(Optional.of("US"));
+    when(geoEntryQueryable.getCountryCode(TEST_POINT, 50)).thenReturn(Optional.of("USA"));
 
     countryCode = gazetteerGeoCoder.getCountryCode(TEST_POINT, 50);
 
@@ -182,8 +182,7 @@ public class GazetteerGeoCoderTest {
 
   @Test
   public void testGetCountryCodeInvalidCountryCode() throws ParseException, GeoEntryQueryException {
-    when(geoEntryQueryable.getCountryCode(TEST_POINT, 50))
-        .thenReturn(Optional.of("not a country code"));
+    when(geoEntryQueryable.getCountryCode(TEST_POINT, 50)).thenReturn(Optional.empty());
 
     countryCode = gazetteerGeoCoder.getCountryCode(TEST_POINT, 50);
 

--- a/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/test/java/org/codice/ddf/spatial/geocoder/GazetteerGeoCoderTest.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-geocoder/src/test/java/org/codice/ddf/spatial/geocoder/GazetteerGeoCoderTest.java
@@ -179,13 +179,4 @@ public class GazetteerGeoCoderTest {
     countryCode = gazetteerGeoCoder.getCountryCode(TEST_POINT, 50);
     assertThat(countryCode.isPresent(), is(false));
   }
-
-  @Test
-  public void testGetCountryCodeInvalidCountryCode() throws ParseException, GeoEntryQueryException {
-    when(geoEntryQueryable.getCountryCode(TEST_POINT, 50)).thenReturn(Optional.empty());
-
-    countryCode = gazetteerGeoCoder.getCountryCode(TEST_POINT, 50);
-
-    assertThat(countryCode.isPresent(), is(false));
-  }
 }


### PR DESCRIPTION
#### What does this PR do?
GeoEntryQueryable getCountryCode javadoc update to match functionality of returning iso3 country code
Update usage in GazetteerGeoCoder getCountryCode method to return ISO3 without attempting convert

#### Who is reviewing it? 
@millerw8 
@bdeining 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@jlcsmith
@millerw8
@ricklarsen - Documentation

#### How should this be tested? (List steps with links to updated documentation)
Upload any geotagged image or one provided below
![holiday-inn](https://user-images.githubusercontent.com/1500423/39936688-41a514aa-551b-11e8-834d-ee1bab4cbc87.jpg)
Query for the image, use inspector view to verify location.country-code is populated with the correct iso3 character country code (USA for the image provided)

#### Any background context you want to provide?


#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
