### PR TITLE
DDF-3930 Deprecating ConfigurationFileProxy and EmbeddedSolrFiles

### DIFF
--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/ConfigurationFileProxy.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/ConfigurationFileProxy.java
@@ -31,9 +31,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Abstraction layer for accessing files or directories on disk. Provides different implementations
- * depending on if the code is run within an OSGi container or not.
+ * @deprecated Intrigue and simple search replace this functionality. Abstraction layer for
+ *     accessing files or directories on disk. Provides different implementations depending on if
+ *     the code is run within an OSGi container or not.
  */
+@Deprecated
 public class ConfigurationFileProxy {
   public static final String DEFAULT_SOLR_CONFIG_PARENT_DIR = "etc";
 

--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/ConfigurationFileProxy.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/ConfigurationFileProxy.java
@@ -31,9 +31,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @deprecated Intrigue and simple search replace this functionality. Abstraction layer for
- *     accessing files or directories on disk. Provides different implementations depending on if
- *     the code is run within an OSGi container or not.
+ * @deprecated DDF is moving toward a standalone/solr cloud configuration instead of referencing the
+ *     UIs.
+ *     <p>Abstraction layer for accessing files or directories on disk. Provides different
+ *     implementations depending on if the code is run within an OSGi container or not.
  */
 @Deprecated
 public class ConfigurationFileProxy {

--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/EmbeddedSolrFiles.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/EmbeddedSolrFiles.java
@@ -34,11 +34,12 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * Maintain embedded Solr configuration and schema files.
- *
- * <p><i>Note:</i> The corresponding {@link SolrConfig} and {@link IndexSchema} will be constructed
- * the first time they are retrieved.
+ * @deprecated Intrigue and simple search replace this functionality. Maintain embedded Solr
+ *     configuration and schema files.
+ *     <p><i>Note:</i> The corresponding {@link SolrConfig} and {@link IndexSchema} will be
+ *     constructed the first time they are retrieved.
  */
+@Deprecated
 class EmbeddedSolrFiles {
   private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedSolrFiles.class);
 

--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/EmbeddedSolrFiles.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/impl/EmbeddedSolrFiles.java
@@ -34,8 +34,9 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * @deprecated Intrigue and simple search replace this functionality. Maintain embedded Solr
- *     configuration and schema files.
+ * @deprecated DDF is moving toward a standalone/solr cloud configuration instead of referencing the
+ *     UIs.
+ *     <p>Maintain embedded Solr configuration and schema files.
  *     <p><i>Note:</i> The corresponding {@link SolrConfig} and {@link IndexSchema} will be
  *     constructed the first time they are retrieved.
  */


### PR DESCRIPTION
#### What does this PR do?
Adds @Deprecates to ConfigurationFileProxy and EmbeddedSolrFiles to account for deprecation of their usage based on solr.data.dir.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@mcalcote 
@garrettfreibott 
@ahoffer 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl 
#### How should this be tested? (List steps with links to updated documentation)
build ddf
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3930](https://codice.atlassian.net/browse/DDF-3930)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
