### PR TITLE
DDF-3863 Update RESTEndpoint respect attribute/metacard overrides

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/CreateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/CreateOperations.java
@@ -575,7 +575,7 @@ public class CreateOperations {
         Metacard overrideMetacard = contentItem.getMetacard();
 
         Metacard updatedMetacard =
-            OverrideAttributesSupport.overrideMetacard(metacard, overrideMetacard, true, true);
+            OverrideAttributesSupport.overrideMetacard(metacard, overrideMetacard, true);
 
         updatedMetacard.setAttribute(
             new AttributeImpl(Metacard.RESOURCE_URI, contentItem.getUri()));

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OverrideAttributesSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OverrideAttributesSupport.java
@@ -16,9 +16,9 @@ package ddf.catalog.impl.operations;
 import ddf.catalog.content.data.ContentItem;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.MetacardTypeImpl;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -43,23 +43,21 @@ public class OverrideAttributesSupport {
       Metacard currentMetacard = metacardMap.get(contentItem.getId());
       Metacard overrideMetacard = contentItem.getMetacard();
 
-      Metacard updatedMetacard = overrideMetacard(currentMetacard, overrideMetacard, false, false);
+      Metacard updatedMetacard = overrideMetacard(currentMetacard, overrideMetacard, false);
 
       metacardMap.put(contentItem.getId(), updatedMetacard);
     }
   }
 
   public static Metacard overrideMetacard(
-      Metacard currentMetacard,
-      Metacard overrideMetacard,
-      boolean ignoreType,
-      boolean onlyFillNull) {
-    MetacardType updatedMetacardType = currentMetacard.getMetacardType();
-    if (!ignoreType && !MetacardImpl.BASIC_METACARD.equals(overrideMetacard.getMetacardType())) {
-      updatedMetacardType = overrideMetacard.getMetacardType();
-    }
+      Metacard currentMetacard, Metacard overrideMetacard, boolean onlyFillNull) {
 
-    Metacard updatedMetacard = new MetacardImpl(currentMetacard, updatedMetacardType);
+    MetacardImpl updatedMetacard = new MetacardImpl(currentMetacard);
+    updatedMetacard.setType(
+        new MetacardTypeImpl(
+            currentMetacard.getMetacardType().getName(),
+            currentMetacard.getMetacardType(),
+            overrideMetacard.getMetacardType().getAttributeDescriptors()));
 
     addAttributes(updatedMetacard, overrideMetacard, onlyFillNull);
     return updatedMetacard;
@@ -67,7 +65,7 @@ public class OverrideAttributesSupport {
 
   private static void addAttributes(
       Metacard metacard, Metacard otherMetacard, boolean onlyFillNull) {
-    otherMetacard
+    metacard
         .getMetacardType()
         .getAttributeDescriptors()
         .stream()

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/UpdateOperations.java
@@ -197,7 +197,7 @@ public class UpdateOperations {
             Metacard overrideMetacard = contentItem.getMetacard();
 
             Metacard updatedMetacard =
-                OverrideAttributesSupport.overrideMetacard(metacard, overrideMetacard, true, true);
+                OverrideAttributesSupport.overrideMetacard(metacard, overrideMetacard, true);
 
             updatedMetacard.setAttribute(
                 new AttributeImpl(Metacard.RESOURCE_SIZE, String.valueOf(contentItem.getSize())));

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -71,7 +71,9 @@ import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.data.impl.types.CoreAttributes;
 import ddf.catalog.data.inject.AttributeInjectorImpl;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.federation.FederationException;
 import ddf.catalog.federation.FederationStrategy;
 import ddf.catalog.filter.FilterBuilder;
@@ -731,6 +733,8 @@ public class CatalogFrameworkImplTest {
             });
 
     when(metacardType.getAttributeDescriptor(Metacard.TITLE)).thenReturn(stringAttributeDescriptor);
+    when(metacardType.getAttributeDescriptors())
+        .thenReturn(Collections.singleton(new CoreAttributes().getAttributeDescriptor(Core.TITLE)));
 
     newCard.setType(metacardType);
 
@@ -807,6 +811,8 @@ public class CatalogFrameworkImplTest {
             });
 
     when(metacardType.getAttributeDescriptor(Metacard.TITLE)).thenReturn(dateAttributeDescriptor);
+    when(metacardType.getAttributeDescriptors())
+        .thenReturn(Collections.singleton(new CoreAttributes().getAttributeDescriptor(Core.TITLE)));
 
     newCard.setType(metacardType);
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/OverrideAttributesSupportTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/OverrideAttributesSupportTest.java
@@ -14,6 +14,7 @@
 package ddf.catalog.impl.operations;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -28,6 +29,8 @@ import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.types.Media;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -125,32 +128,7 @@ public class OverrideAttributesSupportTest {
     assertThat(metacardMap.get("original").getTitle(), is("updated"));
     assertThat(metacardMap.get("original").getResourceURI().toString(), is("content:newstuff"));
     assertThat(metacardMap.get("original").getId(), is("original"));
-    assertThat(metacardMap.get("original").getMetacardType().getName(), is("other"));
-  }
-
-  @Test
-  public void testOverrideMetacardIgnoreType() throws URISyntaxException {
-    MetacardImpl metacard = new MetacardImpl();
-    metacard.setMetadata("original");
-    metacard.setTitle("original");
-    metacard.setId("original");
-    metacard.setResourceURI(new URI("content:stuff"));
-    MetacardImpl overrideMetacard =
-        new MetacardImpl(
-            new MetacardTypeImpl("other", metacard.getMetacardType().getAttributeDescriptors()));
-    overrideMetacard.setTitle("updated");
-    overrideMetacard.setId("updated");
-    overrideMetacard.setMetadata("updated");
-    overrideMetacard.setResourceURI(new URI("content:newstuff"));
-
-    Metacard updatedMetacard =
-        OverrideAttributesSupport.overrideMetacard(metacard, overrideMetacard, true, false);
-
-    assertThat(updatedMetacard.getMetadata(), is("updated"));
-    assertThat(updatedMetacard.getTitle(), is("updated"));
-    assertThat(updatedMetacard.getResourceURI().toString(), is("content:newstuff"));
-    assertThat(updatedMetacard.getId(), is("original"));
-    assertThat(updatedMetacard.getMetacardType().getName(), is("ddf.metacard"));
+    assertThat(metacardMap.get("original").getMetacardType().getName(), is("ddf.metacard"));
   }
 
   @Test
@@ -169,13 +147,45 @@ public class OverrideAttributesSupportTest {
     overrideMetacard.setResourceURI(new URI("content:newstuff"));
 
     Metacard updatedMetacard =
-        OverrideAttributesSupport.overrideMetacard(metacard, overrideMetacard, false, false);
+        OverrideAttributesSupport.overrideMetacard(metacard, overrideMetacard, false);
 
     assertThat(updatedMetacard.getMetadata(), is("updated"));
     assertThat(updatedMetacard.getTitle(), is("updated"));
     assertThat(updatedMetacard.getResourceURI().toString(), is("content:newstuff"));
     assertThat(updatedMetacard.getId(), is("original"));
-    assertThat(updatedMetacard.getMetacardType().getName(), is("other"));
+    assertThat(updatedMetacard.getMetacardType().getName(), is("ddf.metacard"));
+  }
+
+  @Test
+  public void testOverrideMetacardDescriptors() throws URISyntaxException {
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setMetadata("original");
+    metacard.setTitle("original");
+    metacard.setId("original");
+    metacard.setResourceURI(new URI("content:stuff"));
+    MetacardImpl overrideMetacard =
+        new MetacardImpl(
+            new MetacardTypeImpl(
+                "other",
+                metacard.getMetacardType(),
+                new MediaAttributes().getAttributeDescriptors()));
+    overrideMetacard.setTitle("updated");
+    overrideMetacard.setId("updated");
+    overrideMetacard.setMetadata("updated");
+    overrideMetacard.setResourceURI(new URI("content:newstuff"));
+    overrideMetacard.setAttribute(Media.DURATION, 1.0);
+
+    Metacard updatedMetacard =
+        OverrideAttributesSupport.overrideMetacard(metacard, overrideMetacard, false);
+
+    assertThat(updatedMetacard.getMetadata(), is("updated"));
+    assertThat(updatedMetacard.getTitle(), is("updated"));
+    assertThat(updatedMetacard.getResourceURI().toString(), is("content:newstuff"));
+    assertThat(updatedMetacard.getId(), is("original"));
+    assertThat(updatedMetacard.getMetacardType().getName(), is("ddf.metacard"));
+    assertThat(
+        updatedMetacard.getMetacardType().getAttributeDescriptor(Media.DURATION), notNullValue());
+    assertThat(updatedMetacard.getAttribute(Media.DURATION).getValue(), is(1.0));
   }
 
   @Test

--- a/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,6 +22,7 @@
     <reference id="tikaMimeTypeResolver" filter="(name=tikaMimeTypeResolver)" interface="ddf.mime.MimeTypeResolver"/>
     <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
     <reference id="attachmentParser" interface="org.codice.ddf.attachment.AttachmentParser"/>
+    <reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
 
     <bean id="actionFactory"
           class="org.codice.ddf.endpoints.rest.action.MetacardTransformerActionProviderFactory"/>
@@ -39,12 +40,10 @@
     <bean id="restSvc" class="org.codice.ddf.endpoints.rest.RESTEndpoint">
         <argument ref="catalog"/>
         <argument ref="attachmentParser"/>
+        <argument ref="attributeRegistry" />
         <property name="filterBuilder" ref="filterBuilder"/>
         <property name="mimeTypeToTransformerMapper" ref="transformerMapper"/>
         <property name="tikaMimeTypeResolver" ref="tikaMimeTypeResolver"/>
-        <property name="metacardTypes">
-            <reference-list interface="ddf.catalog.data.MetacardType" availability="optional"/>
-        </property>
         <property name="uuidGenerator" ref="uuidGenerator" />
     </bean>
 

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointIT.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointIT.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
 import com.jayway.restassured.RestAssured;
 import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
@@ -95,6 +96,8 @@ public class RestEndpointIT extends AbstractComponentTest {
   @MockOsgiService private AttachmentParser attachmentParser;
 
   @MockOsgiService private MimeTypeToTransformerMapper mimeTypeToTransformerMapper;
+
+  @MockOsgiService private AttributeRegistry attributeRegistry;
 
   @MockOsgiService(answer = Answers.RETURNS_DEEP_STUBS)
   private FilterBuilder filterBuilder;

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointTest.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointTest.java
@@ -423,7 +423,7 @@ public class RestEndpointTest {
 
   @Test
   @SuppressWarnings({"unchecked"})
-  public void testAddDocumentWithMetadataMcardId() throws Exception {
+  public void testAddDocumentWithMetadataMetacardId() throws Exception {
     String inputMcardId = "123456789987654321";
     MetacardImpl inputMcard = new MetacardImpl();
     inputMcard.setId(inputMcardId);

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointTest.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointTest.java
@@ -34,13 +34,18 @@ import com.google.common.base.Strings;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.content.data.ContentItem;
 import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.ContentTypeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.types.CoreAttributes;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.federation.FederationException;
 import ddf.catalog.federation.FederationStrategy;
@@ -78,6 +83,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import javax.activation.MimeType;
@@ -103,6 +109,7 @@ import org.codice.ddf.attachment.impl.AttachmentParserImpl;
 import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -170,6 +177,8 @@ public class RestEndpointTest {
 
   private AttachmentParser attachmentParser;
 
+  private AttributeRegistry attributeRegistry;
+
   @Before
   public void setup() throws MimeTypeResolutionException {
     MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
@@ -177,6 +186,8 @@ public class RestEndpointTest {
     when(mimeTypeMapper.getMimeTypeForFileExtension("xml")).thenReturn("text/xml");
 
     attachmentParser = new AttachmentParserImpl(mimeTypeMapper);
+
+    attributeRegistry = mock(AttributeRegistry.class);
   }
 
   @Test
@@ -184,7 +195,7 @@ public class RestEndpointTest {
 
     CatalogFramework framework = mock(CatalogFramework.class);
 
-    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser);
+    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
 
     HttpHeaders headers = mock(HttpHeaders.class);
 
@@ -222,7 +233,7 @@ public class RestEndpointTest {
 
     HttpHeaders headers = createHeaders(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser);
+    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
 
     addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
 
@@ -248,6 +259,89 @@ public class RestEndpointTest {
 
   @Test
   @SuppressWarnings({"unchecked"})
+  public void testAddDocumentWithAttributeOverrides()
+      throws IOException, CatalogTransformerException, IngestException, SourceUnavailableException,
+          URISyntaxException, InvalidSyntaxException {
+
+    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
+
+    AttributeDescriptor descriptor =
+        new AttributeDescriptorImpl(
+            "custom.attribute", true, true, false, false, BasicTypes.STRING_TYPE);
+
+    HttpHeaders headers = createHeaders(Collections.singletonList(MediaType.APPLICATION_JSON));
+    BundleContext bundleContext = mock(BundleContext.class);
+    Collection<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
+    ServiceReference serviceReference = mock(ServiceReference.class);
+    InputTransformer inputTransformer = mock(InputTransformer.class);
+    when(inputTransformer.transform(any())).thenReturn(new MetacardImpl());
+    when(bundleContext.getService(serviceReference)).thenReturn(inputTransformer);
+    serviceReferences.add(serviceReference);
+    when(bundleContext.getServiceReferences(InputTransformer.class, "(id=xml)"))
+        .thenReturn(serviceReferences);
+
+    when(attributeRegistry.lookup("custom.attribute")).thenReturn(Optional.of(descriptor));
+
+    RESTEndpoint rest =
+        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
+          @Override
+          BundleContext getBundleContext() {
+            return bundleContext;
+          }
+        };
+
+    UuidGenerator uuidGenerator = mock(UuidGenerator.class);
+    when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID().toString());
+    rest.setUuidGenerator(uuidGenerator);
+
+    addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
+
+    UriInfo info = givenUriInfo(SAMPLE_ID);
+
+    List<Attachment> attachments = new ArrayList<>();
+    ContentDisposition contentDisposition =
+        new ContentDisposition("form-data; name=parse.resource; filename=C:\\DDF\\metacard.txt");
+    Attachment attachment =
+        new Attachment(
+            "parse.resource", new ByteArrayInputStream("Some Text".getBytes()), contentDisposition);
+    attachments.add(attachment);
+    ContentDisposition contentDisposition2 =
+        new ContentDisposition("form-data; name=custom.attribute; ");
+    Attachment attachment2 =
+        new Attachment(
+            descriptor.getName(),
+            new ByteArrayInputStream("CustomValue".getBytes()),
+            contentDisposition2);
+    attachments.add(attachment2);
+    MultipartBody multipartBody = new MultipartBody(attachments);
+
+    Response response =
+        rest.addDocument(
+            headers,
+            info,
+            mock(HttpServletRequest.class),
+            multipartBody,
+            null,
+            new ByteArrayInputStream("".getBytes()));
+
+    LOGGER.debug(ToStringBuilder.reflectionToString(response));
+
+    assertThat(response.getStatus(), equalTo(201));
+    ArgumentCaptor<CreateStorageRequest> captor = new ArgumentCaptor<>();
+    verify(framework, times(1)).create(captor.capture());
+    assertThat(
+        captor
+            .getValue()
+            .getContentItems()
+            .get(0)
+            .getMetacard()
+            .getMetacardType()
+            .getAttributeDescriptor(descriptor.getName()),
+        equalTo(descriptor));
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked"})
   public void testAddDocumentWithMetadataPositiveCase()
       throws IOException, CatalogTransformerException, IngestException, SourceUnavailableException,
           URISyntaxException, InvalidSyntaxException {
@@ -266,7 +360,7 @@ public class RestEndpointTest {
         .thenReturn(serviceReferences);
 
     RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser) {
+        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
@@ -276,7 +370,9 @@ public class RestEndpointTest {
     UuidGenerator uuidGenerator = mock(UuidGenerator.class);
     when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID().toString());
     rest.setUuidGenerator(uuidGenerator);
-    rest.setMetacardTypes(Collections.singletonList(MetacardImpl.BASIC_METACARD));
+
+    when(attributeRegistry.lookup(Core.METADATA))
+        .thenReturn(Optional.of(new CoreAttributes().getAttributeDescriptor(Core.METADATA)));
 
     addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
 
@@ -381,13 +477,15 @@ public class RestEndpointTest {
         .thenReturn(serviceReferences);
 
     RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser) {
+        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
           }
         };
-    rest.setMetacardTypes(Collections.singletonList(MetacardImpl.BASIC_METACARD));
+    when(attributeRegistry.lookup(Core.METADATA))
+        .thenReturn(Optional.of(new CoreAttributes().getAttributeDescriptor(Core.METADATA)));
+    when(attributeRegistry.lookup("foo")).thenReturn(Optional.empty());
 
     addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
 
@@ -451,13 +549,15 @@ public class RestEndpointTest {
         .thenReturn(serviceReferences);
 
     RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser) {
+        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
           }
         };
-    rest.setMetacardTypes(Collections.singletonList(MetacardImpl.BASIC_METACARD));
+    when(attributeRegistry.lookup(Core.METADATA))
+        .thenReturn(Optional.of(new CoreAttributes().getAttributeDescriptor(Core.METADATA)));
+    when(attributeRegistry.lookup("foo")).thenReturn(Optional.empty());
 
     addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
 
@@ -662,7 +762,7 @@ public class RestEndpointTest {
     when(framework.getSourceInfo(isA(SourceInfoRequestEnterprise.class)))
         .thenReturn(sourceInfoResponse);
 
-    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser);
+    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
 
     Response response = restEndpoint.getDocument(null, null);
     assertEquals(OK, response.getStatus());
@@ -762,7 +862,7 @@ public class RestEndpointTest {
     when(framework.transform(isA(Metacard.class), anyString(), isNull(Map.class)))
         .thenReturn(content);
 
-    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser);
+    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
 
     // Add a MimeTypeToINputTransformer that the REST endpoint will call to create the metacard
     addMatchingService(restEndpoint, Collections.singletonList(getSimpleTransformer()));
@@ -886,7 +986,7 @@ public class RestEndpointTest {
     when(framework.transform(isA(Metacard.class), anyString(), isA(Map.class)))
         .thenReturn(resource);
 
-    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser);
+    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
     restEndpoint.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
     FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
     restEndpoint.setFilterBuilder(filterBuilder);
@@ -1003,7 +1103,7 @@ public class RestEndpointTest {
       CatalogFramework framework, String transformer, boolean local, HttpServletRequest request)
       throws URISyntaxException {
 
-    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser);
+    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
     restEndpoint.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
     FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
     restEndpoint.setFilterBuilder(filterBuilder);
@@ -1046,7 +1146,7 @@ public class RestEndpointTest {
         .thenReturn(serviceReferences);
 
     RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser) {
+        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
@@ -1055,7 +1155,8 @@ public class RestEndpointTest {
     String generatedMcardId = UUID.randomUUID().toString();
     when(uuidGenerator.generateUuid()).thenReturn(generatedMcardId);
     rest.setUuidGenerator(uuidGenerator);
-    rest.setMetacardTypes(Collections.singletonList(MetacardImpl.BASIC_METACARD));
+    when(attributeRegistry.lookup(Core.METADATA))
+        .thenReturn(Optional.of(new CoreAttributes().getAttributeDescriptor(Core.METADATA)));
 
     addMatchingService(rest, Collections.singletonList(inputTransformer));
 
@@ -1100,7 +1201,7 @@ public class RestEndpointTest {
 
     HttpHeaders headers = createHeaders(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser);
+    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
 
     addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
 


### PR DESCRIPTION
#### What does this PR do?
Updates the rest endpoint and the catalog standard framework to respect attribute/metacard overrides
#### Who is reviewing it? 
@emmberk @peterhuffer @glenhein 
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@lessarderic
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Ingest a metacard with an id via the rest endpoint and verify it has the same id after ingest.
Ingest a metacard with id and product together and verify the metacard has the same id after ingest

To test general attribute override run the command `curl -k -X POST -i -H "Content-Type: multipart/mixed" -F parse.resource=@/path/to/txt/file -F parse.media.duration=5.0 https://localhost:8993/services/catalog` and verify that the ingested text file has the media.duration attribute set.
#### What are the relevant tickets?
[DDF-3863](https://codice.atlassian.net/browse/DDF-3863)


