### PR TITLE
DDF-3895 modified SecurityLogger to allow for custom attributes

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
@@ -217,6 +217,12 @@ org.codice.ddf.http.access.log.enabled=false
 org.codice.ddf.security.ecp.enabled=true
 
 #
+# Security Logging
+#
+security.logger.extra_attributes=
+
+
+#
 # IDP (Identity Provider) Settings
 #
 # How long IDP clients should cache the IDP's metadata, ISO 8601 duration format. Default is 7 days.

--- a/distribution/docs/src/main/resources/content/_plugins/security-logging-plugin.adoc
+++ b/distribution/docs/src/main/resources/content/_plugins/security-logging-plugin.adoc
@@ -11,6 +11,6 @@ The Security Logging Plugin logs operations to the security log.
 
 The Security Logging Plugin is installed by default in a standard installation in the ${ddf-security} application.
 
-===== Configuring the Security Logging Plugin
+===== Enhancing the Security Log
 
-The Security Logging Plugin has no configurable properties.
+The security log contains attributes related to the subject acting on the system. To add additional attributes related to the subject to the logs, append the attribute's key to the comma separated values assigned to `security.logger.extra_attributes` in `/etc/system.properties`.


### PR DESCRIPTION
#### What does this PR do?
Allows a user to define custom attributes in the system properties file to be logged by the security logger.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@bdeining @middlets719 @Schachte @mojogitoverhere @troymohl  

#### Select relevant component teams:
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@millerw8
@stustison 

#### How should this be tested? (List steps with links to updated documentation)
Add property to system properties under security.logger.extra_attributes, (ensure that the additional attribute can be accessed through the `Subject` object. "Clearance" for example), build DDF, check log for added attribute.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3895](https://codice.atlassian.net/browse/DDF-3895)

#### Screenshots (if appropriate)
<img width="1651" alt="screen shot 2018-06-13 at 2 56 41 pm" src="https://user-images.githubusercontent.com/12813760/41416294-bf445a8c-6fa7-11e8-84fe-d44ddaeb02ab.png">

For this screenshot, an additional attribute `CountryOfAffilitaion` was added to the Subject attributes. The log will look differently depending on what is configured in the system.properties file.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
