### PR TITLE
DDF-3696 Allows sending multiple status codes in saml logout response

### DIFF
--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
@@ -51,6 +51,8 @@ import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.SignableSAMLObject;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 import org.opensaml.saml.saml2.core.LogoutResponse;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
 import org.w3c.dom.Document;
@@ -171,17 +173,8 @@ public class LogoutMessageImpl implements LogoutMessage {
   @Override
   public LogoutResponse buildLogoutResponse(
       String issuerOrEntityId, String statusCodeValue, String inResponseTo) {
-    return buildLogoutResponse(
-        issuerOrEntityId, statusCodeValue, inResponseTo, UUID.randomUUID().toString());
-  }
-
-  public LogoutResponse buildLogoutResponse(
-      String issuerOrEntityId, String statusCodeValue, String inResponseTo, String id) {
     if (issuerOrEntityId == null) {
       throw new IllegalArgumentException("Issuer cannot be null");
-    }
-    if (id == null) {
-      throw new IllegalArgumentException("ID cannot be null");
     }
     if (statusCodeValue == null) {
       throw new IllegalArgumentException("Status Code cannot be null");
@@ -191,7 +184,31 @@ public class LogoutMessageImpl implements LogoutMessage {
         SamlProtocol.createIssuer(issuerOrEntityId),
         SamlProtocol.createStatus(statusCodeValue),
         inResponseTo,
-        id);
+        "_" + UUID.randomUUID().toString());
+  }
+
+  @Override
+  public LogoutResponse buildLogoutResponse(
+      String issuerOrEntityId,
+      String topLevelStatusCode,
+      String secondLevelStatusCode,
+      String inResponseTo) {
+    if (issuerOrEntityId == null) {
+      throw new IllegalArgumentException("Issuer cannot be null");
+    }
+    if (topLevelStatusCode == null || secondLevelStatusCode == null) {
+      throw new IllegalArgumentException("Status Codes cannot be null");
+    }
+
+    Status status = SamlProtocol.createStatus(topLevelStatusCode);
+    StatusCode statusCode = SamlProtocol.createStatusCode(secondLevelStatusCode);
+    status.getStatusCode().setStatusCode(statusCode);
+
+    return SamlProtocol.createLogoutResponse(
+        SamlProtocol.createIssuer(issuerOrEntityId),
+        status,
+        inResponseTo,
+        "_" + UUID.randomUUID().toString());
   }
 
   @Override

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
@@ -61,9 +61,11 @@ import org.w3c.dom.Element;
 
 public class LogoutMessageImpl implements LogoutMessage {
 
-  public static final String SOAP_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:SOAP";
+  private static final String SOAP_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:SOAP";
 
-  public static final String SAML_SOAP_ACTION = "http://www.oasis-open.org/committees/security";
+  private static final String SAML_SOAP_ACTION = "http://www.oasis-open.org/committees/security";
+
+  private static final String ISSUER_CANNOT_BE_NULL_MSG = "Issuer cannot be null";
 
   static {
     OpenSAMLUtil.initSamlEngine();
@@ -143,7 +145,7 @@ public class LogoutMessageImpl implements LogoutMessage {
       throw new IllegalArgumentException("Name ID cannot be null");
     }
     if (issuerOrEntityId == null) {
-      throw new IllegalArgumentException("Issuer cannot be null");
+      throw new IllegalArgumentException(ISSUER_CANNOT_BE_NULL_MSG);
     }
     if (id == null) {
       throw new IllegalArgumentException("ID cannot be null");
@@ -174,7 +176,7 @@ public class LogoutMessageImpl implements LogoutMessage {
   @Override
   public LogoutResponse buildLogoutResponse(
       String issuerOrEntityId, String statusCodeValue, String inResponseTo) {
-    Validate.notNull(issuerOrEntityId, "Issuer cannot be null");
+    Validate.notNull(issuerOrEntityId, ISSUER_CANNOT_BE_NULL_MSG);
     Validate.notNull(statusCodeValue, "Status Code cannot be null");
 
     return SamlProtocol.createLogoutResponse(
@@ -190,7 +192,7 @@ public class LogoutMessageImpl implements LogoutMessage {
       String topLevelStatusCode,
       String secondLevelStatusCode,
       String inResponseTo) {
-    Validate.notNull(issuerOrEntityId, "Issuer cannot be null");
+    Validate.notNull(issuerOrEntityId, ISSUER_CANNOT_BE_NULL_MSG);
     Validate.notNull(topLevelStatusCode, "Top level Status Code cannot be null");
     Validate.notNull(secondLevelStatusCode, "Second level Status Code cannot be null");
 

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/LogoutMessageImpl.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import javax.servlet.http.Cookie;
 import javax.ws.rs.core.UriBuilder;
 import javax.xml.stream.XMLStreamException;
+import org.apache.commons.lang.Validate;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.rs.security.saml.sso.SSOConstants;
 import org.apache.cxf.staxutils.StaxUtils;
@@ -173,12 +174,8 @@ public class LogoutMessageImpl implements LogoutMessage {
   @Override
   public LogoutResponse buildLogoutResponse(
       String issuerOrEntityId, String statusCodeValue, String inResponseTo) {
-    if (issuerOrEntityId == null) {
-      throw new IllegalArgumentException("Issuer cannot be null");
-    }
-    if (statusCodeValue == null) {
-      throw new IllegalArgumentException("Status Code cannot be null");
-    }
+    Validate.notNull(issuerOrEntityId, "Issuer cannot be null");
+    Validate.notNull(statusCodeValue, "Status Code cannot be null");
 
     return SamlProtocol.createLogoutResponse(
         SamlProtocol.createIssuer(issuerOrEntityId),
@@ -193,12 +190,9 @@ public class LogoutMessageImpl implements LogoutMessage {
       String topLevelStatusCode,
       String secondLevelStatusCode,
       String inResponseTo) {
-    if (issuerOrEntityId == null) {
-      throw new IllegalArgumentException("Issuer cannot be null");
-    }
-    if (topLevelStatusCode == null || secondLevelStatusCode == null) {
-      throw new IllegalArgumentException("Status Codes cannot be null");
-    }
+    Validate.notNull(issuerOrEntityId, "Issuer cannot be null");
+    Validate.notNull(topLevelStatusCode, "Top level Status Code cannot be null");
+    Validate.notNull(secondLevelStatusCode, "Second level Status Code cannot be null");
 
     Status status = SamlProtocol.createStatus(topLevelStatusCode);
     StatusCode statusCode = SamlProtocol.createStatusCode(secondLevelStatusCode);

--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -16,7 +16,6 @@ package org.codice.ddf.security.idp.server;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
@@ -153,7 +152,6 @@ import org.opensaml.saml.saml2.core.LogoutResponse;
 import org.opensaml.saml.saml2.core.RequestedAuthnContext;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.opensaml.security.credential.UsageType;
 import org.opensaml.xmlsec.signature.SignableXMLObject;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
@@ -167,14 +165,13 @@ import org.w3c.dom.Node;
 @Path("/")
 public class IdpEndpoint implements Idp, SessionHandler {
 
-  public static final String SERVICES_IDP_PATH = SystemBaseUrl.INTERNAL.getRootContext() + "/idp";
-  public static final ImmutableSet<UsageType> USAGE_TYPES =
-      ImmutableSet.of(UsageType.UNSPECIFIED, UsageType.SIGNING);
+  private static final String SERVICES_IDP_PATH = SystemBaseUrl.INTERNAL.getRootContext() + "/idp";
   private static final Logger LOGGER = LoggerFactory.getLogger(IdpEndpoint.class);
   private static final String CERTIFICATES_ATTR = "javax.servlet.request.X509Certificate";
   private static final String IDP_LOGIN = "/idp/login";
   private static final String IDP_LOGOUT = "/idp/logout";
   private static final String AUTHN_REQUEST_MUST_USE_TLS = "Authn Request must use TLS.";
+  private static final int THIRTY_MINUTE_EXPIRATION = 30;
   private static final String COULD_NOT_FIND_ENTITY_SERVICE_INFO_MSG =
       "Could not find entity service info for {}";
 
@@ -1386,7 +1383,7 @@ public class IdpEndpoint implements Idp, SessionHandler {
           return continueLogout(logoutState, cookie, incomingBinding);
         }
 
-        Instant notOnOrAfter = Instant.now().plus(30, ChronoUnit.MINUTES);
+        Instant notOnOrAfter = Instant.now().plus(THIRTY_MINUTE_EXPIRATION, ChronoUnit.MINUTES);
         logoutRequest.setNotOnOrAfter(new DateTime(notOnOrAfter.getEpochSecond()));
         logoutRequest.setDestination(entityServiceInfo.getUrl());
         logoutState.setCurrentRequestId(logoutRequest.getID());

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/LogoutMessage.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/LogoutMessage.java
@@ -48,6 +48,12 @@ public interface LogoutMessage {
   LogoutResponse buildLogoutResponse(
       String issuerOrEntityId, String statusCodeValue, String inResponseTo);
 
+  LogoutResponse buildLogoutResponse(
+      String issuerOrEntityId,
+      String topLevelStatusCode,
+      String secondLevelStatusCode,
+      String inResponseTo);
+
   Element getElementFromSaml(XMLObject xmlObject) throws WSSecurityException;
 
   String sendSamlLogoutRequest(

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
@@ -274,9 +274,7 @@ public class SamlProtocol {
 
   public static Status createStatus(String statusValue) {
     Status status = statusBuilder.buildObject();
-    StatusCode statusCode = statusCodeBuilder.buildObject();
-    statusCode.setValue(statusValue);
-    status.setStatusCode(statusCode);
+    status.setStatusCode(createStatusCode(statusValue));
 
     return status;
   }
@@ -288,6 +286,13 @@ public class SamlProtocol {
     status.setStatusMessage(statusMessage);
 
     return status;
+  }
+
+  public static StatusCode createStatusCode(String statusValue) {
+    StatusCode statusCode = statusCodeBuilder.buildObject();
+    statusCode.setValue(statusValue);
+
+    return statusCode;
   }
 
   @SuppressWarnings("squid:S00107")


### PR DESCRIPTION
#### What does this PR do?
- Allows sending multiple status codes in saml logout response
- Added the NotOnOrAfter attribute on LogoutRequests

#### Who is reviewing it? 
@brjeter @bakejeyner 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@clockard 
@coyotesqrl 
@stustison

#### How should this be tested? (List steps with links to updated documentation)
- Able to log in and log out of DDF correctly
- Use the SAML Conformance Test Kit for further testing

#### Any background context you want to provide?
Core 3.2.2. explains why we can't just return a partial status code. We have to return success with partial as a secondary status code.
```
The value of the topmost <StatusCode> element MUST be from the top-level list provided 
in this section.
```

Core 3.7.3.2 explains why we need to return a `NotOnOeAfter` attribute.
```
When constructing a logout request message, the session authority MUST set the value of 
the NotOnOrAfter attribute of the message to a time value, indicating an expiration time for 
the message, after which the logout request may be discarded by the recipient.
```

#### What are the relevant tickets?
[DDF-3696](https://codice.atlassian.net/browse/DDF-3696)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
