### PR TITLE
[2.11.x] DDF-3831 Removes all key bindings from catalog search ui date time picker

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
+++ b/catalog/ui/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
@@ -51,7 +51,8 @@ define([
         initializeDatepicker: function(){
             this.$el.find('.input-group.date').datetimepicker({
                 format: getDateFormat(),
-                widgetParent: 'body'
+                widgetParent: 'body',
+                keyBinds: null
             });
         },
         handleReadOnly: function () {


### PR DESCRIPTION
[2.11.x] DDF-3831 Removes all key bindings from catalog search ui date time picker
#### What does this PR do?
Key bindings in Catalog Search UI date picker were causing issues with users, especially those who prefer to manually edit/input dates and times. For example, arrow keys could only be used to navigate the calendar, not the input field and pressing the ENTER or ESC key will hide the date picker but disable all key bindings in the process even upon the re-rendering of the date picker. 

The solution is to remove [all key bindings](https://eonasdan.github.io/bootstrap-datetimepicker/Options/#keybinds). Users would no longer be able to interact with the date picker calendar via keyboard but be able to manually edit/input dates and times. 

#### Who is reviewing it? 
@emanns95 @vinamartin  
#### Choose 2 committers to review/merge the PR. 
@tbatie @brendan-hofmann 
#### How should this be tested?
Check that the default key bindings no longer work and that the arrow keys can be used to navigate the input field.

#### What are the relevant tickets?
[DDF-3831](https://codice.atlassian.net/browse/DDF-3831)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
