### PR TITLE
DDF-3860 Change header copying to ensure all lists are strings

### DIFF
--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/paos/PaosInInterceptor.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/paos/PaosInInterceptor.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPHeaderElement;
 import javax.xml.soap.SOAPPart;
@@ -255,7 +256,10 @@ public class PaosInInterceptor extends AbstractPhaseInterceptor<Message> {
                     entry.getKey(),
                     // CXF Expects pairs of <String, List<String>>
                     entry.getValue() instanceof List
-                        ? (List) entry.getValue()
+                        ? ((List<Object>) entry.getValue())
+                            .stream()
+                            .map(String::valueOf)
+                            .collect(Collectors.toList())
                         : Lists.newArrayList(String.valueOf(entry.getValue()))));
 
       } else {

--- a/platform/security/rest/security-rest-cxfwrapper/src/test/java/org/codice/ddf/cxf/paos/PaosInInterceptorTest.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/test/java/org/codice/ddf/cxf/paos/PaosInInterceptorTest.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.cxf.paos;
 
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -73,6 +74,8 @@ public class PaosInInterceptorTest {
         PaosInInterceptorTest.class.getClassLoader().getResource("ecprequest.xml").openStream());
     final String testHeaderKey = "X-Test-Header";
     final String correctHeaderToBeForwarded = "correct header that needs to be forwarded";
+    final String listOfIntsHeaderKey = "X-Test-IntList-Header";
+    final List<Object> listOfIntsHeader = ImmutableList.of(1, 2, 3);
 
     message.put(Message.CONTENT_TYPE, "application/vnd.paos+xml");
     HashMap<String, List<String>> messageHeaders = new HashMap<>();
@@ -98,7 +101,10 @@ public class PaosInInterceptorTest {
               httpResponseWrapper.content = new ByteArrayInputStream("actual content".getBytes());
               httpResponseWrapper.headers =
                   ImmutableMap.of(
-                          testHeaderKey, (Object) ImmutableList.of(correctHeaderToBeForwarded))
+                          testHeaderKey,
+                          (Object) ImmutableList.of(correctHeaderToBeForwarded),
+                          listOfIntsHeaderKey,
+                          listOfIntsHeader)
                       .entrySet();
             } else if (responseConsumerURL.equals("https://idp.example.org/saml2/sso")) {
               httpResponseWrapper.statusCode = 200;
@@ -115,6 +121,7 @@ public class PaosInInterceptorTest {
     assertThat(IOUtils.toString(message.getContent(InputStream.class)), is("actual content"));
     Map<String, List<String>> headers = (Map) message.get(Message.PROTOCOL_HEADERS);
     assertThat(headers.get(testHeaderKey), hasItem(correctHeaderToBeForwarded));
+    assertThat(headers.get(listOfIntsHeaderKey), hasItems("1", "2", "3"));
   }
 
   @Test(expected = Fault.class)


### PR DESCRIPTION
#### What does this PR do?
Ensure that cxf receives all headers in the interceptor are a list of strings. 
#### Who is reviewing it? 
Anyone
@clockard 
#### How should this be tested? (List steps with links to updated documentation)
Ensure that an update over CSW (using IdP as auth method) still works correctly.
#### Any background context you want to provide?
The translation of the headers from the rest client to the cxf interceptor requires a slightly different format. 
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3860
#### Checklist:
- [ ] ~~Documentation Updated~~
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
