### PR TITLE
DDF-3919 Solr connectivity alert

### DIFF
--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminAlertImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminAlertImpl.java
@@ -30,6 +30,7 @@ import org.codice.ddf.persistence.PersistenceException;
 import org.codice.ddf.persistence.PersistentItem;
 import org.codice.ddf.persistence.PersistentStore;
 import org.codice.ddf.system.alerts.Alert;
+import org.codice.ddf.system.alerts.NoticePriority;
 import org.codice.ddf.system.alerts.SystemNotice;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
@@ -75,6 +76,15 @@ public class AdminAlertImpl extends BasicMBean implements AdminAlertMBean {
       }
     } catch (PersistenceException pe) {
       LOGGER.debug("Error retrieving system alert.", pe);
+
+      return Collections.singletonList(
+          new Alert(
+                  "solr",
+                  NoticePriority.CRITICAL,
+                  "Persistent Storage Not Responding. Could Not Retrieve Alerts.",
+                  Collections.singleton(
+                      "Critical alerts may be present, but not displayed because the persistent storage is not responding."))
+              .getProperties());
     }
     alerts.sort(
         (map1, map2) ->

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminAlertImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminAlertImpl.java
@@ -79,7 +79,7 @@ public class AdminAlertImpl extends BasicMBean implements AdminAlertMBean {
 
       return Collections.singletonList(
           new Alert(
-                  "solr",
+                  "unable_to_retrieve_alerts",
                   NoticePriority.CRITICAL,
                   "Persistent Storage Not Responding. Could Not Retrieve Alerts.",
                   Collections.singleton(

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
@@ -111,7 +111,7 @@ public class AdminAlertImplTest {
   public void testGetAlertsPersistentStoreError() throws Exception {
     when(persistentStore.get(eq("alerts"), any())).thenThrow(new PersistenceException("error"));
     List<Map<String, Object>> alertList = adminAlert.getAlerts();
-    assertThat(alertList.size(), equalTo(0));
+    assertThat(alertList.size(), equalTo(1));
   }
 
   @Test

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
@@ -112,7 +112,8 @@ public class AdminAlertImplTest {
     when(persistentStore.get(eq("alerts"), any())).thenThrow(new PersistenceException("error"));
     List<Map<String, Object>> alertList = adminAlert.getAlerts();
     assertThat(alertList.size(), equalTo(1));
-    assertThat(alertList.get(0).get(Alert.SYSTEM_NOTICE_SOURCE_KEY), equalTo("unable_to_retrieve_alerts"));
+    assertThat(
+        alertList.get(0).get(Alert.SYSTEM_NOTICE_SOURCE_KEY), equalTo("unable_to_retrieve_alerts"));
   }
 
   @Test

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
@@ -112,7 +112,7 @@ public class AdminAlertImplTest {
     when(persistentStore.get(eq("alerts"), any())).thenThrow(new PersistenceException("error"));
     List<Map<String, Object>> alertList = adminAlert.getAlerts();
     assertThat(alertList.size(), equalTo(1));
-    assertThat(alertList.get(0).get("source"), equalTo("solr"));
+    assertThat(alertList.get(0).get(Alert.SYSTEM_NOTICE_SOURCE_KEY), equalTo("solr"));
   }
 
   @Test

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
@@ -112,7 +112,7 @@ public class AdminAlertImplTest {
     when(persistentStore.get(eq("alerts"), any())).thenThrow(new PersistenceException("error"));
     List<Map<String, Object>> alertList = adminAlert.getAlerts();
     assertThat(alertList.size(), equalTo(1));
-    assertThat(alertList.get(0).get(Alert.SYSTEM_NOTICE_SOURCE_KEY), equalTo("solr"));
+    assertThat(alertList.get(0).get(Alert.SYSTEM_NOTICE_SOURCE_KEY), equalTo("unable_to_retrieve_alerts"));
   }
 
   @Test

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/AdminAlertImplTest.java
@@ -112,6 +112,7 @@ public class AdminAlertImplTest {
     when(persistentStore.get(eq("alerts"), any())).thenThrow(new PersistenceException("error"));
     List<Map<String, Object>> alertList = adminAlert.getAlerts();
     assertThat(alertList.size(), equalTo(1));
+    assertThat(alertList.get(0).get("source"), equalTo("solr"));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Adds an alert if solr is not reachable. The alert will appear in the admin console. This PR also updates a unit test to expect an alert if solr is down. This PR relies on the new separate solr process.
#### Who is reviewing it? 
@mcalcote 
@rzwiefel 
@ahoffer 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@clockard 
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Manually steps to test:
1) Start the DDF
2) Log in to the admin console
3) Manually stop solr using {DDF_HOME}/solr/bin/solr stop -p 8994
4) Wait for at least 30 seconds
5) The solr connectivity alert should eventually display in the admin console (can try refreshing)
6) Manually start solr using {DDF_HOME}/solr/bin/solr start -p 8994
7) Wait at least 30 seconds
8) Dismiss the solr alert, refresh the admin console page, and you should again see the insecure defaults message and not the solr connectivity message
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
