### PR TITLE
DDF-3900 Fix registry local identity node population

### DIFF
--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitialization.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitialization.java
@@ -153,8 +153,19 @@ public class IdentityNodeInitialization {
                 extrinsicObjectType.setName(internationalStringTypeHelper.create(siteName)));
     Metacard identityMetacard = getRegistryMetacardFromRegistryPackage(registryPackage);
     if (identityMetacard != null) {
+      copyTransientAttributes(identityMetacard, metacard);
       federationAdminService.updateRegistryEntry(identityMetacard);
     }
+  }
+
+  private void copyTransientAttributes(Metacard updateMetacard, Metacard existingMetacard) {
+    RegistryObjectMetacardType.TRANSIENT_ATTRIBUTES
+        .stream()
+        .filter(
+            key ->
+                updateMetacard.getAttribute(key) == null
+                    && existingMetacard.getAttribute(key) != null)
+        .forEach(key -> updateMetacard.setAttribute(existingMetacard.getAttribute(key)));
   }
 
   private void createIdentityNode() throws FederationAdminException {

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitializationTest.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/test/java/org/codice/ddf/registry/federationadmin/service/impl/IdentityNodeInitializationTest.java
@@ -203,6 +203,43 @@ public class IdentityNodeInitializationTest {
     identityNodeInitialization.init();
   }
 
+  @Test
+  public void testCopyTransitiveAttributes() throws Exception {
+    System.setProperty(SystemInfo.SITE_NAME, CHANGED_TEST_SITE_NAME);
+    RegistryPackageType registryPackageType = buildRegistryPackageType();
+
+    testMetacard.setAttribute(
+        new AttributeImpl(
+            Metacard.METADATA, metacardMarshaller.getRegistryPackageAsXml(registryPackageType)));
+    testMetacard.setAttribute(
+        new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID, "registryId"));
+    testMetacard.setAttribute(new AttributeImpl(Metacard.TITLE, TEST_SITE_NAME));
+    testMetacard.setAttribute(
+        new AttributeImpl(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, true));
+    testMetacard.setAttribute(
+        new AttributeImpl(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE, true));
+    when(federationAdminService.getLocalRegistryIdentityMetacard())
+        .thenReturn(Optional.of(testMetacard));
+
+    ArgumentCaptor<Metacard> updatedMetacard = ArgumentCaptor.forClass(Metacard.class);
+    doNothing().when(federationAdminService).updateRegistryEntry(updatedMetacard.capture());
+
+    identityNodeInitialization.init();
+
+    assertThat(
+        updatedMetacard
+            .getValue()
+            .getAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE)
+            .getValue(),
+        is(true));
+    assertThat(
+        updatedMetacard
+            .getValue()
+            .getAttribute(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE)
+            .getValue(),
+        is(true));
+  }
+
   private Metacard getTestMetacard() {
     return new MetacardImpl(new RegistryObjectMetacardType());
   }


### PR DESCRIPTION
#### What does this PR do?

Fixes an issue where local identity node wasn't populated correctly when
using a custom sitename. This was likely introduced when changes were made
to security manager and the solr client causing bundles to start at different times. 

#### Who is reviewing it? 

@peterhuffer @emmberk @JGatley 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .

@bdeining
@clockard

#### How should this be tested? (List steps with links to updated documentation)

message me for details

#### What are the relevant tickets?

[DDF-3900](https://codice.atlassian.net/browse/DDF-3900)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
