### PR TITLE
DDF-3857 grouping spatial critera using logical OR

### DIFF
--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/java/org/codice/ddf/opensearch/endpoint/query/OpenSearchQuery.java
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/java/org/codice/ddf/opensearch/endpoint/query/OpenSearchQuery.java
@@ -452,16 +452,13 @@ public class OpenSearchQuery implements Query {
 
   /** @return a combined spatial, contextual and temporal filters together with a logical AND */
   public Filter getFilter() {
-    Optional<Filter> spatialFiltersOption = getSpatialFilterOption();
-    if (spatialFiltersOption.isPresent()) {
-      return getFilterWithSpatial(spatialFiltersOption.get());
-    } else {
-      return getFilterWithoutSpatial();
-    }
+    return getSpatialFilterOption()
+        .map(filterOption -> getFilterWithSpatial(filterOption))
+        .orElseGet(this::getFilterWithoutSpatial);
   }
 
   private Optional<Filter> getSpatialFilterOption() {
-    if (spatialFilters == null || spatialFilters.isEmpty()) {
+    if (CollectionUtils.isEmpty(spatialFilters)) {
       return Optional.empty();
     } else if (spatialFilters.size() == 1) {
       return Optional.ofNullable(spatialFilters.get(0));

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/test/java/org/codice/ddf/opensearch/endpoint/query/OpenSearchQueryTest.java
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/test/java/org/codice/ddf/opensearch/endpoint/query/OpenSearchQueryTest.java
@@ -744,7 +744,7 @@ public class OpenSearchQueryTest {
     query.addPolygonSpatialFilter("-30,100,-35,100,-35,110,-30,110,-30,100");
 
     Filter filter = query.getFilter();
-    assertThat(filter, notNullValue());
+    assertThat(filter, instanceOf(OrImpl.class));
 
     OrImpl topFilter = (OrImpl) filter;
     List<Filter> spatialFilters = topFilter.getChildren();

--- a/catalog/opensearch/catalog-opensearch-endpoint/src/test/java/org/codice/ddf/opensearch/endpoint/query/OpenSearchQueryTest.java
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/test/java/org/codice/ddf/opensearch/endpoint/query/OpenSearchQueryTest.java
@@ -746,8 +746,7 @@ public class OpenSearchQueryTest {
     Filter filter = query.getFilter();
     assertThat(filter, notNullValue());
 
-    // TODO: fix as OR filter after https://codice.atlassian.net/browse/DDF-3857
-    AndImpl topFilter = (AndImpl) filter;
+    OrImpl topFilter = (OrImpl) filter;
     List<Filter> spatialFilters = topFilter.getChildren();
     assertThat(spatialFilters.size(), is(5));
     assertThat(

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
@@ -58,6 +58,9 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
   private static final String ONLY_AND_MSG =
       "The OpenSearch Source only supports AND operations for non-contextual criteria.";
 
+  private static final String NOT_UNSUPPORTED_MSG =
+      "The OpenSearch Source does not support NOT operation.";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchFilterVisitor.class);
 
   @Override
@@ -398,9 +401,8 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
       return;
     }
 
-    if (openSearchFilterVisitorObject.getCurrentNest() != null
-        && !NestedTypes.AND.equals(openSearchFilterVisitorObject.getCurrentNest())) {
-      LOGGER.debug(ONLY_AND_MSG);
+    if (NestedTypes.NOT.equals(openSearchFilterVisitorObject.getCurrentNest())) {
+      LOGGER.debug(NOT_UNSUPPORTED_MSG);
       return;
     }
 
@@ -455,9 +457,8 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
       return;
     }
 
-    if (openSearchFilterVisitorObject.getCurrentNest() != null
-        && !NestedTypes.AND.equals(openSearchFilterVisitorObject.getCurrentNest())) {
-      LOGGER.debug(ONLY_AND_MSG);
+    if (NestedTypes.NOT.equals(openSearchFilterVisitorObject.getCurrentNest())) {
+      LOGGER.debug(NOT_UNSUPPORTED_MSG);
       return;
     }
 

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
@@ -58,7 +58,7 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
   private static final String ONLY_AND_MSG =
       "The OpenSearch Source only supports AND operations for non-contextual criteria.";
 
-  private static final String NOT_UNSUPPORTED_MSG =
+  private static final String NOT_OPERATOR_UNSUPPORTED_MSG =
       "The OpenSearch Source does not support NOT operation.";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchFilterVisitor.class);
@@ -402,7 +402,7 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
     }
 
     if (NestedTypes.NOT.equals(openSearchFilterVisitorObject.getCurrentNest())) {
-      LOGGER.debug(NOT_UNSUPPORTED_MSG);
+      LOGGER.debug(NOT_OPERATOR_UNSUPPORTED_MSG);
       return;
     }
 
@@ -458,7 +458,7 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
     }
 
     if (NestedTypes.NOT.equals(openSearchFilterVisitorObject.getCurrentNest())) {
-      LOGGER.debug(NOT_UNSUPPORTED_MSG);
+      LOGGER.debug(NOT_OPERATOR_UNSUPPORTED_MSG);
       return;
     }
 

--- a/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/OpenSearchSourceSpec.groovy
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/OpenSearchSourceSpec.groovy
@@ -153,7 +153,7 @@ class OpenSearchSourceSpec extends Specification {
                 filterBuilder.allOf(D_WITHIN_FILTER, filterBuilder.attribute(OpenSearchConstants.SUPPORTED_SPATIAL_SEARCH_TERM).is().withinBuffer().wkt("POINT(0.0 0.0)", 804672), PROPERTY_IS_LIKE_FILTER, DURING_FILTER), //multiple point radius filter
                 filterBuilder.allOf(D_WITHIN_FILTER, INTERSECTS_FILTER, PROPERTY_IS_LIKE_FILTER, DURING_FILTER),  //point radius and polygon filters
                 filterBuilder.allOf(INTERSECTS_FILTER, CONTAINS_FILTER, PROPERTY_IS_LIKE_FILTER, DURING_FILTER),  // multiple polygon filters
-                filterBuilder.allOf(GEOMETRY_COLLECTION, CONTAINS_FILTER, INTERSECTS_FILTER, D_WITHIN_FILTER),  // polygon, geometry, point radius filters
+                filterBuilder.anyOf(GEOMETRY_COLLECTION, CONTAINS_FILTER, INTERSECTS_FILTER, D_WITHIN_FILTER),  // polygon, geometry, point radius filters
 
                 /*not supported filters and supported filters*/
                 filterBuilder.allOf(NOT_SUPPORTED_DURING_FILTER, PROPERTY_IS_LIKE_FILTER),
@@ -218,9 +218,9 @@ class OpenSearchSourceSpec extends Specification {
                 D_WITHIN_FILTER,
                 CONTAINS_FILTER,
                 INTERSECTS_FILTER,
-                filterBuilder.allOf(D_WITHIN_FILTER, INTERSECTS_FILTER), // point-radius and polygon filters
-                filterBuilder.allOf(INTERSECTS_FILTER, CONTAINS_FILTER), // different polygon filters
-                filterBuilder.allOf(D_WITHIN_FILTER, filterBuilder.attribute(OpenSearchConstants.SUPPORTED_SPATIAL_SEARCH_TERM).is().withinBuffer().wkt("POINT(0.0 0.0)", 804672)) // different point-radius filters
+                filterBuilder.anyOf(D_WITHIN_FILTER, INTERSECTS_FILTER), // point-radius and polygon filters
+                filterBuilder.anyOf(INTERSECTS_FILTER, CONTAINS_FILTER), // different polygon filters
+                filterBuilder.anyOf(D_WITHIN_FILTER, filterBuilder.attribute(OpenSearchConstants.SUPPORTED_SPATIAL_SEARCH_TERM).is().withinBuffer().wkt("POINT(0.0 0.0)", 804672)) // different point-radius filters
         ]
         expectedQueryParameters << [
                 [start: ["1"], count: ["20"], mt: ["0"], bbox: ["0.9999550570408705,1.999954933135129,1.0000449429591296,2.000045066864871"], src: [""]],

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitorTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitorTest.java
@@ -1005,11 +1005,11 @@ public class OpenSearchFilterVisitorTest {
 
     final Queue<PointRadius> pointRadiusSearches = result.getPointRadiusSearches();
     assertThat(
-        "The OpenSearchFilterVisitorObject should contain contain two point-radius searches from the two unique point-radius filters in the AND filter.",
+        "The OpenSearchFilterVisitorObject should contain two point-radius searches from the two unique point-radius filters in the OR filter.",
         pointRadiusSearches,
         hasSize(2));
     assertThat(
-        "The OpenSearchFilterVisitorObject should contain contain the point-radius searches in the order that they appear in the AND filter.",
+        "The OpenSearchFilterVisitorObject should contain the point-radius searches in the order that they appear in the OR filter.",
         pointRadiusSearches,
         contains(
             allOf(
@@ -1023,11 +1023,11 @@ public class OpenSearchFilterVisitorTest {
 
     final Queue<Geometry> geometrySearches = result.getGeometrySearches();
     assertThat(
-        "The OpenSearchFilterVisitorObject should contain contain two geometry searches from the two unique geometry filters in the AND filter.",
+        "The OpenSearchFilterVisitorObject should contain contain two geometry searches from the two unique geometry filters in the OR filter.",
         geometrySearches,
         hasSize(2));
     assertThat(
-        "The OpenSearchFilterVisitorObject should contain contain the geometry searches in the order that they appear in the AND filter.",
+        "The OpenSearchFilterVisitorObject should contain contain the geometry searches in the order that they appear in the OR filter.",
         geometrySearches,
         contains(hasToString(is(WKT_POLYGON)), hasToString(is(anotherWktPolygon))));
   }

--- a/distribution/docs/src/main/resources/content/_endpoints/opensearch-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/opensearch-endpoint.adoc
@@ -114,7 +114,7 @@ The start and end temporal criteria must be of the format specified above. Other
 ====
 
 .Geospatial Extension
-These geospatial query parameters are used to create a geospatial `INTERSECTS` query, where `INTERSECTS` means geometries that are not `DISJOINT` of the given geospatial parameter. 
+These geospatial query parameters are used to create a geospatial `INTERSECTS` query, where `INTERSECTS` means geometries that are not `DISJOINT` of the given geospatial parameters. 
 
 [cols="4", options="header"]
 |===


### PR DESCRIPTION
spatial criteria are always joined as an OR operation for OpenSearch Endpoint.
To be consistent with OpenSearch geo extension Draft 2 which support WKT GeometryCollection

Who is reviewing it?
Please choose AT LEAST four reviewers.
@bdeining
@millerw8
@mackncheesiest
@emmberk 

At least one reviewer should be a code owner.

How should this be tested? Justify why only a full build is sufficient for testing.
Configure a Open Search federated source with bounding box as OFF
Ingest 3 records somewhat close together ( for easy testing)
Draw a polygon around the left record only
Draw a bounding box around the right record only
Draw a point radius anywhere not on any of the record
Search should find the left and right records
Turn Source Bounding Box as ON
Search should find all 3 records
Try again with OR operation instead of AND for the criteria grouping

This test verify multiple geometry is support via OpenSearch Federation
Bounding box does an approximation search to support backward compatibility
Spatial criteria is always an OR operation regardless of UI selection.
Previously if OR is selected in UI, nothing is returned.

Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/projects/DDF/issues/DDF-3857

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
