### PR TITLE
[2.12.x] DDF-3817 Fixes typo in metatypes and documentation

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,7 +24,7 @@
 
         <AD name="OpenSearch service URL" id="endpointUrl" required="true"
             type="String"
-            default="${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.external.rootContext}/catalog/query"
+            default="${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.system.rootContext}/catalog/query"
             description="The OpenSearch endpoint URL or DDF's OpenSearch endpoint (https://localhost:8993/services/catalog/query)"/>
 
         <AD name="Username" id="username" required="false"

--- a/distribution/docs/src/main/resources/content/_tables/Csw_Federated_Source.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/Csw_Federated_Source.adoc
@@ -27,14 +27,14 @@
 |cswUrl
 |String
 |URL to the endpoint implementing the Catalogue Service for Web (CSW) spec
-|${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.external.rootContext}/csw
+|${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.system.rootContext}/csw
 |true
 
 |Event Service Address
 |eventServiceAddress
 |String
 |DDF Event Service endpoint.
-|${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.external.rootContext}/csw/subscription
+|${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.system.rootContext}/csw/subscription
 |false
 
 |Register for Events

--- a/distribution/docs/src/main/resources/content/_tables/Csw_Federation_Profile_Source.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/Csw_Federation_Profile_Source.adoc
@@ -27,14 +27,14 @@
 |cswUrl
 |String
 |URL to the endpoint implementing the Catalogue Service for Web (CSW) spec
-|${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.external.rootContext}/csw
+|${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.system.rootContext}/csw
 |true
 
 |CSW Event Service Address
 |eventServiceAddress
 |String
 |CSW Event Service endpoint.
-|${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.external.rootContext}/csw/subscription
+|${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.system.rootContext}/csw/subscription
 |false
 
 |Register for Events


### PR DESCRIPTION
Port of https://github.com/codice/ddf/pull/3316
@clockard @brendan-hofmann 