### PR TITLE
DDF-3855: Add CSRF Protections to Jolokia and Intrigue Endpoints

### DIFF
--- a/distribution/docs/src/main/resources/content/_appReferences/mg-broker-app.adoc
+++ b/distribution/docs/src/main/resources/content/_appReferences/mg-broker-app.adoc
@@ -66,7 +66,7 @@ Once both servers are started, the following command can be run using curl or a 
 [source,bash]
 ----
 sh
-curl ${secure_url}/admin/jolokia/read/org.apache.activemq.artemis:broker=%22<FQDN>%22/ReplicaSync --user admin:admin --insecure
+curl ${secure_url}/admin/jolokia/read/org.apache.activemq.artemis:broker=%22<FQDN>%22/ReplicaSync --user admin:admin --header "Origin: ${secure_url}" --header "X-Requested-With: XMLHttpRequest" --insecure
 ----
 
 .Example ReplicaSync JSON Response
@@ -100,7 +100,7 @@ Additionally, for more details about the health of the cluster, the following co
 [source]
 ----
 sh
-curl ${secure_url}/admin/jolokia/read/org.apache.activemq.artemis:broker=%22<FQDN>%22,component=cluster-connections,name=%22broker-cluster%22/Topology --user admin:admin --insecure
+curl ${secure_url}/admin/jolokia/read/org.apache.activemq.artemis:broker=%22<FQDN>%22,component=cluster-connections,name=%22broker-cluster%22/Topology --user admin:admin --header "Origin: ${secure_url}" --header "X-Requested-With: XMLHttpRequest" --insecure
 ----
 
 This endpoint returns diagnostic info about the cluster that can be used for troubleshooting. Values of interest in the response are the `node=2` value which is a count of the nodes in the cluster and the port/host values for each node.

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerImpl.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerImpl.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.itests.common;
 
 import static com.jayway.restassured.RestAssured.get;
+import static com.jayway.restassured.RestAssured.given;
 import static org.apache.karaf.features.FeaturesService.Option.NoAutoRefreshBundles;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.fail;
