### PR TITLE
DDF-3660 [2.11.x] Fix cached WebDav files being left behind

### DIFF
--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/inputtransformer/InputTransformerProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/inputtransformer/InputTransformerProducer.java
@@ -61,6 +61,7 @@ public class InputTransformerProducer extends TransformerProducer {
     super(endpoint);
   }
 
+  @SuppressWarnings("squid:S2095" /* The TFBOS is in a try-with-resources and will be closed */)
   protected Object transform(
       Message in, String mimeType, String transformerId, MimeTypeToTransformerMapper mapper)
       throws MimeTypeParseException, CatalogTransformerException {
@@ -185,7 +186,8 @@ public class InputTransformerProducer extends TransformerProducer {
       return ((CatalogEndpoint) getEndpoint()).getMimeTypeMapper().guessMimeType(is, fileExtension);
     } catch (MimeTypeResolutionException e) {
       LOGGER.debug(
-          "Failed to get mimeType for file extension [{}] received from exchange headers.");
+          "Failed to get mimeType for file extension [{}] received from exchange headers.",
+          fileExtension);
       return null;
     }
   }
@@ -194,7 +196,9 @@ public class InputTransformerProducer extends TransformerProducer {
     String value = message.getHeader(key, String.class);
     if (value != null) {
       LOGGER.trace(
-          "Retrieved and removed header [{}] from exchange message [{}]", message.getMessageId());
+          "Retrieved and removed header [{}] from exchange message [{}]",
+          key,
+          message.getMessageId());
       message.removeHeader(key);
       return value;
     }

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/FileDeletionSynchonization.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/FileDeletionSynchonization.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.content.monitor.synchronizations;
+
+import java.io.File;
+import org.apache.camel.Exchange;
+import org.apache.camel.spi.Synchronization;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileDeletionSynchonization implements Synchronization {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileDeletionSynchonization.class);
+
+  private final File file;
+
+  public FileDeletionSynchonization(final File file) {
+    this.file = file;
+  }
+
+  @Override
+  public void onComplete(Exchange exchange) {
+    FileUtils.deleteQuietly(file);
+  }
+
+  @Override
+  public void onFailure(Exchange exchange) {
+    LOGGER.debug(
+        "Error while processing exchange [{}]. File [{}] won't be deleted by this synchronization.",
+        exchange.getExchangeId(),
+        file.toPath());
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
For WebDav CDM, deletes the cached WebDav file after creates or updates.
Also resolves blocker Sonar findings from the original PR.

#### Who is reviewing it? 
@roelens8 @emmberk @brendan-hofmann 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
@clockard
@lessarderic 

#### How should this be tested? (List steps with links to updated documentation)
- Setup a CDM to monitor a WebDav server.
- Drop files on the WebDav server for ingest.
- Verify no `dav*` files are in `<INSTALL_DIR>/data/tmp`
- Update the ingested file
- Verify no `dav*` files again.

#### Any background context you want to provide?
An oversight in the original PR.

#### What are the relevant tickets?
[DDF-3660](https://codice.atlassian.net/browse/DDF-3660)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
