### PR TITLE
DDF-3843 Added queryType to CqlRequests

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
@@ -61,6 +61,8 @@ public class CqlRequest {
 
   private String cql;
 
+  private String queryType;
+
   private List<Sort> sorts = Collections.emptyList();
 
   private boolean normalize = false;
@@ -69,6 +71,14 @@ public class CqlRequest {
 
   public String getSrc() {
     return src;
+  }
+
+  public void setQueryType(String queryType) {
+    this.queryType = queryType;
+  }
+
+  public String getQueryType() {
+    return queryType;
   }
 
   public void setSrc(String src) {
@@ -160,6 +170,10 @@ public class CqlRequest {
       queryRequest
           .getProperties()
           .put(ADDITIONAL_SORT_BYS, sortBys.subList(1, sortBys.size()).toArray(new SortBy[0]));
+    }
+
+    if (StringUtils.isNotEmpty(queryType)) {
+      queryRequest.getProperties().put("queryType", queryType);
     }
 
     return queryRequest;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
@@ -154,7 +154,7 @@ public class CqlRequest {
     QueryRequest queryRequest;
     if (CACHE_SOURCE.equals(source)) {
       queryRequest = new QueryRequestImpl(query, true);
-      queryRequest.getProperties().put("mode", "cache");
+      queryRequest.getProperties().put("mode", CACHE_SOURCE);
     } else {
       queryRequest = new QueryRequestImpl(query, Collections.singleton(source));
       queryRequest.getProperties().put("mode", "update");


### PR DESCRIPTION
#### What does this PR do?
This PR adds the notion of a QueryType to eventually be used to distinguish between Ad Hoc, Standing and Scheduled queries within the system.  This is added to the QueryRequest properties map.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@mackncheesiest @middlets719 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@rzwiefel
@jlcsmith 
#### How should this be tested? (List steps with links to updated documentation)
Full Build / This property is not used anywhere currently
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3843](https://codice.atlassian.net/browse/DDF-3843)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
