### PR TITLE
GSR-1974: Fixed workspace being modified by paging

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -104,7 +104,7 @@ module.exports = Backbone.AssociatedModel.extend({
     handleChange: function (model) {
         if (model !== undefined &&
             _.intersection(Object.keys(model.changedAttributes()), [
-                'result', 'saved', 'metacard.modified', 'id', 'subscribed'
+                'result', 'saved', 'metacard.modified', 'id', 'subscribed', 'serverPageIndex'
             ]).length === 0) {
             this.set('saved', false);
         }


### PR DESCRIPTION
Added `serverPageIndex` event to the list of those to be ignored when setting the `Workspace` model 'dirty'

#### What does this PR do?
Fixes workspace being set into `unsaved` state when paging through the results, specifically when attempting to get a new serve page.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler 
@millerw8 

#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
