### PR TITLE
DDF-3763 Moving SAML metadata reads into privileged blocks.

### DIFF
--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -234,7 +234,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.58</minimum>
+                                            <minimum>0.59</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -244,7 +244,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.41</minimum>
+                                            <minimum>0.44</minimum>
                                         </limit>
                                     </limits>
                                 </rule>


### PR DESCRIPTION
#### What does this PR do?
This moves the code that reads local files for IdP metadata into privileged blocks. During testing of the fabric8 feature that was added (but is currently not enabled) in DDF-3763, it was discovered that its bundle required permissions to read the metadata as it attempted to connect. As there is nothing confidential in the IdP metadata, it is safe to privilege the calls to read the file within the `MetadataConfigurationParser` so permission checks won't go up the chain from there.

This is not a high-priority change and is not targeting 2.12.0.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@peterhuffer @oconnormi @brjeter 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@rzwiefel
@stustison

#### How should this be tested? (List steps with links to updated documentation)
A full install and light regression pass - ingest, query, at command line and through Intrigue - should be sufficient to ensure that metadata is still available. A run against the SAML CTK would probably also be good.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-3763](https://codice.atlassian.net/browse/DDF-3763)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
