### PR TITLE
DDF-3884 Terminates DDF if any security policy file is malformed.

### DIFF
--- a/platform/osgi/platform-osgi-condpermadmin/pom.xml
+++ b/platform/osgi/platform-osgi-condpermadmin/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
             <version>3.11.3</version>
@@ -125,7 +129,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.62</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/osgi/platform-osgi-condpermadmin/src/test/java/org/codice/ddf/condpermadmin/PermissionActivatorTest.java
+++ b/platform/osgi/platform-osgi-condpermadmin/src/test/java/org/codice/ddf/condpermadmin/PermissionActivatorTest.java
@@ -188,6 +188,20 @@ public class PermissionActivatorTest {
     permissionActivator.start(mock(BundleContext.class));
   }
 
+  @Test(expected = RuntimeException.class)
+  public void malformedPolicyFile() throws Exception {
+    File malformedPolicy = temporaryFolder.newFile("security/badformat.policy");
+    FileOutputStream malformedOutStream = new FileOutputStream(malformedPolicy);
+    InputStream malformedStream =
+        PermissionActivatorTest.class.getResourceAsStream("/badformat.policy");
+    IOUtils.copy(malformedStream, malformedOutStream);
+    IOUtils.closeQuietly(malformedOutStream);
+    IOUtils.closeQuietly(malformedStream);
+
+    PermissionActivatorForTest permissionActivator = new PermissionActivatorForTest();
+    permissionActivator.start(mock(BundleContext.class));
+  }
+
   private class PermissionActivatorForTest extends PermissionActivator {
     SecurityAdmin securityAdmin;
 
@@ -198,6 +212,11 @@ public class PermissionActivatorTest {
         securityAdmin = new SecurityAdmin(equinoxSecurityManager, permissionData);
       }
       return securityAdmin;
+    }
+
+    @Override
+    void systemExit(File file) {
+      throw new RuntimeException("Expected System Exit");
     }
   }
 }

--- a/platform/osgi/platform-osgi-condpermadmin/src/test/resources/badformat.policy
+++ b/platform/osgi/platform-osgi-condpermadmin/src/test/resources/badformat.policy
@@ -1,0 +1,24 @@
+priority "grant";
+
+deny {
+    permission java.io.FilePermission "<<ALL FILES>>", "read, write, execute";
+}
+
+grant
+  codeBase "file:/test-bundle" {
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}pdp", "read";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}pdp${/}-", "read, delete";
+};
+
+grant
+  codeBase "file:/test-bundle1/test-bundle2/test-bundle3" {
+    permission java.io.FilePermission "${ddf.home.perm}etc", "read";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}-", "read, delete";
+};
+
+grant signedBy "somedude" {
+    permission java.io.FilePermission "${ddf.home.perm}data", "read";
+}
+
+grant principal "someothercoolerdude", principal javax.security.auth.kerberos.KerberosPrincipal "waycooldude" {
+    permission java.io.FilePermission "${ddf.home.perm}system", "read";


### PR DESCRIPTION
#### What does this PR do?
Prints the name of the failing policy file to the command line and executes a hard system exit.

This prevents the system from initializing in an unsecured state.

#### Who is reviewing it? 
@brjeter @blen-desta 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@rzwiefel
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Edit any policy file in the `security` directory to make it badly formatted. Attempt to start the server. It should exit immediately, printing the name of the invalid file to the command line.

Will fail fast on the first badly formatted file it encounters.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3884](https://codice.atlassian.net/browse/DDF-3884)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
