### PR TITLE
DDF-3808 Appending queryId to the action provided urls

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/MetacardAction.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/MetacardAction.js
@@ -12,8 +12,8 @@
 var Backbone = require('backbone');
 require('backbone-associations');
 const URITemplate = require('urijs/src/URITemplate');
-const ENCODED_QUERY_ID_TEMPLATE = '%7B%26queryId%7D';
 const DECODED_QUERY_ID_TEMPLATE = '{&queryId}';
+const ENCODED_QUERY_ID_TEMPLATE = encodeURIComponent(DECODED_QUERY_ID_TEMPLATE);
 
 module.exports = Backbone.AssociatedModel.extend({
     defaults: function() {
@@ -44,9 +44,11 @@ module.exports = Backbone.AssociatedModel.extend({
             // So that's why the string replace "decoding" is currently being done
             const url = this.get('url');
             const replacedUrl = url.replace(ENCODED_QUERY_ID_TEMPLATE, DECODED_QUERY_ID_TEMPLATE);
-            const expandedUrl = URITemplate(replacedUrl).expand({
+            const replacedUrlTemplate = new URITemplate(replacedUrl);
+            const expandedUrl = replacedUrlTemplate.expand({
                 queryId: this.get('queryId')
             });
+
             this.set('url', expandedUrl);
         }
     }


### PR DESCRIPTION
Removing the call to decode the url
Changing it to do a string replace 'decoding' of the {&queryId} template

#### What does this PR do?
This PR undoes the url decode of the urls returned by action providers.

#### Who is reviewing it? 
@BernardIgiri @dcruver @GabrielFabian @mojogitoverhere @AzGoalie @rymach @djblue @andrewkfiedler 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui
#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@jlcsmith
@pklinef 
#### How should this be tested? (List steps with links to updated documentation)
Using Intrigue, perform a search
Open Inspector for a selected result
Select Actions
Hover cursor over metacard actions or Right click -> Copy link address
Verify there is a query param for query id only for actions with the queryId parameter
Verify that the Overlay On the Map action does that (if applicable)

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
