### PR TITLE
DDF-3866 Added ws-security for poller and jolokia to default policy

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -264,9 +264,8 @@ grant codeBase "file:/admin-core-insecuredefaults/org.apache.felix.scr/org.apach
     permission java.io.FilePermission "${ddf.home.perm}etc${/}artemis.xml", "read";
 }
 
-grant codeBase "file:/admin-core-impl/catalog-admin-poller-service" {
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}profiles.json", "read";
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}attributeMap.properties", "read";
+grant codeBase "file:/admin-core-impl/catalog-admin-poller-service/admin-core-jolokia" {
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}-", "read";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}system.properties", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}users.properties", "read,write";


### PR DESCRIPTION
#### What does this PR do?
Adds recursive ws-security permission to source poller and jolokia.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@SmithJosh 
@peterhuffer 
@oconnormi 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/security
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@stustison
#### What are the relevant tickets?
[DDF-3866](https://codice.atlassian.net/browse/DDF-3866)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
