### PR TITLE
DDF-3836 OpenSearch source to support Geometry search criteria.

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
@@ -47,8 +47,6 @@ public class OpenSearchParserImpl implements OpenSearchParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchParserImpl.class);
 
-  private static final WKTWriter WKT_WRITER = new WKTWriter();
-
   @VisibleForTesting static final String USER_DN = "dn";
 
   @VisibleForTesting static final String FILTER = "filter";
@@ -161,7 +159,7 @@ public class OpenSearchParserImpl implements OpenSearchParser {
     }
 
     if (geometry != null) {
-      checkAndReplace(client, WKT_WRITER.write(geometry), OpenSearchConstants.GEOMETRY, parameters);
+      checkAndReplace(client, new WKTWriter().write(geometry), OpenSearchConstants.GEOMETRY, parameters);
     } else if (boundingBox != null) {
       checkAndReplace(
           client,

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
@@ -47,6 +47,9 @@ public class OpenSearchParserImpl implements OpenSearchParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchParserImpl.class);
 
+  private static final ThreadLocal<WKTWriter> WKT_WRITER_THREAD_LOCAL =
+      ThreadLocal.withInitial(WKTWriter::new);
+
   @VisibleForTesting static final String USER_DN = "dn";
 
   @VisibleForTesting static final String FILTER = "filter";
@@ -159,7 +162,11 @@ public class OpenSearchParserImpl implements OpenSearchParser {
     }
 
     if (geometry != null) {
-      checkAndReplace(client, new WKTWriter().write(geometry), OpenSearchConstants.GEOMETRY, parameters);
+      checkAndReplace(
+          client,
+          WKT_WRITER_THREAD_LOCAL.get().write(geometry),
+          OpenSearchConstants.GEOMETRY,
+          parameters);
     } else if (boundingBox != null) {
       checkAndReplace(
           client,

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
@@ -16,6 +16,7 @@ package org.codice.ddf.opensearch.source;
 import com.google.common.annotations.VisibleForTesting;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.io.WKTWriter;
 import ddf.catalog.data.Result;
 import ddf.catalog.impl.filter.TemporalFilter;
 import ddf.catalog.operation.Query;
@@ -45,6 +46,8 @@ import org.slf4j.LoggerFactory;
 public class OpenSearchParserImpl implements OpenSearchParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchParserImpl.class);
+
+  private static final WKTWriter WKT_WRITER = new WKTWriter();
 
   @VisibleForTesting static final String USER_DN = "dn";
 
@@ -158,10 +161,7 @@ public class OpenSearchParserImpl implements OpenSearchParser {
     }
 
     if (geometry != null) {
-      throw new IllegalArgumentException(
-          "Setting the "
-              + OpenSearchConstants.GEOMETRY
-              + " query parameter is currently not supported by the OpenSearchSource");
+      checkAndReplace(client, WKT_WRITER.write(geometry), OpenSearchConstants.GEOMETRY, parameters);
     } else if (boundingBox != null) {
       checkAndReplace(
           client,

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchParserImplTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchParserImplTest.java
@@ -58,8 +58,6 @@ public class OpenSearchParserImplTest {
 
   private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
 
-  private static final WKTReader WKT_READER = new WKTReader();
-
   private static final String MAX_RESULTS = "2000";
 
   private static final String TIMEOUT = "30000";
@@ -388,7 +386,7 @@ public class OpenSearchParserImplTest {
   @Test
   public void populateSpatialGeometry() throws ParseException {
 
-    Geometry geometry = WKT_READER.read(WKT_GEOMETRY);
+    Geometry geometry = new WKTReader().read(WKT_GEOMETRY);
     openSearchParser.populateSpatial(
         webClient,
         geometry,

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchParserImplTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchParserImplTest.java
@@ -26,6 +26,8 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
 import ddf.catalog.data.Result;
 import ddf.catalog.filter.impl.SortByImpl;
 import ddf.catalog.impl.filter.TemporalFilter;
@@ -56,11 +58,16 @@ public class OpenSearchParserImplTest {
 
   private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
 
+  private static final WKTReader WKT_READER = new WKTReader();
+
   private static final String MAX_RESULTS = "2000";
 
   private static final String TIMEOUT = "30000";
 
   private static final String DESCENDING_TEMPORAL_SORT = "date:desc";
+
+  private static final String WKT_GEOMETRY =
+      "GEOMETRYCOLLECTION (POINT (-105.2071712 40.0160994), LINESTRING (4 6, 7 10))";
 
   private OpenSearchParser openSearchParser;
 
@@ -378,17 +385,21 @@ public class OpenSearchParserImplTest {
 
   // {@link OpenSearchParser#populateSpatial(WebClient, SpatialSearch, List)} tests
 
-  @Test(expected = IllegalArgumentException.class)
-  public void populateSpatialGeometry() {
+  @Test
+  public void populateSpatialGeometry() throws ParseException {
+
+    Geometry geometry = WKT_READER.read(WKT_GEOMETRY);
     openSearchParser.populateSpatial(
         webClient,
-        mock(Geometry.class),
+        geometry,
         null,
         null,
         null,
         Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
+            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,geometry,polygon,dtstart,dtend,dateName,filter,sort"
                 .split(",")));
+
+    assertQueryParameterPopulated(OpenSearchConstants.GEOMETRY, WKT_GEOMETRY);
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
When Geometry object is encountered. Construct a WKT geometry parameters for web client.

#### Who is reviewing it? 
@millerw8 
@bdeining 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@bdeining
@jlcsmith
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Ingest any record with a geolocation information
Using curl or postman to query using geometry search argument based on Open Search extension Geo Draft 2.0
http://www.opensearch.org/Specifications/OpenSearch/Extensions/Geo/1.0/Draft_2#The_.22geometry.22_parameter

Example:
https://localhost:8993/services/catalog/query?q=*&geometry=POLYGON((15%2011%2C15%2045%2C-20%2038%2C-15%20-20%2C15%2011))


#### Any background context you want to provide?

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
