### PR TITLE
DDF-3882 Integration Tests running slowly and timing out

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -66,6 +66,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
 import org.apache.karaf.shell.api.console.SessionFactory;
@@ -77,6 +78,8 @@ import org.codice.ddf.test.common.LoggingUtils;
 import org.codice.ddf.test.common.annotations.PaxExamRule;
 import org.codice.ddf.test.common.annotations.PostTestConstruct;
 import org.junit.Rule;
+import org.junit.rules.Stopwatch;
+import org.junit.runner.Description;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.karaf.options.KarafDistributionOption;
@@ -149,6 +152,8 @@ public abstract class AbstractIntegrationTest {
   protected static String ddfHome;
 
   @Rule public PaxExamRule paxExamRule = new PaxExamRule(this);
+
+  @Rule public Stopwatch stopwatch = new TestMethodTimer();
 
   @Inject protected ConfigurationAdmin configAdmin;
 
@@ -1015,6 +1020,18 @@ public abstract class AbstractIntegrationTest {
             .orElseGet(super::getOption);
       } catch (IOException e) {
         throw new RuntimeException("Unable to determine current exam directory", e);
+      }
+    }
+  }
+
+  private static class TestMethodTimer extends Stopwatch {
+    @Override
+    protected void succeeded(long nanos, Description description) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "{} execution time: {}",
+            description.getMethodName(),
+            DurationFormatUtils.formatDuration(TimeUnit.NANOSECONDS.toMillis(nanos), "HH:mm:ss.S"));
       }
     }
   }

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -143,6 +143,11 @@ public abstract class AbstractIntegrationTest {
 
   public static final long GENERIC_TIMEOUT_MILLISECONDS = TimeUnit.MINUTES.toMillis(10);
 
+  private static final String UNABLE_TO_DETERMINE_EXAM_DIR_ERROR =
+      "Unable to determine current exam directory";
+
+  private static final String KARAF_HOME = "{karaf.home}";
+
   protected static ServerSocket placeHolderSocket;
 
   protected static Integer basePort;
@@ -918,7 +923,7 @@ public abstract class AbstractIntegrationTest {
             try {
               return Files.readAttributes(path, BasicFileAttributes.class).creationTime();
             } catch (IOException e) {
-              throw new RuntimeException("Unable to determine current exam directory", e);
+              throw new RuntimeException(UNABLE_TO_DETERMINE_EXAM_DIR_ERROR, e);
             }
           };
 
@@ -927,12 +932,12 @@ public abstract class AbstractIntegrationTest {
             .max(Comparator.comparing(createTimeComp))
             .map(Path::toAbsolutePath)
             .map(Path::toString)
-            .map(s -> StringUtils.replace(super.getOption(), "{karaf.home}", s))
+            .map(s -> StringUtils.replace(super.getOption(), KARAF_HOME, s))
             .map(s -> s.replace('\\', '/'))
             .map(s -> s.replace("/bin/..", "/"))
             .orElseGet(super::getOption);
       } catch (IOException e) {
-        throw new RuntimeException("Unable to determine current exam directory", e);
+        throw new RuntimeException(UNABLE_TO_DETERMINE_EXAM_DIR_ERROR, e);
       }
     }
   }
@@ -960,7 +965,7 @@ public abstract class AbstractIntegrationTest {
             try {
               return Files.readAttributes(path, BasicFileAttributes.class).creationTime();
             } catch (IOException e) {
-              throw new RuntimeException("Unable to determine current exam directory", e);
+              throw new RuntimeException(UNABLE_TO_DETERMINE_EXAM_DIR_ERROR, e);
             }
           };
 
@@ -969,7 +974,7 @@ public abstract class AbstractIntegrationTest {
             .max(Comparator.comparing(createTimeComp))
             .map(Path::toAbsolutePath)
             .map(Path::toString)
-            .map(s -> StringUtils.replace(super.getOption(), "{karaf.home}", s))
+            .map(s -> StringUtils.replace(super.getOption(), KARAF_HOME, s))
             .map(s -> s.replace('\\', '/'))
             .map(s -> s.replace("/bin/..", "/"))
             .map(s -> s.replace("c:", "C:"))
@@ -977,7 +982,7 @@ public abstract class AbstractIntegrationTest {
             .map(s -> s + "/")
             .orElseGet(super::getOption);
       } catch (IOException e) {
-        throw new RuntimeException("Unable to determine current exam directory", e);
+        throw new RuntimeException(UNABLE_TO_DETERMINE_EXAM_DIR_ERROR, e);
       }
     }
   }
@@ -1005,7 +1010,7 @@ public abstract class AbstractIntegrationTest {
             try {
               return Files.readAttributes(path, BasicFileAttributes.class).creationTime();
             } catch (IOException e) {
-              throw new RuntimeException("Unable to determine current exam directory", e);
+              throw new RuntimeException(UNABLE_TO_DETERMINE_EXAM_DIR_ERROR, e);
             }
           };
 
@@ -1014,12 +1019,12 @@ public abstract class AbstractIntegrationTest {
             .max(Comparator.comparing(createTimeComp))
             .map(Path::toAbsolutePath)
             .map(Path::toString)
-            .map(s -> StringUtils.replace(super.getOption(), "{karaf.home}", s))
+            .map(s -> StringUtils.replace(super.getOption(), KARAF_HOME, s))
             .map(s -> s.replace(File.separator + "bin" + File.separator + "..", File.separator))
             .map(s -> s + File.separator)
             .orElseGet(super::getOption);
       } catch (IOException e) {
-        throw new RuntimeException("Unable to determine current exam directory", e);
+        throw new RuntimeException(UNABLE_TO_DETERMINE_EXAM_DIR_ERROR, e);
       }
     }
   }
@@ -1029,7 +1034,8 @@ public abstract class AbstractIntegrationTest {
     protected void succeeded(long nanos, Description description) {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug(
-            "{} execution time: {}",
+            "{}.{} execution time: {}",
+            description.getClassName(),
             description.getMethodName(),
             DurationFormatUtils.formatDuration(TimeUnit.NANOSECONDS.toMillis(nanos), "HH:mm:ss.S"));
       }


### PR DESCRIPTION
#### What does this PR do?
Changes URLResourceReaderConfigurator to only update the root resource directory if it has changed to reduce the impact of waiting for the configuration changes to complete.

Also adds the Stopwatch JUnit Rule to the AbstractIntegrationTest class to log the time it takes to execute each test method.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@Lambeaux 
@paouelle  

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/test

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@stustison
@figliold

#### How should this be tested? (List steps with links to updated documentation)
Successful CI/CD and local builds, including downstream projects.

#### Any background context you want to provide?
The following test performance improvements were observed when building on local laptop:

TestCatalog
- Original: 34:51 min
- With changes: 13:51 min

All itests
- Original: 01:16 h
- With changes: 39:43 min

#### What are the relevant tickets?
[DDF-3882](https://codice.atlassian.net/browse/DDF-3882)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
