### PR TITLE
DDF-3842 Renames ffmpeg binaries based on codice/thirdparty change

### DIFF
--- a/catalog/plugin/catalog-plugin-videothumbnail/pom.xml
+++ b/catalog/plugin/catalog-plugin-videothumbnail/pom.xml
@@ -27,7 +27,7 @@
     <packaging>bundle</packaging>
 
     <properties>
-        <ffmpeg.version>4.0_1</ffmpeg.version>
+        <ffmpeg.version>4.0_2</ffmpeg.version>
         <ffmpeg.unpackDirectory>target/ffmpeg</ffmpeg.unpackDirectory>
     </properties>
 

--- a/catalog/plugin/catalog-plugin-videothumbnail/src/main/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPlugin.java
+++ b/catalog/plugin/catalog-plugin-videothumbnail/src/main/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPlugin.java
@@ -100,11 +100,11 @@ public class VideoThumbnailPlugin implements PostCreateStoragePlugin, PostUpdate
 
   private String getBundledFFmpegBinaryPath() {
     if (SystemUtils.IS_OS_LINUX) {
-      return "linux/ffmpeg";
+      return "linux/ffmpeg-4.0";
     } else if (SystemUtils.IS_OS_MAC) {
-      return "osx/ffmpeg";
+      return "osx/ffmpeg-4.0";
     } else if (SystemUtils.IS_OS_WINDOWS) {
-      return "windows/ffmpeg.exe";
+      return "windows/ffmpeg-4.0.exe";
     } else {
       throw new IllegalStateException(
           "OS is not Linux, Mac, or Windows."

--- a/catalog/plugin/catalog-plugin-videothumbnail/src/test/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPluginTest.java
+++ b/catalog/plugin/catalog-plugin-videothumbnail/src/test/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPluginTest.java
@@ -347,9 +347,9 @@ public class VideoThumbnailPluginTest {
     URL ffmpegBinaryUrl;
 
     if (SystemUtils.IS_OS_LINUX) {
-      ffmpegResourcePath = "linux/ffmpeg";
+      ffmpegResourcePath = "linux/ffmpeg-4.0";
     } else if (SystemUtils.IS_OS_MAC) {
-      ffmpegResourcePath = "osx/ffmpeg";
+      ffmpegResourcePath = "osx/ffmpeg-4.0";
       //      Skip unit tests on Windows. See DDF-3503.
       //    } else if (SystemUtils.IS_OS_WINDOWS) {
       //      ffmpegResourcePath = "windows/ffmpeg.exe";


### PR DESCRIPTION
#### What does this PR do?
Renames ffmpeg binary Strings based on change in https://github.com/codice/thirdparty/pull/19

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@blen-desta @brjeter @bakejeyner 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@brendan-hofmann
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Verify the unit/itests involving this bundle still function built on top of https://github.com/codice/thirdparty/pull/19

#### Any background context you want to provide?
The upstream codice/thirdparty changes rename the ffmpeg binaries so that downstream projects that utilize dependency-check-maven have less false positive CVE detections. CVE detections increased in some cases after https://github.com/codice/thirdparty/pull/18 due to dependency-check-maven using filename as evidence for version of a binary executable

#### What are the relevant tickets?
[DDF-3842](https://codice.atlassian.net/browse/DDF-3842)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
