### PR TITLE
DDF-3925 Fixed workspace state being modified by paging

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -104,7 +104,7 @@ module.exports = Backbone.AssociatedModel.extend({
     handleChange: function (model) {
         if (model !== undefined &&
             _.intersection(Object.keys(model.changedAttributes()), [
-                'result', 'saved', 'metacard.modified', 'id', 'subscribed'
+                'result', 'saved', 'metacard.modified', 'id', 'subscribed', 'serverPageIndex'
             ]).length === 0) {
             this.set('saved', false);
         }

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -19,6 +19,15 @@ var ColorGenerator = require('js/ColorGenerator');
 var QueryPolling = require('js/QueryPolling');
 require('backbone-associations');
 
+// This is a list of model attributes that if changed we do not want save the workspace for
+const IGNORED_WORKSPACE_ATTRIBUTES = ['result', 'saved', 'metacard.modified', 'id', 'subscribed', 'serverPageIndex'];
+
+/**
+ * Check if any of the `changedAttributes` fall outside of the `IGNORED_WORKSPACE_ATTRIBUTES` list.
+ * @param {model} model 
+ */
+const workspaceShouldBeResaved = (model) => model && _.intersection(Object.keys(model.changedAttributes()), IGNORED_WORKSPACE_ATTRIBUTES).length === 0;
+
 const WorkspaceQueryCollection = Backbone.Collection.extend({
     model: Query.Model,
     initialize: function () {
@@ -102,10 +111,7 @@ module.exports = Backbone.AssociatedModel.extend({
         this.set('saved', false);
     },
     handleChange: function (model) {
-        if (model !== undefined &&
-            _.intersection(Object.keys(model.changedAttributes()), [
-                'result', 'saved', 'metacard.modified', 'id', 'subscribed', 'serverPageIndex'
-            ]).length === 0) {
+        if (workspaceShouldBeResaved(model)) {
             this.set('saved', false);
         }
     },


### PR DESCRIPTION
#### What does this PR do?
Fixes workspace being set into unsaved state when paging through the results, specifically when attempting to get a new serve page.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@millerw8 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@millerw8 
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3925
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
