### PR TITLE
DDF-3889 Accept qualified content item's metacard

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/OperationsMetacardSupport.java
@@ -147,16 +147,20 @@ public class OperationsMetacardSupport {
           fileName = updateFileExtension(mimeTypeRaw, fileName);
         }
 
-        Metacard metacard =
-            metacardFactory.generateMetacard(mimeTypeRaw, contentItem.getId(), fileName, tmpPath);
+        Metacard metacard;
+        boolean qualifiedContent = StringUtils.isNotEmpty(contentItem.getQualifier());
+        if (qualifiedContent) {
+          metacard = contentItem.getMetacard();
+        } else {
+          metacard =
+              metacardFactory.generateMetacard(mimeTypeRaw, contentItem.getId(), fileName, tmpPath);
+        }
         metacardMap.put(metacard.getId(), metacard);
 
         ContentItem generatedContentItem =
             new ContentItemImpl(
                 metacard.getId(),
-                StringUtils.isNotEmpty(contentItem.getQualifier())
-                    ? contentItem.getQualifier()
-                    : "",
+                qualifiedContent ? contentItem.getQualifier() : "",
                 com.google.common.io.Files.asByteSource(tmpPath.toFile()),
                 mimeTypeRaw,
                 fileName,

--- a/catalog/plugin/catalog-plugin-checksum/pom.xml
+++ b/catalog/plugin/catalog-plugin-checksum/pom.xml
@@ -95,17 +95,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.79</minimum>
+                                            <minimum>0.83</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.71</minimum>
+                                            <minimum>0.96</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.96</minimum>
                                         </limit>
 
                                     </limits>

--- a/catalog/plugin/catalog-plugin-checksum/src/main/java/org/codice/ddf/catalog/content/plugin/checksum/Checksum.java
+++ b/catalog/plugin/catalog-plugin-checksum/src/main/java/org/codice/ddf/catalog/content/plugin/checksum/Checksum.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.checksum.ChecksumProvider;
 
 public class Checksum implements PreCreateStoragePlugin, PreUpdateStoragePlugin {
@@ -56,6 +57,12 @@ public class Checksum implements PreCreateStoragePlugin, PreUpdateStoragePlugin 
 
   private void runChecksum(List<ContentItem> contentItems) throws PluginExecutionException {
     for (ContentItem contentItem : contentItems) {
+      if (StringUtils.isNotEmpty(contentItem.getQualifier())) {
+        // We are dealing with a derived resource, and this Metacard's checksum should reflect the
+        // original products
+        continue;
+      }
+
       try (InputStream inputStream = contentItem.getInputStream()) {
         // calculate checksum so that it can be added as an attribute on metacard
         String checksumAlgorithm = checksumProvider.getChecksumAlgorithm();

--- a/catalog/plugin/catalog-plugin-checksum/src/test/java/org/codice/ddf/catalog/content/plugin/checksum/ChecksumTest.java
+++ b/catalog/plugin/catalog-plugin-checksum/src/test/java/org/codice/ddf/catalog/content/plugin/checksum/ChecksumTest.java
@@ -20,11 +20,14 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ddf.catalog.content.data.ContentItem;
 import ddf.catalog.content.operation.CreateStorageRequest;
 import ddf.catalog.content.operation.UpdateStorageRequest;
+import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.plugin.PluginExecutionException;
@@ -154,5 +157,41 @@ public class ChecksumTest {
     } catch (PluginExecutionException e) {
       assertThat(e.getCause(), instanceOf(IOException.class));
     }
+  }
+
+  @Test
+  public void testProcessCreateDerivedContentDoesNotSetAttribute() throws Exception {
+    Metacard metacard = mock(Metacard.class);
+    ContentItem mockContentItem = mock(ContentItem.class);
+    when(mockContentItem.getQualifier()).thenReturn("some-qualifier");
+    when(mockContentItem.getMetacard()).thenReturn(metacard);
+
+    List<ContentItem> mockContentItems = new ArrayList<>();
+    mockContentItems.add(mockContentItem);
+
+    CreateStorageRequest mockCreateRequest = mock(CreateStorageRequest.class);
+    when(mockCreateRequest.getContentItems()).thenReturn(mockContentItems);
+
+    checksum.process(mockCreateRequest);
+
+    verify(metacard, never()).setAttribute(any(Attribute.class));
+  }
+
+  @Test
+  public void testProcessUpdateDerivedContentDoesNotSetAttribute() throws Exception {
+    Metacard metacard = mock(Metacard.class);
+    ContentItem mockContentItem = mock(ContentItem.class);
+    when(mockContentItem.getQualifier()).thenReturn("some-qualifier");
+    when(mockContentItem.getMetacard()).thenReturn(metacard);
+
+    List<ContentItem> mockContentItems = new ArrayList<>();
+    mockContentItems.add(mockContentItem);
+
+    UpdateStorageRequest mockUpdateRequest = mock(UpdateStorageRequest.class);
+    when(mockUpdateRequest.getContentItems()).thenReturn(mockContentItems);
+
+    checksum.process(mockUpdateRequest);
+
+    verify(metacard, never()).setAttribute(any(Attribute.class));
   }
 }


### PR DESCRIPTION
#### What does this PR do?
If an incoming content item is qualified (derived product), accept its metacard and don't generate a metacard for the qualified content item.
Update checksum plugin to ignore qualified (derived) content.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@roelens8 @emmberk @clockard

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Unit tests

#### Any background context you want to provide?
The Chipping action provider in Alliance not generate actions since the original products metacard's type was modified to be the derived content's metacard type.

#### What are the relevant tickets?
[DDF-3899](https://codice.atlassian.net/browse/DDF-3899)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
