### PR TITLE
[2.12.x] - DDF-3924 Prevents more than one tab from showing at once

### DIFF
--- a/ui/packages/ui/src/main/webapp/components/tab-content/tab-content.view.js
+++ b/ui/packages/ui/src/main/webapp/components/tab-content/tab-content.view.js
@@ -34,6 +34,7 @@ define([
         initialize: function(options){
             this.applicationModel = options.applicationModel;
             this.listenTo(wreqr.vent, 'application:tabShown', this.handleTabShown);
+            this.listenTo(wreqr.vent, 'application:tabHidden', this.handleTabHidden);
         },
         onBeforeRender: function(){
             this.$el.attr('id', this.model.get('id'));
@@ -51,6 +52,11 @@ define([
                 view.tabContentInner.show(new IFrameView({
                     model: new Backbone.Model({url : iframeLocation})
                 }));
+            }
+        },
+        handleTabHidden: function(id) {
+            if (id === this.model.id) {
+                this.$el.removeClass('active in');
             }
         },
         handleTabShown: function(id){

--- a/ui/packages/ui/src/main/webapp/components/tab-item/tab-item.less
+++ b/ui/packages/ui/src/main/webapp/components/tab-item/tab-item.less
@@ -26,7 +26,8 @@
 @{customElementNamespace}tab-item.is-active {
     border: 1px solid rgba(0,0,0,.3);
     border-bottom: 0px;
-    border-radius: 4px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
 
     a {
         color: black;
@@ -42,7 +43,7 @@
     position: absolute;
     width: ~'calc(100% + 2px)';
     height: 2px;
-    bottom: -2px;
+    bottom: -1px;
     left: -1px;
     background: white;
     border-left: 1px solid rgba(0,0,0,.3);

--- a/ui/packages/ui/src/main/webapp/components/tab-item/tab-item.view.js
+++ b/ui/packages/ui/src/main/webapp/components/tab-item/tab-item.view.js
@@ -29,6 +29,7 @@ define([
             this.$el.toggleClass('is-active', true);
         },
         triggerHidden: function() {
+            wreqr.vent.trigger('application:tabHidden', this.model.id);
             this.$el.toggleClass('is-active', false);
         }
     });

--- a/ui/packages/ui/src/main/webapp/js/views/Module.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/Module.view.js
@@ -33,6 +33,21 @@ define([
             tabs: '#tabs',
             tabContent: '#tabContent'
         },
+        events: {
+            'shown.bs.tab': 'tabShown'
+        },
+        tabShown: function(event){
+            if (this.$el.find('#tabs').find(event.target).length === 0) {
+                return;
+            }
+            var id = event.target.getAttribute('data-id');
+            this.tabs.currentView.children.each(function(childView) {
+                childView.$el.toggleClass('active', childView.model.id === id);
+            });
+            this.tabContent.currentView.children.each(function(childView) {
+                childView.$el.toggleClass('active in', childView.model.id === id);
+            });
+        },
         onRender: function() {
             this.tabs.show(new Marionette.CollectionView({
                 tagName: 'ul',

--- a/ui/packages/ui/src/main/webapp/templates/moduleTab.handlebars
+++ b/ui/packages/ui/src/main/webapp/templates/moduleTab.handlebars
@@ -11,4 +11,4 @@
  *
  **/
  --}}
-<a href="#{{id}}" data-toggle="tab">{{name}}</a>
+<a href="#{{id}}" data-toggle="tab" data-id="{{id}}">{{name}}</a>


### PR DESCRIPTION
backport of https://github.com/codice/ddf/pull/3359

#### What does this PR do?
Prevents the possibility of more than one tab being shown at once in the even that multiple shown events get generated at the same time.

#### Who is reviewing it? 
@roelens8 
@mcalcote 
@mackncheesiest 
@djblue 
@clockard 

#### How should this be tested? (List steps with links to updated documentation)
Go to the admin UI and run either manually attempt to click tabs fast, or use this in the web console.
```$('[data-toggle=tab]').click()```
Verify only one tab gets shown at once.

#### What are the relevant tickets?
[DDF-3924](https://codice.atlassian.net/browse/DDF-3924)
