### PR TITLE
DDF-3763 removed fabric8-karaf-checks from default boot features

### DIFF
--- a/features/kernel/src/main/feature/feature.xml
+++ b/features/kernel/src/main/feature/feature.xml
@@ -26,7 +26,6 @@
         <feature version="${karaf.version}">eventadmin</feature>
         <feature version="${karaf.version}">jasypt-encryption</feature>
         <feature version="${karaf.version}">http</feature>
-        <feature version="${fabric8.version}">fabric8-karaf-checks</feature>
     </feature>
 
     <feature name="javax-validation" version="${project.version}">


### PR DESCRIPTION
#### What does this PR do?

After #3155 was merged some inconsistencies were soon during startup of the system. This change will leave the `fabric8-karaf-features` repo in ddf but will remove the `fabric8-karaf-checks` feature from the boot features. The feature can be turned on manually in the future until the underlying issue is found

#### Who is reviewing it? 
@peterhuffer @roelens8 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
@coyotesqrl @clockard 

#### How should this be tested? (List steps with links to updated documentation)
Verify that things are back to normal after starting up the system. Check Intrigue and ingest through Intrigue

#### What are the relevant tickets?
[DDF-3763](https://codice.atlassian.net/browse/DDF-3763)
#### Screenshots (if appropriate)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
