### PR TITLE
DDF-3844 Fixes Product overwrite versioning bug

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -233,7 +233,15 @@ public class Historian {
     }
 
     Map<String, Metacard> originalMetacards =
-        query(forIds(updatedMetacards.stream().map(Metacard::getId).collect(Collectors.toList())));
+        updateResponse
+            .getUpdatedMetacards()
+            .stream()
+            .map(Update::getOldMetacard)
+            .collect(
+                Collectors.toMap(
+                    Metacard::getId,
+                    Function.identity(),
+                    (oldMetacard, newMetacard) -> oldMetacard));
 
     if (LOGGER.isTraceEnabled()) {
       LOGGER.trace(
@@ -464,15 +472,6 @@ public class Historian {
         .map(Result::getMetacard)
         .filter(Objects::nonNull)
         .collect(Collectors.toMap(Metacard::getId, Function.identity()));
-  }
-
-  private Filter forIds(List<String> ids) {
-    List<Filter> idFilters =
-        ids.stream()
-            .map(id -> filterBuilder.attribute(Metacard.ID).is().equalTo().text(id))
-            .collect(Collectors.toList());
-
-    return filterBuilder.anyOf(idFilters);
   }
 
   /*

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -31,6 +31,7 @@ import ddf.catalog.content.operation.impl.ReadStorageRequestImpl;
 import ddf.catalog.core.versioning.MetacardVersion.Action;
 import ddf.catalog.core.versioning.impl.DeletedMetacardImpl;
 import ddf.catalog.core.versioning.impl.MetacardVersionImpl;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.Result;
@@ -239,9 +240,7 @@ public class Historian {
             .map(Update::getOldMetacard)
             .collect(
                 Collectors.toMap(
-                    Metacard::getId,
-                    Function.identity(),
-                    (oldMetacard, newMetacard) -> oldMetacard));
+                    Metacard::getId, Function.identity(), Historian::firstInWinsMerge));
 
     if (LOGGER.isTraceEnabled()) {
       LOGGER.trace(
@@ -325,7 +324,11 @@ public class Historian {
 
     // [OriginalMetacardId: Original Metacard]
     Map<String, Metacard> originalMetacardsMap =
-        originalMetacards.stream().collect(Collectors.toMap(Metacard::getId, Function.identity()));
+        originalMetacards
+            .stream()
+            .collect(
+                Collectors.toMap(
+                    Metacard::getId, Function.identity(), Historian::firstInWinsMerge));
 
     // [ContentItem.getId: content items]
     Map<String, List<ContentItem>> contentItems =
@@ -471,7 +474,8 @@ public class Historian {
         .stream()
         .map(Result::getMetacard)
         .filter(Objects::nonNull)
-        .collect(Collectors.toMap(Metacard::getId, Function.identity()));
+        .collect(
+            Collectors.toMap(Metacard::getId, Function.identity(), Historian::firstInWinsMerge));
   }
 
   /*
@@ -605,7 +609,11 @@ public class Historian {
                     metacard,
                     action.apply(metacard.getId()),
                     subject))
-        .collect(Collectors.toMap(MetacardVersionImpl::getVersionOfId, Function.identity()));
+        .collect(
+            Collectors.toMap(
+                MetacardVersionImpl::getVersionOfId,
+                Function.identity(),
+                Historian::firstInWinsMerge));
   }
 
   /**
@@ -692,6 +700,48 @@ public class Historian {
 
   private static String getList(Collection<String> set) {
     return set.stream().collect(TO_A_STRING);
+  }
+
+  private static Metacard firstInWinsMerge(Metacard oldMetacard, Metacard newMetacard) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(
+          "While merging results into a map, there was a duplicate (conflict) of metacards with the same id ({}). For full metacard set logging to trace `log:set TRACE ddf.catalog.history`.",
+          oldMetacard.getId());
+    }
+
+    if (LOGGER.isTraceEnabled()) {
+      // TODO (DDF-3845) - This should be removed when we have a logging utility library.
+      Function<Metacard, String> metacardToString =
+          (metacard) ->
+              metacard
+                  .getMetacardType()
+                  .getAttributeDescriptors()
+                  .stream()
+                  .map(AttributeDescriptor::getName)
+                  .map(oldMetacard::getAttribute)
+                  .filter(Objects::nonNull)
+                  .map(
+                      (attribute) ->
+                          new StringBuilder()
+                              .append(attribute.getName())
+                              .append("=")
+                              .append(
+                                  attribute.getValues() == null
+                                      ? "null"
+                                      : attribute
+                                          .getValues()
+                                          .stream()
+                                          .map(Object::toString)
+                                          .collect(Collectors.joining(", ", "{", "}"))))
+                  .collect(Collectors.joining(", ", "{", "}"));
+      LOGGER.trace(
+          "Old Metacard: {}\nNew Metacard: {}",
+          metacardToString.apply(oldMetacard),
+          metacardToString.apply(newMetacard));
+    }
+
+    // return metacard already there (the first one or "old" metacard)
+    return oldMetacard;
   }
 
   public void setMetacardTypes(List<MetacardType> metacardTypes) {

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/history/HistorianTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import ddf.catalog.content.StorageException;
 import ddf.catalog.content.StorageProvider;
 import ddf.catalog.content.data.ContentItem;
@@ -202,6 +203,9 @@ public class HistorianTest {
     when(storageResponse.getProperties()).thenReturn(storageResponseProperties);
 
     UpdateResponse updateResponse = mock(UpdateResponse.class);
+    Update update1 = mock(Update.class);
+    when(update1.getOldMetacard()).thenReturn(metacards.get(0));
+    when(updateResponse.getUpdatedMetacards()).thenReturn(ImmutableList.of(update1));
 
     storeMetacard(metacards.get(0));
 
@@ -241,6 +245,9 @@ public class HistorianTest {
     UpdateStorageRequest storageRequest = mock(UpdateStorageRequest.class);
     UpdateStorageResponse storageResponse = mock(UpdateStorageResponse.class);
     UpdateResponse updateResponse = mock(UpdateResponse.class);
+    Update update1 = mock(Update.class);
+    when(update1.getOldMetacard()).thenReturn(metacards.get(0));
+    when(updateResponse.getUpdatedMetacards()).thenReturn(ImmutableList.of(update1));
 
     storeMetacard(metacards.get(0));
 
@@ -450,6 +457,10 @@ public class HistorianTest {
     UpdateStorageResponse storageResponse = mock(UpdateStorageResponse.class);
     UpdateResponse updateResponse = mock(UpdateResponse.class);
 
+    Update update1 = mock(Update.class);
+    when(update1.getOldMetacard()).thenReturn(metacards.get(0));
+    when(updateResponse.getUpdatedMetacards()).thenReturn(ImmutableList.of(update1));
+
     // send a request to update the metacard
     updateMetacard(storageRequest, storageResponse, metacards.get(1));
 
@@ -487,6 +498,10 @@ public class HistorianTest {
     UpdateStorageResponse storageResponse = mock(UpdateStorageResponse.class);
     UpdateResponse updateResponse = mock(UpdateResponse.class);
 
+    Update update1 = mock(Update.class);
+    when(update1.getOldMetacard()).thenReturn(metacards.get(0));
+    when(updateResponse.getUpdatedMetacards()).thenReturn(ImmutableList.of(update1));
+
     // send a request to update the metacard
     updateMetacard(storageRequest, storageResponse, metacards.get(1));
 
@@ -506,6 +521,10 @@ public class HistorianTest {
     UpdateStorageRequest storageRequest = mock(UpdateStorageRequest.class);
     UpdateStorageResponse storageResponse = mock(UpdateStorageResponse.class);
     UpdateResponse updateResponse = mock(UpdateResponse.class);
+
+    Update update1 = mock(Update.class);
+    when(update1.getOldMetacard()).thenReturn(metacards.get(0));
+    when(updateResponse.getUpdatedMetacards()).thenReturn(ImmutableList.of(update1));
 
     storeMetacard(metacards.get(0));
 


### PR DESCRIPTION
#### What does this PR do?
There was a possibility previously that we would version the wrong metacard
when versioning a product overwrite. However it did not appear to impact us
because when quering for the already updated metacard we got returned a
cached version that hid the issue. Now we are using the already included
metacard (in the updateRequest) which we should have been doing all along.


#### Who is reviewing it? 
`@anyone`

#### How should this be tested? (List steps with links to updated documentation)
overwrite a product/resource in intrigue and ensure the correct metadata is stored in the revision that is created of the original metacard.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3844

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
