### PR TITLE
DDF-3912 Custom template menu actions are now available inline on search view

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -9,7 +9,7 @@
 
   .search-form-interaction {
     white-space: nowrap;
-    padding-right: @minimumSpacing;
+    padding: 0px @minimumSpacing 0px 10px;
     cursor: pointer;
     overflow: hidden;
   }
@@ -52,5 +52,11 @@
 
   > .interaction-edit {
       display: none;
+  }
+}
+
+@{customElementNamespace}search-form-interactions.is-non-deletable-template {
+  > .interaction-trash {
+    display: none;
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -47,13 +47,13 @@ module.exports =  Marionette.ItemView.extend({
             this.checkIfDefaultSearchForm();
             this.checkIfResultForm();
             this.isSystemTemplate();
+            this.isAbleToDeleteTemplate();
         },
         checkIfSubscribed: function() {
             this.$el.toggleClass('is-subscribed', Boolean(this.model.get('subscribed')));
         },
         handleTrash: function() {
-            let loginUser = user.get('user');
-            if(loginUser.get('email') === this.model.get('createdBy'))
+            if(this.isTemplateOwner())
             {
                 this.listenTo(ConfirmationView.generateConfirmation({
                     prompt: 'This will permanently delete the template. Are you sure?',
@@ -142,6 +142,12 @@ module.exports =  Marionette.ItemView.extend({
         },
         isSystemTemplate: function() {
             this.$el.toggleClass('is-system-template', this.model.get('createdBy') === 'system');
+        },
+        isTemplateOwner() {
+            return user.get('user') && user.get('user').get('email') === this.model.get('createdBy');
+        },
+        isAbleToDeleteTemplate() {
+            this.options && this.$el.toggleClass('is-non-deletable-template', !this.isTemplateOwner());
         },
         handleEdit: function() {
             if(this.model.get('type') === 'custom')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.hbs
@@ -29,8 +29,6 @@
     </div>
 </div>
 
-{{#is type 'custom'}}
-    <span class="interaction interaction-custom"></span>
-{{/is}}
+<div class="interaction interaction-custom composed-menu"></div>
 
 <div class="interaction interaction-settings" title="Contains search settings and defaults." data-help="Contains search settings and defaults."></div>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.hbs
@@ -29,4 +29,8 @@
     </div>
 </div>
 
+{{#is type 'custom'}}
+    <span class="interaction interaction-custom"></span>
+{{/is}}
+
 <div class="interaction interaction-settings" title="Contains search settings and defaults." data-help="Contains search settings and defaults."></div>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.less
@@ -34,6 +34,11 @@
   .interaction-revert {
     display: none;
   }
+
+  .interaction-custom {
+    display: inline-table;
+  }
+
   .interaction-form > .interaction-text .fa-level-up {
     transform: rotate(90deg);
     font-size: @mediumFontSize;

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.less
@@ -7,11 +7,6 @@
     overflow: hidden;
     line-height: @minimumButtonSize;
     height: @minimumButtonSize;
-
-    &:hover,
-    &.is-active {
-      background: fade(contrast(@backgroundDropdown), 10%);
-    }
   }
   
   .interaction-icon,
@@ -36,13 +31,21 @@
   }
 
   .interaction-custom {
-    display: inline-table;
+    display: none;
   }
 
   .interaction-form > .interaction-text .fa-level-up {
     transform: rotate(90deg);
     font-size: @mediumFontSize;
     margin-right: @minimumSpacing;
+  }
+}
+
+@{customElementNamespace}search-interactions.is-custom {
+  > .interaction-custom {
+    display: block;
+    height: auto;
+    padding: 0px;
   }
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
@@ -40,17 +40,18 @@ module.exports = Marionette.LayoutView.extend({
         'click > .interaction-reset': 'triggerReset',
         'click > .interaction-type-advanced': 'triggerTypeAdvanced'
     },
+    initialize() {
+        this.listenTo(this.model, 'change:type', this.toggleCustomActions);
+    },
     onRender(){
         this.listenTo(this.model, 'change:type closeDropdown', this.triggerCloseDropdown);
-        this.listenTo(this.model, 'change:type', this.triggerRender);
         this.generateSearchFormSelector();
         if(properties.hasExperimentalEnabled()) { 
             this.generateResultFormSelector() 
         }
-        if(this.model.get('type') === 'custom') {
-            this.generateCustomFormSelector();
-        }
         this.generateSearchSettings();
+        this.generateCustomFormSelector();
+        this.toggleCustomActions();
     },
     generateResultFormSelector() {
         this.resultType.show(new ResultFormSelectorDropdownView({
@@ -117,13 +118,13 @@ module.exports = Marionette.LayoutView.extend({
         user.savePreferences();
         this.triggerCloseDropdown();
     },
-    triggerRender() {
-        this.render();
+    toggleCustomActions() {
+        const isCustom = this.model && this.model.get('type') === 'custom';
+        this.$el.toggleClass('is-custom', isCustom);
     },
     serializeData() {
         return {
-            experimental: properties.hasExperimentalEnabled(),
-            type: this.model.get('type')
+            experimental: properties.hasExperimentalEnabled()
         };
     }
 });


### PR DESCRIPTION
#### What does this PR do?
Adds inline menu options for custom templates so users do not have to navigate to template browser to perform those actions.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@Lambeaux 
@brianfelix 
@Variadicism 
@Bdthomson 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining 
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3912
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
