### PR TITLE
DDF-3833 Prevent NPE when parseContent returns null; add Nullable ann…

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -598,6 +598,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     return results;
   }
 
+  @Nullable
   private Metacard parseContent(String content, String id) throws UnsupportedQueryException {
     if (StringUtils.isNotEmpty(content)) {
       InputTransformer inputTransformer =
@@ -699,6 +700,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
         "Unable to find applicable InputTransformer for metacard content from Atom feed.");
   }
 
+  @Nullable
   protected InputTransformer lookupTransformerReference(String namespaceUri)
       throws InvalidSyntaxException {
     LOGGER.trace("Looking up Input Transformer by schema : {}", namespaceUri);
@@ -967,7 +969,9 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     if (CollectionUtils.isNotEmpty(markUpSet) && markUpSet.contains(element.getName())) {
       XMLOutputter xmlOutputter = new XMLOutputter();
       Metacard metacard = parseContent(xmlOutputter.outputString(element), id);
-      metacards.add(metacard);
+      if (metacard != null) {
+        metacards.add(metacard);
+      }
     }
     return metacards;
   }

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchSourceTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchSourceTest.java
@@ -776,6 +776,22 @@ public class OpenSearchSourceTest {
     assertThat(foreignMarkupConsumer.getTotalResults(), is(1L));
   }
 
+  @Test
+  public void testForeignMarkupWithBadTransformer()
+      throws UnsupportedQueryException, IOException, CatalogTransformerException,
+          InvalidSyntaxException {
+
+    InputTransformer inputTransformer = mock(InputTransformer.class);
+    when(inputTransformer.transform(isA(InputStream.class)))
+        .thenThrow(new CatalogTransformerException());
+    when(inputTransformer.transform(isA(InputStream.class), isA(String.class)))
+        .thenThrow(new CatalogTransformerException());
+
+    source.setBundle(getMockBundleContext(inputTransformer));
+
+    testForeignMarkupExample();
+  }
+
   /** Test to make sure the foreign markup consumer is called as expected. */
   @Test
   public void testForeignMarkupConsumer() throws UnsupportedQueryException {


### PR DESCRIPTION
…otation to methods for clarity

#### What does this PR do?
Adds a null check to OpenSearchSource.java
#### Who is reviewing it? 
@gordocanchola 
@AzGoalie 
@GabrielFabian 
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@jlcsmith
@millerw8
#### How should this be tested? (List steps with links to updated documentation)
Run the new unit test
#### What are the relevant tickets?
[DDF-3833](https://codice.atlassian.net/browse/DDF-3833)
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
