### PR TITLE
DDF-3710 Updates drawing tools to take into account units

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.circle.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.circle.js
@@ -22,9 +22,10 @@ define([
         './notification.view',
         '@turf/turf',
         '@turf/circle',
-        './drawing.controller'
+        './drawing.controller',
+        'js/DistanceUtils'
     ],
-    function(Marionette, Backbone, Cesium, _, wreqr, DrawBbox, maptype, NotificationView, Turf, TurfCircle, DrawingController) {
+    function(Marionette, Backbone, Cesium, _, wreqr, DrawBbox, maptype, NotificationView, Turf, TurfCircle, DrawingController, DistanceUtils) {
         "use strict";
         var DrawCircle = {};
 
@@ -40,7 +41,7 @@ define([
             initialize: function() {
                 this.mouseHandler = new Cesium.ScreenSpaceEventHandler(this.options.map.scene.canvas);
 
-                this.listenTo(this.model, 'change:lat change:lon change:radius', this.updatePrimitive);
+                this.listenTo(this.model, 'change:lat change:lon change:radius change:radiusUnits', this.updatePrimitive);
                 this.updatePrimitive(this.model);
             },
             enableInput: function() {
@@ -68,7 +69,7 @@ define([
                 var modelProp = {
                     lat: (mn.latitude * 180 / Math.PI).toFixed(14),
                     lon: (mn.longitude * 180 / Math.PI).toFixed(14),
-                    radius: radius
+                    radius: DistanceUtils.getDistanceFromMeters(radius, this.model.get('radiusUnits'))
 
                 };
 
@@ -116,7 +117,7 @@ define([
                 var color = this.model.get('color');
 
                 var centerPt = Turf.point([modelProp.lon, modelProp.lat]);
-                var circleToCheck = new TurfCircle(centerPt, modelProp.radius, 64, 'meters');
+                var circleToCheck = new TurfCircle(centerPt, DistanceUtils.getDistanceInMeters(modelProp.radius, modelProp.radiusUnits), 64, 'meters');
 
                 this.primitive = new Cesium.PolylineCollection();
                 this.primitive.add({

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
@@ -19,9 +19,10 @@ define([
         'maptype',
         './notification.view',
         '@turf/turf',
-        './drawing.controller'
+        './drawing.controller',
+        'js/DistanceUtils'
     ],
-    function(Marionette, Backbone, Cesium, _, wreqr, maptype, NotificationView, Turf, DrawingController) {
+    function(Marionette, Backbone, Cesium, _, wreqr, maptype, NotificationView, Turf, DrawingController, DistanceUtils) {
         "use strict";
         var Draw = {};
 
@@ -48,7 +49,7 @@ define([
             animationFrameId: undefined,
             initialize: function() {
                 this.updatePrimitive();
-                this.listenTo(this.model, 'change:line change:lineWidth', this.updatePrimitive);
+                this.listenTo(this.model, 'change:line change:lineWidth change:lineUnits', this.updatePrimitive);
                 this.listenForCameraChange();
             },
             modelEvents: {
@@ -59,7 +60,7 @@ define([
             },
             drawLine: function(model) {
                 var linePoints = model.toJSON().line;
-                var lineWidth = model.toJSON().lineWidth || 1;
+                var lineWidth = DistanceUtils.getDistanceInMeters(model.toJSON().lineWidth, model.get('lineUnits')) || 1;
                 if (!linePoints) {
                     return;
                 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.circle.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.circle.js
@@ -24,10 +24,11 @@ define([
         '@turf/turf',
         '@turf/circle',
         './drawing.controller',
-        '../OpenLayersGeometryUtils'
+        '../OpenLayersGeometryUtils',
+        'js/DistanceUtils'
     ],
     function (Marionette, Backbone, ol, _, properties, wreqr, maptype, NotificationView,
-              Terraformer, Turf, TurfCircle, DrawingController, olUtils) {
+              Terraformer, Turf, TurfCircle, DrawingController, olUtils, DistanceUtils) {
         "use strict";
 
         function translateFromOpenlayersCoordinate(coord){
@@ -51,7 +52,7 @@ define([
         Draw.CircleView = Marionette.View.extend({
             initialize: function (options) {
                 this.map = options.map;
-                this.listenTo(this.model, 'change:lat change:lon change:radius', this.updateGeometry);
+                this.listenTo(this.model, 'change:lat change:lon change:radius change:radiusUnits', this.updateGeometry);
                 this.updateGeometry(this.model);
             },
             setModelFromGeometry: function (geometry) {
@@ -59,7 +60,7 @@ define([
                 this.model.set({
                     lat: center[1],
                     lon: center[0],
-                    radius: geometry.getRadius() * this.map.getView().getProjection().getMetersPerUnit()
+                    radius: DistanceUtils.getDistanceFromMeters(geometry.getRadius() * this.map.getView().getProjection().getMetersPerUnit(), this.model.get('radiusUnits'))
                 });
             },
 
@@ -67,7 +68,7 @@ define([
                 if (model.get('lon') === undefined || model.get('lat') === undefined){
                     return undefined;
                 }
-                var rectangle = new ol.geom.Circle(translateToOpenlayersCoordinate([model.get('lon'), model.get('lat')]), model.get('radius') / this.map.getView().getProjection().getMetersPerUnit());
+                var rectangle = new ol.geom.Circle(translateToOpenlayersCoordinate([model.get('lon'), model.get('lat')]), DistanceUtils.getDistanceInMeters(model.get('radius'), model.get('radiusUnits')) / this.map.getView().getProjection().getMetersPerUnit());
                 return rectangle;
             },
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -22,10 +22,11 @@ define([
         './notification.view',
         '@turf/turf',
         './drawing.controller',
-        '../OpenLayersGeometryUtils'
+        '../OpenLayersGeometryUtils',
+        'js/DistanceUtils'
     ],
     function (Marionette, Backbone, ol, _, properties, wreqr, maptype, NotificationView,
-              Turf, DrawingController, olUtils) {
+              Turf, DrawingController, olUtils, DistanceUtils) {
         "use strict";
 
         function translateFromOpenlayersCoordinates(coords) {
@@ -60,7 +61,7 @@ define([
         Draw.LineView = Marionette.View.extend({
             initialize: function (options) {
                 this.map = options.map;
-                this.listenTo(this.model, 'change:line change:lineWidth', this.updatePrimitive);
+                this.listenTo(this.model, 'change:line change:lineWidth change:lineUnits', this.updatePrimitive);
                 this.updatePrimitive(this.model);
             },
             setModelFromGeometry: function (geometry) {
@@ -101,7 +102,7 @@ define([
                     // handles case where model changes to empty vars and we don't want to draw anymore
                     return;
                 }
-                var lineWidth = this.model.get('lineWidth') || 1;
+                var lineWidth = DistanceUtils.getDistanceInMeters(this.model.get('lineWidth'), this.model.get('lineUnits')) || 1;
 
                 var turfLine = Turf.lineString(translateFromOpenlayersCoordinates(rectangle.getCoordinates()));
                 var bufferedLine = Turf.buffer(turfLine, lineWidth, 'meters');


### PR DESCRIPTION
#### What does this PR do?
 - Previously everything in the location model got normalized to meters, but that is no longer the case.  As such the drawing tools needed to be updated to convert things to meters when using the model value, and to convert to the proper units when updating the model value.

#### Who is reviewing it? 
@bdeining
@millerw8 
@djblue 
@mackncheesiest 

#### How should this be tested? (List steps with links to updated documentation)
Open both the 2d and 3d map side by side.  Use the drawing tools to draw a point radius.  Update the units and verify that drawing changes accordingly.  Do the same with the line drawing.  

#### What are the relevant tickets?
[DDF-3710](https://codice.atlassian.net/browse/DDF-3710)
