### PR TITLE
DDF-3669 Use list and workspace metacards to determine list actions

### DIFF
--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/EmbeddedListMetacardsHandlerTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/EmbeddedListMetacardsHandlerTest.java
@@ -122,10 +122,8 @@ public class EmbeddedListMetacardsHandlerTest {
     verifyActionList(listMetacardMap);
   }
 
-  private void verifyActionList(Map listMetacardMap) {
-    assertTrue(
-        "The list metacard map didn't contain the 'actions' key.",
-        listMetacardMap.containsKey(ACTIONS_KEY));
+  private void verifyActionList(Map<String, Object> listMetacardMap) {
+    assertThat(listMetacardMap, hasKey(ACTIONS_KEY));
     List<Map<String, Object>> listMetacardActions = (List) listMetacardMap.get(ACTIONS_KEY);
     assertThat(listMetacardActions, hasSize(1));
     final Map<String, Object> actionMap = listMetacardActions.get(0);

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/EmbeddedListMetacardsHandlerTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/EmbeddedListMetacardsHandlerTest.java
@@ -16,12 +16,18 @@ package org.codice.ddf.catalog.ui.metacard.workspace.transformer.impl;
 import static java.util.Collections.singletonList;
 import static org.codice.ddf.catalog.ui.metacard.workspace.transformer.impl.EmbeddedListMetacardsHandler.ACTIONS_KEY;
 import static org.codice.ddf.catalog.ui.metacard.workspace.transformer.impl.EmbeddedListMetacardsHandler.LIST_ACTION_PREFIX;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -37,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.codice.ddf.catalog.ui.metacard.workspace.transformer.WorkspaceTransformer;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,7 +69,13 @@ public class EmbeddedListMetacardsHandlerTest {
   public void setup() throws MalformedURLException {
     embeddedListMetacardsHandler = new EmbeddedListMetacardsHandler(actionRegistry);
     final Action action = getMockAction();
-    doReturn(singletonList(action)).when(actionRegistry).list(any());
+    doReturn(singletonList(action))
+        .when(actionRegistry)
+        .list(
+            argThat(
+                Matchers.<Map<String, Metacard>>allOf(
+                    hasEntry("workspace", workspaceMetacard),
+                    hasEntry(is("list"), isA(Metacard.class)))));
   }
 
   @Test
@@ -79,11 +92,14 @@ public class EmbeddedListMetacardsHandlerTest {
     final List<Map<String, Object>> metacardMaps = jsonArgumentCaptor.getAllValues();
 
     assertThat(metacardMaps, hasSize(1));
-    assertThat(metacardMaps.get(0).get("other"), is("otherAttributes"));
+
+    final Map<String, Object> transformedMetacardMap = metacardMaps.get(0);
+    assertThat(transformedMetacardMap, hasEntry("other", "otherAttributes"));
+    assertThat(transformedMetacardMap, not(hasKey("actions")));
   }
 
   @Test
-  public void addActionList() {
+  public void addListActions() {
     final Map<String, Object> metacardMap = new HashMap<>();
     metacardMap.put("other", "otherAttributes");
 
@@ -95,24 +111,33 @@ public class EmbeddedListMetacardsHandlerTest {
         embeddedListMetacardsHandler.metacardValueToJsonValue(
             workspaceTransformer, singletonList(""), workspaceMetacard);
 
-    listMetacardsOptional.ifPresent(
-        listMetacards ->
-            ((List<Object>) listMetacards)
-                .stream()
-                .filter(Map.class::isInstance)
-                .map(Map.class::cast)
-                .forEach(listMetacardMap -> verifyActionList(listMetacardMap)));
+    assertTrue(
+        "The handler did not return any list metacard JSON maps.",
+        listMetacardsOptional.isPresent());
+
+    final List<Object> listMetacards = listMetacardsOptional.get();
+    assertThat(listMetacards, hasSize(1));
+
+    final Map listMetacardMap = (Map) listMetacards.get(0);
+    verifyActionList(listMetacardMap);
   }
 
   private void verifyActionList(Map listMetacardMap) {
-    assertTrue(listMetacardMap.containsKey(ACTIONS_KEY));
+    assertTrue(
+        "The list metacard map didn't contain the 'actions' key.",
+        listMetacardMap.containsKey(ACTIONS_KEY));
     List<Map<String, Object>> listMetacardActions = (List) listMetacardMap.get(ACTIONS_KEY);
     assertThat(listMetacardActions, hasSize(1));
     final Map<String, Object> actionMap = listMetacardActions.get(0);
-    assertThat(actionMap.get("id"), is(LIST_ACTION_PREFIX + ".test"));
-    assertThat(actionMap.get("title"), is("title"));
-    assertThat(actionMap.get("description"), is("description"));
-    assertThat(actionMap.get("url"), is("http://test.com"));
+    assertThat(actionMap, hasEntry("id", LIST_ACTION_PREFIX + ".test"));
+    assertThat(actionMap, hasEntry("title", "title"));
+    assertThat(actionMap, hasEntry("description", "description"));
+
+    try {
+      assertThat(actionMap, hasEntry("url", new URL("http://test.com")));
+    } catch (MalformedURLException e) {
+      fail(e.getMessage());
+    }
   }
 
   private Action getMockAction() throws MalformedURLException {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.hbs
@@ -40,7 +40,7 @@
     </div>
 </div>
 {{#each actions}}
-<div class="interaction interaction-action" title="{{title}}" data-help="{{description}}" data-url="{{{url}}}&listId={{../id}}">
+<div class="interaction interaction-action" title="{{title}}" data-help="{{description}}" data-url="{{{url}}}">
     <div class="interaction-icon fa fa-list">
     </div>
     <div class="interaction-text">


### PR DESCRIPTION
#### What does this PR do?
This PR changes the way list actions are obtained. Currently we are passing only the workspace metacard to the `ActionProvider`s to obtain the list actions. This PR updates the list action retrieval code so that it passes a map containing both the workspace metacard _and_ the list metacard to the `ActionProvider`s instead.

This change will make it easier for `ActionProvider` implementors to write simple and correct code. For example, prior to this change, writing an `ActionProvider` for lists that returns actions only when the list is not empty would require the implementor to deal with the list metacard XML. Now that the list is being provided to each `ActionProvider` as a `Metacard`, writing code that deals with the details of the list is easier.

##### Update
Removes the hostname fix now that support for internal/external URLs has been added.

#### Who is reviewing it? 
@Bdthomson 
@Variadicism 
@glenhein 
@dimitry-sherman

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining 

#### How should this be tested? (List steps with links to updated documentation)
Build [this branch](https://github.com/jrnorth/ddf/tree/list-action-provider-test) from my DDF fork and run `install -s mvn:ddf.catalog.core/catalog-core-listactionprovider/2.12.0-SNAPSHOT` in the DDF console. It's an action provider that provides list actions. Create a list, add some items, and verify that the list actions still work.

#### What are the relevant tickets?
[DDF-3669](https://codice.atlassian.net/browse/DDF-3669)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
