### PR TITLE
DDF-3817 Revert destroy argument

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
@@ -221,6 +221,8 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
    * <p>Only remove routes that this Content Directory Monitor created since the same CamelContext
    * is shared across all Content Directory Monitors.
    */
+  @SuppressWarnings(
+      "squid:S1172" /* The code parameter is required in blueprint-cm-1.0.7. See https://issues.apache.org/jira/browse/ARIES-1436. */)
   public void destroy(int code) {
     if (routeCollection == null) {
       return;

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -1872,7 +1872,9 @@ public abstract class AbstractCswSource extends MaskableImpl
   }
 
   /** Clean-up when shutting down the CswSource */
-  public void destroy() {
+  @SuppressWarnings(
+      "squid:S1172" /* The code parameter is required in blueprint-cm-1.0.7. See https://issues.apache.org/jira/browse/ARIES-1436. */)
+  public void destroy(int code) {
     LOGGER.debug("{}: Entering destroy()", cswSourceConfiguration.getId());
     availabilityPollFuture.cancel(true);
     scheduler.shutdownNow();

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -281,6 +281,8 @@ public class WfsSource extends AbstractWfsSource {
     setupAvailabilityPoll();
   }
 
+  @SuppressWarnings(
+      "squid:S1172" /* The code parameter is required in blueprint-cm-1.0.7. See https://issues.apache.org/jira/browse/ARIES-1436. */)
   public void destroy(int code) {
     unregisterAllMetacardTypes();
     availabilityPollFuture.cancel(true);

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
@@ -280,6 +280,8 @@ public class WfsSource extends AbstractWfsSource {
     setupAvailabilityPoll();
   }
 
+  @SuppressWarnings(
+      "squid:S1172" /* The code parameter is required in blueprint-cm-1.0.7. See https://issues.apache.org/jira/browse/ARIES-1436. */)
   public void destroy(int code) {
     unregisterAllMetacardTypes();
     availabilityPollFuture.cancel(true);


### PR DESCRIPTION
#### What does this PR do?
Reverts a recent change to destroy method in AbstractCswSource and adds suppression in other areas.

#### Who is reviewing it? 
@vinamartin @emmberk 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@stustison

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
See https://issues.apache.org/jira/browse/ARIES-1436. Bug fixed in 1.2.0, DDF is on 1.1.0. This causes the destroy method to not be called.

#### What are the relevant tickets?
[DDF-3817](https://codice.atlassian.net/browse/DDF-3817)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