@@ -495,7 +496,8 @@ public class ServiceManagerImpl implements ServiceManager {
     boolean available = false;
 
     while (!available) {
-      Response response = get(path);
+      Response response =
+          given().header("X-Requested-With", "XMLHttpRequest").header("Origin", path).get(path);
       available = response.getStatusCode() == 200 && response.getBody().asString().length() > 0;
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Response body: {}", response.getBody().asString());

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -932,6 +932,8 @@ public class TestFederation extends AbstractIntegrationTest {
         .auth()
         .preemptive()
         .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", ADMIN_ALL_SOURCES_PATH.getUrl())
         .when()
         .get(ADMIN_ALL_SOURCES_PATH.getUrl())
         .then()
@@ -950,6 +952,8 @@ public class TestFederation extends AbstractIntegrationTest {
             .auth()
             .preemptive()
             .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+            .header("X-Requested-With", "XMLHttpRequest")
+            .header("Origin", ADMIN_ALL_SOURCES_PATH.getUrl())
             .when()
             .get(ADMIN_ALL_SOURCES_PATH.getUrl())
             .asString();
@@ -967,6 +971,8 @@ public class TestFederation extends AbstractIntegrationTest {
     given()
         .auth()
         .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", ADMIN_STATUS_PATH.getUrl())
         .when()
         .get(ADMIN_STATUS_PATH.getUrl() + openSearchPid)
         .then()
@@ -988,6 +994,8 @@ public class TestFederation extends AbstractIntegrationTest {
         given()
             .auth()
             .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+            .header("X-Requested-With", "XMLHttpRequest")
+            .header("Origin", ADMIN_ALL_SOURCES_PATH.getUrl())
             .when()
             .get(ADMIN_ALL_SOURCES_PATH.getUrl())
             .asString();
@@ -1006,6 +1014,8 @@ public class TestFederation extends AbstractIntegrationTest {
     given()
         .auth()
         .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", ADMIN_STATUS_PATH.getUrl())
         .when()
         .get(ADMIN_STATUS_PATH.getUrl() + connectedSourcePid)
         .then()
@@ -1670,13 +1680,19 @@ public class TestFederation extends AbstractIntegrationTest {
 
     // This query will put the ingested metacards from the BeforeExam method into the cache
     given()
+        .log()
+        .all()
         .contentType("application/json")
         .auth()
         .basic(LOCALHOST_USERNAME, LOCALHOST_PASSWORD)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", cqlUrl)
         .body(srcRequest)
         .when()
         .post(cqlUrl)
         .then()
+        .log()
+        .all()
         .statusCode(200);
 
     // CacheBulkProcessor could take up to 10 seconds to flush the cached results into solr
@@ -2843,6 +2859,8 @@ public class TestFederation extends AbstractIntegrationTest {
         .contentType("application/json")
         .auth()
         .basic(LOCALHOST_USERNAME, LOCALHOST_PASSWORD)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", cqlUrl)
         .body(cacheRequest)
         .when()
         .post(cqlUrl)

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestMessageBroker.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestMessageBroker.java
@@ -261,6 +261,8 @@ public class TestMessageBroker extends AbstractIntegrationTest {
         .auth()
         .preemptive()
         .basic(ADMIN_USERNAME, ADMIN_PASSWORD)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", operationUrl)
         .when()
         .get(operationUrl)
         .asString();

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
@@ -62,6 +62,8 @@ public class TestPlatform extends AbstractIntegrationTest {
             .auth()
             .preemptive()
             .basic("admin", "admin")
+            .header("X-Requested-With", "XMLHttpRequest")
+            .header("Origin", LOGGING_SERVICE_JOLOKIA_URL.getUrl())
             .expect()
             .statusCode(200)
             .when()

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
@@ -1420,6 +1420,8 @@ public class TestSecurity extends AbstractIntegrationTest {
     return given()
         .auth()
         .basic("admin", "admin")
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", SECURE_ROOT_AND_PORT.getUrl())
         .get(SECURE_ROOT_AND_PORT + jolokiaEndpoint)
         .body()
         .print();
@@ -1429,6 +1431,8 @@ public class TestSecurity extends AbstractIntegrationTest {
     return given()
         .auth()
         .basic(SYSTEM_ADMIN_USER, SYSTEM_ADMIN_USER_PASSWORD)
+        .header("X-Requested-With", "XMLHttpRequest")
+        .header("Origin", SECURE_ROOT_AND_PORT.getUrl())
         .get(SECURE_ROOT_AND_PORT + jolokiaEndpoint)
         .body()
         .print();

--- a/features/security/pom.xml
+++ b/features/security/pom.xml
@@ -218,6 +218,11 @@
         </dependency>
         <dependency>
             <groupId>ddf.security.filter</groupId>
+            <artifactId>security-filter-csrf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.filter</groupId>
             <artifactId>security-filter-login</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -337,6 +337,13 @@
         <bundle>mvn:ddf.security.handler/security-handler-basic/${project.version}</bundle>
     </feature>
 
+    <feature name="security-filter-csrf" version="${project.version}"
+             description="CSRF Filter for web applications.">
+        <feature>security-core-api</feature>
+        <feature>platform-filter-delegate</feature>
+        <bundle>mvn:ddf.security.filter/security-filter-csrf/${project.version}</bundle>
+    </feature>
+
     <feature name="security-filter-login" version="${project.version}"
              description="Login Filter for web applications.">
         <feature>security-core</feature>
@@ -577,6 +584,7 @@
         <feature>security-expansion-metacard-attributes</feature>
         <feature>security-sts-server</feature>
         <feature>security-filter-web-sso</feature>
+        <feature>security-filter-csrf</feature>
         <feature>security-filter-login</feature>
         <feature>security-handler-saml</feature>
         <feature>security-handler-basic</feature>

--- a/platform/security/filter/pom.xml
+++ b/platform/security/filter/pom.xml
@@ -37,5 +37,6 @@
         <module>security-filter-web-sso</module>
         <module>security-filter-login</module>
         <module>security-filter-authorization</module>
+        <module>security-filter-csrf</module>
     </modules>
 </project>

--- a/platform/security/filter/security-filter-csrf/pom.xml
+++ b/platform/security/filter/security-filter-csrf/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>filter</artifactId>
+        <groupId>ddf.security.filter</groupId>
+        <version>2.12.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>DDF :: Security :: Filter :: CSRF</name>
+    <artifactId>security-filter-csrf</artifactId>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-filter-delegate</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- TEST DEPENDENCIES -->
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.91</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.91</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.84</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/security/filter/security-filter-csrf/src/main/java/org/codice/ddf/security/filter/csrf/CsrfFilter.java
+++ b/platform/security/filter/security-filter-csrf/src/main/java/org/codice/ddf/security/filter/csrf/CsrfFilter.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.filter.csrf;
+
+import ddf.security.common.audit.SecurityLogger;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.platform.filter.SecurityFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Contains multiple checks to prevent cross-site requests for protected context paths. */
+public class CsrfFilter implements SecurityFilter {
+
+  public static final String CSRF_HEADER = "X-Requested-With";
+  public static final String ORIGIN_HEADER = "Origin";
+  public static final String REFERER_HEADER = "Referer";
+
+  public static final String JOLOKIA_CONTEXT = "/admin/jolokia";
+  public static final String INTRIGUE_CONTEXT = "/search/catalog/internal";
+  public static final String WEBSOCKET_CONTEXT = "/search/catalog/ws";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CsrfFilter.class);
+
+  // List of context paths that require cross-site protections
+  private List<String> protectedContexts;
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    LOGGER.debug("Starting CSRF filter.");
+
+    protectedContexts = new ArrayList<>();
+    protectedContexts.add(JOLOKIA_CONTEXT);
+    protectedContexts.add(INTRIGUE_CONTEXT);
+    protectedContexts.add(WEBSOCKET_CONTEXT);
+  }
+
+  /**
+   * Checks that the origin or referer header of the request matches the target origin when
+   * attempting to access certain contexts. Also checks for the existence of anti-CSRF header
+   * "X-Requested-With". A 403 is returned and the request is stopped if one or more of these
+   * conditions are met: - No Origin or Referer header is present on the request. - Neither the
+   * Origin or Referer header match the target origin. - An X-Requested-With header is not present
+   * on the request.
+   *
+   * @param request incoming http request
+   * @param response response stream for returning the response
+   * @param chain chain of filters to be invoked following this filter
+   * @throws IOException
+   * @throws ServletException
+   */
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    LOGGER.debug("Performing doFilter() on CsrfFilter");
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    HttpServletResponse httpResponse = (HttpServletResponse) response;
+    String targetContextPath = httpRequest.getRequestURI();
+
+    // Begin CSRF checks if request is accessing a Cross-Site protected context
+    if (protectedContexts.stream().anyMatch(targetContextPath::startsWith)) {
+
+      String targetOrigin = httpRequest.getRequestURL().toString();
+      String sourceOrigin = httpRequest.getHeader(ORIGIN_HEADER);
+      String sourceReferer = httpRequest.getHeader(REFERER_HEADER);
+      String csrfHeader = httpRequest.getHeader(CSRF_HEADER);
+
+      // Reject if no origin or referer header is present on the request
+      if (sourceOrigin == null && sourceReferer == null) {
+        respondForbidden(
+            httpResponse, "Incoming request did not have an Origin or Referer header.");
+        return;
+      }
+
+      // Reject if neither the Origin or Referer header match the target origin
+      if (!isSameOrigin(sourceOrigin, targetOrigin) && !isSameOrigin(sourceReferer, targetOrigin)) {
+        respondForbidden(
+            httpResponse, "Origin or Referer header of request did not match target origin.");
+        return;
+      }
+
+      // Check for presence of anti-CSRF header
+      // WebSockets API does not allow for custom headers, origin check is sufficient
+      if (!targetContextPath.startsWith(WEBSOCKET_CONTEXT) && csrfHeader == null) {
+        respondForbidden(httpResponse, "Request did not have required X-Requested-With header.");
+        return;
+      }
+    }
+
+    // All checks passed
+    chain.doFilter(request, response);
+  }
+
+  /**
+   * Returns true if both URLs have the same host and port. If either are null or empty, false is
+   * returned
+   *
+   * @param source source URL
+   * @param target destination URL
+   * @return true if matching, false if different or a parsing error occurs
+   */
+  private Boolean isSameOrigin(String source, String target) {
+    if (StringUtils.isBlank(source) || StringUtils.isBlank(target)) {
+      return false;
+    } else {
+      try {
+        String sourceOrigin = new URL(source).getAuthority();
+        String targetOrigin = new URL(target).getAuthority();
+        return (sourceOrigin.equals(targetOrigin));
+      } catch (MalformedURLException e) {
+        LOGGER.debug("Could not extract origin from URLs", e);
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Security audits, logs, and then responds with a 403.
+   *
+   * @param httpResponse
+   * @param msg
+   */
+  private void respondForbidden(HttpServletResponse httpResponse, String msg) {
+    SecurityLogger.audit(msg);
+    LOGGER.debug(msg);
+    try {
+      httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN);
+      httpResponse.flushBuffer();
+    } catch (IOException ioe) {
+      LOGGER.debug("Failed to send auth response: {}", ioe);
+    }
+  }
+
+  @Override
+  public void destroy() {
+    LOGGER.debug("Destroying CSRF filter.");
+  }
+}

--- a/platform/security/filter/security-filter-csrf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/filter/security-filter-csrf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="
+  http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="filter" class="org.codice.ddf.security.filter.csrf.CsrfFilter"/>
+
+    <service ref="filter"
+             interface="org.codice.ddf.platform.filter.SecurityFilter" ranking="100">
+        <service-properties>
+            <entry key="osgi.http.whiteboard.filter.name" value="csrf-filter"/>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/platform/security/filter/security-filter-csrf/src/test/groovy/org/codice/ddf/security/filter/csrf/CsrfFilterSpec.groovy
+++ b/platform/security/filter/security-filter-csrf/src/test/groovy/org/codice/ddf/security/filter/csrf/CsrfFilterSpec.groovy
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.filter.csrf
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class CsrfFilterSpec extends Specification {
+
+    @Unroll
+    def 'test allowed'(String requestContext, String originHeader, String refererHeader, boolean hasCsrfHeader) {
+        given:
+        CsrfFilter csrfFilter = new CsrfFilter()
+        csrfFilter.init()
+        HttpServletResponse response = Mock(HttpServletResponse)
+        FilterChain chain = Mock(FilterChain)
+
+        when:
+        String requestUrl = "https://ddf:123" + requestContext
+        HttpServletRequest request = Mock(HttpServletRequest)
+        request.getRequestURL() >> new StringBuffer(requestUrl)
+        request.getRequestURI() >> requestContext
+        request.getHeader(CsrfFilter.ORIGIN_HEADER) >> originHeader
+        request.getHeader(CsrfFilter.REFERER_HEADER) >> refererHeader
+        if (hasCsrfHeader) {
+            request.getHeader(CsrfFilter.CSRF_HEADER) >> "XMLHttpRequest"
+        } else {
+            request.getHeader(CsrfFilter.CSRF_HEADER) >> null
+        }
+
+        csrfFilter.doFilter(request, response, chain)
+
+        then:
+        0 * response.setStatus(HttpServletResponse.SC_FORBIDDEN)
+        0 * response.sendError(HttpServletResponse.SC_FORBIDDEN)
+        0 * response.flushBuffer()
+        1 * chain.doFilter(_, _)
+
+        where:
+        requestContext             | originHeader          | refererHeader         | hasCsrfHeader
+        // Cross origin allowed contexts
+        "/"                        | null                  | null                  | false
+        "/test"                    | null                  | null                  | false
+        "/test"                    | "https://example.com" | null                  | false
+        "/test"                    | null                  | "https://example.com" | false
+        "/test"                    | "https://example.com" | "https://example.com" | false
+        "/test"                    | "https://ddf:123/"    | "https://ddf:123/"    | false
+        "/test"                    | "https://example.com" | "https://example.com" | true
+        "/test"                    | "https://ddf:123/"    | "https://ddf:123/"    | true
+        // Cross origin protected contexts
+        "/admin/jolokia"           | "https://ddf:123/"    | null                  | true
+        "/admin/jolokia"           | null                  | "https://ddf:123/"    | true
+        "/admin/jolokia"           | "https://ddf:123/"    | "https://ddf:123/"    | true
+        "/search/catalog/internal" | "https://ddf:123/"    | null                  | true
+        "/search/catalog/internal" | null                  | "https://ddf:123/"    | true
+        "/search/catalog/internal" | "https://ddf:123/"    | "https://ddf:123/"    | true
+        // Web sockets endpoint requiring same origin but no CSRF header
+        "/search/catalog/ws"       | "https://ddf:123/"    | null                  | true
+        "/search/catalog/ws"       | null                  | "https://ddf:123/"    | true
+        "/search/catalog/ws"       | "https://ddf:123/"    | "https://ddf:123/"    | true
+
+    }
+
+    @Unroll
+    def 'test forbidden'(String requestContext, String originHeader, String refererHeader, boolean hasCsrfHeader) {
+        given:
+        CsrfFilter csrfFilter = new CsrfFilter()
+        csrfFilter.init()
+        HttpServletResponse response = Mock(HttpServletResponse)
+        FilterChain chain = Mock(FilterChain)
+
+        when:
+        String requestUrl = "https://ddf:123" + requestContext
+        HttpServletRequest request = Mock(HttpServletRequest)
+        request.getRequestURL() >> new StringBuffer(requestUrl)
+        request.getRequestURI() >> requestContext
+        request.getHeader(CsrfFilter.ORIGIN_HEADER) >> originHeader
+        request.getHeader(CsrfFilter.REFERER_HEADER) >> refererHeader
+        if (hasCsrfHeader) {
+            request.getHeader(CsrfFilter.CSRF_HEADER) >> "XMLHttpRequest"
+        } else {
+            request.getHeader(CsrfFilter.CSRF_HEADER) >> null
+        }
+
+        csrfFilter.doFilter(request, response, chain)
+
+        then:
+        1 * response.setStatus(HttpServletResponse.SC_FORBIDDEN)
+        1 * response.sendError(HttpServletResponse.SC_FORBIDDEN)
+        1 * response.flushBuffer()
+        0 * chain.doFilter(_, _)
+
+        where:
+        requestContext             | originHeader          | refererHeader         | hasCsrfHeader
+        // No CSRF Header - same origin
+        "/admin/jolokia"           | "https://ddf:123/"    | null                  | false
+        "/admin/jolokia"           | null                  | "https://ddf:123/"    | false
+        "/admin/jolokia"           | "https://ddf:123/"    | "https://ddf:123/"    | false
+        "/search/catalog/internal" | "https://ddf:123/"    | null                  | false
+        "/search/catalog/internal" | null                  | "https://ddf:123/"    | false
+        "/search/catalog/internal" | "https://ddf:123/"    | "https://ddf:123/"    | false
+        // CSRF header - different origin
+        "/admin/jolokia"           | "https://example.com" | null                  | true
+        "/admin/jolokia"           | null                  | "https://example.com" | true
+        "/admin/jolokia"           | "https://example.com" | "https://example.com" | true
+        "/search/catalog/internal" | "https://example.com" | null                  | true
+        "/search/catalog/internal" | null                  | "https://example.com" | true
+        "/search/catalog/internal" | "https://example.com" | "https://example.com" | true
+        // completely cross-site
+        "/admin/jolokia"           | null                  | null                  | false
+        "/admin/jolokia"           | "https://example.com" | null                  | false
+        "/admin/jolokia"           | null                  | "https://example.com" | false
+        "/admin/jolokia"           | "https://example.com" | "https://example.com" | false
+        "/search/catalog/internal" | null                  | null                  | false
+        "/search/catalog/internal" | "https://example.com" | null                  | false
+        "/search/catalog/internal" | null                  | "https://example.com" | false
+        "/search/catalog/internal" | "https://example.com" | "https://example.com" | false
+        // Web sockets endpoint requiring same origin but no CSRF header -
+        "/search/catalog/ws"       | "https://example.com" | null                  | true
+        "/search/catalog/ws"       | null                  | "https://example.com" | true
+        "/search/catalog/ws"       | "https://example.com" | "https://example.com" | true
+        // Corrupted origin/referer headers
+        "/admin/jolokia"           | "com?ht.p://*example" | null                  | true
+        "/admin/jolokia"           | null                  | "com?ht.p://*example" | true
+        "/admin/jolokia"           | "com?ht.p://*example" | "com?ht.p://*example" | true
+        "/admin/jolokia"           | "!@#\$%^&*(){}:<>?"   | "!@#\$%^&*(){}:<>?"   | true
+    }
+}

--- a/ui/packages/admin-core-logviewer/src/main/webapp/js/backend/index.js
+++ b/ui/packages/admin-core-logviewer/src/main/webapp/js/backend/index.js
@@ -20,7 +20,12 @@ require('isomorphic-fetch')
 export const getLogs = (done) => {
   const endpoint = '/admin/jolokia/exec/org.codice.ddf.platform.logging.LoggingService:service=logging-service/retrieveLogEvents'
 
-  window.fetch(endpoint, {credentials: 'same-origin'})
+  window.fetch(endpoint, {
+    credentials: 'same-origin',
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest'
+    }
+  })
     .then((res) => res.json())
     .then((json) => done(null, json.value))
     .catch(done)

--- a/ui/packages/admin-core-logviewer/src/main/webapp/js/components/log-entry/log-entry.js
+++ b/ui/packages/admin-core-logviewer/src/main/webapp/js/components/log-entry/log-entry.js
@@ -82,4 +82,3 @@ export default ({ entry, marks, expandedHash, dispatch }) => {
     </tr>
   )
 }
-

--- a/ui/packages/admin-core-logviewer/src/test/js/actions.js
+++ b/ui/packages/admin-core-logviewer/src/test/js/actions.js
@@ -82,4 +82,3 @@ test('append with new logs', (t) => {
 
   fetch(getLogs)(dispatch, getState)
 })
-

--- a/ui/packages/admin-security-certificate-ui/src/main/webapp/main.js
+++ b/ui/packages/admin-security-certificate-ui/src/main/webapp/main.js
@@ -129,6 +129,13 @@ require(['underscore',
             return ich[template](data);
         };
 
+        // Add anti-CSRF header to outgoing calls
+        Backbone.$.ajaxSetup({
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        });
+
         // Actually start up the application.
         app.App.start({});
     });

--- a/ui/packages/broker-undelivered-messages-ui/src/main/webapp/index.js
+++ b/ui/packages/broker-undelivered-messages-ui/src/main/webapp/index.js
@@ -13,18 +13,18 @@ import React from 'react'
 import {render} from 'react-dom'
 import store from './store'
 import {
-    isAllSelected,
-    getSelectedIds,
-    getSelectedMessages,
-    getIds
+  isAllSelected,
+  getSelectedIds,
+  getSelectedMessages,
+  getIds
 } from './reducer'
 import {
-    addMessage,
-    checkAllMessages,
-    togglePolling,
-    expandAllMessages,
-    updateDeleted,
-    removeMessages
+  addMessage,
+  checkAllMessages,
+  togglePolling,
+  expandAllMessages,
+  updateDeleted,
+  removeMessages
 } from './actions'
 import TableView from './table.view'
 
@@ -34,7 +34,12 @@ require('isomorphic-fetch')
 const getMessagesURI = '/admin/jolokia/exec/org.codice.ddf.broker.ui.UndeliveredMessages:service=UndeliveredMessages/getMessages/DLQ/DLQ/'
 
 const retrieveData = (data, url) =>
-  window.fetch(url, {credentials: 'same-origin'})
+  window.fetch(url, {
+    credentials: 'same-origin',
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest'
+    }
+  })
     .then((res) => res.json())
     .then((json) => {
       json.value.filter((message) => !(getIds(data).includes(message.messageID))).map((message) => {
@@ -57,7 +62,8 @@ const operateOnData = (data, method) => {
     method: 'POST',
     credentials: 'same-origin',
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest'
     },
     body: JSON.stringify({
       type: 'EXEC',

--- a/ui/packages/catalog-admin-module-layout/src/main/webapp/default-layout/reducer.js
+++ b/ui/packages/catalog-admin-module-layout/src/main/webapp/default-layout/reducer.js
@@ -114,7 +114,10 @@ export const fetch = () => (dispatch, getState) => {
   ].join('/')
 
   window.fetch(url, {
-    credentials: 'same-origin'
+    credentials: 'same-origin',
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest'
+    }
   }).then((res) => res.json())
     .then((json) => {
       const config = fromJS(json)
@@ -157,7 +160,8 @@ export const save = () => (dispatch, getState) => {
     credentials: 'same-origin',
     headers: {
       'Content-Type': 'application/json',
-      'Accept': 'application/json'
+      'Accept': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest'
     },
     body: JSON.stringify(body)
   }

--- a/ui/packages/catalog-admin-module-layout/src/main/webapp/lib/react-mount/index.js
+++ b/ui/packages/catalog-admin-module-layout/src/main/webapp/lib/react-mount/index.js
@@ -32,4 +32,3 @@ export default class extends Component {
     return null
   }
 }
-

--- a/ui/packages/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
+++ b/ui/packages/catalog-admin-module-maplayers/src/main/webapp/map-layers/index.js
@@ -280,8 +280,8 @@ const ProviderEditor = ({ provider, onUpdate, buffer, onEdit, error = Map() }) =
           <div key='ace' style={{ margin: '0 15px' }}>
             <Error errorText={
               ['buffer', 'proxyEnabled', 'order', 'show', 'withCredentials']
-              .map((key) => error.get(key))
-              .filter((msg) => msg !== undefined)[0]
+                .map((key) => error.get(key))
+                .filter((msg) => msg !== undefined)[0]
             }>
               <AceEditor
                 mode='json'
@@ -430,12 +430,12 @@ const MapLayers = (props) => {
             {(i === 0)
               ? <div style={{textAlign: 'center', paddingTop: 20, fontWeight: 'bold', fontSize: '1.2rem'}}>
                   Topmost Layer
-                </div>
+              </div>
               : null}
             {(i > 0 && i === providers.size - 1)
               ? <div style={{textAlign: 'center', paddingTop: 20, fontWeight: 'bold', fontSize: '1.2rem'}}>
                   Bottommost Layer
-                </div>
+              </div>
               : null}
             <div style={{ position: 'absolute', top: 20, right: 20 }}>
               {(i < providers.size - 1)

--- a/ui/packages/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
+++ b/ui/packages/catalog-admin-module-maplayers/src/main/webapp/map-layers/reducer.js
@@ -44,7 +44,12 @@ export const fetch = () => (dispatch) => {
     '(service.pid=org.codice.ddf.catalog.ui.config)'
   ].join('/')
 
-  window.fetch(url, { credentials: 'same-origin' })
+  window.fetch(url, {
+    credentials: 'same-origin',
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest'
+    }
+  })
     .then((res) => res.json())
     .then((json) => {
       const config = fromJS(json).getIn(configPath)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
@@ -14,7 +14,10 @@
 require('styles/styles.less');
 var $ = require('jquery')
 $.ajaxSetup({
-    cache: false
+    cache: false,
+    headers: {
+        'X-Requested-With': 'XMLHttpRequest'
+    }
 });
 
 if (process.env.NODE_ENV !== 'production') {

--- a/ui/packages/ui/src/main/webapp/main.js
+++ b/ui/packages/ui/src/main/webapp/main.js
@@ -152,7 +152,14 @@
             Application.App.mainRegion.show(new ModuleView({model: Application.ModuleModel}));
         });
 
-        //setup the header
+        // add anti-csrf header to outgoing requests
+        $.ajaxSetup({
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        });
+
+        // setup the header
         app.addInitializer(function () {
             if (Properties.ui.header && Properties.ui.header !== '') {
                 $('html').addClass('has-header');


### PR DESCRIPTION
#### What does this PR do?
Adds the header "X-Requested-With" as a required header on the backend so that all incoming requests to anything under `/admin/jolokia` or `/search/catalog/internal` must contain this header or a 403 will be returned. Value of this header can be anything, only it's presence is checked. The incoming request must also have either an origin or referer header that matches the target origin or a 403 will be returned. Also adds this header to any necessary UI packages.

#### Who is reviewing it? 
@djblue 
@rzwiefel 
@tbatie 

#### Select relevant component teams: 
@codice/security 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler 
@stustison

#### How should this be tested?
Make sure the admin UI and Intrigue still work. Watch network requests and make sure no 403s are returned. Try accessing jolokia & intrigue internal URLs directly and ensure that they cannot be accessed - a 403 should be returned. See below for a list of packages and contexts that make jolokia and intrigue contexts that should be checked for compatibility.

#### Any background context you want to provide?
Currently holding out on merging this PR while downstream Codice project frontends are checked and modified to ensure compatibility with this new requirement.

The following UI packages under `/ui/packages` make jolokia or intrigue calls and were checked for functionality to ensure that the header was being attached to any outgoing jolokia requests:
`jQuery-updated` ui - /admin
`ok` spatial-geocoding-admin-module - /admin/spatial-config
`ok` resourcemanagement-usage-ui - /admin/data-usage
`ok` resourcemanagement-querymonitor-ui - /admin/queries
`ok` registry-admin-remote-ui - /admin/registry/remote
`ok` registry-admin-local-ui - /admin/registry/local
`ok` catalog-admin-module-sources - /admin/sources
`fetch-updated` catalog-admin-module-maplayers - /admin/map-layers
`fetch-updated` catalog-admin-module-layout - /admin/default-layout
`fetch-updated` broker-undelivered-messages-ui - /admin/undeliveredMessages
`ok` admin-security-certificate-ui - /admin/certificate
`used in test-only` admin-metrics-ui - /admin/metrics
`fetch-updated` admin-core-logviewer - /admin/logviewer

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3855

#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [X] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
