### PR TITLE
DDF-3885 Fixes System Usage Message on Intrigue

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/system-usage/system-usage.view.js
@@ -23,7 +23,7 @@ var $ = require('jquery');
 
 function getSrc() {
     return '<html class="is-iframe" style="font-size: '+preferences.get('fontSize')+'px">' +
-    '<link href="css/styles.' + document.querySelector('link[href*="css/styles."]').href.split('css/styles.')[1] + '" rel="stylesheet">' +
+    '<link href="styles.' + document.querySelector('link[href*="styles."]').href.split('styles.')[1] + '" rel="stylesheet">' +
     properties.ui.systemUsageMessage +
     '</html>';
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes `Uncaught TypeError: Cannot read property 'href' of null
 at HTMLDocument.<anonymous> (system-usage.view.js:26)` that prevented System Usage Message from populating. 
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@emanns95 @bantillo @djblue 
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
@andrewkfiedler
@tbatie 
#### How should this be tested? (List steps with links to updated documentation)
Configure System Usage Message and confirm that it is populated on Intrigue.
#### Any background context you want to provide?
Systme Usage Message did not populate on Intrigue.
#### What are the relevant tickets?
[DDF-3885](https://codice.atlassian.net/browse/DDF-3885)
#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
