### PR TITLE
DDF-3696 IdP logout does 303 redirect instead of manual javascript redirect

### DIFF
--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -1449,7 +1449,9 @@ public class IdpEndpoint implements Idp, SessionHandler {
     }
     UriBuilder uriBuilder = UriBuilder.fromUri(targetUrl);
     uriBuilder.queryParam(samlType.getKey(), encodedResponse);
-    uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState == null ? "" : relayState);
+    if (relayState != null) {
+      uriBuilder.queryParam(SSOConstants.RELAY_STATE, relayState);
+    }
     new SimpleSign(systemCrypto).signUriString(requestToSign.toString(), uriBuilder);
     LOGGER.debug("Signing successful.");
     return Response.temporaryRedirect(uriBuilder.build()).status(303).build();

--- a/platform/security/idp/security-idp-server/src/test/groovy/org/codice/ddf/security/idp/server/IdpEndpointSpec.groovy
+++ b/platform/security/idp/security-idp-server/src/test/groovy/org/codice/ddf/security/idp/server/IdpEndpointSpec.groovy
@@ -239,6 +239,8 @@ class IdpEndpointSpec extends Specification {
 
         then:
         notThrown(Exception)
+        response.status == 303
+        (response.location as String).contains(targetSp)
     }
 
     def "process redirect logout initial with one other sp partial logout"() {


### PR DESCRIPTION
#### What does this PR do?
Fixes a SAML compliance issue where DDF is manually redirecting using javascript code instead of responding with an HTTP status code of 303 and putting the URL in the Location header.

From the SAML Bindings document:
>The SAML response is returned in the same fashion as described for the SAML request in step 2.

and
>The SAML request is returned encoded into the HTTP response's Location header, and the HTTP status MUST be either 303 or 302.

Note: 303 was chosen over 302 based on the definition for 303 according to the HTTP spec. See https://github.com/codice/ddf/pull/3084#issuecomment-377244473.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@blen-desta @bakejeyner 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
- Verify that logout still works as expected.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3696](https://codice.atlassian.net/browse/DDF-3696)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
