### PR TITLE
DDF-3918: Allow search field ordering (dragging) in Firefox

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
@@ -32,7 +32,9 @@ module.exports = Marionette.CollectionView.extend({
     },
     tagName: CustomElements.register('filter-collection'),
     onBeforeRenderCollection: function() {
+        const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
         this.sortable = Sortable.create(this.el, {
+            forceFallback: isFirefox,
             handle: 'button.filter-rearrange',
             animation: 250,
             draggable: '>*',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
@@ -32,10 +32,8 @@ module.exports = Marionette.CollectionView.extend({
     },
     tagName: CustomElements.register('filter-collection'),
     onBeforeRenderCollection: function() {
-        const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
         this.sortable = Sortable.create(this.el, {
-            forceFallback: isFirefox,
-            handle: 'button.filter-rearrange',
+            handle: 'div.filter-rearrange',
             animation: 250,
             draggable: '>*',
             disabled: this.options.isForm && !this.options.isFormBuilder,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.hbs
@@ -11,9 +11,9 @@
  *
  **/
  --}}
-<button class="filter-rearrange">
+<div class="filter-rearrange">
     <span class="cf cf-sort-grabber"/>
-</button>
+</div>
 <button class="filter-remove is-negative">
     <span class="fa fa-minus"></span>
 </button><div class="filter-attribute" data-help="Property to compare against.">


### PR DESCRIPTION
#### What does this PR do?
Fixes Firefox bug observed when attempting to re-order (drag-and-drop) filters in search form
#### Who is reviewing it? 
@Lambeaux 
@brianfelix 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@andrewkfiedler
@bdeining
#### How should this be tested? (List steps with links to updated documentation)
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3918
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
