### PR TITLE
DDF-3855, DDF-3916: UI Dev Server Proxy CSRF Compatibility

### DIFF
--- a/ui/packages/ace/lib/webpack.config.js
+++ b/ui/packages/ace/lib/webpack.config.js
@@ -183,7 +183,7 @@ const proxyConfig = ({target = 'https://localhost:8993', auth}) => ({
   target,
   ws: true,
   secure: false,
-  changeOrigin: true,
+  changeOrigin: false,
   onProxyRes: handleProxyRes,
   auth
 })


### PR DESCRIPTION
#### What does this PR do?
Resolves ticket: DDF-3916
Updates the UI Dev Server's proxy configuration to be compatible with the recent CSRF changes.

#### Who is reviewing it? 
@adimka 
@djblue 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, 
@andrewkfiedler
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Run the dev server with the CSRF Filter running (enabled by default) and ensure that no 403s are returned when requests to /search/catalog/internal are made.

#### Any background context you want to provide?
The CSRF Filter enforces that requests to protected contexts that an Origin or Referer header that matches the hostname & port of the request's target.

#### What are the relevant tickets?
[DDF-3855](https://codice.atlassian.net/browse/DDF-3855)
[DDF-3916](https://codice.atlassian.net/browse/DDF-3916)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
