### PR TITLE
DDF-3836 Extend query abilities to support multiple geometries

### DIFF
--- a/catalog/common/catalog-common-geo-formatter/src/main/java/ddf/geo/formatter/CompositeGeometry.java
+++ b/catalog/common/catalog-common-geo-formatter/src/main/java/ddf/geo/formatter/CompositeGeometry.java
@@ -159,7 +159,7 @@ public abstract class CompositeGeometry {
    * @return an array of {@link Coordinate} objects, if input is <code>null</code> or empty, it will
    *     return an empty array
    */
-  protected static Coordinate[] getCoordinates(List<List<String>> primitiveCoordinatesList) {
+  protected static Coordinate[] getCoordinates(List<List> primitiveCoordinatesList) {
     if (primitiveCoordinatesList != null && !primitiveCoordinatesList.isEmpty()) {
       Coordinate[] coordinatesArray = new Coordinate[primitiveCoordinatesList.size()];
 

--- a/catalog/common/catalog-common-geo-formatter/src/main/java/ddf/geo/formatter/Polygon.java
+++ b/catalog/common/catalog-common-geo-formatter/src/main/java/ddf/geo/formatter/Polygon.java
@@ -38,7 +38,7 @@ public class Polygon extends MultiPoint {
     return new Polygon(buildPolygon(coordinates));
   }
 
-  protected static com.vividsolutions.jts.geom.Polygon buildPolygon(List coordinates) {
+  public static com.vividsolutions.jts.geom.Polygon buildPolygon(List coordinates) {
 
     // according to the GeoJson specification, first ring is the exterior
     LinearRing exterior =

--- a/catalog/opensearch/catalog-opensearch-api/src/main/java/org/codice/ddf/opensearch/source/BoundingBox.java
+++ b/catalog/opensearch/catalog-opensearch-api/src/main/java/org/codice/ddf/opensearch/source/BoundingBox.java
@@ -18,7 +18,7 @@ package org.codice.ddf.opensearch.source;
  * #west} may be greater than {@link #east} in a bounding box but not in an {@link
  * com.vividsolutions.jts.geom.Envelope}.
  */
-class BoundingBox {
+public class BoundingBox {
 
   private final double west;
 

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/java/org/codice/ddf/opensearch/endpoint/OpenSearchEndpoint.java
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/java/org/codice/ddf/opensearch/endpoint/OpenSearchEndpoint.java
@@ -112,7 +112,7 @@ public class OpenSearchEndpoint implements OpenSearch {
    * @param maxTimeout Maximum timeout (msec) for query to respond (default: mt=30000).
    * @param startIndex Index of first result to return. Integer >= 0 (default: start=1).
    * @param count Number of results to retrieve per page (default: count=10).
-   * @param geometry WKT Geometries (Support POINT and POLYGON).
+   * @param geometry WKT Geometries.
    * @param bbox Comma-delimited list of lat/lon (deg) bounding box coordinates (geo format:
    *     geo:bbox ~ West,South,East,North).
    * @param polygon Comma-delimited list of lat/lon (deg) pairs, in clockwise order around the
@@ -263,7 +263,6 @@ public class OpenSearchEndpoint implements OpenSearch {
    * @param radius - the radius for a point radius search
    * @param lat - the latitude of the point.
    * @param lon - the longitude of the point.
-   * @return - the spatialCriterion created, can be null
    */
   private void addSpatialFilter(
       OpenSearchQuery query,

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/java/org/codice/ddf/opensearch/endpoint/OpenSearchEndpoint.java
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/java/org/codice/ddf/opensearch/endpoint/OpenSearchEndpoint.java
@@ -276,13 +276,19 @@ public class OpenSearchEndpoint implements OpenSearch {
     if (StringUtils.isNotBlank(geometry)) {
       LOGGER.trace("Adding SpatialCriterion geometry: {}", geometry);
       query.addGeometrySpatialFilter(geometry.trim());
-    } else if (StringUtils.isNotBlank(bbox)) {
+    }
+
+    if (StringUtils.isNotBlank(bbox)) {
       LOGGER.trace("Adding SpatialCriterion bbox: {}", bbox);
       query.addBBoxSpatialFilter(bbox.trim());
-    } else if (StringUtils.isNotBlank(polygon)) {
+    }
+
+    if (StringUtils.isNotBlank(polygon)) {
       LOGGER.trace("Adding SpatialCriterion polygon: {}", polygon);
       query.addPolygonSpatialFilter(polygon.trim());
-    } else if (StringUtils.isNotBlank(lat) && StringUtils.isNotBlank(lon)) {
+    }
+
+    if (StringUtils.isNotBlank(lat) && StringUtils.isNotBlank(lon)) {
       if (StringUtils.isBlank(radius)) {
         LOGGER.debug("Adding default radius {}", DEFAULT_RADIUS);
         query.addPointRadiusSpatialFilter(lon.trim(), lat.trim(), DEFAULT_RADIUS);

--- a/catalog/opensearch/catalog-opensearch-source/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-source/pom.xml
@@ -111,6 +111,7 @@
       <dependency>
         <groupId>ddf.catalog.common</groupId>
         <artifactId>geo-formatter</artifactId>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
     <build>

--- a/catalog/opensearch/catalog-opensearch-source/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-source/pom.xml
@@ -108,6 +108,10 @@
             <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>ddf.catalog.common</groupId>
+        <artifactId>geo-formatter</artifactId>
+      </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/BoundingBoxUtils.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/BoundingBoxUtils.java
@@ -15,6 +15,8 @@ package org.codice.ddf.opensearch.source;
 
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Polygon;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -188,5 +190,42 @@ public final class BoundingBoxUtils {
     }
 
     return new BoundingBox(west, south, east, north);
+  }
+
+  /**
+   * Takes in a {@link BoundingBox} and extract the coordinates in a counter clockwise matter with
+   * first and last coordinate being the same point
+   *
+   * @param boundingBox
+   * @return
+   */
+  public static List<List> getPrimativeCoordinates(BoundingBox boundingBox) {
+    List<List> coordinates = new ArrayList<>();
+    List coordinate = new ArrayList<>();
+    coordinate.add(boundingBox.getWest());
+    coordinate.add(boundingBox.getSouth());
+    coordinates.add(coordinate);
+
+    coordinate = new ArrayList<>();
+    coordinate.add(boundingBox.getEast());
+    coordinate.add(boundingBox.getSouth());
+    coordinates.add(coordinate);
+
+    coordinate = new ArrayList<>();
+    coordinate.add(boundingBox.getEast());
+    coordinate.add(boundingBox.getNorth());
+    coordinates.add(coordinate);
+
+    coordinate = new ArrayList<>();
+    coordinate.add(boundingBox.getWest());
+    coordinate.add(boundingBox.getNorth());
+    coordinates.add(coordinate);
+
+    coordinate = new ArrayList<>();
+    coordinate.add(boundingBox.getWest());
+    coordinate.add(boundingBox.getSouth());
+    coordinates.add(coordinate);
+
+    return coordinates;
   }
 }

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/BoundingBoxUtils.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/BoundingBoxUtils.java
@@ -193,13 +193,13 @@ public final class BoundingBoxUtils {
   }
 
   /**
-   * Takes in a {@link BoundingBox} and extract the coordinates in a counter clockwise matter with
+   * Takes in a {@link BoundingBox} and extracts the coordinates in a counter clockwise matter with
    * first and last coordinate being the same point
    *
    * @param boundingBox
    * @return
    */
-  public static List<List> getPrimativeCoordinates(BoundingBox boundingBox) {
+  public static List<List> getBoundingBoxCoordinatesList(BoundingBox boundingBox) {
     List<List> coordinates = new ArrayList<>();
     List coordinate = new ArrayList<>();
     coordinate.add(boundingBox.getWest());

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.opensearch.source;
 
 import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 import ddf.catalog.data.Metacard;
@@ -27,6 +28,7 @@ import org.codice.ddf.opensearch.OpenSearchConstants;
 import org.geotools.filter.AttributeExpressionImpl;
 import org.geotools.filter.LikeFilterImpl;
 import org.geotools.filter.visitor.DefaultFilterVisitor;
+import org.geotools.geometry.jts.spatialschema.geometry.GeometryImpl;
 import org.geotools.geometry.jts.spatialschema.geometry.primitive.PointImpl;
 import org.geotools.geometry.jts.spatialschema.geometry.primitive.SurfaceImpl;
 import org.geotools.temporal.object.DefaultInstant;
@@ -483,8 +485,11 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
     } else if (geometryExpression instanceof Polygon) {
       Polygon polygon = (Polygon) literalWrapper.evaluate(null);
       openSearchFilterVisitorObject.addGeometrySearch(polygon);
+    } else if (geometryExpression instanceof GeometryImpl) {
+      Geometry polygon = ((GeometryImpl) geometryExpression).getJTSGeometry();
+      openSearchFilterVisitorObject.addGeometrySearch(polygon);
     } else {
-      LOGGER.debug("Only POLYGON geometry WKT for Contains/Intersects filter is supported");
+      LOGGER.debug("Unsupported filter constraint");
     }
   }
 

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
@@ -29,7 +29,6 @@ import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -156,18 +155,15 @@ public class OpenSearchParserImpl implements OpenSearchParser {
       @Nullable PointRadius pointRadius,
       List<String> parameters) {
 
-    if (Stream.of(geometry, boundingBox, polygon, pointRadius).filter(Objects::nonNull).count()
-        > 1) {
-      throw new IllegalArgumentException("Only one spatial search may be populated");
-    }
-
     if (geometry != null) {
       checkAndReplace(
           client,
           WKT_WRITER_THREAD_LOCAL.get().write(geometry),
           OpenSearchConstants.GEOMETRY,
           parameters);
-    } else if (boundingBox != null) {
+    }
+
+    if (boundingBox != null) {
       checkAndReplace(
           client,
           Stream.of(
@@ -179,7 +175,9 @@ public class OpenSearchParserImpl implements OpenSearchParser {
               .collect(Collectors.joining(OpenSearchConstants.BBOX_DELIMITER)),
           OpenSearchConstants.BBOX,
           parameters);
-    } else if (polygon != null) {
+    }
+
+    if (polygon != null) {
       checkAndReplace(
           client,
           Arrays.stream(polygon.getCoordinates())
@@ -188,7 +186,9 @@ public class OpenSearchParserImpl implements OpenSearchParser {
               .collect(Collectors.joining(OpenSearchConstants.POLYGON_LON_LAT_DELIMITER)),
           OpenSearchConstants.POLYGON,
           parameters);
-    } else if (pointRadius != null) {
+    }
+
+    if (pointRadius != null) {
       checkAndReplace(
           client, String.valueOf(pointRadius.getLat()), OpenSearchConstants.LAT, parameters);
       checkAndReplace(

--- a/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -73,6 +73,7 @@
                     <value>lon</value>
                     <value>radius</value>
                     <value>bbox</value>
+                    <value>geometry</value>
                     <value>polygon</value>
                     <value>dtstart</value>
                     <value>dtend</value>

--- a/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -39,7 +39,7 @@
 
         <AD name="OpenSearch query parameters" id="parameters" required="true"
             type="String"
-            default="q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
+            default="q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,geometry,polygon,dtstart,dtend,dateName,filter,sort"
             cardinality="100"
             description="Query parameters to use with the OpenSearch connection."/>
 

--- a/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/BoundingBoxUtilsSpec.groovy
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/BoundingBoxUtilsSpec.groovy
@@ -14,10 +14,12 @@
 package org.codice.ddf.opensearch.source
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class BoundingBoxUtilsSpec extends Specification {
 
-    def 'create BBox from point radius'(double lon, double lat, double expectedWest, double expectedSouth, double expectedEast, double expectedNorth) {
+    @Unroll
+    def 'create BBox from point radius (#lon, #lat)'(double lon, double lat, double expectedWest, double expectedSouth, double expectedEast, double expectedNorth) {
         given:
         final double searchRadiusInMeters = 804672 // 500 miles
 

--- a/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/OpenSearchSourceSpec.groovy
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/OpenSearchSourceSpec.groovy
@@ -39,6 +39,7 @@ import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
 import org.osgi.framework.ServiceReference
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import javax.ws.rs.core.Response
 import java.nio.charset.StandardCharsets
@@ -111,7 +112,8 @@ class OpenSearchSourceSpec extends Specification {
         queryRequestProperties.put(SecurityConstants.SECURITY_SUBJECT, subject)
     }
 
-    def testQueries(Filter filter, Map<String, Object> expectedQueryParameters) throws UnsupportedQueryException {
+    @Unroll
+    def 'testQueries #filter'(Filter filter, Map<String, Object> expectedQueryParameters) throws UnsupportedQueryException {
         given:
         final Map<String, Object> webClientQueryParameters = [:]
 
@@ -170,7 +172,7 @@ class OpenSearchSourceSpec extends Specification {
                 [start: ["1"], count: ["20"], mt: ["0"], q: ["someSearchPhrase"], dtstart: ["1970-01-01T00:00:10.000Z"], dtend: ["1970-01-01T00:00:10.005Z"], geometry:["GEOMETRYCOLLECTION (POLYGON ((0.9999550570408705 1.999954933135129, 1.0000449429591296 1.999954933135129, 1.0000449429591296 2.000045066864871, 0.9999550570408705 2.000045066864871, 0.9999550570408705 1.999954933135129)), POLYGON ((-7.228491563030235 -7.25280885791844, 7.228491563030235 -7.25280885791844, 7.228491563030235 7.25280885791844, -7.228491563030235 7.25280885791844, -7.228491563030235 -7.25280885791844)))"], src: [""]],
                 [start: ["1"], count: ["20"], mt: ["0"], q: ["someSearchPhrase"], dtstart: ["1970-01-01T00:00:10.000Z"], dtend: ["1970-01-01T00:00:10.005Z"], geometry:["POLYGON ((10.2 10.2, 10.2 20.2, 20.2 20.2, 20.2 10.2, 10.2 10.2))"], lat:["2.0"], lon:["1.0"], radius:["5.0"], src: [""]],
                 [start: ["1"], count: ["20"], mt: ["0"], q: ["someSearchPhrase"], dtstart: ["1970-01-01T00:00:10.000Z"], dtend: ["1970-01-01T00:00:10.005Z"], geometry:["GEOMETRYCOLLECTION (POLYGON ((10.2 10.2, 10.2 20.2, 20.2 20.2, 20.2 10.2, 10.2 10.2)), POLYGON ((1.1 1.1, 1.1 2.1, 2.1 2.1, 2.1 1.1, 1.1 1.1)))"], src: [""]],
-                [start: ["1"], count: ["20"], mt: ["0"], geometry:["GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (4 6), LINESTRING (4 6, 7 10)), POLYGON ((1.1 1.1, 1.1 2.1, 2.1 2.1, 2.1 1.1, 1.1 1.1)), POLYGON ((10.2 10.2, 10.2 20.2, 20.2 20.2, 20.2 10.2, 10.2 10.2)))"], lat: ["2.0"], lon: ["1.0"], radius: ["5.0"], src: [""]],
+                [start: ["1"], count: ["20"], mt: ["0"], geometry:["GEOMETRYCOLLECTION (POLYGON ((1.1 1.1, 1.1 2.1, 2.1 2.1, 2.1 1.1, 1.1 1.1)), POLYGON ((10.2 10.2, 10.2 20.2, 20.2 20.2, 20.2 10.2, 10.2 10.2)), GEOMETRYCOLLECTION (POINT (4 6), LINESTRING (4 6, 7 10)))"], lat: ["2.0"], lon: ["1.0"], radius: ["5.0"], src: [""]],
 
                 /*not supported filters and supported filters*/
                 [start: ["1"], count: ["20"], mt: ["0"], q: ["someSearchPhrase"], src: [""]],
@@ -180,7 +182,8 @@ class OpenSearchSourceSpec extends Specification {
         ]
     }
 
-    def testBboxSpatialQueries(Filter filter, Map<String, Object> expectedQueryParameters) throws UnsupportedQueryException {
+    @Unroll
+    def 'testBboxSpatialQueries #filter'(Filter filter, Map<String, Object> expectedQueryParameters) throws UnsupportedQueryException {
         given:
         final Map<String, Object> webClientQueryParameters = [:]
 
@@ -229,7 +232,8 @@ class OpenSearchSourceSpec extends Specification {
         ]
     }
 
-    def testUnsupportedQuery(Filter filter) {
+    @Unroll
+    def 'testUnsupportedQuery #filter'(Filter filter) {
         given:
         final QueryRequestImpl queryRequest = new QueryRequestImpl(new QueryImpl(filter), queryRequestProperties)
 

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitorTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitorTest.java
@@ -64,14 +64,21 @@ import org.opengis.filter.temporal.TOverlaps;
 
 public class OpenSearchFilterVisitorTest {
 
-  private static final double WKT_LON = 1;
+  private static final double WKT_LON = 1.1;
 
-  private static final double WKT_LAT = 2;
+  private static final double WKT_LAT = 2.2;
 
-  private static final String WKT_POINT = "POINT(" + WKT_LON + " " + WKT_LAT + ")";
+  private static final String WKT_POINT = "POINT (" + WKT_LON + " " + WKT_LAT + ")";
 
   private static final String WKT_POLYGON =
       "POLYGON ((1.1 1.1, 1.1 2.1, 2.1 2.1, 2.1 1.1, 1.1 1.1))";
+
+  private static final String WKT_MULTI_POLYGON =
+      "MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), "
+          + "((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), "
+          + "(30 20, 20 15, 20 25, 30 20)))";
+  private static final String WKT_GEO_COLLECTION =
+      "GEOMETRYCOLLECTION (POINT (4 6), LINESTRING (4 6, 7 10))";
 
   private static final String TEST_STRING = "test";
 
@@ -331,6 +338,7 @@ public class OpenSearchFilterVisitorTest {
         (OpenSearchFilterVisitorObject)
             openSearchFilterVisitor.visit(containsFilter, openSearchFilterVisitorObject);
     assertThat(result.getPointRadiusSearches(), is(empty()));
+    assertThat(result.getGeometrySearches(), contains(hasToString(is(WKT_POINT))));
   }
 
   @Test
@@ -359,6 +367,43 @@ public class OpenSearchFilterVisitorTest {
         (OpenSearchFilterVisitorObject)
             openSearchFilterVisitor.visit(intersectsFilter, openSearchFilterVisitorObject);
     assertThat(result.getPointRadiusSearches(), is(empty()));
+    assertThat(result.getGeometrySearches(), contains(hasToString(is(WKT_POINT))));
+  }
+
+  @Test
+  public void testIntersectsWithMultipolygon() {
+    Intersects intersectsFilter =
+        (Intersects)
+            geotoolsFilterBuilder
+                .attribute(SPATIAL_ATTRIBUTE_NAME)
+                .intersecting()
+                .wkt(WKT_MULTI_POLYGON);
+    OpenSearchFilterVisitorObject openSearchFilterVisitorObject =
+        new OpenSearchFilterVisitorObject();
+    openSearchFilterVisitorObject.setCurrentNest(NestedTypes.AND);
+    OpenSearchFilterVisitorObject result =
+        (OpenSearchFilterVisitorObject)
+            openSearchFilterVisitor.visit(intersectsFilter, openSearchFilterVisitorObject);
+    assertThat(result.getPointRadiusSearches(), is(empty()));
+    assertThat(result.getGeometrySearches(), contains(hasToString(is(WKT_MULTI_POLYGON))));
+  }
+
+  @Test
+  public void testIntersectsWithCollection() {
+    Intersects intersectsFilter =
+        (Intersects)
+            geotoolsFilterBuilder
+                .attribute(SPATIAL_ATTRIBUTE_NAME)
+                .intersecting()
+                .wkt(WKT_GEO_COLLECTION);
+    OpenSearchFilterVisitorObject openSearchFilterVisitorObject =
+        new OpenSearchFilterVisitorObject();
+    openSearchFilterVisitorObject.setCurrentNest(NestedTypes.AND);
+    OpenSearchFilterVisitorObject result =
+        (OpenSearchFilterVisitorObject)
+            openSearchFilterVisitor.visit(intersectsFilter, openSearchFilterVisitorObject);
+    assertThat(result.getPointRadiusSearches(), is(empty()));
+    assertThat(result.getGeometrySearches(), contains(hasToString(is(WKT_GEO_COLLECTION))));
   }
 
   @Test

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitorTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitorTest.java
@@ -244,8 +244,6 @@ public class OpenSearchFilterVisitorTest {
 
   @Test
   public void testDWithinCqlFilter() throws CQLException {
-    final double lon = 1.0;
-    final double lat = 2.0;
     final double radius = 1;
     DWithin dWithinFilter =
         (DWithin)
@@ -267,8 +265,8 @@ public class OpenSearchFilterVisitorTest {
         result.getPointRadiusSearches(),
         contains(
             allOf(
-                hasProperty("lon", is(lon)),
-                hasProperty("lat", is(lat)),
+                hasProperty("lon", is(WKT_LON)),
+                hasProperty("lat", is(WKT_LAT)),
                 hasProperty("radius", is(radius)))));
   }
 

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchSourceTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchSourceTest.java
@@ -118,6 +118,7 @@ public class OpenSearchSourceTest {
           "lon",
           "radius",
           "bbox",
+          "geometry",
           "polygon",
           "dtstart",
           "dtend",

--- a/distribution/docs/src/main/resources/content/_endpoints/opensearch-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/opensearch-endpoint.adoc
@@ -162,7 +162,11 @@ Examples:
 `POINT(10 20)` where 10 is the longitude and 20 is the latitude.
 
 `POLYGON ( ( 30 10, 10 20, 20 40, 40 40, 30 10 ) )`. 30 is longitude and 10 is latitude for the first point.
-|Make sure to repeat the starting point as the last point to close the polygon. Only `POINT` and `POLYGON` are supported.
+
+`MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))`
+
+`GEOMETRYCOLLECTION(POINT(4 6),LINESTRING(4 6,7 10))`
+|Make sure to repeat the starting point as the last point to close the polygon.
 
 |===
 

--- a/distribution/docs/src/main/resources/content/_sources/opensearch-source.adoc
+++ b/distribution/docs/src/main/resources/content/_sources/opensearch-source.adoc
@@ -99,7 +99,7 @@ Area between the geometries are also included in the bounding box. Hence widen t
 
 |geometry
 |geometry
-|Pulled from the ${branding} query and combine as a geometry collection if multiple spatial query exist.
+|Pulled from the ${branding} query and combined as a geometry collection if multiple spatial query exist.
 
 |polygon
 |polygon

--- a/distribution/docs/src/main/resources/content/_sources/opensearch-source.adoc
+++ b/distribution/docs/src/main/resources/content/_sources/opensearch-source.adoc
@@ -76,7 +76,8 @@ Use the OpenSearch source if querying a CDR-compliant search service is desired.
 
 |lat
 |lat
-.3+|Pulled from the query if it is a point-radius query and the radius is > 0.
+.3+|Pulled from the query if it is a point-radius query and the radius is > 0. +
+If multiple point radius searches are encountered, each point radius is converted to an approximate polygon as geometry criteria.
 
 |lon
 |lon
@@ -88,15 +89,21 @@ Use the OpenSearch source if querying a CDR-compliant search service is desired.
 |bbox
 |Pulled from the query if it is a bounding-box query. +
  +
-Or else, calculated from the query if it is a polygon query and the <<shouldConvertToBBox,`shouldConvertToBBox`>> configuration option is `true`.
+Or else, calculated from the query if it is a single geometry or polygon query and the <<shouldConvertToBBox,`shouldConvertToBBox`>> configuration option is `true`.
 NOTE: Converting a polygon that crosses the antimeridian to a bounding box will produce an incorrect bounding box. +
 //TODO DDF-3742
  +
-Or else, calculated from query if it is a point-radius query, the radius of point-radius query is > 0, and the <<shouldConvertToBBox,`shouldConvertToBBox`>> configuration option is `true`.
+Or else, calculated from the query if it is a geometry collection and the <<shouldConvertToBBox,`shouldConvertToBBox`>> configuration option is `true`.
+Note: An approximate bounding box is used to represent the geometry collection encompassing all of the geometries within it +
+Area between the geometries are also included in the bounding box. Hence widen the search area.
+
+|geometry
+|geometry
+|Pulled from the ${branding} query and combine as a geometry collection if multiple spatial query exist.
 
 |polygon
 |polygon
-|Pulled from the ${branding} query.
+|According to the OpenSearch Geo Specification this is deprecated. Use the geometry parameter instead.
 
 |start
 |dtstart

--- a/distribution/docs/src/main/resources/content/_tables/OpenSearchSource.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/OpenSearchSource.adoc
@@ -48,7 +48,7 @@
 |parameters
 |String
 |Query parameters to use with the OpenSearch connection.
-|q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort
+|q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,geometry,polygon,dtstart,dtend,dateName,filter,sort
 |true
 
 |Always perform local query


### PR DESCRIPTION
#### What does this PR do?
OpenSearch capabilities (Search/Endpoint) to OpenSearch geo Draft 2 by allowing geometries instead of polygons

OpenSearch endpoints are both upgraded to accept geometries and polygons.

OpenSearch endpoint support multiple spatial criteria at the same time (geometry, polygon, bounding box, point radius).

OpenSearch Sources generate a GeometryCollection to put in the geometry field when user defines multiple geospatial criteria in the UI.

OpenSearch Sources generate a polygon to put in the geometry field when user defines a polygon geospatial criteria in the UI.

With convertToBoundingBox as false, if OpenSearch Source encounters multiple point radius search, an approximate polygon (square) is formulated and add to a geometry collection.

With convertToBoundingBox as true, if OpenSearch Source encounters multiple point radius search, an an approximate polygon (square) is formulated and add to a geometry collection. Then the bounding box is computed from the geometry collection's envelope encompassing all the geometries. Resulting in a wider search

DDF loopback federation correctly supports multiple geometries. 

DDF loopback federation correctly supports polygon searches. 


#### Who is reviewing it? 
@millerw8 
@bdeining 
@mackncheesiest 
@mojogitoverhere 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
@bdeining
@millerw8

#### How should this be tested? (List steps with links to updated documentation)
Setup:
1. On karaf console: log:set INFO org.apache.cxf
2. Configure a Opensearch source. Turn off Convert to Bounding Box
3. Upload a geotagged image onto DDF
4. Open Advanced search dialog

Case 1
Specify a polygon and a bounding box, with one containing the uploaded image
Verify record is found. OR operation the spatial criteria. As they are combined to a Geometry Collection
Check DDF cxf log for OpenSearch request url. Verify geometry argument containing a GeometryCollection with 2 polygons

Case 2
Specify a polygon and a point radius with one containing the uploaded image
Verify the record is NOT found.  AND operation between the spatial criteria
https://codice.atlassian.net/browse/DDF-3857 to address this issue
Check DDF cxf log for OpenSearch request url. Verify a geometry argument as a POLYGON and a lat/long/radius argument.

Case 3
Specify two point radius with one containing the uploaded image or at the edge of the point radius
Verify the record is found.  Point radius is converted into two approximate polygon (square) that's group as a Geometry Collection
Check DDF cxf log for OpenSearch request url. Verify a GeometryCollection with 2 polygons

Case 4
Turn on convertToBoudningBox = true
Specify a polygon and a point radius with the uploaded image between the two spatial criteria
Verify the record is found.
Check DDF cxf log verify a large bounding box envelope was used for the search that encompassed the two spatial criteria and the result. 


#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3836

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
