### PR TITLE
DDF-3941 - Move intrigue from using the REST Endpoint under /services

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -211,6 +211,16 @@
         </dependency>
         <dependency>
             <groupId>ddf.catalog.rest</groupId>
+            <artifactId>catalog-rest-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.rest</groupId>
+            <artifactId>catalog-rest-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.rest</groupId>
             <artifactId>catalog-rest-endpoint</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -144,6 +144,8 @@
 
     <feature name="catalog-rest-endpoint" version="${project.version}"
              description="REST Endpoint provides CRUD operations on the Catalog Framework.">
+        <bundle>mvn:ddf.catalog.rest/catalog-rest-service/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.rest/catalog-rest-impl/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.rest/catalog-rest-endpoint/${project.version}</bundle>
     </feature>
 

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -15,136 +15,53 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>catalog-rest-pom</artifactId>
         <groupId>ddf.catalog.rest</groupId>
+        <artifactId>catalog-rest-pom</artifactId>
         <version>2.13.0-SNAPSHOT</version>
     </parent>
+
+    <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-rest-endpoint</artifactId>
     <packaging>bundle</packaging>
     <name>DDF :: Catalog :: REST :: Endpoint</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${hamcrest-all.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.objenesis</groupId>
-                <artifactId>objenesis</artifactId>
-                <version>${objenesis.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
-
-        <!-- Compile and Runtime -->
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api-impl</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.platform</groupId>
-            <artifactId>platform-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>asm</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.mime.core</groupId>
-            <artifactId>mime-core-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-actions</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>ddf.action.core</groupId>
-            <artifactId>action-core-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.mime.tika</groupId>
-            <artifactId>mime-tika-resolver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.lib</groupId>
-            <artifactId>common-system</artifactId>
+            <groupId>ddf.catalog.rest</groupId>
+            <artifactId>catalog-rest-service</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.transformer</groupId>
-            <artifactId>catalog-transformer-attribute</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>util-uuidgenerator-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
-            <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>${owasp-html-sanitizer.version}</version>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
         </dependency>
 
         <!-- Unit Tests -->
         <dependency>
             <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-attachment-impl</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.rest</groupId>
+            <artifactId>catalog-rest-impl</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
             <artifactId>filter-proxy</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Common Tests -->
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -217,34 +134,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- Pax-Exam -->
-        <dependency>
-            <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-junit4</artifactId>
-            <version>${pax.exam.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.karaf.features</groupId>
-            <artifactId>org.apache.karaf.features.core</artifactId>
-            <version>${karaf.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-attachment</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-attachment-impl</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -253,19 +143,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>
-                            asm,
-                            catalog-core-actions,
-                            catalog-core-api-impl,
-                            json-smart,
-                            platform-util,
-                            owasp-java-html-sanitizer
-                        </Embed-Dependency>
-                        <Import-Package>
-                            !org.codice.ddf.platform.util,
-                            javax.ws.rs.*,
-                            *
-                        </Import-Package>
+                        <Import-Package>*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>
@@ -316,17 +194,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.57</minimum>
+                                            <minimum>0.41</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.40</minimum>
+                                            <minimum>0.52</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.35</minimum>
+                                            <minimum>0.29</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -143,7 +143,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Import-Package>*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -13,86 +13,26 @@
  */
 package org.codice.ddf.endpoints.rest;
 
-import static ddf.catalog.data.AttributeType.AttributeFormat.BINARY;
-import static ddf.catalog.data.AttributeType.AttributeFormat.OBJECT;
+import static org.codice.ddf.rest.service.CatalogService.BYTES;
+import static org.codice.ddf.rest.service.CatalogService.HEADER_ACCEPT_RANGES;
+import static org.codice.ddf.rest.service.CatalogService.HEADER_CONTENT_DISPOSITION;
+import static org.codice.ddf.rest.service.CatalogService.HEADER_CONTENT_LENGTH;
 
-import ddf.action.Action;
-import ddf.catalog.CatalogFramework;
-import ddf.catalog.Constants;
-import ddf.catalog.content.data.impl.ContentItemImpl;
-import ddf.catalog.content.operation.CreateStorageRequest;
-import ddf.catalog.content.operation.UpdateStorageRequest;
-import ddf.catalog.content.operation.impl.CreateStorageRequestImpl;
-import ddf.catalog.content.operation.impl.UpdateStorageRequestImpl;
-import ddf.catalog.data.Attribute;
-import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.AttributeRegistry;
-import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.BinaryContent;
-import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardCreationException;
-import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.Result;
-import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BinaryContentImpl;
-import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.data.impl.MetacardTypeImpl;
-import ddf.catalog.federation.FederationException;
-import ddf.catalog.filter.FilterBuilder;
-import ddf.catalog.operation.CreateRequest;
-import ddf.catalog.operation.CreateResponse;
-import ddf.catalog.operation.QueryResponse;
-import ddf.catalog.operation.SourceInfoResponse;
-import ddf.catalog.operation.UpdateRequest;
-import ddf.catalog.operation.impl.CreateRequestImpl;
-import ddf.catalog.operation.impl.DeleteRequestImpl;
-import ddf.catalog.operation.impl.QueryImpl;
-import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.operation.impl.SourceInfoRequestEnterprise;
-import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.resource.DataUsageLimitExceededException;
 import ddf.catalog.resource.Resource;
-import ddf.catalog.source.IngestException;
-import ddf.catalog.source.InternalIngestException;
-import ddf.catalog.source.SourceDescriptor;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
-import ddf.catalog.transform.CatalogTransformerException;
-import ddf.catalog.transform.InputTransformer;
-import ddf.mime.MimeTypeResolver;
-import ddf.mime.MimeTypeToTransformerMapper;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URLDecoder;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import javax.activation.MimeType;
-import javax.activation.MimeTypeParseException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -101,110 +41,29 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import net.minidev.json.JSONArray;
-import net.minidev.json.JSONObject;
-import net.minidev.json.JSONValue;
 import org.apache.commons.codec.CharEncoding;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
-import org.codice.ddf.attachment.AttachmentInfo;
-import org.codice.ddf.attachment.AttachmentParser;
-import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
-import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
-import org.opengis.filter.Filter;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
-import org.owasp.html.HtmlPolicyBuilder;
+import org.codice.ddf.rest.service.CatalogException;
+import org.codice.ddf.rest.service.CatalogService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Path("/")
 public class RESTEndpoint implements RESTService {
-
-  static final String DEFAULT_METACARD_TRANSFORMER = "xml";
-
-  private static final String BYTES_TO_SKIP = "BytesToSkip";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RESTEndpoint.class);
 
-  private static final Logger INGEST_LOGGER = LoggerFactory.getLogger(Constants.INGEST_LOGGER_NAME);
+  private CatalogService catalogService;
 
-  private static final String HEADER_RANGE = "Range";
-
-  private static final String HEADER_ACCEPT_RANGES = "Accept-Ranges";
-
-  private static final String HEADER_CONTENT_LENGTH = "Content-Length";
-
-  private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
-
-  private static final String FILE_ATTACHMENT_CONTENT_ID = "file";
-
-  private static final String FILENAME_CONTENT_DISPOSITION_PARAMETER_NAME = "filename";
-
-  private static final String BYTES = "bytes";
-
-  private static final String BYTES_EQUAL = "bytes=";
-
-  private static final String JSON_MIME_TYPE_STRING = "application/json";
-
-  public static final int MAX_INPUT_SIZE = 65_536;
-
-  private UuidGenerator uuidGenerator;
-
-  private static MimeType jsonMimeType;
-
-  static {
-    MimeType mime = null;
-    try {
-      mime = new MimeType(JSON_MIME_TYPE_STRING);
-    } catch (MimeTypeParseException e) {
-      LOGGER.info("Failed to create json mimetype.");
-    }
-    jsonMimeType = mime;
-  }
-
-  private FilterBuilder filterBuilder;
-
-  private CatalogFramework catalogFramework;
-
-  private MimeTypeToTransformerMapper mimeTypeToTransformerMapper;
-
-  private MimeTypeResolver tikaMimeTypeResolver;
-
-  private final AttachmentParser attachmentParser;
-
-  private AttributeRegistry attributeRegistry;
-
-  public RESTEndpoint(
-      CatalogFramework framework,
-      AttachmentParser attachmentParser,
-      AttributeRegistry attributeRegistry) {
+  public RESTEndpoint(CatalogService catalogService) {
     LOGGER.trace("Constructing REST Endpoint");
-    this.catalogFramework = framework;
-    this.attachmentParser = attachmentParser;
-    this.attributeRegistry = attributeRegistry;
+    this.catalogService = catalogService;
     LOGGER.trace(("Rest Endpoint constructed successfully"));
-  }
-
-  BundleContext getBundleContext() {
-    Bundle bundle = FrameworkUtil.getBundle(RESTEndpoint.class);
-    return bundle.getBundleContext();
   }
 
   @HEAD
@@ -251,120 +110,50 @@ public class RESTEndpoint implements RESTService {
       @PathParam("id") String id,
       @Context UriInfo uriInfo,
       @Context HttpServletRequest httpRequest) {
+    try {
+      Response.ResponseBuilder responseBuilder;
+      String filename = null;
 
-    Response response;
-    Response.ResponseBuilder responseBuilder;
-    QueryResponse queryResponse;
-    Metacard card = null;
+      final BinaryContent content =
+          catalogService.getHeaders(
+              sourceid, id, uriInfo.getAbsolutePath(), uriInfo.getQueryParameters());
 
-    LOGGER.trace("getHeaders");
-    URI absolutePath = uriInfo.getAbsolutePath();
-    MultivaluedMap<String, String> map = uriInfo.getQueryParameters();
-
-    if (id != null) {
-      LOGGER.debug("Got id: {}", id);
-      LOGGER.debug("Map of query parameters: \n{}", map);
-
-      Map<String, Serializable> convertedMap = convert(map);
-      convertedMap.put("url", absolutePath.toString());
-
-      LOGGER.debug("Map converted, retrieving product.");
-
-      // default to xml if no transformer specified
-      try {
-        String transformer = DEFAULT_METACARD_TRANSFORMER;
-
-        Filter filter = getFilterBuilder().attribute(Metacard.ID).is().equalTo().text(id);
-
-        Collection<String> sources = null;
-        if (sourceid != null) {
-          sources = new ArrayList<>();
-          sources.add(sourceid);
-        }
-
-        QueryRequestImpl request = new QueryRequestImpl(new QueryImpl(filter), sources);
-        request.setProperties(convertedMap);
-        queryResponse = catalogFramework.query(request, null);
-
-        // pull the metacard out of the blocking queue
-        List<Result> results = queryResponse.getResults();
-
-        // TODO: should be poll? do we want to specify a timeout? (will
-        // return null if timeout elapsed)
-        if (results != null && !results.isEmpty()) {
-          card = results.get(0).getMetacard();
-        }
-
-        if (card == null) {
-          return Response.status(Status.NOT_FOUND)
-              .entity("<pre>Unable to retrieve requested metacard.</pre>")
-              .type(MediaType.TEXT_HTML)
-              .build();
-        }
-
-        LOGGER.debug("Calling transform.");
-        final BinaryContent content = catalogFramework.transform(card, transformer, convertedMap);
-        LOGGER.debug("Read and transform complete, preparing response.");
-
-        responseBuilder = Response.noContent();
-
-        // Add the Accept-ranges header to let the client know that we accept ranges in bytes
-        responseBuilder.header(HEADER_ACCEPT_RANGES, BYTES);
-
-        String filename = null;
-
-        if (content instanceof Resource) {
-          // If we got a resource, we can extract the filename.
-          filename = ((Resource) content).getName();
-        } else {
-          String fileExtension = getFileExtensionForMimeType(content.getMimeTypeValue());
-          if (StringUtils.isNotBlank(fileExtension)) {
-            filename = id + fileExtension;
-          }
-        }
-
-        if (StringUtils.isNotBlank(filename)) {
-          LOGGER.debug("filename: {}", filename);
-          responseBuilder.header(
-              HEADER_CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"");
-        }
-
-        long size = content.getSize();
-        if (size > 0) {
-          responseBuilder.header(HEADER_CONTENT_LENGTH, size);
-        }
-
-        response = responseBuilder.build();
-
-      } catch (FederationException e) {
-        String exceptionMessage = "READ failed due to unexpected exception: ";
-        LOGGER.info(exceptionMessage, e);
-        throw new InternalServerErrorException(exceptionMessage);
-      } catch (CatalogTransformerException e) {
-        String exceptionMessage = "Unable to transform Metacard.  Try different transformer: ";
-        LOGGER.info(exceptionMessage, e);
-        throw new InternalServerErrorException(exceptionMessage);
-      } catch (SourceUnavailableException e) {
-        String exceptionMessage = "Cannot obtain query results because source is unavailable: ";
-        LOGGER.info(exceptionMessage, e);
-        throw new InternalServerErrorException(exceptionMessage);
-      } catch (UnsupportedQueryException e) {
-        String errorMessage = "Specified query is unsupported.  Change query and resubmit: ";
-        LOGGER.info(errorMessage, e);
-        return createBadRequestResponse(errorMessage);
-
-        // The catalog framework will throw this if any of the transformers blow up. We need to
-        // catch this exception
-        // here or else execution will return to CXF and we'll lose this message and end up with
-        // a huge stack trace
-        // in a GUI or whatever else is connected to this endpoint
-      } catch (IllegalArgumentException e) {
-        return createBadRequestResponse(e.getMessage());
+      if (content == null) {
+        return Response.status(Status.NOT_FOUND)
+            .entity("<pre>Unable to retrieve requested metacard.</pre>")
+            .type(MediaType.TEXT_HTML)
+            .build();
       }
-    } else {
-      return createBadRequestResponse("No ID specified.");
+
+      responseBuilder = Response.noContent();
+
+      // Add the Accept-ranges header to let the client know that we accept ranges in bytes
+      responseBuilder.header(HEADER_ACCEPT_RANGES, BYTES);
+
+      if (content instanceof Resource) {
+        // If we got a resource, we can extract the filename.
+        filename = ((Resource) content).getName();
+      } else {
+        String fileExtension =
+            catalogService.getFileExtensionForMimeType(content.getMimeTypeValue());
+        if (StringUtils.isNotBlank(fileExtension)) {
+          filename = id + fileExtension;
+        }
+      }
+
+      if (StringUtils.isNotBlank(filename)) {
+        LOGGER.debug("filename: {}", filename);
+        responseBuilder.header(HEADER_CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"");
+      }
+
+      long size = content.getSize();
+      if (size > 0) {
+        responseBuilder.header(HEADER_CONTENT_LENGTH, size);
+      }
+      return responseBuilder.build();
+    } catch (CatalogException e) {
+      return createBadRequestResponse(e.getMessage());
     }
-    return response;
   }
 
   /**
@@ -375,7 +164,6 @@ public class RESTEndpoint implements RESTService {
    * @param transformerParam (OPTIONAL)
    * @param uriInfo
    * @return
-   * @throws InternalServerErrorException
    */
   @GET
   @Path("/{id}")
@@ -388,14 +176,6 @@ public class RESTEndpoint implements RESTService {
     return getDocument(null, id, transformerParam, uriInfo, httpRequest);
   }
 
-  private JSONObject sourceActionToJSON(Action action) {
-    JSONObject jsonObject = new JSONObject();
-    jsonObject.put("title", action.getTitle());
-    jsonObject.put("url", action.getUrl().toString());
-    jsonObject.put("description", action.getDescription());
-    return jsonObject;
-  }
-
   /**
    * REST Get. Retrieves information regarding sources available.
    *
@@ -406,57 +186,13 @@ public class RESTEndpoint implements RESTService {
   @GET
   @Path(SOURCES_PATH)
   public Response getDocument(@Context UriInfo uriInfo, @Context HttpServletRequest httpRequest) {
-    BinaryContent content;
     ResponseBuilder responseBuilder;
-    String sourcesString;
 
-    JSONArray resultsList = new JSONArray();
-    SourceInfoResponse sources;
-    try {
-      SourceInfoRequestEnterprise sourceInfoRequestEnterprise =
-          new SourceInfoRequestEnterprise(true);
-
-      sources = catalogFramework.getSourceInfo(sourceInfoRequestEnterprise);
-      for (SourceDescriptor source : sources.getSourceInfo()) {
-        JSONObject sourceObj = new JSONObject();
-        sourceObj.put("id", source.getSourceId());
-        sourceObj.put("version", source.getVersion() != null ? source.getVersion() : "");
-        sourceObj.put("available", Boolean.valueOf(source.isAvailable()));
-
-        List<JSONObject> sourceActions =
-            source.getActions().stream().map(this::sourceActionToJSON).collect(Collectors.toList());
-
-        sourceObj.put("sourceActions", sourceActions);
-
-        JSONArray contentTypesObj = new JSONArray();
-        if (source.getContentTypes() != null) {
-          for (ContentType contentType : source.getContentTypes()) {
-            if (contentType != null && contentType.getName() != null) {
-              JSONObject contentTypeObj = new JSONObject();
-              contentTypeObj.put("name", contentType.getName());
-              contentTypeObj.put(
-                  "version", contentType.getVersion() != null ? contentType.getVersion() : "");
-              contentTypesObj.add(contentTypeObj);
-            }
-          }
-        }
-        sourceObj.put("contentTypes", contentTypesObj);
-        resultsList.add(sourceObj);
-      }
-    } catch (SourceUnavailableException e) {
-      LOGGER.info("Unable to retrieve Sources. {}", e.getMessage());
-      LOGGER.debug("Unable to retrieve Sources", e);
-    }
-
-    sourcesString = JSONValue.toJSONString(resultsList);
-    content =
-        new BinaryContentImpl(
-            new ByteArrayInputStream(sourcesString.getBytes(StandardCharsets.UTF_8)), jsonMimeType);
+    final BinaryContent content = catalogService.getDocument();
     responseBuilder = Response.ok(content.getInputStream(), content.getMimeTypeValue());
 
     // Add the Accept-ranges header to let the client know that we accept ranges in bytes
     responseBuilder.header(HEADER_ACCEPT_RANGES, BYTES);
-
     return responseBuilder.build();
   }
 
@@ -479,142 +215,71 @@ public class RESTEndpoint implements RESTService {
       @QueryParam("transform") String transformerParam,
       @Context UriInfo uriInfo,
       @Context HttpServletRequest httpRequest) {
+    try {
+      Response.ResponseBuilder responseBuilder;
+      String id = URLDecoder.decode(encodedId, CharEncoding.UTF_8);
 
-    Response response;
-    Response.ResponseBuilder responseBuilder;
-    QueryResponse queryResponse;
-    Metacard card = null;
+      final BinaryContent content =
+          catalogService.getDocument(
+              encodedSourceId,
+              encodedId,
+              transformerParam,
+              uriInfo.getAbsolutePath(),
+              uriInfo.getQueryParameters(),
+              httpRequest);
 
-    LOGGER.trace("GET");
-    URI absolutePath = uriInfo.getAbsolutePath();
-    MultivaluedMap<String, String> map = uriInfo.getQueryParameters();
-
-    if (encodedId != null) {
-      LOGGER.debug("Got id: {}", encodedId);
-      LOGGER.debug("Got service: {}", transformerParam);
-      LOGGER.debug("Map of query parameters: \n{}", map);
-
-      Map<String, Serializable> convertedMap = convert(map);
-      convertedMap.put("url", absolutePath.toString());
-
-      LOGGER.debug("Map converted, retrieving product.");
-
-      // default to xml if no transformer specified
-      try {
-        String id = URLDecoder.decode(encodedId, CharEncoding.UTF_8);
-
-        String transformer = DEFAULT_METACARD_TRANSFORMER;
-        if (transformerParam != null) {
-          transformer = transformerParam;
-        }
-        Filter filter = getFilterBuilder().attribute(Metacard.ID).is().equalTo().text(id);
-
-        Collection<String> sources = null;
-        if (encodedSourceId != null) {
-          String sourceid = URLDecoder.decode(encodedSourceId, CharEncoding.UTF_8);
-          sources = new ArrayList<>();
-          sources.add(sourceid);
-        }
-
-        QueryRequestImpl request = new QueryRequestImpl(new QueryImpl(filter), sources);
-        request.setProperties(convertedMap);
-        queryResponse = catalogFramework.query(request, null);
-
-        // pull the metacard out of the blocking queue
-        List<Result> results = queryResponse.getResults();
-
-        // TODO: should be poll? do we want to specify a timeout? (will
-        // return null if timeout elapsed)
-        if (results != null && !results.isEmpty()) {
-          card = results.get(0).getMetacard();
-        }
-
-        if (card == null) {
-          return Response.status(Status.NOT_FOUND)
-              .entity("<pre>Unable to retrieve requested metacard.</pre>")
-              .type(MediaType.TEXT_HTML)
-              .build();
-        }
-
-        // Check for Range header set the value in the map appropriately so that the
-        // catalogFramework
-        // can take care of the skipping
-        long bytesToSkip = getRangeStart(httpRequest);
-
-        if (bytesToSkip > 0) {
-          LOGGER.debug("Bytes to skip: {}", bytesToSkip);
-          convertedMap.put(BYTES_TO_SKIP, bytesToSkip);
-        }
-
-        LOGGER.debug("Calling transform.");
-        final BinaryContent content = catalogFramework.transform(card, transformer, convertedMap);
-        LOGGER.debug("Read and transform complete, preparing response.");
-
-        responseBuilder = Response.ok(content.getInputStream(), content.getMimeTypeValue());
-
-        // Add the Accept-ranges header to let the client know that we accept ranges in bytes
-        responseBuilder.header(HEADER_ACCEPT_RANGES, BYTES);
-
-        String filename = null;
-
-        if (content instanceof Resource) {
-          // If we got a resource, we can extract the filename.
-          filename = ((Resource) content).getName();
-        } else {
-          String fileExtension = getFileExtensionForMimeType(content.getMimeTypeValue());
-          if (StringUtils.isNotBlank(fileExtension)) {
-            filename = id + fileExtension;
-          }
-        }
-
-        if (StringUtils.isNotBlank(filename)) {
-          LOGGER.debug("filename: {}", filename);
-          responseBuilder.header(
-              HEADER_CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"");
-        }
-
-        long size = content.getSize();
-        if (size > 0) {
-          responseBuilder.header(HEADER_CONTENT_LENGTH, size);
-        }
-
-        response = responseBuilder.build();
-      } catch (FederationException e) {
-        String exceptionMessage = "READ failed due to unexpected exception: ";
-        LOGGER.info(exceptionMessage, e);
-        throw new InternalServerErrorException(exceptionMessage);
-      } catch (CatalogTransformerException e) {
-        String exceptionMessage = "Unable to transform Metacard.  Try different transformer: ";
-        LOGGER.info(exceptionMessage, e);
-        throw new InternalServerErrorException(exceptionMessage);
-      } catch (SourceUnavailableException e) {
-        String exceptionMessage = "Cannot obtain query results because source is unavailable: ";
-        LOGGER.info(exceptionMessage, e);
-        throw new InternalServerErrorException(exceptionMessage);
-      } catch (UnsupportedQueryException e) {
-        String errorMessage = "Specified query is unsupported.  Change query and resubmit: ";
-        LOGGER.info(errorMessage, e);
-        return createBadRequestResponse(errorMessage);
-      } catch (DataUsageLimitExceededException e) {
-        String errorMessage = "Unable to process request. Data usage limit exceeded: ";
-        LOGGER.debug(errorMessage, e);
-        return Response.status(Status.REQUEST_ENTITY_TOO_LARGE)
-            .entity("<pre>" + errorMessage + "</pre>")
+      if (content == null) {
+        return Response.status(Status.NOT_FOUND)
+            .entity("<pre>Unable to retrieve requested metacard.</pre>")
             .type(MediaType.TEXT_HTML)
             .build();
-        // The catalog framework will throw this if any of the transformers blow up.
-        // We need to catch this exception here or else execution will return to CXF and
-        // we'll lose this message and end up with a huge stack trace in a GUI or whatever
-        // else is connected to this endpoint
-      } catch (RuntimeException | UnsupportedEncodingException e) {
-        String exceptionMessage = "Unknown error occurred while processing request: ";
-        LOGGER.info(exceptionMessage, e);
-        throw new InternalServerErrorException(exceptionMessage);
       }
-    } else {
-      return createBadRequestResponse("No ID specified.");
+
+      LOGGER.debug("Read and transform complete, preparing response.");
+      responseBuilder = Response.ok(content.getInputStream(), content.getMimeTypeValue());
+
+      // Add the Accept-ranges header to let the client know that we accept ranges in bytes
+      responseBuilder.header(HEADER_ACCEPT_RANGES, BYTES);
+
+      String filename = null;
+
+      if (content instanceof Resource) {
+        // If we got a resource, we can extract the filename.
+        filename = ((Resource) content).getName();
+      } else {
+        String fileExtension =
+            catalogService.getFileExtensionForMimeType(content.getMimeTypeValue());
+        if (StringUtils.isNotBlank(fileExtension)) {
+          filename = id + fileExtension;
+        }
+      }
+
+      if (StringUtils.isNotBlank(filename)) {
+        LOGGER.debug("filename: {}", filename);
+        responseBuilder.header(HEADER_CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"");
+      }
+
+      long size = content.getSize();
+      if (size > 0) {
+        responseBuilder.header(HEADER_CONTENT_LENGTH, size);
+      }
+
+      return responseBuilder.build();
+
+    } catch (CatalogException e) {
+      return createBadRequestResponse(e.getMessage());
+
+    } catch (DataUsageLimitExceededException e) {
+      return Response.status(Status.REQUEST_ENTITY_TOO_LARGE)
+          .entity("<pre>" + e.getMessage() + "</pre>")
+          .type(MediaType.TEXT_HTML)
+          .build();
+
+    } catch (UnsupportedEncodingException e) {
+      String exceptionMessage = "Unknown error occurred while processing request: ";
+      LOGGER.info(exceptionMessage, e);
+      throw new InternalServerErrorException(exceptionMessage);
     }
-    return response;
   }
 
   @POST
@@ -623,76 +288,15 @@ public class RESTEndpoint implements RESTService {
       MultipartBody multipartBody,
       @Context UriInfo requestUriInfo,
       @QueryParam("transform") String transformerParam) {
-
-    LOGGER.trace("ENTERING: createMetacard");
-
-    String contentUri = multipartBody.getAttachmentObject("contentUri", String.class);
-    LOGGER.debug("contentUri = {}", contentUri);
-
-    InputStream stream = null;
-    String contentType = null;
-    Response response;
-
-    String transformer = DEFAULT_METACARD_TRANSFORMER;
-    if (transformerParam != null) {
-      transformer = transformerParam;
-    }
-
-    Attachment contentPart = multipartBody.getAttachment(FILE_ATTACHMENT_CONTENT_ID);
-    if (contentPart != null) {
-      // Example Content-Type header:
-      // Content-Type: application/json;id=geojson
-      if (contentPart.getContentType() != null) {
-        contentType = contentPart.getContentType().toString();
-      }
-
-      // Get the file contents as an InputStream and ensure the stream is positioned
-      // at the beginning
-      try {
-        stream = contentPart.getDataHandler().getInputStream();
-        if (stream != null && stream.available() == 0) {
-          stream.reset();
-        }
-      } catch (IOException e) {
-        LOGGER.info("IOException reading stream from file attachment in multipart body", e);
-      }
-    } else {
-      LOGGER.debug("No file contents attachment found");
-    }
-
-    MimeType mimeType = null;
-    if (contentType != null) {
-      try {
-        mimeType = new MimeType(contentType);
-      } catch (MimeTypeParseException e) {
-        LOGGER.debug("Unable to create MimeType from raw data {}", contentType);
-      }
-    } else {
-      LOGGER.debug("No content type specified in request");
-    }
-
     try {
-      Metacard metacard = generateMetacard(mimeType, null, stream, null);
-      String metacardId = metacard.getId();
-      LOGGER.debug("Metacard {} created", metacardId);
-      LOGGER.debug(
-          "Transforming metacard {} to {} to be able to return it to client",
-          metacardId,
-          transformer);
-      final BinaryContent content = catalogFramework.transform(metacard, transformer, null);
-      LOGGER.debug(
-          "Metacard to {} transform complete for {}, preparing response.", transformer, metacardId);
+      final BinaryContent content = catalogService.createMetacard(multipartBody, transformerParam);
 
       Response.ResponseBuilder responseBuilder =
           Response.ok(content.getInputStream(), content.getMimeTypeValue());
-      response = responseBuilder.build();
-    } catch (MetacardCreationException | CatalogTransformerException e) {
-      return createBadRequestResponse("Unable to create metacard");
+      return responseBuilder.build();
+    } catch (CatalogException e) {
+      return createBadRequestResponse(e.getMessage());
     }
-
-    LOGGER.trace("EXITING: createMetacard");
-
-    return response;
   }
 
   /**
@@ -731,64 +335,15 @@ public class RESTEndpoint implements RESTService {
       MultipartBody multipartBody,
       @QueryParam("transform") String transformerParam,
       InputStream message) {
-    LOGGER.trace("PUT");
-    Response response;
-
     try {
-      if (id != null && message != null) {
+      List<String> contentTypeList = headers.getRequestHeader(HttpHeaders.CONTENT_TYPE);
+      catalogService.updateDocument(id, contentTypeList, multipartBody, transformerParam, message);
 
-        MimeType mimeType = getMimeType(headers);
+      return Response.ok().build();
 
-        Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard = null;
-        if (multipartBody != null) {
-          List<Attachment> contentParts = multipartBody.getAllAttachments();
-          if (CollectionUtils.isNotEmpty(contentParts)) {
-            attachmentInfoAndMetacard = parseAttachments(contentParts, transformerParam);
-          } else {
-            LOGGER.debug("No file contents attachment found");
-          }
-        }
-
-        if (attachmentInfoAndMetacard == null) {
-          UpdateRequest updateRequest =
-              new UpdateRequestImpl(id, generateMetacard(mimeType, id, message, transformerParam));
-          catalogFramework.update(updateRequest);
-        } else {
-          UpdateStorageRequest streamUpdateRequest =
-              new UpdateStorageRequestImpl(
-                  Collections.singletonList(
-                      new IncomingContentItem(
-                          id,
-                          attachmentInfoAndMetacard.getLeft().getStream(),
-                          attachmentInfoAndMetacard.getLeft().getContentType(),
-                          attachmentInfoAndMetacard.getLeft().getFilename(),
-                          0,
-                          attachmentInfoAndMetacard.getRight())),
-                  null);
-          catalogFramework.update(streamUpdateRequest);
-        }
-
-        LOGGER.debug("Metacard {} updated.", id);
-        response = Response.ok().build();
-      } else {
-        String errorResponseString = "Both ID and content are needed to perform UPDATE.";
-        LOGGER.info(errorResponseString);
-        return createBadRequestResponse(errorResponseString);
-      }
-    } catch (SourceUnavailableException e) {
-      String exceptionMessage = "Cannot update catalog entry: Source is unavailable: ";
-      LOGGER.info(exceptionMessage, e);
-      throw new InternalServerErrorException(exceptionMessage);
-    } catch (InternalIngestException e) {
-      String exceptionMessage = "Error cataloging updated metadata: ";
-      LOGGER.info(exceptionMessage, e);
-      throw new InternalServerErrorException(exceptionMessage);
-    } catch (MetacardCreationException | IngestException e) {
-      String errorMessage = "Error cataloging updated metadata: ";
-      LOGGER.info(errorMessage, e);
-      return createBadRequestResponse(errorMessage);
+    } catch (CatalogException e) {
+      return createBadRequestResponse(e.getMessage());
     }
-    return response;
   }
 
   @POST
@@ -817,275 +372,20 @@ public class RESTEndpoint implements RESTService {
       MultipartBody multipartBody,
       @QueryParam("transform") String transformerParam,
       InputStream message) {
-    LOGGER.debug("POST");
-    Response response;
-
-    MimeType mimeType = getMimeType(headers);
-
     try {
-      if (message != null) {
-        Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard = null;
-        if (multipartBody != null) {
-          List<Attachment> contentParts = multipartBody.getAllAttachments();
-          if (CollectionUtils.isNotEmpty(contentParts)) {
-            attachmentInfoAndMetacard = parseAttachments(contentParts, transformerParam);
-          } else {
-            LOGGER.debug("No file contents attachment found");
-          }
-        }
+      List<String> contentTypeList = headers.getRequestHeader(HttpHeaders.CONTENT_TYPE);
+      String id =
+          catalogService.addDocument(contentTypeList, multipartBody, transformerParam, message);
 
-        CreateResponse createResponse;
-        if (attachmentInfoAndMetacard == null) {
-          CreateRequest createRequest =
-              new CreateRequestImpl(generateMetacard(mimeType, null, message, transformerParam));
-          createResponse = catalogFramework.create(createRequest);
-        } else {
-          String id =
-              attachmentInfoAndMetacard.getRight() == null
-                  ? null
-                  : attachmentInfoAndMetacard.getRight().getId();
-          if (id == null) {
-            id = uuidGenerator.generateUuid();
-          }
-          CreateStorageRequest streamCreateRequest =
-              new CreateStorageRequestImpl(
-                  Collections.singletonList(
-                      new IncomingContentItem(
-                          id,
-                          attachmentInfoAndMetacard.getLeft().getStream(),
-                          attachmentInfoAndMetacard.getLeft().getContentType(),
-                          attachmentInfoAndMetacard.getLeft().getFilename(),
-                          0L,
-                          attachmentInfoAndMetacard.getRight())),
-                  null);
-          createResponse = catalogFramework.create(streamCreateRequest);
-        }
+      UriBuilder uriBuilder = requestUriInfo.getAbsolutePathBuilder().path("/" + id);
+      ResponseBuilder responseBuilder = Response.created(uriBuilder.build());
+      responseBuilder.header(Metacard.ID, id);
 
-        String id = createResponse.getCreatedMetacards().get(0).getId();
+      return responseBuilder.build();
 
-        LOGGER.debug("Create Response id [{}]", id);
-
-        UriBuilder uriBuilder = requestUriInfo.getAbsolutePathBuilder().path("/" + id);
-
-        ResponseBuilder responseBuilder = Response.created(uriBuilder.build());
-
-        responseBuilder.header(Metacard.ID, id);
-
-        response = responseBuilder.build();
-
-        LOGGER.debug("Entry successfully saved, id: {}", id);
-        if (INGEST_LOGGER.isInfoEnabled()) {
-          INGEST_LOGGER.info("Entry successfully saved, id: {}", id);
-        }
-      } else {
-        String errorMessage = "No content found, cannot do CREATE.";
-        LOGGER.info(errorMessage);
-        return createBadRequestResponse(errorMessage);
-      }
-    } catch (SourceUnavailableException e) {
-      String exceptionMessage = "Cannot create catalog entry because source is unavailable: ";
-      LOGGER.info(exceptionMessage, e);
-      // Catalog framework logs these exceptions to the ingest logger so we don't have to.
-      throw new InternalServerErrorException(exceptionMessage);
-    } catch (InternalIngestException e) {
-      String exceptionMessage = "Error while storing entry in catalog: ";
-      LOGGER.info(exceptionMessage, e);
-      // Catalog framework logs these exceptions to the ingest logger so we don't have to.
-      throw new InternalServerErrorException(exceptionMessage);
-    } catch (MetacardCreationException | IngestException e) {
-      String errorMessage = "Error while storing entry in catalog: ";
-      LOGGER.info(errorMessage, e);
-      // Catalog framework logs these exceptions to the ingest logger so we don't have to.
-      return createBadRequestResponse(errorMessage);
-    } finally {
-      IOUtils.closeQuietly(message);
+    } catch (CatalogException e) {
+      return createBadRequestResponse(e.getMessage());
     }
-
-    return response;
-  }
-
-  Pair<AttachmentInfo, Metacard> parseAttachments(
-      List<Attachment> contentParts, String transformerParam) {
-
-    if (contentParts.size() == 1) {
-      Attachment contentPart = contentParts.get(0);
-
-      InputStream attachmentInputStream = null;
-
-      try {
-        attachmentInputStream = contentPart.getDataHandler().getInputStream();
-      } catch (IOException e) {
-        LOGGER.debug("IOException reading stream from file attachment in multipart body.", e);
-      }
-
-      return new ImmutablePair<>(
-          attachmentParser.generateAttachmentInfo(
-              attachmentInputStream,
-              contentPart.getContentType().toString(),
-              contentPart
-                  .getContentDisposition()
-                  .getParameter(FILENAME_CONTENT_DISPOSITION_PARAMETER_NAME)),
-          null);
-    }
-
-    Map<String, AttributeImpl> attributeMap = new HashMap<>();
-    Metacard metacard = null;
-    AttachmentInfo attachmentInfo = null;
-
-    for (Attachment attachment : contentParts) {
-      String name = attachment.getContentDisposition().getParameter("name");
-      String parsedName = (name.startsWith("parse.")) ? name.substring(6) : name;
-      try {
-        InputStream inputStream = attachment.getDataHandler().getInputStream();
-        if (name.equals("parse.resource")) {
-          attachmentInfo =
-              attachmentParser.generateAttachmentInfo(
-                  inputStream,
-                  attachment.getContentType().toString(),
-                  attachment
-                      .getContentDisposition()
-                      .getParameter(FILENAME_CONTENT_DISPOSITION_PARAMETER_NAME));
-        } else if (name.equals("parse.metadata")) {
-          metacard = parseMetadata(transformerParam, metacard, attachment, inputStream);
-        } else {
-          parseOverrideAttributes(attributeMap, parsedName, inputStream);
-        }
-      } catch (IOException e) {
-        LOGGER.debug(
-            "Unable to get input stream for mime attachment. Ignoring override attribute: {}",
-            name,
-            e);
-      }
-    }
-    if (attachmentInfo == null) {
-      throw new IllegalArgumentException("No parse.resource specified in request.");
-    }
-    if (metacard == null) {
-      metacard = new MetacardImpl();
-    }
-
-    Set<AttributeDescriptor> missingDescriptors = new HashSet<>();
-    for (Attribute attribute : attributeMap.values()) {
-      if (metacard.getMetacardType().getAttributeDescriptor(attribute.getName()) == null) {
-        attributeRegistry
-            .lookup(attribute.getName())
-            .ifPresent(descriptor -> missingDescriptors.add(descriptor));
-      }
-      metacard.setAttribute(attribute);
-    }
-
-    if (!missingDescriptors.isEmpty()) {
-      MetacardType original = metacard.getMetacardType();
-      MetacardImpl newMetacard = new MetacardImpl(metacard);
-      newMetacard.setType(new MetacardTypeImpl(original.getName(), original, missingDescriptors));
-      metacard = newMetacard;
-    }
-
-    return new ImmutablePair<>(attachmentInfo, metacard);
-  }
-
-  private void parseOverrideAttributes(
-      Map<String, AttributeImpl> attributeMap, String parsedName, InputStream inputStream) {
-    attributeRegistry
-        .lookup(parsedName)
-        .ifPresent(
-            descriptor ->
-                parseAttribute(
-                    attributeMap,
-                    parsedName,
-                    inputStream,
-                    descriptor.getType().getAttributeFormat()));
-  }
-
-  private void parseAttribute(
-      Map<String, AttributeImpl> attributeMap,
-      String parsedName,
-      InputStream inputStream,
-      AttributeType.AttributeFormat attributeFormat) {
-    try (InputStream is = inputStream;
-        InputStream boundedStream = new BoundedInputStream(is, MAX_INPUT_SIZE + 1)) {
-      if (attributeFormat == OBJECT) {
-        LOGGER.debug("Object type not supported for override");
-        return;
-      }
-
-      byte[] bytes = IOUtils.toByteArray(boundedStream);
-      if (bytes.length > MAX_INPUT_SIZE) {
-        LOGGER.debug("Attribute length is limited to {} bytes", MAX_INPUT_SIZE);
-        return;
-      }
-
-      AttributeImpl attribute;
-      if (attributeMap.containsKey(parsedName)) {
-        attribute = attributeMap.get(parsedName);
-      } else {
-        attribute = new AttributeImpl(parsedName, Collections.emptyList());
-        attributeMap.put(parsedName, attribute);
-      }
-
-      if (attributeFormat == BINARY) {
-        attribute.addValue(bytes);
-        return;
-      }
-
-      String value = new String(bytes, Charset.defaultCharset());
-
-      switch (attributeFormat) {
-        case XML:
-        case GEOMETRY:
-        case STRING:
-          attribute.addValue(value);
-          break;
-        case BOOLEAN:
-          attribute.addValue(Boolean.valueOf(value));
-          break;
-        case SHORT:
-          attribute.addValue(Short.valueOf(value));
-          break;
-        case LONG:
-          attribute.addValue(Long.valueOf(value));
-          break;
-        case INTEGER:
-          attribute.addValue(Integer.valueOf(value));
-          break;
-        case FLOAT:
-          attribute.addValue(Float.valueOf(value));
-          break;
-        case DOUBLE:
-          attribute.addValue(Double.valueOf(value));
-          break;
-        case DATE:
-          try {
-            Instant instant = Instant.parse(value);
-            attribute.addValue(Date.from(instant));
-          } catch (DateTimeParseException e) {
-            LOGGER.debug("Unable to parse instant '{}'", attribute, e);
-          }
-          break;
-        default:
-          LOGGER.debug("Attribute format '{}' not supported", attributeFormat);
-          break;
-      }
-    } catch (IOException e) {
-      LOGGER.debug("Unable to read attribute to override", e);
-    }
-  }
-
-  private Metacard parseMetadata(
-      String transformerParam, Metacard metacard, Attachment attachment, InputStream inputStream) {
-    String transformer = DEFAULT_METACARD_TRANSFORMER;
-    if (transformerParam != null) {
-      transformer = transformerParam;
-    }
-    try {
-      MimeType mimeType = new MimeType(attachment.getContentType().toString());
-      metacard = generateMetacard(mimeType, null, inputStream, transformer);
-    } catch (MimeTypeParseException | MetacardCreationException e) {
-      LOGGER.debug("Unable to parse metadata {}", attachment.getContentType().toString());
-    } finally {
-      IOUtils.closeQuietly(inputStream);
-    }
-    return metacard;
   }
 
   /**
@@ -1098,36 +398,13 @@ public class RESTEndpoint implements RESTService {
   @Path("/{id}")
   public Response deleteDocument(
       @PathParam("id") String id, @Context HttpServletRequest httpRequest) {
-    LOGGER.debug("DELETE");
-    Response response;
     try {
-      if (id != null) {
-        DeleteRequestImpl deleteReq =
-            new DeleteRequestImpl(new HtmlPolicyBuilder().toFactory().sanitize(id));
+      catalogService.deleteDocument(id);
+      return Response.ok(id).build();
 
-        catalogFramework.delete(deleteReq);
-        response = Response.ok(id).build();
-        LOGGER.debug("Attempting to delete Metacard with id: {}", id);
-      } else {
-        String errorMessage = "ID of entry not specified, cannot do DELETE.";
-        LOGGER.info(errorMessage);
-        return createBadRequestResponse(errorMessage);
-      }
-    } catch (SourceUnavailableException ce) {
-      String exceptionMessage =
-          "Could not delete entry from catalog since the source is unavailable: ";
-      LOGGER.info(exceptionMessage, ce);
-      throw new InternalServerErrorException(exceptionMessage);
-    } catch (InternalIngestException e) {
-      String exceptionMessage = "Error deleting entry from catalog: ";
-      LOGGER.info(exceptionMessage, e);
-      throw new InternalServerErrorException(exceptionMessage);
-    } catch (IngestException e) {
-      String errorMessage = "Error deleting entry from catalog: ";
-      LOGGER.info(errorMessage, e);
-      return createBadRequestResponse(errorMessage);
+    } catch (CatalogException e) {
+      return createBadRequestResponse(e.getMessage());
     }
-    return response;
   }
 
   private Response createBadRequestResponse(String entityMessage) {
@@ -1135,214 +412,5 @@ public class RESTEndpoint implements RESTService {
         .entity("<pre>" + entityMessage + "</pre>")
         .type(MediaType.TEXT_HTML)
         .build();
-  }
-
-  private Map<String, Serializable> convert(MultivaluedMap<String, String> map) {
-    Map<String, Serializable> convertedMap = new HashMap<>();
-
-    for (Map.Entry<String, List<String>> entry : map.entrySet()) {
-      String key = entry.getKey();
-      List<String> value = entry.getValue();
-
-      if (value.size() == 1) {
-        convertedMap.put(key, value.get(0));
-      } else {
-        // List is not serializable so we make it a String array
-        convertedMap.put(key, value.toArray());
-      }
-    }
-
-    return convertedMap;
-  }
-
-  private Metacard generateMetacard(
-      MimeType mimeType, String id, InputStream message, String transformerId)
-      throws MetacardCreationException {
-
-    Metacard generatedMetacard = null;
-
-    List<InputTransformer> listOfCandidates =
-        mimeTypeToTransformerMapper.findMatches(InputTransformer.class, mimeType);
-    List<String> stackTraceList = new ArrayList<>();
-
-    LOGGER.trace("Entering generateMetacard.");
-
-    LOGGER.debug("List of matches for mimeType [{}]: {}", mimeType, listOfCandidates);
-
-    try (TemporaryFileBackedOutputStream fileBackedOutputStream =
-        new TemporaryFileBackedOutputStream()) {
-
-      try {
-        if (null != message) {
-          IOUtils.copy(message, fileBackedOutputStream);
-        } else {
-          throw new MetacardCreationException(
-              "Could not copy bytes of content message.  Message was NULL.");
-        }
-      } catch (IOException e) {
-        throw new MetacardCreationException("Could not copy bytes of content message.", e);
-      }
-
-      Iterator<InputTransformer> it = listOfCandidates.iterator();
-      if (StringUtils.isNotEmpty(transformerId)) {
-        BundleContext bundleContext = getBundleContext();
-        Collection<ServiceReference<InputTransformer>> serviceReferences =
-            bundleContext.getServiceReferences(
-                InputTransformer.class, "(id=" + transformerId + ")");
-        it = serviceReferences.stream().map(bundleContext::getService).iterator();
-      }
-
-      while (it.hasNext()) {
-        InputTransformer transformer = it.next();
-        try (InputStream inputStreamMessageCopy =
-            fileBackedOutputStream.asByteSource().openStream()) {
-          generatedMetacard = transformer.transform(inputStreamMessageCopy);
-        } catch (CatalogTransformerException | IOException e) {
-          List<String> stackTraces = Arrays.asList(ExceptionUtils.getRootCauseStackTrace(e));
-          stackTraceList.add(
-              String.format("Transformer [%s] could not create metacard.", transformer));
-          stackTraceList.addAll(stackTraces);
-          LOGGER.debug("Transformer [{}] could not create metacard.", transformer, e);
-        }
-        if (generatedMetacard != null) {
-          break;
-        }
-      }
-
-      if (generatedMetacard == null) {
-        throw new MetacardCreationException(
-            String.format(
-                "Could not create metacard with mimeType %s : %s",
-                mimeType, StringUtils.join(stackTraceList, "\n")));
-      }
-
-      if (id != null) {
-        generatedMetacard.setAttribute(new AttributeImpl(Metacard.ID, id));
-      }
-      LOGGER.debug("Metacard id is {}", generatedMetacard.getId());
-
-    } catch (IOException e) {
-      throw new MetacardCreationException("Could not create metacard.", e);
-    } catch (InvalidSyntaxException e) {
-      throw new MetacardCreationException("Could not determine transformer", e);
-    }
-    return generatedMetacard;
-  }
-
-  private MimeType getMimeType(HttpHeaders headers) {
-    List<String> contentTypeList = headers.getRequestHeader(HttpHeaders.CONTENT_TYPE);
-
-    String singleMimeType = null;
-
-    if (contentTypeList != null && !contentTypeList.isEmpty()) {
-      singleMimeType = contentTypeList.get(0);
-      LOGGER.debug("Encountered [{}] {}", singleMimeType, HttpHeaders.CONTENT_TYPE);
-    }
-
-    MimeType mimeType = null;
-
-    // Sending a null argument to MimeType causes NPE
-    if (singleMimeType != null) {
-      try {
-        mimeType = new MimeType(singleMimeType);
-      } catch (MimeTypeParseException e) {
-        LOGGER.debug("Could not parse mime type from headers.", e);
-      }
-    }
-
-    return mimeType;
-  }
-
-  private String getFileExtensionForMimeType(String mimeType) {
-    String fileExtension = this.tikaMimeTypeResolver.getFileExtensionForMimeType(mimeType);
-    LOGGER.debug("Mime Type [{}] resolves to file extension [{}].", mimeType, fileExtension);
-    return fileExtension;
-  }
-
-  private boolean rangeHeaderExists(HttpServletRequest httpRequest) {
-    boolean response = false;
-
-    if (httpRequest != null && httpRequest.getHeader(HEADER_RANGE) != null) {
-      response = true;
-    }
-
-    return response;
-  }
-
-  // Return 0 (beginning of stream) if the range header does not exist.
-  private long getRangeStart(HttpServletRequest httpRequest) throws UnsupportedQueryException {
-    long response = 0;
-
-    if (httpRequest != null && rangeHeaderExists(httpRequest)) {
-      String rangeHeader = httpRequest.getHeader(HEADER_RANGE);
-      String range = getRange(rangeHeader);
-
-      if (range != null) {
-        response = Long.parseLong(range);
-      }
-    }
-
-    return response;
-  }
-
-  private String getRange(String rangeHeader) throws UnsupportedQueryException {
-    String response = null;
-
-    if (rangeHeader != null) {
-      if (rangeHeader.startsWith(BYTES_EQUAL)) {
-        String tempString = rangeHeader.substring(BYTES_EQUAL.length());
-        if (tempString.contains("-")) {
-          response = rangeHeader.substring(BYTES_EQUAL.length(), rangeHeader.lastIndexOf('-'));
-        } else {
-          response = rangeHeader.substring(BYTES_EQUAL.length());
-        }
-      } else {
-        throw new UnsupportedQueryException("Invalid range header: " + rangeHeader);
-      }
-    }
-
-    return response;
-  }
-
-  public void setMimeTypeToTransformerMapper(
-      MimeTypeToTransformerMapper mimeTypeToTransformerMapper) {
-    this.mimeTypeToTransformerMapper = mimeTypeToTransformerMapper;
-  }
-
-  public FilterBuilder getFilterBuilder() {
-    return filterBuilder;
-  }
-
-  public void setFilterBuilder(FilterBuilder filterBuilder) {
-    this.filterBuilder = filterBuilder;
-  }
-
-  public void setTikaMimeTypeResolver(MimeTypeResolver mimeTypeResolver) {
-    this.tikaMimeTypeResolver = mimeTypeResolver;
-  }
-
-  public void setUuidGenerator(UuidGenerator uuidGenerator) {
-    this.uuidGenerator = uuidGenerator;
-  }
-
-  protected static class IncomingContentItem extends ContentItemImpl {
-
-    private InputStream inputStream;
-
-    public IncomingContentItem(
-        String id,
-        InputStream inputStream,
-        String mimeTypeRawData,
-        String filename,
-        long size,
-        Metacard metacard) {
-      super(id, null, mimeTypeRawData, filename, size, metacard);
-      this.inputStream = inputStream;
-    }
-
-    @Override
-    public InputStream getInputStream() {
-      return inputStream;
-    }
   }
 }

--- a/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,38 +13,15 @@
 <blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd">
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+           http://cxf.apache.org/blueprint/jaxrs
+           http://cxf.apache.org/schemas/blueprint/jaxrs.xsd">
 
-    <reference id="transformerMapper" interface="ddf.mime.MimeTypeToTransformerMapper"/>
-    <reference id="catalog" interface="ddf.catalog.CatalogFramework"/>
-    <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
-    <reference id="tikaMimeTypeResolver" filter="(name=tikaMimeTypeResolver)" interface="ddf.mime.MimeTypeResolver"/>
-    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
-    <reference id="attachmentParser" interface="org.codice.ddf.attachment.AttachmentParser"/>
-    <reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
-
-    <bean id="actionFactory"
-          class="org.codice.ddf.endpoints.rest.action.MetacardTransformerActionProviderFactory"/>
-
-    <reference-list id="metacardTransformerRefList"
-                    interface="ddf.catalog.transform.MetacardTransformer" availability="optional"
-                    filter="(!(generateActionProvider=false))">
-        <reference-listener bind-method="bind" unbind-method="unbind">
-            <bean class="org.codice.ddf.endpoints.rest.action.ActionProviderRegistryProxy">
-                <argument ref="actionFactory"/>
-            </bean>
-        </reference-listener>
-    </reference-list>
+    <reference id="catalogService" interface="org.codice.ddf.rest.service.CatalogService"/>
 
     <bean id="restSvc" class="org.codice.ddf.endpoints.rest.RESTEndpoint">
-        <argument ref="catalog"/>
-        <argument ref="attachmentParser"/>
-        <argument ref="attributeRegistry" />
-        <property name="filterBuilder" ref="filterBuilder"/>
-        <property name="mimeTypeToTransformerMapper" ref="transformerMapper"/>
-        <property name="tikaMimeTypeResolver" ref="tikaMimeTypeResolver"/>
-        <property name="uuidGenerator" ref="uuidGenerator" />
+        <argument ref="catalogService"/>
     </bean>
 
     <jaxrs:server id="restService" address="/catalog">
@@ -62,16 +39,5 @@
             <bean class="org.apache.cxf.jaxrs.provider.jsonp.JsonpPostStreamInterceptor"/>
         </jaxrs:outInterceptors>
     </jaxrs:server>
-
-    <bean id="viewActionProvider"
-          class="org.codice.ddf.endpoints.rest.action.ViewMetacardActionProvider">
-        <argument value="catalog.data.metacard.view"/>
-    </bean>
-
-    <service ref="viewActionProvider" interface="ddf.action.ActionProvider">
-        <service-properties>
-            <entry key="id" value="catalog.data.metacard.view"/>
-        </service-properties>
-    </service>
 
 </blueprint>

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RESTEndpointTest.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RESTEndpointTest.java
@@ -1,0 +1,438 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.endpoints.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.data.AttributeRegistry;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.federation.FederationStrategy;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.impl.CreateResponseImpl;
+import ddf.catalog.resource.Resource;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.mime.MimeTypeMapper;
+import ddf.mime.tika.TikaMimeTypeResolver;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.apache.tika.io.IOUtils;
+import org.codice.ddf.attachment.impl.AttachmentParserImpl;
+import org.codice.ddf.rest.impl.CatalogServiceImpl;
+import org.junit.Test;
+
+public class RESTEndpointTest {
+
+  private static final int OK = 200;
+
+  private static final int NO_CONTENT = 204;
+
+  private static final int NOT_FOUND = 404;
+
+  private static final String SAMPLE_ID = "12345678900987654321abcdeffedcba";
+
+  private static final String LOCAL_RETRIEVE_ADDRESS = "http://localhost:8181/services/catalog";
+
+  private static final String FED_RETRIEVE_ADDRESS =
+      "http://localhost:8181/services/catalog/sources/test/abc123456def";
+
+  private static final String GET_SITENAME = "test";
+
+  private static final String GET_ID = "abc123456def";
+
+  private static final String GET_STREAM = "Test string for inputstream.";
+
+  private static final String GET_OUTPUT_TYPE = "UTF-8";
+
+  private static final String GET_MIME_TYPE = "text/xml";
+
+  private static final String GET_KML_MIME_TYPE = "application/vnd.google-earth.kml+xml";
+
+  private static final String GET_FILENAME = "example.xml";
+
+  private static final String GET_TYPE_OUTPUT =
+      "{Content-Type=[text/xml], Accept-Ranges=[bytes], "
+          + "Content-Disposition=[inline; filename=\""
+          + GET_FILENAME
+          + "\"]}";
+
+  private static final String GET_KML_TYPE_OUTPUT =
+      "{Content-Type=[application/vnd.google-earth.kml+xml], "
+          + "Accept-Ranges=[bytes], Content-Disposition=[inline; filename=\""
+          + GET_ID
+          + ".kml"
+          + "\"]}";
+
+  private static final String HEADER_ACCEPT_RANGES = "Accept-Ranges";
+
+  private static final String ACCEPT_RANGES_VALUE = "bytes";
+
+  private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
+
+  private static final String CONTENT_DISPOSITION_VALUE =
+      "inline; filename=\"" + GET_FILENAME + "\"";
+
+  /**
+   * Test using a Head request to find out if Range headers are supported and to get resource size
+   * of a local resource for use when using Range headers.
+   */
+  @Test
+  public void testHeadRequestLocal() throws Exception {
+    Response response = headTest(true);
+
+    assertEquals(NO_CONTENT, response.getStatus());
+    assertEquals(ACCEPT_RANGES_VALUE, response.getHeaderString(HEADER_ACCEPT_RANGES));
+    assertEquals(CONTENT_DISPOSITION_VALUE, response.getHeaderString(HEADER_CONTENT_DISPOSITION));
+  }
+
+  /**
+   * Test using a Head request to find out if Range headers are supported and to get resource size
+   * of a resource at a federated site for use when using Range headers.
+   */
+  @Test
+  public void testHeadRequestFederated() throws Exception {
+    Response response = headTest(false);
+
+    assertEquals(NO_CONTENT, response.getStatus());
+    assertEquals(ACCEPT_RANGES_VALUE, response.getHeaderString(HEADER_ACCEPT_RANGES));
+    assertEquals(CONTENT_DISPOSITION_VALUE, response.getHeaderString(HEADER_CONTENT_DISPOSITION));
+  }
+
+  @SuppressWarnings({"unchecked"})
+  private Response headTest(boolean local) throws Exception {
+
+    MetacardImpl metacard;
+    List<Result> list = new ArrayList<>();
+    Result result = mock(Result.class);
+    InputStream inputStream;
+    UriInfo uriInfo;
+    Response response;
+
+    CatalogFramework framework = givenCatalogFramework();
+    list.add(result);
+
+    QueryResponse queryResponse = mock(QueryResponse.class);
+    when(queryResponse.getResults()).thenReturn(list);
+    when(framework.query(isA(QueryRequest.class), isNull(FederationStrategy.class)))
+        .thenReturn(queryResponse);
+
+    metacard = new MetacardImpl();
+    metacard.setSourceId(GET_SITENAME);
+    when(result.getMetacard()).thenReturn(metacard);
+
+    Resource resource = mock(Resource.class);
+    inputStream = new ByteArrayInputStream(GET_STREAM.getBytes(GET_OUTPUT_TYPE));
+    when(resource.getInputStream()).thenReturn(inputStream);
+    when(resource.getMimeTypeValue()).thenReturn(GET_MIME_TYPE);
+    when(resource.getName()).thenReturn(GET_FILENAME);
+    when(framework.transform(isA(Metacard.class), anyString(), isA(Map.class)))
+        .thenReturn(resource);
+
+    MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
+    when(mimeTypeMapper.getMimeTypeForFileExtension("txt")).thenReturn("text/plain");
+    when(mimeTypeMapper.getMimeTypeForFileExtension("xml")).thenReturn("text/xml");
+
+    CatalogServiceImpl catalogServiceImpl =
+        new CatalogServiceImpl(
+            framework, new AttachmentParserImpl(mimeTypeMapper), mock(AttributeRegistry.class));
+    catalogServiceImpl.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
+    FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+    catalogServiceImpl.setFilterBuilder(filterBuilder);
+
+    uriInfo = createSpecificUriInfo(LOCAL_RETRIEVE_ADDRESS);
+
+    RESTEndpoint restEndpoint = new RESTEndpoint(catalogServiceImpl);
+
+    if (local) {
+      response = restEndpoint.getHeaders(GET_ID, uriInfo, null);
+    } else {
+      response = restEndpoint.getHeaders(null, GET_ID, uriInfo, null);
+    }
+
+    return response;
+  }
+
+  /** Tests local retrieve with a null QueryResponse */
+  @Test
+  public void testGetDocumentLocalNullQueryResponse() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.QUERY_RESPONSE_TEST);
+    Response response = executeTest(framework, transformer, true);
+    assertEquals(response.getStatus(), NOT_FOUND);
+    assertEquals(response.getEntity(), "<pre>Unable to retrieve requested metacard.</pre>");
+  }
+
+  /** Tests federated retrieve with a null QueryResponse */
+  @Test
+  public void testGetDocumentFedNullQueryResponse() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.QUERY_RESPONSE_TEST);
+    Response response = executeTest(framework, transformer, false);
+    assertEquals(response.getStatus(), NOT_FOUND);
+    assertEquals(response.getEntity(), "<pre>Unable to retrieve requested metacard.</pre>");
+  }
+
+  /** Tests local retrieve with a null Metacard */
+  @Test
+  public void testGetDocumentLocalNullMetacard() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.METACARD_TEST);
+    Response response = executeTest(framework, transformer, true);
+    assertEquals(response.getStatus(), NOT_FOUND);
+    assertEquals(response.getEntity(), "<pre>Unable to retrieve requested metacard.</pre>");
+  }
+
+  /** Tests federated retrieve with a null Metacard */
+  @Test
+  public void testGetDocumentFedNullMetacard() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.METACARD_TEST);
+    Response response = executeTest(framework, transformer, false);
+    assertEquals(response.getStatus(), NOT_FOUND);
+    assertEquals(response.getEntity(), "<pre>Unable to retrieve requested metacard.</pre>");
+  }
+
+  /** Tests local retrieve with a successful response */
+  @Test
+  public void testGetDocumentLocalSuccess() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.SUCCESS_TEST);
+    Response response = executeTest(framework, transformer, true);
+
+    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
+    assertEquals(GET_STREAM, responseMessage);
+    assertEquals(OK, response.getStatus());
+    assertEquals(GET_TYPE_OUTPUT, response.getMetadata().toString());
+  }
+
+  @Test
+  public void testGetDocumentKml() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.KML_TEST);
+    Response response = executeTest(framework, transformer, true);
+
+    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
+    assertEquals(GET_STREAM, responseMessage);
+    assertEquals(OK, response.getStatus());
+    assertEquals(GET_KML_TYPE_OUTPUT, response.getMetadata().toString());
+  }
+
+  /** Tests federated retrieve with a successful response */
+  @Test
+  public void testGetDocumentFedSuccess() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.SUCCESS_TEST);
+    Response response = executeTest(framework, transformer, false);
+
+    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
+    assertEquals(GET_STREAM, responseMessage);
+    assertEquals(OK, response.getStatus());
+    assertEquals(GET_TYPE_OUTPUT, response.getMetadata().toString());
+  }
+
+  /** Tests retrieving a local resource with a successful response */
+  @Test
+  public void testGetDocumentResourceLocalSuccess() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.RESOURCE_TEST);
+    Response response = executeTest(framework, transformer, true);
+
+    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
+    assertEquals(GET_STREAM, responseMessage);
+    assertEquals(OK, response.getStatus());
+    assertEquals(GET_TYPE_OUTPUT, response.getMetadata().toString());
+  }
+
+  /** Tests retrieving a federated resource with a successful response */
+  @Test
+  public void testGetDocumentResourceFedSuccess() throws Exception {
+
+    CatalogFramework framework = givenCatalogFramework();
+    String transformer = mockTestSetup(framework, TestType.RESOURCE_TEST);
+    Response response = executeTest(framework, transformer, false);
+
+    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
+    assertEquals(GET_STREAM, responseMessage);
+    assertEquals(OK, response.getStatus());
+    assertEquals(GET_TYPE_OUTPUT, response.getMetadata().toString());
+  }
+
+  /**
+   * Creates the mock setup for the GET tests above. Parameters provide the CatalogFramework, which
+   * will be setup for the test, and also specify which test case is being run.
+   */
+  @SuppressWarnings({"unchecked"})
+  private String mockTestSetup(CatalogFramework framework, TestType testType) throws Exception {
+    String transformer = null;
+    QueryResponse queryResponse = mock(QueryResponse.class);
+    when(framework.query(isA(QueryRequest.class), isNull(FederationStrategy.class)))
+        .thenReturn(queryResponse);
+
+    List<Result> list = null;
+    MetacardImpl metacard = null;
+    Result result = mock(Result.class);
+    InputStream inputStream;
+
+    switch (testType) {
+      case QUERY_RESPONSE_TEST:
+        when(queryResponse.getResults()).thenReturn(list);
+        break;
+
+      case METACARD_TEST:
+        list = new ArrayList<>();
+        list.add(result);
+        when(queryResponse.getResults()).thenReturn(list);
+
+        when(result.getMetacard()).thenReturn(metacard);
+        break;
+
+      case RESOURCE_TEST:
+        transformer = "resource";
+        /* FALLTHRU */
+        // fall through
+      case SUCCESS_TEST:
+        list = new ArrayList<>();
+        list.add(result);
+        when(queryResponse.getResults()).thenReturn(list);
+
+        metacard = new MetacardImpl();
+        metacard.setSourceId(GET_SITENAME);
+        when(result.getMetacard()).thenReturn(metacard);
+
+        Resource resource = mock(Resource.class);
+        inputStream = new ByteArrayInputStream(GET_STREAM.getBytes(GET_OUTPUT_TYPE));
+        when(resource.getInputStream()).thenReturn(inputStream);
+        when(resource.getMimeTypeValue()).thenReturn(GET_MIME_TYPE);
+        when(resource.getName()).thenReturn(GET_FILENAME);
+        when(framework.transform(isA(Metacard.class), anyString(), isA(Map.class)))
+            .thenReturn(resource);
+        break;
+
+      case KML_TEST:
+        transformer = "kml";
+        list = new ArrayList<>();
+        list.add(result);
+        when(queryResponse.getResults()).thenReturn(list);
+
+        metacard = new MetacardImpl();
+        metacard.setSourceId(GET_SITENAME);
+        when(result.getMetacard()).thenReturn(metacard);
+
+        BinaryContent content = mock(BinaryContent.class);
+        inputStream = new ByteArrayInputStream(GET_STREAM.getBytes(GET_OUTPUT_TYPE));
+        when(content.getInputStream()).thenReturn(inputStream);
+        when(content.getMimeTypeValue()).thenReturn(GET_KML_MIME_TYPE);
+        when(framework.transform(isA(Metacard.class), anyString(), isA(Map.class)))
+            .thenReturn(content);
+        break;
+    }
+
+    return transformer;
+  }
+
+  private Response executeTest(CatalogFramework framework, String transformer, boolean local)
+      throws Exception {
+
+    MimeTypeMapper mimeTypeMapper = mock(MimeTypeMapper.class);
+    when(mimeTypeMapper.getMimeTypeForFileExtension("txt")).thenReturn("text/plain");
+    when(mimeTypeMapper.getMimeTypeForFileExtension("xml")).thenReturn("text/xml");
+
+    CatalogServiceImpl catalogServiceImpl =
+        new CatalogServiceImpl(
+            framework, new AttachmentParserImpl(mimeTypeMapper), mock(AttributeRegistry.class));
+
+    catalogServiceImpl.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
+    FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+    catalogServiceImpl.setFilterBuilder(filterBuilder);
+
+    RESTEndpoint restEndpoint = new RESTEndpoint(catalogServiceImpl);
+
+    UriInfo uriInfo;
+    Response response;
+    if (local) {
+      uriInfo = createSpecificUriInfo(LOCAL_RETRIEVE_ADDRESS);
+      response = restEndpoint.getDocument(GET_ID, transformer, uriInfo, null);
+    } else {
+      uriInfo = createSpecificUriInfo(FED_RETRIEVE_ADDRESS);
+      response = restEndpoint.getDocument(GET_SITENAME, GET_ID, transformer, uriInfo, null);
+    }
+
+    return response;
+  }
+
+  /** Creates a UriInfo with a user specified URL */
+  @SuppressWarnings({"unchecked"})
+  private UriInfo createSpecificUriInfo(String url) throws URISyntaxException {
+
+    UriInfo uriInfo = mock(UriInfo.class);
+    URI uri = new URI(url);
+
+    when(uriInfo.getAbsolutePath()).thenReturn(uri);
+    when(uriInfo.getQueryParameters()).thenReturn(mock(MultivaluedMap.class));
+
+    return uriInfo;
+  }
+
+  private CatalogFramework givenCatalogFramework()
+      throws IngestException, SourceUnavailableException {
+    CatalogFramework framework = mock(CatalogFramework.class);
+    Metacard returnMetacard = mock(Metacard.class);
+
+    when(returnMetacard.getId()).thenReturn(RESTEndpointTest.SAMPLE_ID);
+    when(framework.create(isA(CreateRequest.class)))
+        .thenReturn(new CreateResponseImpl(null, null, Collections.singletonList(returnMetacard)));
+    when(framework.create(isA(CreateStorageRequest.class)))
+        .thenReturn(new CreateResponseImpl(null, null, Collections.singletonList(returnMetacard)));
+    return framework;
+  }
+
+  protected enum TestType {
+    QUERY_RESPONSE_TEST,
+    METACARD_TEST,
+    SUCCESS_TEST,
+    RESOURCE_TEST,
+    KML_TEST
+  }
+}

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointIT.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RestEndpointIT.java
@@ -22,37 +22,24 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.same;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
 import com.jayway.restassured.RestAssured;
-import ddf.catalog.CatalogFramework;
-import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.BinaryContent;
-import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
-import ddf.catalog.federation.FederationStrategy;
-import ddf.catalog.filter.FilterBuilder;
-import ddf.catalog.operation.QueryRequest;
-import ddf.catalog.operation.QueryResponse;
-import ddf.mime.MimeTypeMapper;
-import ddf.mime.MimeTypeResolver;
-import ddf.mime.MimeTypeToTransformerMapper;
 import java.io.ByteArrayInputStream;
+import java.net.URI;
 import java.util.Arrays;
-import java.util.Map;
 import javax.inject.Inject;
-import org.codice.ddf.attachment.AttachmentParser;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MultivaluedMap;
 import org.codice.ddf.configuration.SystemBaseUrl;
-import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
+import org.codice.ddf.rest.service.CatalogService;
 import org.codice.ddf.test.common.AbstractComponentTest;
 import org.codice.ddf.test.common.UrlBuilder;
 import org.codice.ddf.test.common.annotations.BeforeExam;
 import org.codice.ddf.test.common.annotations.MockOsgiService;
-import org.codice.ddf.test.common.annotations.MockOsgiService.Property;
 import org.codice.ddf.test.common.annotations.PaxExamRule;
 import org.codice.ddf.test.common.configurators.ApplicationOptions;
 import org.codice.ddf.test.common.configurators.BundleOptionBuilder.BundleOption;
@@ -64,8 +51,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Answers;
-import org.opengis.filter.Filter;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
@@ -91,24 +76,7 @@ public class RestEndpointIT extends AbstractComponentTest {
 
   @Inject private BundleContext bundleContext;
 
-  @MockOsgiService private CatalogFramework catalogFramework;
-
-  @MockOsgiService private AttachmentParser attachmentParser;
-
-  @MockOsgiService private MimeTypeToTransformerMapper mimeTypeToTransformerMapper;
-
-  @MockOsgiService private AttributeRegistry attributeRegistry;
-
-  @MockOsgiService(answer = Answers.RETURNS_DEEP_STUBS)
-  private FilterBuilder filterBuilder;
-
-  @MockOsgiService(properties = {@Property(key = "name", value = "tikaMimeTypeResolver")})
-  private MimeTypeResolver mimeTypeResolver;
-
-  @MockOsgiService private MimeTypeMapper mimeTypeMapper;
-
-  @MockOsgiService(properties = {@Property(key = "id", value = "uuidGenerator")})
-  private UuidGenerator uuidGenerator;
+  @MockOsgiService private CatalogService catalogService;
 
   @BeforeExam
   public void setupClass() {
@@ -140,18 +108,15 @@ public class RestEndpointIT extends AbstractComponentTest {
     String contentText = "Content";
     byte[] contentBytes = contentText.getBytes();
 
-    Filter filter = mock(Filter.class);
-    QueryResponse queryResponse = mock(QueryResponse.class);
-    Result result = mock(Result.class);
-    Metacard metacard = mock(Metacard.class);
     BinaryContent content = mock(BinaryContent.class);
-
-    given(filterBuilder.attribute(Metacard.ID).is().equalTo().text(metacardId)).willReturn(filter);
-    given(catalogFramework.query(any(QueryRequest.class), any(FederationStrategy.class)))
-        .willReturn(queryResponse);
-    given(queryResponse.getResults()).willReturn(ImmutableList.of(result));
-    given(result.getMetacard()).willReturn(metacard);
-    given(catalogFramework.transform(same(metacard), eq("xml"), any(Map.class)))
+    given(
+            catalogService.getDocument(
+                anyString(),
+                anyString(),
+                anyString(),
+                any(URI.class),
+                any(MultivaluedMap.class),
+                any(HttpServletRequest.class)))
         .willReturn(content);
     given(content.getInputStream()).willReturn(new ByteArrayInputStream(contentBytes));
     given(content.getMimeTypeValue()).willReturn(contentType);
@@ -172,13 +137,16 @@ public class RestEndpointIT extends AbstractComponentTest {
   public void testGetInvalidMetacardId() throws Exception {
     String metacardId = "123";
 
-    Filter filter = mock(Filter.class);
-    QueryResponse queryResponse = mock(QueryResponse.class);
-
-    given(filterBuilder.attribute(Metacard.ID).is().equalTo().text(metacardId)).willReturn(filter);
-    given(catalogFramework.query(any(QueryRequest.class), any(FederationStrategy.class)))
-        .willReturn(queryResponse);
-    given(queryResponse.getResults()).willReturn(ImmutableList.of());
+    BinaryContent content = mock(BinaryContent.class);
+    given(
+            catalogService.getDocument(
+                anyString(),
+                anyString(),
+                anyString(),
+                any(URI.class),
+                any(MultivaluedMap.class),
+                any(HttpServletRequest.class)))
+        .willReturn(null);
 
     when()
         .get(restEndpointUrlBuilder.add(metacardId).build())
@@ -197,7 +165,8 @@ public class RestEndpointIT extends AbstractComponentTest {
         return super.getBundleOptions()
             .add("org.bouncycastle", "bcprov-jdk15on")
             .add("ddf.catalog.transformer", "catalog-transformer-attribute")
-            .add("ddf.catalog.core", "catalog-core-attachment");
+            .add("ddf.catalog.core", "catalog-core-attachment")
+            .add("ddf.catalog.rest", "catalog-rest-service");
       }
 
       @Override
@@ -216,9 +185,6 @@ public class RestEndpointIT extends AbstractComponentTest {
             .addFeatures("ddf.features", "utilities", utilitiesFeatures)
             .addFeatures("ddf.features", "kernel", kernelFeatures)
             .addFeatureFrom("ddf.thirdparty", "rest-assured", "feature", "rest-assured")
-            .addFeatureFrom(
-                "ddf.platform.util", "util-uuidgenerator-api", "feature", "uuidgenerator-api")
-            .addFeatureFrom("ddf.mime.core", "mime-core-api", "feature", "mime-core-api-only")
             .addFeatureFrom(
                 "ddf.catalog.core", "catalog-core-api", "feature", "catalog-core-api-only");
       }

--- a/catalog/rest/catalog-rest-impl/pom.xml
+++ b/catalog/rest/catalog-rest-impl/pom.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>catalog-rest-pom</artifactId>
+        <groupId>ddf.catalog.rest</groupId>
+        <version>2.13.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>catalog-rest-impl</artifactId>
+    <packaging>bundle</packaging>
+    <name>DDF :: Catalog :: REST :: Impl</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest-all.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.objenesis</groupId>
+                <artifactId>objenesis</artifactId>
+                <version>${objenesis.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Compile and Runtime -->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>asm</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.mime.core</groupId>
+            <artifactId>mime-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-actions</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.mime.tika</groupId>
+            <artifactId>mime-tika-resolver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.transformer</groupId>
+            <artifactId>catalog-transformer-attribute</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <version>${owasp-html-sanitizer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-attachment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.rest</groupId>
+            <artifactId>catalog-rest-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Unit Tests -->
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>filter-proxy</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-attachment-impl</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            asm,
+                            catalog-core-actions,
+                            catalog-core-api-impl,
+                            json-smart,
+                            platform-util,
+                            owasp-java-html-sanitizer
+                        </Embed-Dependency>
+                        <Import-Package>
+                            !org.codice.ddf.platform.util,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/AbstractMetacardActionProvider*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.48</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.41</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.38</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/CatalogServiceImpl.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/CatalogServiceImpl.java
@@ -1,0 +1,1295 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.rest.impl;
+
+import static ddf.catalog.data.AttributeType.AttributeFormat.BINARY;
+import static ddf.catalog.data.AttributeType.AttributeFormat.OBJECT;
+
+import com.google.common.collect.Iterables;
+import ddf.action.Action;
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.Constants;
+import ddf.catalog.content.data.impl.ContentItemImpl;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.content.operation.UpdateStorageRequest;
+import ddf.catalog.content.operation.impl.CreateStorageRequestImpl;
+import ddf.catalog.content.operation.impl.UpdateStorageRequestImpl;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeRegistry;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.ContentType;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardCreationException;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.BinaryContentImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.SourceInfoResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.operation.impl.SourceInfoRequestEnterprise;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.resource.DataUsageLimitExceededException;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.InternalIngestException;
+import ddf.catalog.source.SourceDescriptor;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+import ddf.mime.MimeTypeResolver;
+import ddf.mime.MimeTypeToTransformerMapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.activation.MimeType;
+import javax.activation.MimeTypeParseException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Part;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.ContentDisposition;
+import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
+import org.codice.ddf.attachment.AttachmentInfo;
+import org.codice.ddf.attachment.AttachmentParser;
+import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
+import org.codice.ddf.rest.service.CatalogException;
+import org.codice.ddf.rest.service.CatalogService;
+import org.opengis.filter.Filter;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CatalogServiceImpl implements CatalogService {
+
+  public static final String CONTEXT_ROOT = "catalog";
+
+  public static final String SOURCES_PATH = "/sources";
+
+  static final String DEFAULT_METACARD_TRANSFORMER = "xml";
+
+  private static final String BYTES_TO_SKIP = "BytesToSkip";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CatalogServiceImpl.class);
+
+  private static final Logger INGEST_LOGGER = LoggerFactory.getLogger(Constants.INGEST_LOGGER_NAME);
+
+  private static final String HEADER_RANGE = "Range";
+
+  private static final String FILE_ATTACHMENT_CONTENT_ID = "file";
+
+  private static final String FILENAME_CONTENT_DISPOSITION_PARAMETER_NAME = "filename";
+
+  private static final String BYTES_EQUAL = "bytes=";
+
+  private static final String JSON_MIME_TYPE_STRING = "application/json";
+
+  public static final int MAX_INPUT_SIZE = 65_536;
+
+  private UuidGenerator uuidGenerator;
+
+  private static MimeType jsonMimeType;
+
+  static {
+    MimeType mime = null;
+    try {
+      mime = new MimeType(JSON_MIME_TYPE_STRING);
+    } catch (MimeTypeParseException e) {
+      LOGGER.info("Failed to create json mimetype.");
+    }
+    jsonMimeType = mime;
+  }
+
+  private FilterBuilder filterBuilder;
+
+  private CatalogFramework catalogFramework;
+
+  private MimeTypeToTransformerMapper mimeTypeToTransformerMapper;
+
+  private MimeTypeResolver tikaMimeTypeResolver;
+
+  private final AttachmentParser attachmentParser;
+
+  private AttributeRegistry attributeRegistry;
+
+  public CatalogServiceImpl(
+      CatalogFramework framework,
+      AttachmentParser attachmentParser,
+      AttributeRegistry attributeRegistry) {
+    LOGGER.trace("Constructing REST Endpoint");
+    this.catalogFramework = framework;
+    this.attachmentParser = attachmentParser;
+    this.attributeRegistry = attributeRegistry;
+    LOGGER.trace(("Rest Endpoint constructed successfully"));
+  }
+
+  BundleContext getBundleContext() {
+    Bundle bundle = FrameworkUtil.getBundle(CatalogServiceImpl.class);
+    return bundle.getBundleContext();
+  }
+
+  public BinaryContent getHeaders(
+      String sourceid, String id, URI absolutePath, MultivaluedMap<String, String> queryParameters)
+      throws CatalogException {
+    QueryResponse queryResponse;
+    Metacard card = null;
+    LOGGER.trace("getHeaders");
+
+    if (id != null) {
+      LOGGER.debug("Got id: {}", id);
+      LOGGER.debug("Map of query parameters: \n{}", queryParameters);
+
+      Map<String, Serializable> convertedMap = convert(queryParameters);
+      convertedMap.put("url", absolutePath.toString());
+
+      LOGGER.debug("Map converted, retrieving product.");
+
+      // default to xml if no transformer specified
+      try {
+        String transformer = DEFAULT_METACARD_TRANSFORMER;
+
+        Filter filter = getFilterBuilder().attribute(Metacard.ID).is().equalTo().text(id);
+
+        Collection<String> sources = null;
+        if (sourceid != null) {
+          sources = new ArrayList<>();
+          sources.add(sourceid);
+        }
+
+        QueryRequestImpl request = new QueryRequestImpl(new QueryImpl(filter), sources);
+        request.setProperties(convertedMap);
+        queryResponse = catalogFramework.query(request, null);
+
+        // pull the metacard out of the blocking queue
+        List<Result> results = queryResponse.getResults();
+
+        // TODO: should be poll? do we want to specify a timeout? (will
+        // return null if timeout elapsed)
+        if (results != null && !results.isEmpty()) {
+          card = results.get(0).getMetacard();
+        }
+
+        if (card == null) {
+          return null;
+        }
+
+        LOGGER.debug("Calling transform.");
+        final BinaryContent content = catalogFramework.transform(card, transformer, convertedMap);
+        LOGGER.debug("Read and transform complete, preparing response.");
+
+        return content;
+
+      } catch (FederationException e) {
+        String exceptionMessage = "READ failed due to unexpected exception: ";
+        LOGGER.info(exceptionMessage, e);
+        throw new InternalServerErrorException(exceptionMessage);
+      } catch (CatalogTransformerException e) {
+        String exceptionMessage = "Unable to transform Metacard.  Try different transformer: ";
+        LOGGER.info(exceptionMessage, e);
+        throw new InternalServerErrorException(exceptionMessage);
+      } catch (SourceUnavailableException e) {
+        String exceptionMessage = "Cannot obtain query results because source is unavailable: ";
+        LOGGER.info(exceptionMessage, e);
+        throw new InternalServerErrorException(exceptionMessage);
+      } catch (UnsupportedQueryException e) {
+        String errorMessage = "Specified query is unsupported.  Change query and resubmit: ";
+        LOGGER.info(errorMessage, e);
+        throw new CatalogException(errorMessage);
+
+        // The catalog framework will throw this if any of the transformers blow up. We need to
+        // catch this exception
+        // here or else execution will return to CXF and we'll lose this message and end up with
+        // a huge stack trace
+        // in a GUI or whatever else is connected to this endpoint
+      } catch (IllegalArgumentException e) {
+        throw new CatalogException(e.getMessage());
+      }
+    } else {
+      throw new CatalogException("No ID specified.");
+    }
+  }
+
+  private JSONObject sourceActionToJSON(Action action) {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("title", action.getTitle());
+    jsonObject.put("url", action.getUrl().toString());
+    jsonObject.put("description", action.getDescription());
+    return jsonObject;
+  }
+
+  public BinaryContent getDocument() {
+    JSONArray resultsList = new JSONArray();
+    SourceInfoResponse sources;
+    String sourcesString;
+
+    try {
+      SourceInfoRequestEnterprise sourceInfoRequestEnterprise =
+          new SourceInfoRequestEnterprise(true);
+
+      sources = catalogFramework.getSourceInfo(sourceInfoRequestEnterprise);
+      for (SourceDescriptor source : sources.getSourceInfo()) {
+        JSONObject sourceObj = new JSONObject();
+        sourceObj.put("id", source.getSourceId());
+        sourceObj.put("version", source.getVersion() != null ? source.getVersion() : "");
+        sourceObj.put("available", Boolean.valueOf(source.isAvailable()));
+
+        List<JSONObject> sourceActions =
+            source.getActions().stream().map(this::sourceActionToJSON).collect(Collectors.toList());
+
+        sourceObj.put("sourceActions", sourceActions);
+
+        JSONArray contentTypesObj = new JSONArray();
+        if (source.getContentTypes() != null) {
+          for (ContentType contentType : source.getContentTypes()) {
+            if (contentType != null && contentType.getName() != null) {
+              JSONObject contentTypeObj = new JSONObject();
+              contentTypeObj.put("name", contentType.getName());
+              contentTypeObj.put(
+                  "version", contentType.getVersion() != null ? contentType.getVersion() : "");
+              contentTypesObj.add(contentTypeObj);
+            }
+          }
+        }
+        sourceObj.put("contentTypes", contentTypesObj);
+        resultsList.add(sourceObj);
+      }
+    } catch (SourceUnavailableException e) {
+      LOGGER.info("Unable to retrieve Sources. {}", e.getMessage());
+      LOGGER.debug("Unable to retrieve Sources", e);
+    }
+
+    sourcesString = JSONValue.toJSONString(resultsList);
+    final BinaryContent content =
+        new BinaryContentImpl(
+            new ByteArrayInputStream(sourcesString.getBytes(StandardCharsets.UTF_8)), jsonMimeType);
+
+    return content;
+  }
+
+  public BinaryContent getDocument(
+      String encodedSourceId,
+      String encodedId,
+      String transformerParam,
+      URI absolutePath,
+      MultivaluedMap<String, String> queryParameters,
+      HttpServletRequest httpRequest)
+      throws CatalogException, DataUsageLimitExceededException {
+
+    QueryResponse queryResponse;
+    Metacard card = null;
+    LOGGER.trace("GET");
+
+    if (encodedId != null) {
+      LOGGER.debug("Got id: {}", encodedId);
+      LOGGER.debug("Got service: {}", transformerParam);
+      LOGGER.debug("Map of query parameters: \n{}", queryParameters);
+
+      Map<String, Serializable> convertedMap = convert(queryParameters);
+      convertedMap.put("url", absolutePath.toString());
+
+      LOGGER.debug("Map converted, retrieving product.");
+
+      // default to xml if no transformer specified
+      try {
+        String id = URLDecoder.decode(encodedId, CharEncoding.UTF_8);
+
+        String transformer = DEFAULT_METACARD_TRANSFORMER;
+        if (transformerParam != null) {
+          transformer = transformerParam;
+        }
+        Filter filter = getFilterBuilder().attribute(Metacard.ID).is().equalTo().text(id);
+
+        Collection<String> sources = null;
+        if (encodedSourceId != null) {
+          String sourceid = URLDecoder.decode(encodedSourceId, CharEncoding.UTF_8);
+          sources = new ArrayList<>();
+          sources.add(sourceid);
+        }
+
+        QueryRequestImpl request = new QueryRequestImpl(new QueryImpl(filter), sources);
+        request.setProperties(convertedMap);
+        queryResponse = catalogFramework.query(request, null);
+
+        // pull the metacard out of the blocking queue
+        List<Result> results = queryResponse.getResults();
+
+        // TODO: should be poll? do we want to specify a timeout? (will
+        // return null if timeout elapsed)
+        if (results != null && !results.isEmpty()) {
+          card = results.get(0).getMetacard();
+        }
+
+        if (card == null) {
+          return null;
+        }
+
+        // Check for Range header set the value in the map appropriately so that the
+        // catalogFramework
+        // can take care of the skipping
+        long bytesToSkip = getRangeStart(httpRequest);
+
+        if (bytesToSkip > 0) {
+          LOGGER.debug("Bytes to skip: {}", bytesToSkip);
+          convertedMap.put(BYTES_TO_SKIP, bytesToSkip);
+        }
+
+        LOGGER.debug("Calling transform.");
+        final BinaryContent content = catalogFramework.transform(card, transformer, convertedMap);
+        LOGGER.debug("Read and transform complete, preparing response.");
+
+        return content;
+
+      } catch (FederationException e) {
+        String exceptionMessage = "READ failed due to unexpected exception: ";
+        LOGGER.info(exceptionMessage, e);
+        throw new InternalServerErrorException(exceptionMessage);
+      } catch (CatalogTransformerException e) {
+        String exceptionMessage = "Unable to transform Metacard.  Try different transformer: ";
+        LOGGER.info(exceptionMessage, e);
+        throw new InternalServerErrorException(exceptionMessage);
+      } catch (SourceUnavailableException e) {
+        String exceptionMessage = "Cannot obtain query results because source is unavailable: ";
+        LOGGER.info(exceptionMessage, e);
+        throw new InternalServerErrorException(exceptionMessage);
+      } catch (UnsupportedQueryException e) {
+        String errorMessage = "Specified query is unsupported.  Change query and resubmit: ";
+        LOGGER.info(errorMessage, e);
+        throw new CatalogException(errorMessage);
+      } catch (DataUsageLimitExceededException e) {
+        String errorMessage = "Unable to process request. Data usage limit exceeded: ";
+        LOGGER.debug(errorMessage, e);
+        throw new DataUsageLimitExceededException(errorMessage);
+        // The catalog framework will throw this if any of the transformers blow up.
+        // We need to catch this exception here or else execution will return to CXF and
+        // we'll lose this message and end up with a huge stack trace in a GUI or whatever
+        // else is connected to this endpoint
+      } catch (RuntimeException | UnsupportedEncodingException e) {
+        String exceptionMessage = "Unknown error occurred while processing request: ";
+        LOGGER.info(exceptionMessage, e);
+        throw new InternalServerErrorException(exceptionMessage);
+      }
+    } else {
+      throw new CatalogException("No ID specified.");
+    }
+  }
+
+  public BinaryContent createMetacard(MultipartBody multipartBody, String transformerParam)
+      throws CatalogException {
+    LOGGER.trace("ENTERING: createMetacard");
+
+    String contentUri = multipartBody.getAttachmentObject("contentUri", String.class);
+    LOGGER.debug("contentUri = {}", contentUri);
+
+    InputStream stream = null;
+    String contentType = null;
+
+    Attachment contentPart = multipartBody.getAttachment(FILE_ATTACHMENT_CONTENT_ID);
+    if (contentPart != null) {
+      // Example Content-Type header:
+      // Content-Type: application/json;id=geojson
+      if (contentPart.getContentType() != null) {
+        contentType = contentPart.getContentType().toString();
+      }
+
+      // Get the file contents as an InputStream and ensure the stream is positioned
+      // at the beginning
+      try {
+        stream = contentPart.getDataHandler().getInputStream();
+        if (stream != null && stream.available() == 0) {
+          stream.reset();
+        }
+      } catch (IOException e) {
+        LOGGER.info("IOException reading stream from file attachment in multipart body", e);
+      }
+    } else {
+      LOGGER.debug("No file contents attachment found");
+    }
+
+    return createMetacard(stream, contentType, transformerParam);
+  }
+
+  public BinaryContent createMetacard(
+      HttpServletRequest httpServletRequest, String transformerParam) throws CatalogException {
+    LOGGER.trace("ENTERING: createMetacard");
+
+    InputStream stream = null;
+    String contentType = null;
+
+    try {
+      Part contentPart = httpServletRequest.getPart(FILE_ATTACHMENT_CONTENT_ID);
+      if (contentPart != null) {
+        // Example Content-Type header:
+        // Content-Type: application/json;id=geojson
+        if (contentPart.getContentType() != null) {
+          contentType = contentPart.getContentType();
+        }
+
+        // Get the file contents as an InputStream and ensure the stream is positioned
+        // at the beginning
+        try {
+          stream = contentPart.getInputStream();
+          if (stream != null && stream.available() == 0) {
+            stream.reset();
+          }
+        } catch (IOException e) {
+          LOGGER.info("IOException reading stream from file attachment in multipart body", e);
+        }
+      } else {
+        LOGGER.debug("No file contents attachment found");
+      }
+    } catch (ServletException | IOException e) {
+      LOGGER.info("No file contents part found: ", e);
+    }
+
+    return createMetacard(stream, contentType, transformerParam);
+  }
+
+  private BinaryContent createMetacard(
+      InputStream stream, String contentType, String transformerParam) throws CatalogException {
+    String transformer = DEFAULT_METACARD_TRANSFORMER;
+    if (transformerParam != null) {
+      transformer = transformerParam;
+    }
+
+    MimeType mimeType = null;
+    if (contentType != null) {
+      try {
+        mimeType = new MimeType(contentType);
+      } catch (MimeTypeParseException e) {
+        LOGGER.debug("Unable to create MimeType from raw data {}", contentType);
+      }
+    } else {
+      LOGGER.debug("No content type specified in request");
+    }
+
+    try {
+      Metacard metacard = generateMetacard(mimeType, null, stream, null);
+      String metacardId = metacard.getId();
+      LOGGER.debug("Metacard {} created", metacardId);
+      LOGGER.debug(
+          "Transforming metacard {} to {} to be able to return it to client",
+          metacardId,
+          transformer);
+      final BinaryContent content = catalogFramework.transform(metacard, transformer, null);
+      LOGGER.debug(
+          "Metacard to {} transform complete for {}, preparing response.", transformer, metacardId);
+
+      LOGGER.trace("EXITING: createMetacard");
+      return content;
+
+    } catch (MetacardCreationException | CatalogTransformerException e) {
+      throw new CatalogException("Unable to create metacard");
+    }
+  }
+
+  public void updateDocument(
+      String id,
+      List<String> contentTypeList,
+      MultipartBody multipartBody,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException {
+    LOGGER.trace("PUT");
+
+    if (id == null || message == null) {
+      String errorResponseString = "Both ID and content are needed to perform UPDATE.";
+      LOGGER.info(errorResponseString);
+      throw new CatalogException(errorResponseString);
+    }
+
+    Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard = null;
+    if (multipartBody != null) {
+      List<Attachment> contentParts = multipartBody.getAllAttachments();
+      if (CollectionUtils.isNotEmpty(contentParts)) {
+        attachmentInfoAndMetacard = parseAttachments(contentParts, transformerParam);
+      } else {
+        LOGGER.debug("No file contents attachment found");
+      }
+    }
+
+    updateDocument(attachmentInfoAndMetacard, id, contentTypeList, transformerParam, message);
+  }
+
+  public void updateDocument(
+      String id,
+      List<String> contentTypeList,
+      HttpServletRequest httpServletRequest,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException {
+    LOGGER.trace("PUT");
+
+    if (id == null || message == null) {
+      String errorResponseString = "Both ID and content are needed to perform UPDATE.";
+      LOGGER.info(errorResponseString);
+      throw new CatalogException(errorResponseString);
+    }
+
+    Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard = null;
+    try {
+      if (httpServletRequest != null) {
+        Collection<Part> contentParts = httpServletRequest.getParts();
+        if (CollectionUtils.isNotEmpty(contentParts)) {
+          attachmentInfoAndMetacard = parseParts(contentParts, transformerParam);
+        } else {
+          LOGGER.debug("No file contents attachment found");
+        }
+      }
+    } catch (ServletException | IOException e) {
+      LOGGER.info("Unable to get contents part: ", e);
+    }
+
+    updateDocument(attachmentInfoAndMetacard, id, contentTypeList, transformerParam, message);
+  }
+
+  private void updateDocument(
+      Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard,
+      String id,
+      List<String> contentTypeList,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException {
+    try {
+      MimeType mimeType = getMimeType(contentTypeList);
+
+      if (attachmentInfoAndMetacard == null) {
+        UpdateRequest updateRequest =
+            new UpdateRequestImpl(id, generateMetacard(mimeType, id, message, transformerParam));
+        catalogFramework.update(updateRequest);
+      } else {
+        UpdateStorageRequest streamUpdateRequest =
+            new UpdateStorageRequestImpl(
+                Collections.singletonList(
+                    new IncomingContentItem(
+                        id,
+                        attachmentInfoAndMetacard.getLeft().getStream(),
+                        attachmentInfoAndMetacard.getLeft().getContentType(),
+                        attachmentInfoAndMetacard.getLeft().getFilename(),
+                        0,
+                        attachmentInfoAndMetacard.getRight())),
+                null);
+        catalogFramework.update(streamUpdateRequest);
+      }
+
+      LOGGER.debug("Metacard {} updated.", id);
+
+    } catch (SourceUnavailableException e) {
+      String exceptionMessage = "Cannot update catalog entry: Source is unavailable: ";
+      LOGGER.info(exceptionMessage, e);
+      throw new InternalServerErrorException(exceptionMessage);
+    } catch (InternalIngestException e) {
+      String exceptionMessage = "Error cataloging updated metadata: ";
+      LOGGER.info(exceptionMessage, e);
+      throw new InternalServerErrorException(exceptionMessage);
+    } catch (MetacardCreationException | IngestException e) {
+      String errorMessage = "Error cataloging updated metadata: ";
+      LOGGER.info(errorMessage, e);
+      throw new CatalogException(errorMessage);
+    }
+  }
+
+  public String addDocument(
+      List<String> contentTypeList,
+      MultipartBody multipartBody,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException {
+    LOGGER.debug("POST");
+
+    if (message == null) {
+      String errorMessage = "No content found, cannot do CREATE.";
+      LOGGER.info(errorMessage);
+      throw new CatalogException(errorMessage);
+    }
+
+    Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard = null;
+    if (multipartBody != null) {
+      List<Attachment> contentParts = multipartBody.getAllAttachments();
+      if (CollectionUtils.isNotEmpty(contentParts)) {
+        attachmentInfoAndMetacard = parseAttachments(contentParts, transformerParam);
+      } else {
+        LOGGER.debug("No file contents attachment found");
+      }
+    }
+
+    return addDocument(attachmentInfoAndMetacard, contentTypeList, transformerParam, message);
+  }
+
+  public String addDocument(
+      List<String> contentTypeList,
+      HttpServletRequest httpServletRequest,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException {
+    LOGGER.debug("POST");
+
+    if (message == null) {
+      String errorMessage = "No content found, cannot do CREATE.";
+      LOGGER.info(errorMessage);
+      throw new CatalogException(errorMessage);
+    }
+
+    Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard = null;
+    try {
+      if (httpServletRequest != null) {
+        Collection<Part> contentParts = httpServletRequest.getParts();
+        if (CollectionUtils.isNotEmpty(contentParts)) {
+          attachmentInfoAndMetacard = parseParts(contentParts, transformerParam);
+        } else {
+          LOGGER.debug("No file contents attachment found");
+        }
+      }
+    } catch (ServletException | IOException e) {
+      LOGGER.info("Unable to get contents part: ", e);
+    }
+
+    return addDocument(attachmentInfoAndMetacard, contentTypeList, transformerParam, message);
+  }
+
+  private String addDocument(
+      Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard,
+      List<String> contentTypeList,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException {
+    try {
+      LOGGER.debug("POST");
+
+      MimeType mimeType = getMimeType(contentTypeList);
+      CreateResponse createResponse;
+      if (attachmentInfoAndMetacard == null) {
+        CreateRequest createRequest =
+            new CreateRequestImpl(generateMetacard(mimeType, null, message, transformerParam));
+        createResponse = catalogFramework.create(createRequest);
+      } else {
+        String id =
+            attachmentInfoAndMetacard.getRight() == null
+                ? null
+                : attachmentInfoAndMetacard.getRight().getId();
+        if (id == null) {
+          id = uuidGenerator.generateUuid();
+        }
+        CreateStorageRequest streamCreateRequest =
+            new CreateStorageRequestImpl(
+                Collections.singletonList(
+                    new IncomingContentItem(
+                        id,
+                        attachmentInfoAndMetacard.getLeft().getStream(),
+                        attachmentInfoAndMetacard.getLeft().getContentType(),
+                        attachmentInfoAndMetacard.getLeft().getFilename(),
+                        0L,
+                        attachmentInfoAndMetacard.getRight())),
+                null);
+        createResponse = catalogFramework.create(streamCreateRequest);
+      }
+
+      String id = createResponse.getCreatedMetacards().get(0).getId();
+      LOGGER.debug("Create Response id [{}]", id);
+
+      LOGGER.debug("Entry successfully saved, id: {}", id);
+      if (INGEST_LOGGER.isInfoEnabled()) {
+        INGEST_LOGGER.info("Entry successfully saved, id: {}", id);
+      }
+
+      return id;
+
+    } catch (SourceUnavailableException e) {
+      String exceptionMessage = "Cannot create catalog entry because source is unavailable: ";
+      LOGGER.info(exceptionMessage, e);
+      // Catalog framework logs these exceptions to the ingest logger so we don't have to.
+      throw new InternalServerErrorException(exceptionMessage);
+    } catch (InternalIngestException e) {
+      String exceptionMessage = "Error while storing entry in catalog: ";
+      LOGGER.info(exceptionMessage, e);
+      // Catalog framework logs these exceptions to the ingest logger so we don't have to.
+      throw new InternalServerErrorException(exceptionMessage);
+    } catch (MetacardCreationException | IngestException e) {
+      String errorMessage = "Error while storing entry in catalog: ";
+      LOGGER.info(errorMessage, e);
+      // Catalog framework logs these exceptions to the ingest logger so we don't have to.
+      throw new CatalogException(errorMessage);
+    } finally {
+      IOUtils.closeQuietly(message);
+    }
+  }
+
+  Pair<AttachmentInfo, Metacard> parseAttachments(
+      List<Attachment> contentParts, String transformerParam) {
+
+    if (contentParts.size() == 1) {
+      Attachment contentPart = contentParts.get(0);
+
+      InputStream attachmentInputStream = null;
+
+      try {
+        attachmentInputStream = contentPart.getDataHandler().getInputStream();
+      } catch (IOException e) {
+        LOGGER.debug("IOException reading stream from file attachment in multipart body.", e);
+      }
+
+      return new ImmutablePair<>(
+          attachmentParser.generateAttachmentInfo(
+              attachmentInputStream,
+              contentPart.getContentType().toString(),
+              contentPart
+                  .getContentDisposition()
+                  .getParameter(FILENAME_CONTENT_DISPOSITION_PARAMETER_NAME)),
+          null);
+    }
+
+    Map<String, AttributeImpl> attributeMap = new HashMap<>();
+    Metacard metacard = null;
+    AttachmentInfo attachmentInfo = null;
+
+    for (Attachment attachment : contentParts) {
+      String name = attachment.getContentDisposition().getParameter("name");
+      String parsedName = (name.startsWith("parse.")) ? name.substring(6) : name;
+      try {
+        InputStream inputStream = attachment.getDataHandler().getInputStream();
+        switch (name) {
+          case "parse.resource":
+            attachmentInfo =
+                attachmentParser.generateAttachmentInfo(
+                    inputStream,
+                    attachment.getContentType().toString(),
+                    attachment
+                        .getContentDisposition()
+                        .getParameter(FILENAME_CONTENT_DISPOSITION_PARAMETER_NAME));
+            break;
+          case "parse.metadata":
+            metacard = parseMetadata(transformerParam, metacard, attachment, inputStream);
+            break;
+          default:
+            parseOverrideAttributes(attributeMap, parsedName, inputStream);
+            break;
+        }
+      } catch (IOException e) {
+        LOGGER.debug(
+            "Unable to get input stream for mime attachment. Ignoring override attribute: {}",
+            name,
+            e);
+      }
+    }
+    if (attachmentInfo == null) {
+      throw new IllegalArgumentException("No parse.resource specified in request.");
+    }
+    if (metacard == null) {
+      metacard = new MetacardImpl();
+    }
+
+    Set<AttributeDescriptor> missingDescriptors = new HashSet<>();
+    for (Attribute attribute : attributeMap.values()) {
+      if (metacard.getMetacardType().getAttributeDescriptor(attribute.getName()) == null) {
+        attributeRegistry
+            .lookup(attribute.getName())
+            .ifPresent(descriptor -> missingDescriptors.add(descriptor));
+      }
+      metacard.setAttribute(attribute);
+    }
+
+    if (!missingDescriptors.isEmpty()) {
+      MetacardType original = metacard.getMetacardType();
+      MetacardImpl newMetacard = new MetacardImpl(metacard);
+      newMetacard.setType(new MetacardTypeImpl(original.getName(), original, missingDescriptors));
+      metacard = newMetacard;
+    }
+
+    return new ImmutablePair<>(attachmentInfo, metacard);
+  }
+
+  Pair<AttachmentInfo, Metacard> parseParts(
+      Collection<Part> contentParts, String transformerParam) {
+    if (contentParts.size() == 1) {
+      Part part = Iterables.get(contentParts, 0);
+
+      try (InputStream inputStream = part.getInputStream()) {
+        ContentDisposition contentDisposition =
+            new ContentDisposition(part.getHeader(HEADER_CONTENT_DISPOSITION));
+        return new ImmutablePair<>(
+            attachmentParser.generateAttachmentInfo(
+                inputStream,
+                part.getContentType(),
+                contentDisposition.getParameter(FILENAME_CONTENT_DISPOSITION_PARAMETER_NAME)),
+            null);
+
+      } catch (IOException e) {
+        LOGGER.debug("IOException reading stream from file attachment in multipart body.", e);
+      }
+    }
+
+    Metacard metacard = null;
+    AttachmentInfo attachmentInfo = null;
+    Map<String, AttributeImpl> attributeMap = new HashMap<>();
+
+    for (Part part : contentParts) {
+      String name = part.getName();
+      String parsedName = (name.startsWith("parse.")) ? name.substring(6) : name;
+
+      try (InputStream inputStream = part.getInputStream()) {
+        ContentDisposition contentDisposition =
+            new ContentDisposition(part.getHeader(HEADER_CONTENT_DISPOSITION));
+        switch (name) {
+          case "parse.resource":
+            attachmentInfo =
+                attachmentParser.generateAttachmentInfo(
+                    inputStream,
+                    part.getContentType(),
+                    contentDisposition.getParameter(FILENAME_CONTENT_DISPOSITION_PARAMETER_NAME));
+            break;
+          case "parse.metadata":
+            metacard = parseMetacard(transformerParam, metacard, part, inputStream);
+            break;
+          default:
+            parseOverrideAttributes(attributeMap, parsedName, inputStream);
+            break;
+        }
+      } catch (IOException e) {
+        LOGGER.debug(
+            "Unable to get input stream for mime attachment. Ignoring override attribute: {}",
+            name,
+            e);
+      }
+    }
+    if (attachmentInfo == null) {
+      throw new IllegalArgumentException("No parse.resource specified in request.");
+    }
+    if (metacard == null) {
+      metacard = new MetacardImpl();
+    }
+
+    Set<AttributeDescriptor> missingDescriptors = new HashSet<>();
+    for (Attribute attribute : attributeMap.values()) {
+      if (metacard.getMetacardType().getAttributeDescriptor(attribute.getName()) == null) {
+        attributeRegistry.lookup(attribute.getName()).ifPresent(missingDescriptors::add);
+      }
+      metacard.setAttribute(attribute);
+    }
+
+    if (!missingDescriptors.isEmpty()) {
+      MetacardType original = metacard.getMetacardType();
+      MetacardImpl newMetacard = new MetacardImpl(metacard);
+      newMetacard.setType(new MetacardTypeImpl(original.getName(), original, missingDescriptors));
+      metacard = newMetacard;
+    }
+
+    return new ImmutablePair<>(attachmentInfo, metacard);
+  }
+
+  private void parseOverrideAttributes(
+      Map<String, AttributeImpl> attributeMap, String parsedName, InputStream inputStream) {
+    attributeRegistry
+        .lookup(parsedName)
+        .ifPresent(
+            descriptor ->
+                parseAttribute(
+                    attributeMap,
+                    parsedName,
+                    inputStream,
+                    descriptor.getType().getAttributeFormat()));
+  }
+
+  private void parseAttribute(
+      Map<String, AttributeImpl> attributeMap,
+      String parsedName,
+      InputStream inputStream,
+      AttributeType.AttributeFormat attributeFormat) {
+    try (InputStream is = inputStream;
+        InputStream boundedStream = new BoundedInputStream(is, MAX_INPUT_SIZE + 1)) {
+      if (attributeFormat == OBJECT) {
+        LOGGER.debug("Object type not supported for override");
+        return;
+      }
+
+      byte[] bytes = IOUtils.toByteArray(boundedStream);
+      if (bytes.length > MAX_INPUT_SIZE) {
+        LOGGER.debug("Attribute length is limited to {} bytes", MAX_INPUT_SIZE);
+        return;
+      }
+
+      AttributeImpl attribute;
+      if (attributeMap.containsKey(parsedName)) {
+        attribute = attributeMap.get(parsedName);
+      } else {
+        attribute = new AttributeImpl(parsedName, Collections.emptyList());
+        attributeMap.put(parsedName, attribute);
+      }
+
+      if (attributeFormat == BINARY) {
+        attribute.addValue(bytes);
+        return;
+      }
+
+      String value = new String(bytes, Charset.defaultCharset());
+
+      switch (attributeFormat) {
+        case XML:
+        case GEOMETRY:
+        case STRING:
+          attribute.addValue(value);
+          break;
+        case BOOLEAN:
+          attribute.addValue(Boolean.valueOf(value));
+          break;
+        case SHORT:
+          attribute.addValue(Short.valueOf(value));
+          break;
+        case LONG:
+          attribute.addValue(Long.valueOf(value));
+          break;
+        case INTEGER:
+          attribute.addValue(Integer.valueOf(value));
+          break;
+        case FLOAT:
+          attribute.addValue(Float.valueOf(value));
+          break;
+        case DOUBLE:
+          attribute.addValue(Double.valueOf(value));
+          break;
+        case DATE:
+          try {
+            Instant instant = Instant.parse(value);
+            attribute.addValue(Date.from(instant));
+          } catch (DateTimeParseException e) {
+            LOGGER.debug("Unable to parse instant '{}'", attribute, e);
+          }
+          break;
+        default:
+          LOGGER.debug("Attribute format '{}' not supported", attributeFormat);
+          break;
+      }
+    } catch (IOException e) {
+      LOGGER.debug("Unable to read attribute to override", e);
+    }
+  }
+
+  private Metacard parseMetadata(
+      String transformerParam, Metacard metacard, Attachment attachment, InputStream inputStream) {
+    String transformer = DEFAULT_METACARD_TRANSFORMER;
+    if (transformerParam != null) {
+      transformer = transformerParam;
+    }
+    try {
+      MimeType mimeType = new MimeType(attachment.getContentType().toString());
+      metacard = generateMetacard(mimeType, null, inputStream, transformer);
+    } catch (MimeTypeParseException | MetacardCreationException e) {
+      LOGGER.debug("Unable to parse metadata {}", attachment.getContentType().toString());
+    } finally {
+      IOUtils.closeQuietly(inputStream);
+    }
+    return metacard;
+  }
+
+  private Metacard parseMetacard(
+      String transformerParam, Metacard metacard, Part part, InputStream inputStream) {
+    String transformer = "xml";
+    if (transformerParam != null) {
+      transformer = transformerParam;
+    }
+    try {
+      MimeType mimeType = new MimeType(part.getContentType());
+      metacard = generateMetacard(mimeType, null, inputStream, transformer);
+    } catch (MimeTypeParseException | MetacardCreationException e) {
+      LOGGER.debug("Unable to parse metadata {}", part.getContentType());
+    }
+    return metacard;
+  }
+
+  public void deleteDocument(String id) throws CatalogException {
+    LOGGER.debug("DELETE");
+    try {
+      if (id != null) {
+        DeleteRequestImpl deleteReq =
+            new DeleteRequestImpl(new HtmlPolicyBuilder().toFactory().sanitize(id));
+
+        catalogFramework.delete(deleteReq);
+        LOGGER.debug("Attempting to delete Metacard with id: {}", id);
+      } else {
+        String errorMessage = "ID of entry not specified, cannot do DELETE.";
+        LOGGER.info(errorMessage);
+        throw new CatalogException(errorMessage);
+      }
+    } catch (SourceUnavailableException ce) {
+      String exceptionMessage =
+          "Could not delete entry from catalog since the source is unavailable: ";
+      LOGGER.info(exceptionMessage, ce);
+      throw new InternalServerErrorException(exceptionMessage);
+    } catch (InternalIngestException e) {
+      String exceptionMessage = "Error deleting entry from catalog: ";
+      LOGGER.info(exceptionMessage, e);
+      throw new InternalServerErrorException(exceptionMessage);
+    } catch (IngestException e) {
+      String errorMessage = "Error deleting entry from catalog: ";
+      LOGGER.info(errorMessage, e);
+      throw new CatalogException(errorMessage);
+    }
+  }
+
+  private Map<String, Serializable> convert(MultivaluedMap<String, String> map) {
+    Map<String, Serializable> convertedMap = new HashMap<>();
+
+    for (Map.Entry<String, List<String>> entry : map.entrySet()) {
+      String key = entry.getKey();
+      List<String> value = entry.getValue();
+
+      if (value.size() == 1) {
+        convertedMap.put(key, value.get(0));
+      } else {
+        // List is not serializable so we make it a String array
+        convertedMap.put(key, value.toArray());
+      }
+    }
+
+    return convertedMap;
+  }
+
+  private Metacard generateMetacard(
+      MimeType mimeType, String id, InputStream message, String transformerId)
+      throws MetacardCreationException {
+
+    Metacard generatedMetacard = null;
+
+    List<InputTransformer> listOfCandidates =
+        mimeTypeToTransformerMapper.findMatches(InputTransformer.class, mimeType);
+    List<String> stackTraceList = new ArrayList<>();
+
+    LOGGER.trace("Entering generateMetacard.");
+
+    LOGGER.debug("List of matches for mimeType [{}]: {}", mimeType, listOfCandidates);
+
+    try (TemporaryFileBackedOutputStream fileBackedOutputStream =
+        new TemporaryFileBackedOutputStream()) {
+
+      try {
+        if (null != message) {
+          IOUtils.copy(message, fileBackedOutputStream);
+        } else {
+          throw new MetacardCreationException(
+              "Could not copy bytes of content message.  Message was NULL.");
+        }
+      } catch (IOException e) {
+        throw new MetacardCreationException("Could not copy bytes of content message.", e);
+      }
+
+      Iterator<InputTransformer> it = listOfCandidates.iterator();
+      if (StringUtils.isNotEmpty(transformerId)) {
+        BundleContext bundleContext = getBundleContext();
+        Collection<ServiceReference<InputTransformer>> serviceReferences =
+            bundleContext.getServiceReferences(
+                InputTransformer.class, "(id=" + transformerId + ")");
+        it = serviceReferences.stream().map(bundleContext::getService).iterator();
+      }
+
+      while (it.hasNext()) {
+        InputTransformer transformer = it.next();
+        try (InputStream inputStreamMessageCopy =
+            fileBackedOutputStream.asByteSource().openStream()) {
+          generatedMetacard = transformer.transform(inputStreamMessageCopy);
+        } catch (CatalogTransformerException | IOException e) {
+          List<String> stackTraces = Arrays.asList(ExceptionUtils.getRootCauseStackTrace(e));
+          stackTraceList.add(
+              String.format("Transformer [%s] could not create metacard.", transformer));
+          stackTraceList.addAll(stackTraces);
+          LOGGER.debug("Transformer [{}] could not create metacard.", transformer, e);
+        }
+        if (generatedMetacard != null) {
+          break;
+        }
+      }
+
+      if (generatedMetacard == null) {
+        throw new MetacardCreationException(
+            String.format(
+                "Could not create metacard with mimeType %s : %s",
+                mimeType, StringUtils.join(stackTraceList, "\n")));
+      }
+
+      if (id != null) {
+        generatedMetacard.setAttribute(new AttributeImpl(Metacard.ID, id));
+      }
+      LOGGER.debug("Metacard id is {}", generatedMetacard.getId());
+
+    } catch (IOException e) {
+      throw new MetacardCreationException("Could not create metacard.", e);
+    } catch (InvalidSyntaxException e) {
+      throw new MetacardCreationException("Could not determine transformer", e);
+    }
+    return generatedMetacard;
+  }
+
+  private MimeType getMimeType(List<String> contentTypeList) {
+    String singleMimeType = null;
+
+    if (contentTypeList != null && !contentTypeList.isEmpty()) {
+      singleMimeType = contentTypeList.get(0);
+      LOGGER.debug("Encountered [{}] {}", singleMimeType, HttpHeaders.CONTENT_TYPE);
+    }
+
+    MimeType mimeType = null;
+
+    // Sending a null argument to MimeType causes NPE
+    if (singleMimeType != null) {
+      try {
+        mimeType = new MimeType(singleMimeType);
+      } catch (MimeTypeParseException e) {
+        LOGGER.debug("Could not parse mime type from headers.", e);
+      }
+    }
+
+    return mimeType;
+  }
+
+  public String getFileExtensionForMimeType(String mimeType) {
+    String fileExtension = this.tikaMimeTypeResolver.getFileExtensionForMimeType(mimeType);
+    LOGGER.debug("Mime Type [{}] resolves to file extension [{}].", mimeType, fileExtension);
+    return fileExtension;
+  }
+
+  private boolean rangeHeaderExists(HttpServletRequest httpRequest) {
+    boolean response = false;
+
+    if (httpRequest != null && httpRequest.getHeader(HEADER_RANGE) != null) {
+      response = true;
+    }
+
+    return response;
+  }
+
+  // Return 0 (beginning of stream) if the range header does not exist.
+  private long getRangeStart(HttpServletRequest httpRequest) throws UnsupportedQueryException {
+    long response = 0;
+
+    if (httpRequest != null && rangeHeaderExists(httpRequest)) {
+      String rangeHeader = httpRequest.getHeader(HEADER_RANGE);
+      String range = getRange(rangeHeader);
+
+      if (range != null) {
+        response = Long.parseLong(range);
+      }
+    }
+
+    return response;
+  }
+
+  private String getRange(String rangeHeader) throws UnsupportedQueryException {
+    String response = null;
+
+    if (rangeHeader != null) {
+      if (rangeHeader.startsWith(BYTES_EQUAL)) {
+        String tempString = rangeHeader.substring(BYTES_EQUAL.length());
+        if (tempString.contains("-")) {
+          response = rangeHeader.substring(BYTES_EQUAL.length(), rangeHeader.lastIndexOf('-'));
+        } else {
+          response = rangeHeader.substring(BYTES_EQUAL.length());
+        }
+      } else {
+        throw new UnsupportedQueryException("Invalid range header: " + rangeHeader);
+      }
+    }
+
+    return response;
+  }
+
+  public void setMimeTypeToTransformerMapper(
+      MimeTypeToTransformerMapper mimeTypeToTransformerMapper) {
+    this.mimeTypeToTransformerMapper = mimeTypeToTransformerMapper;
+  }
+
+  public FilterBuilder getFilterBuilder() {
+    return filterBuilder;
+  }
+
+  public void setFilterBuilder(FilterBuilder filterBuilder) {
+    this.filterBuilder = filterBuilder;
+  }
+
+  public void setTikaMimeTypeResolver(MimeTypeResolver mimeTypeResolver) {
+    this.tikaMimeTypeResolver = mimeTypeResolver;
+  }
+
+  public void setUuidGenerator(UuidGenerator uuidGenerator) {
+    this.uuidGenerator = uuidGenerator;
+  }
+
+  protected static class IncomingContentItem extends ContentItemImpl {
+
+    private InputStream inputStream;
+
+    public IncomingContentItem(
+        String id,
+        InputStream inputStream,
+        String mimeTypeRawData,
+        String filename,
+        long size,
+        Metacard metacard) {
+      super(id, null, mimeTypeRawData, filename, size, metacard);
+      this.inputStream = inputStream;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return inputStream;
+    }
+  }
+}

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/InternalServerErrorException.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/InternalServerErrorException.java
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest;
+package org.codice.ddf.rest.impl;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/AbstractMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/AbstractMetacardActionProvider.java
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.impl.action;
 
 import ddf.action.Action;
 import ddf.action.ActionProvider;

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/ActionProviderRegistryProxy.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/ActionProviderRegistryProxy.java
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.impl.action;
 
 import ddf.action.ActionProvider;
 import ddf.catalog.Constants;

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/MetacardTransformerActionProvider.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/MetacardTransformerActionProvider.java
@@ -11,10 +11,10 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.impl.action;
 
-import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
-import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
+import static org.codice.ddf.rest.impl.CatalogServiceImpl.CONTEXT_ROOT;
+import static org.codice.ddf.rest.impl.CatalogServiceImpl.SOURCES_PATH;
 
 import ddf.action.Action;
 import ddf.action.impl.ActionImpl;

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/MetacardTransformerActionProviderFactory.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/MetacardTransformerActionProviderFactory.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.rest.impl.action;
+
+public class MetacardTransformerActionProviderFactory {
+
+  public MetacardTransformerActionProvider createActionProvider(
+      String id, String transformer, String attributeName) {
+    return new MetacardTransformerActionProvider(id, transformer, attributeName);
+  }
+}

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/ViewMetacardActionProvider.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/action/ViewMetacardActionProvider.java
@@ -11,10 +11,10 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.impl.action;
 
-import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
-import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
+import static org.codice.ddf.rest.impl.CatalogServiceImpl.CONTEXT_ROOT;
+import static org.codice.ddf.rest.impl.CatalogServiceImpl.SOURCES_PATH;
 
 import ddf.action.Action;
 import ddf.action.impl.ActionImpl;

--- a/catalog/rest/catalog-rest-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <reference id="transformerMapper" interface="ddf.mime.MimeTypeToTransformerMapper"/>
+    <reference id="catalog" interface="ddf.catalog.CatalogFramework"/>
+    <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
+    <reference id="tikaMimeTypeResolver" filter="(name=tikaMimeTypeResolver)" interface="ddf.mime.MimeTypeResolver"/>
+    <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
+    <reference id="attachmentParser" interface="org.codice.ddf.attachment.AttachmentParser"/>
+    <reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
+
+    <bean id="actionFactory"
+          class="org.codice.ddf.rest.impl.action.MetacardTransformerActionProviderFactory"/>
+
+    <reference-list id="metacardTransformerRefList"
+                    interface="ddf.catalog.transform.MetacardTransformer" availability="optional"
+                    filter="(!(generateActionProvider=false))">
+        <reference-listener bind-method="bind" unbind-method="unbind">
+            <bean class="org.codice.ddf.rest.impl.action.ActionProviderRegistryProxy">
+                <argument ref="actionFactory"/>
+            </bean>
+        </reference-listener>
+    </reference-list>
+
+    <bean id="catalogService" class="org.codice.ddf.rest.impl.CatalogServiceImpl">
+        <argument ref="catalog"/>
+        <argument ref="attachmentParser"/>
+        <argument ref="attributeRegistry" />
+        <property name="filterBuilder" ref="filterBuilder"/>
+        <property name="mimeTypeToTransformerMapper" ref="transformerMapper"/>
+        <property name="tikaMimeTypeResolver" ref="tikaMimeTypeResolver"/>
+        <property name="uuidGenerator" ref="uuidGenerator" />
+    </bean>
+
+    <service ref="catalogService" interface="org.codice.ddf.rest.service.CatalogService"/>
+
+    <bean id="viewActionProvider"
+          class="org.codice.ddf.rest.impl.action.ViewMetacardActionProvider">
+        <argument value="catalog.data.metacard.view"/>
+    </bean>
+
+    <service ref="viewActionProvider" interface="ddf.action.ActionProvider">
+        <service-properties>
+            <entry key="id" value="catalog.data.metacard.view"/>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/CatalogServiceImplTest.java
+++ b/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/CatalogServiceImplTest.java
@@ -11,8 +11,9 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest;
+package org.codice.ddf.rest.impl;
 
+import static org.codice.ddf.rest.service.CatalogService.HEADER_CONTENT_DISPOSITION;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
@@ -40,7 +41,6 @@ import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.BasicTypes;
@@ -55,17 +55,13 @@ import ddf.catalog.federation.FederationStrategy;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.CreateRequest;
-import ddf.catalog.operation.QueryRequest;
-import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.SourceInfoResponse;
 import ddf.catalog.operation.impl.CreateResponseImpl;
 import ddf.catalog.operation.impl.SourceInfoRequestEnterprise;
 import ddf.catalog.operation.impl.SourceInfoResponseImpl;
-import ddf.catalog.resource.Resource;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceDescriptor;
 import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.source.impl.SourceDescriptorImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
@@ -76,9 +72,6 @@ import ddf.mime.tika.TikaMimeTypeResolver;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -90,13 +83,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import javax.activation.MimeType;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Part;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
@@ -110,6 +101,7 @@ import org.codice.ddf.attachment.AttachmentInfo;
 import org.codice.ddf.attachment.AttachmentParser;
 import org.codice.ddf.attachment.impl.AttachmentParserImpl;
 import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
+import org.codice.ddf.rest.service.CatalogException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -119,64 +111,16 @@ import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Tests methods of the {@link RESTEndpoint} */
-public class RestEndpointTest {
-  private static final int OK = 200;
-
-  private static final int NO_CONTENT = 204;
+/** Tests methods of the {@link CatalogServiceImpl} */
+public class CatalogServiceImplTest {
 
   private static final int INTERNAL_SERVER_ERROR = 500;
 
-  private static final int BAD_REQUEST = 400;
-
-  private static final int NOT_FOUND = 404;
-
   private static final String SAMPLE_ID = "12345678900987654321abcdeffedcba";
 
-  private static final String ENDPOINT_ADDRESS = "http://localhost:8181/services/catalog";
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(RestEndpointTest.class);
-
-  private static final String LOCAL_RETRIEVE_ADDRESS = "http://localhost:8181/services/catalog";
-
-  private static final String FED_RETRIEVE_ADDRESS =
-      "http://localhost:8181/services/catalog/sources/test/abc123456def";
-
-  private static final String GET_SITENAME = "test";
-
-  private static final String GET_ID = "abc123456def";
-
-  private static final String GET_STREAM = "Test string for inputstream.";
+  private static final Logger LOGGER = LoggerFactory.getLogger(CatalogServiceImplTest.class);
 
   private static final String GET_OUTPUT_TYPE = "UTF-8";
-
-  private static final String GET_MIME_TYPE = "text/xml";
-
-  private static final String GET_KML_MIME_TYPE = "application/vnd.google-earth.kml+xml";
-
-  private static final String GET_FILENAME = "example.xml";
-
-  private static final String GET_TYPE_OUTPUT =
-      "{Content-Type=[text/xml], Accept-Ranges=[bytes], "
-          + "Content-Disposition=[inline; filename=\""
-          + GET_FILENAME
-          + "\"]}";
-
-  private static final String GET_KML_TYPE_OUTPUT =
-      "{Content-Type=[application/vnd.google-earth.kml+xml], "
-          + "Accept-Ranges=[bytes], Content-Disposition=[inline; filename=\""
-          + GET_ID
-          + ".kml"
-          + "\"]}";
-
-  private static final String HEADER_ACCEPT_RANGES = "Accept-Ranges";
-
-  private static final String ACCEPT_RANGES_VALUE = "bytes";
-
-  private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
-
-  private static final String CONTENT_DISPOSITION_VALUE =
-      "inline; filename=\"" + GET_FILENAME + "\"";
 
   private AttachmentParser attachmentParser;
 
@@ -198,75 +142,63 @@ public class RestEndpointTest {
 
     CatalogFramework framework = mock(CatalogFramework.class);
 
-    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
+    CatalogServiceImpl catalogService =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry);
 
     HttpHeaders headers = mock(HttpHeaders.class);
 
-    Response response =
-        rest.addDocument(
-            headers,
-            mock(UriInfo.class),
-            mock(HttpServletRequest.class),
-            mock(MultipartBody.class),
-            null,
-            null);
-    assertEquals(response.getStatus(), BAD_REQUEST);
-    assertEquals(response.getEntity(), "<pre>No content found, cannot do CREATE.</pre>");
+    try {
+      catalogService.addDocument(
+          headers.getRequestHeader(HttpHeaders.CONTENT_TYPE),
+          mock(MultipartBody.class),
+          null,
+          null);
+    } catch (CatalogException e) {
+      assertEquals(e.getMessage(), "No content found, cannot do CREATE.");
+    }
   }
 
   @Test
-  public void testAddDocumentFrameworkIngestException()
-      throws IngestException, SourceUnavailableException, URISyntaxException {
+  public void testAddDocumentFrameworkIngestException() throws Exception {
 
     assertExceptionThrown(IngestException.class);
   }
 
   @Test
-  public void testAddDocumentFrameworkSourceUnavailableException()
-      throws IngestException, SourceUnavailableException, URISyntaxException {
+  public void testAddDocumentFrameworkSourceUnavailableException() throws Exception {
 
     assertExceptionThrown(SourceUnavailableException.class);
   }
 
   @Test
-  public void testAddDocumentPositiveCase()
-      throws IngestException, SourceUnavailableException, URISyntaxException {
+  public void testAddDocumentPositiveCase() throws Exception {
 
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
+    CatalogFramework framework = givenCatalogFramework();
 
     HttpHeaders headers = createHeaders(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
+    CatalogServiceImpl catalogService =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry);
 
-    addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
+    addMatchingService(catalogService, Collections.singletonList(getSimpleTransformer()));
 
-    UriInfo info = givenUriInfo(SAMPLE_ID);
-
-    Response response =
-        rest.addDocument(
-            headers,
-            info,
-            mock(HttpServletRequest.class),
+    String response =
+        catalogService.addDocument(
+            headers.getRequestHeader(HttpHeaders.CONTENT_TYPE),
             mock(MultipartBody.class),
             null,
             new ByteArrayInputStream("".getBytes()));
 
     LOGGER.debug(ToStringBuilder.reflectionToString(response));
 
-    assertThat(response.getStatus(), equalTo(201));
-
-    assertThat(response.getMetadata(), notNullValue());
-
-    assertThat(response.getMetadata().get(Metacard.ID).get(0).toString(), equalTo(SAMPLE_ID));
+    assertThat(response, equalTo(SAMPLE_ID));
   }
 
   @Test
   @SuppressWarnings({"unchecked"})
-  public void testAddDocumentWithAttributeOverrides()
-      throws IOException, CatalogTransformerException, IngestException, SourceUnavailableException,
-          URISyntaxException, InvalidSyntaxException {
+  public void testAddDocumentWithAttributeOverrides() throws Exception {
 
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
+    CatalogFramework framework = givenCatalogFramework();
 
     AttributeDescriptor descriptor =
         new AttributeDescriptorImpl(
@@ -285,8 +217,8 @@ public class RestEndpointTest {
 
     when(attributeRegistry.lookup("custom.attribute")).thenReturn(Optional.of(descriptor));
 
-    RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
+    CatalogServiceImpl catalogService =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
@@ -295,11 +227,9 @@ public class RestEndpointTest {
 
     UuidGenerator uuidGenerator = mock(UuidGenerator.class);
     when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID().toString());
-    rest.setUuidGenerator(uuidGenerator);
+    catalogService.setUuidGenerator(uuidGenerator);
 
-    addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
-
-    UriInfo info = givenUriInfo(SAMPLE_ID);
+    addMatchingService(catalogService, Collections.singletonList(getSimpleTransformer()));
 
     List<Attachment> attachments = new ArrayList<>();
     ContentDisposition contentDisposition =
@@ -318,18 +248,15 @@ public class RestEndpointTest {
     attachments.add(attachment2);
     MultipartBody multipartBody = new MultipartBody(attachments);
 
-    Response response =
-        rest.addDocument(
-            headers,
-            info,
-            mock(HttpServletRequest.class),
+    String response =
+        catalogService.addDocument(
+            headers.getRequestHeader(HttpHeaders.CONTENT_TYPE),
             multipartBody,
             null,
             new ByteArrayInputStream("".getBytes()));
 
     LOGGER.debug(ToStringBuilder.reflectionToString(response));
 
-    assertThat(response.getStatus(), equalTo(201));
     ArgumentCaptor<CreateStorageRequest> captor = new ArgumentCaptor<>();
     verify(framework, times(1)).create(captor.capture());
     assertThat(
@@ -345,11 +272,9 @@ public class RestEndpointTest {
 
   @Test
   @SuppressWarnings({"unchecked"})
-  public void testAddDocumentWithMetadataPositiveCase()
-      throws IOException, CatalogTransformerException, IngestException, SourceUnavailableException,
-          URISyntaxException, InvalidSyntaxException {
+  public void testAddDocumentWithMetadataPositiveCase() throws Exception {
 
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
+    CatalogFramework framework = givenCatalogFramework();
 
     HttpHeaders headers = createHeaders(Collections.singletonList(MediaType.APPLICATION_JSON));
     BundleContext bundleContext = mock(BundleContext.class);
@@ -362,8 +287,8 @@ public class RestEndpointTest {
     when(bundleContext.getServiceReferences(InputTransformer.class, "(id=xml)"))
         .thenReturn(serviceReferences);
 
-    RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
+    CatalogServiceImpl catalogService =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
@@ -372,14 +297,12 @@ public class RestEndpointTest {
 
     UuidGenerator uuidGenerator = mock(UuidGenerator.class);
     when(uuidGenerator.generateUuid()).thenReturn(UUID.randomUUID().toString());
-    rest.setUuidGenerator(uuidGenerator);
+    catalogService.setUuidGenerator(uuidGenerator);
 
     when(attributeRegistry.lookup(Core.METADATA))
         .thenReturn(Optional.of(new CoreAttributes().getAttributeDescriptor(Core.METADATA)));
 
-    addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
-
-    UriInfo info = givenUriInfo(SAMPLE_ID);
+    addMatchingService(catalogService, Collections.singletonList(getSimpleTransformer()));
 
     List<Attachment> attachments = new ArrayList<>();
     ContentDisposition contentDisposition =
@@ -406,22 +329,16 @@ public class RestEndpointTest {
     attachments.add(attachment2);
     MultipartBody multipartBody = new MultipartBody(attachments);
 
-    Response response =
-        rest.addDocument(
-            headers,
-            info,
-            mock(HttpServletRequest.class),
+    String response =
+        catalogService.addDocument(
+            headers.getRequestHeader(HttpHeaders.CONTENT_TYPE),
             multipartBody,
             null,
             new ByteArrayInputStream("".getBytes()));
 
     LOGGER.debug(ToStringBuilder.reflectionToString(response));
 
-    assertThat(response.getStatus(), equalTo(201));
-
-    assertThat(response.getMetadata(), notNullValue());
-
-    assertThat(response.getMetadata().get(Metacard.ID).get(0).toString(), equalTo(SAMPLE_ID));
+    assertThat(response, equalTo(SAMPLE_ID));
   }
 
   @Test
@@ -432,13 +349,9 @@ public class RestEndpointTest {
     inputMcard.setId(inputMcardId);
     UuidGenerator uuidGenerator = mock(UuidGenerator.class);
 
-    Response response = mcardIdTest(inputMcard, uuidGenerator);
+    String response = mcardIdTest(inputMcard, uuidGenerator);
 
-    assertThat(response.getStatus(), equalTo(201));
-
-    assertThat(response.getMetadata(), notNullValue());
-
-    assertThat(response.getMetadata().get(Metacard.ID).get(0).toString(), equalTo(inputMcardId));
+    assertThat(response, equalTo(inputMcardId));
 
     verify(uuidGenerator, never()).generateUuid();
   }
@@ -450,13 +363,9 @@ public class RestEndpointTest {
     MetacardImpl inputMcard = new MetacardImpl();
     UuidGenerator uuidGenerator = mock(UuidGenerator.class);
 
-    Response response = mcardIdTest(inputMcard, uuidGenerator);
+    String response = mcardIdTest(inputMcard, uuidGenerator);
 
-    assertThat(response.getStatus(), equalTo(201));
-
-    assertThat(response.getMetadata(), notNullValue());
-
-    assertThat(response.getMetadata().get(Metacard.ID).get(0).toString(), notNullValue());
+    assertThat(response, notNullValue());
 
     verify(uuidGenerator, times(1)).generateUuid();
   }
@@ -466,7 +375,7 @@ public class RestEndpointTest {
   public void testParseAttachments()
       throws IOException, CatalogTransformerException, SourceUnavailableException, IngestException,
           InvalidSyntaxException {
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
+    CatalogFramework framework = givenCatalogFramework();
     BundleContext bundleContext = mock(BundleContext.class);
     Collection<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
     ServiceReference serviceReference = mock(ServiceReference.class);
@@ -479,8 +388,8 @@ public class RestEndpointTest {
     when(bundleContext.getServiceReferences(InputTransformer.class, "(id=xml)"))
         .thenReturn(serviceReferences);
 
-    RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
+    CatalogServiceImpl rest =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
@@ -586,10 +495,10 @@ public class RestEndpointTest {
 
   @Test
   @SuppressWarnings({"unchecked"})
-  public void testParseAttachmentsTooLarge()
+  public void testParseParts()
       throws IOException, CatalogTransformerException, SourceUnavailableException, IngestException,
-          InvalidSyntaxException {
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
+          InvalidSyntaxException, ServletException {
+    CatalogFramework framework = givenCatalogFramework();
     BundleContext bundleContext = mock(BundleContext.class);
     Collection<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
     ServiceReference serviceReference = mock(ServiceReference.class);
@@ -602,8 +511,81 @@ public class RestEndpointTest {
     when(bundleContext.getServiceReferences(InputTransformer.class, "(id=xml)"))
         .thenReturn(serviceReferences);
 
-    RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
+    CatalogServiceImpl catalogServiceImpl =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry) {
+          @Override
+          BundleContext getBundleContext() {
+            return bundleContext;
+          }
+        };
+    when(attributeRegistry.lookup(Core.METADATA))
+        .thenReturn(Optional.of(new CoreAttributes().getAttributeDescriptor(Core.METADATA)));
+    when(attributeRegistry.lookup("foo")).thenReturn(Optional.empty());
+
+    addMatchingService(catalogServiceImpl, Collections.singletonList(getSimpleTransformer()));
+
+    List<Part> parts = new ArrayList<>();
+    Part part =
+        createPart(
+            "parse.resource",
+            new ByteArrayInputStream("Some Text".getBytes()),
+            "form-data; name=parse.resource; filename=C:\\DDF\\metacard.txt");
+    Part part1 =
+        createPart(
+            "parse.metadata",
+            new ByteArrayInputStream("Some Text Again".getBytes()),
+            "form-data; name=parse.metadata; filename=C:\\DDF\\metacard.xml");
+
+    parts.add(part);
+    parts.add(part1);
+
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    when(httpServletRequest.getParts()).thenReturn(parts);
+
+    Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard =
+        catalogServiceImpl.parseParts(parts, "xml");
+    assertThat(attachmentInfoAndMetacard.getRight().getMetadata(), equalTo("Some Text Again"));
+
+    Part part2 =
+        createPart(
+            "metadata",
+            new ByteArrayInputStream("<meta>beta</meta>".getBytes()),
+            "form-data; name=metadata; filename=C:\\DDF\\metacard.xml");
+    Part part3 =
+        createPart(
+            "foo",
+            new ByteArrayInputStream("bar".getBytes()),
+            "form-data; name=foo; filename=C:\\DDF\\metacard.xml");
+
+    parts.add(part2);
+    parts.add(part3);
+
+    attachmentInfoAndMetacard = catalogServiceImpl.parseParts(parts, "xml");
+
+    assertThat(attachmentInfoAndMetacard.getRight().getMetadata(), equalTo("<meta>beta</meta>"));
+    assertThat(attachmentInfoAndMetacard.getRight().getAttribute("foo"), equalTo(null));
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked"})
+  public void testParseAttachmentsTooLarge()
+      throws IOException, CatalogTransformerException, SourceUnavailableException, IngestException,
+          InvalidSyntaxException {
+    CatalogFramework framework = givenCatalogFramework();
+    BundleContext bundleContext = mock(BundleContext.class);
+    Collection<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
+    ServiceReference serviceReference = mock(ServiceReference.class);
+    InputTransformer inputTransformer = mock(InputTransformer.class);
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setMetadata("Some Text Again");
+    when(inputTransformer.transform(any())).thenReturn(metacard);
+    when(bundleContext.getService(serviceReference)).thenReturn(inputTransformer);
+    serviceReferences.add(serviceReference);
+    when(bundleContext.getServiceReferences(InputTransformer.class, "(id=xml)"))
+        .thenReturn(serviceReferences);
+
+    CatalogServiceImpl rest =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
@@ -656,120 +638,82 @@ public class RestEndpointTest {
     assertThat(attachmentInfoAndMetacard.getRight().getMetadata(), equalTo("Some Text Again"));
     assertThat(attachmentInfoAndMetacard.getRight().getAttribute("foo"), equalTo(null));
   }
-  /**
-   * Tests local retrieve with a null QueryResponse
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testGetDocumentLocalNullQueryResponse() throws Exception {
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.QUERY_RESPONSE_TEST);
-    Response response = executeTest(framework, transformer, true, null);
-    assertEquals(response.getStatus(), NOT_FOUND);
-    assertEquals(response.getEntity(), "<pre>Unable to retrieve requested metacard.</pre>");
-  }
-
-  /**
-   * Tests federated retrieve with a null QueryResponse
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testGetDocumentFedNullQueryResponse() throws Exception {
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.QUERY_RESPONSE_TEST);
-    Response response = executeTest(framework, transformer, false, null);
-    assertEquals(response.getStatus(), NOT_FOUND);
-    assertEquals(response.getEntity(), "<pre>Unable to retrieve requested metacard.</pre>");
-  }
-
-  /**
-   * Tests local retrieve with a null Metacard
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testGetDocumentLocalNullMetacard() throws Exception {
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.METACARD_TEST);
-    Response response = executeTest(framework, transformer, true, null);
-    assertEquals(response.getStatus(), NOT_FOUND);
-    assertEquals(response.getEntity(), "<pre>Unable to retrieve requested metacard.</pre>");
-  }
-
-  /**
-   * Tests federated retrieve with a null Metacard
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testGetDocumentFedNullMetacard() throws Exception {
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.METACARD_TEST);
-    Response response = executeTest(framework, transformer, false, null);
-    assertEquals(response.getStatus(), NOT_FOUND);
-    assertEquals(response.getEntity(), "<pre>Unable to retrieve requested metacard.</pre>");
-  }
-
-  /**
-   * Tests local retrieve with a successful response
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testGetDocumentLocalSuccess() throws Exception {
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.SUCCESS_TEST);
-    Response response = executeTest(framework, transformer, true, null);
-
-    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
-    assertEquals(GET_STREAM, responseMessage);
-    assertEquals(OK, response.getStatus());
-    assertEquals(GET_TYPE_OUTPUT, response.getMetadata().toString());
-  }
 
   @Test
-  public void testGetDocumentKml() throws Exception {
+  @SuppressWarnings({"unchecked"})
+  public void testParsePartsTooLarge()
+      throws IOException, CatalogTransformerException, SourceUnavailableException, IngestException,
+          InvalidSyntaxException, ServletException {
+    CatalogFramework framework = givenCatalogFramework();
+    BundleContext bundleContext = mock(BundleContext.class);
+    Collection<ServiceReference<InputTransformer>> serviceReferences = new ArrayList<>();
+    ServiceReference serviceReference = mock(ServiceReference.class);
+    InputTransformer inputTransformer = mock(InputTransformer.class);
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setMetadata("Some Text Again");
+    when(inputTransformer.transform(any())).thenReturn(metacard);
+    when(bundleContext.getService(serviceReference)).thenReturn(inputTransformer);
+    serviceReferences.add(serviceReference);
+    when(bundleContext.getServiceReferences(InputTransformer.class, "(id=xml)"))
+        .thenReturn(serviceReferences);
 
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.KML_TEST);
-    Response response = executeTest(framework, transformer, true, null);
+    CatalogServiceImpl catalogServiceImpl =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry) {
+          @Override
+          BundleContext getBundleContext() {
+            return bundleContext;
+          }
+        };
+    when(attributeRegistry.lookup(Core.METADATA))
+        .thenReturn(Optional.of(new CoreAttributes().getAttributeDescriptor(Core.METADATA)));
+    when(attributeRegistry.lookup("foo")).thenReturn(Optional.empty());
 
-    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
-    assertEquals(GET_STREAM, responseMessage);
-    assertEquals(OK, response.getStatus());
-    assertEquals(GET_KML_TYPE_OUTPUT, response.getMetadata().toString());
+    addMatchingService(catalogServiceImpl, Collections.singletonList(getSimpleTransformer()));
+
+    List<Part> parts = new ArrayList<>();
+    Part part =
+        createPart(
+            "parse.resource",
+            new ByteArrayInputStream("Some Text".getBytes()),
+            "form-data; name=parse.resource; filename=C:\\DDF\\metacard.txt");
+    Part part1 =
+        createPart(
+            "parse.metadata",
+            new ByteArrayInputStream("Some Text Again".getBytes()),
+            "form-data; name=parse.metadata; filename=C:\\DDF\\metacard.xml");
+
+    parts.add(part);
+    parts.add(part1);
+
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    when(httpServletRequest.getParts()).thenReturn(parts);
+
+    Pair<AttachmentInfo, Metacard> attachmentInfoAndMetacard =
+        catalogServiceImpl.parseParts(parts, "xml");
+    assertThat(attachmentInfoAndMetacard.getRight().getMetadata(), equalTo("Some Text Again"));
+
+    Part part2 =
+        createPart(
+            "metadata",
+            new ByteArrayInputStream(Strings.repeat("hi", 100_000).getBytes()),
+            "form-data; name=metadata; filename=C:\\DDF\\metacard.xml");
+    Part part3 =
+        createPart(
+            "foo",
+            new ByteArrayInputStream("bar".getBytes()),
+            "form-data; name=foo; filename=C:\\DDF\\metacard.xml");
+
+    parts.add(part2);
+    parts.add(part3);
+
+    attachmentInfoAndMetacard = catalogServiceImpl.parseParts(parts, "xml");
+
+    // Ensure that the metadata was not overriden because it was too large to be parsed
+    assertThat(attachmentInfoAndMetacard.getRight().getMetadata(), equalTo("Some Text Again"));
+    assertThat(attachmentInfoAndMetacard.getRight().getAttribute("foo"), equalTo(null));
   }
 
-  /**
-   * Tests federated retrieve with a successful response
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testGetDocumentFedSuccess() throws Exception {
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.SUCCESS_TEST);
-    Response response = executeTest(framework, transformer, false, null);
-
-    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
-    assertEquals(GET_STREAM, responseMessage);
-    assertEquals(OK, response.getStatus());
-    assertEquals(GET_TYPE_OUTPUT, response.getMetadata().toString());
-  }
-
-  /**
-   * Tests getting source information
-   *
-   * @throws Exception
-   */
+  /** Tests getting source information */
   @Test
   @SuppressWarnings({"unchecked"})
   public void testGetDocumentSourcesSuccess() throws Exception {
@@ -816,13 +760,13 @@ public class RestEndpointTest {
     when(framework.getSourceInfo(isA(SourceInfoRequestEnterprise.class)))
         .thenReturn(sourceInfoResponse);
 
-    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
+    CatalogServiceImpl catalogService =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry);
 
-    Response response = restEndpoint.getDocument(null, null);
-    assertEquals(OK, response.getStatus());
-    assertEquals(jsonMimeTypeString, response.getMetadata().get("Content-Type").get(0));
+    BinaryContent content = catalogService.getDocument();
+    assertEquals(jsonMimeTypeString, content.getMimeTypeValue());
 
-    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
+    String responseMessage = IOUtils.toString(content.getInputStream());
     JSONArray srcList = (JSONArray) new JSONParser().parse(responseMessage);
 
     assertEquals(3, srcList.size());
@@ -851,52 +795,14 @@ public class RestEndpointTest {
   }
 
   /**
-   * Tests retrieving a local resource with a successful response
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testGetDocumentResourceLocalSuccess() throws Exception {
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.RESOURCE_TEST);
-    Response response = executeTest(framework, transformer, true, null);
-
-    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
-    assertEquals(GET_STREAM, responseMessage);
-    assertEquals(OK, response.getStatus());
-    assertEquals(GET_TYPE_OUTPUT, response.getMetadata().toString());
-  }
-
-  /**
-   * Tests retrieving a federated resource with a successful response
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testGetDocumentResourceFedSuccess() throws Exception {
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-    String transformer = mockTestSetup(framework, TestType.RESOURCE_TEST);
-    Response response = executeTest(framework, transformer, false, null);
-
-    String responseMessage = IOUtils.toString((ByteArrayInputStream) response.getEntity());
-    assertEquals(GET_STREAM, responseMessage);
-    assertEquals(OK, response.getStatus());
-    assertEquals(GET_TYPE_OUTPUT, response.getMetadata().toString());
-  }
-
-  /**
    * Tests that a geojson input has its InputTransformer invoked by the REST endpoint to create a
    * metacard that is then converted to XML and returned from the REST endpoint.
-   *
-   * @throws Exception
    */
   @Test
   @SuppressWarnings({"unchecked"})
   public void testGetMetacardAsXml() throws Exception {
 
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
+    CatalogFramework framework = givenCatalogFramework();
     String metacardXml =
         "<metacard ns2:id=\"assigned-when-ingested\">\r\n"
             + "<type>type.metacard</type>\r\n"
@@ -916,13 +822,14 @@ public class RestEndpointTest {
     when(framework.transform(isA(Metacard.class), anyString(), isNull(Map.class)))
         .thenReturn(content);
 
-    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
+    CatalogServiceImpl catalogService =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry);
 
     // Add a MimeTypeToINputTransformer that the REST endpoint will call to create the metacard
-    addMatchingService(restEndpoint, Collections.singletonList(getSimpleTransformer()));
-    restEndpoint.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
+    addMatchingService(catalogService, Collections.singletonList(getSimpleTransformer()));
+    catalogService.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
     FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
-    restEndpoint.setFilterBuilder(filterBuilder);
+    catalogService.setFilterBuilder(filterBuilder);
 
     String json =
         "{\r\n"
@@ -958,224 +865,15 @@ public class RestEndpointTest {
     MediaType mediaType = new MediaType(MediaType.APPLICATION_JSON, "id=geojson");
     MultipartBody multipartBody = new MultipartBody(attachments, mediaType, true);
 
-    UriInfo uriInfo = createSpecificUriInfo(LOCAL_RETRIEVE_ADDRESS);
-    Response response =
-        restEndpoint.createMetacard(
-            multipartBody, uriInfo, RESTEndpoint.DEFAULT_METACARD_TRANSFORMER);
-    assertEquals(OK, response.getStatus());
-    InputStream responseEntity = (InputStream) response.getEntity();
+    BinaryContent binaryContent =
+        catalogService.createMetacard(
+            multipartBody, CatalogServiceImpl.DEFAULT_METACARD_TRANSFORMER);
+    InputStream responseEntity = binaryContent.getInputStream();
     String responseXml = IOUtils.toString(responseEntity);
     assertEquals(metacardXml, responseXml);
   }
 
-  /**
-   * Test using a Head request to find out if Range headers are supported and to get resource size
-   * of a local resource for use when using Range headers.
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testHeadRequestLocal() throws Exception {
-
-    boolean isLocal = true;
-
-    Response response = headTest(isLocal);
-
-    assertEquals(NO_CONTENT, response.getStatus());
-    assertEquals(ACCEPT_RANGES_VALUE, response.getHeaderString(HEADER_ACCEPT_RANGES));
-    assertEquals(CONTENT_DISPOSITION_VALUE, response.getHeaderString(HEADER_CONTENT_DISPOSITION));
-  }
-
-  /**
-   * Test using a Head request to find out if Range headers are supported and to get resource size
-   * of a resource at a federated site for use when using Range headers.
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testHeadRequestFederated() throws Exception {
-
-    boolean isLocal = false;
-
-    Response response = headTest(isLocal);
-
-    assertEquals(NO_CONTENT, response.getStatus());
-    assertEquals(ACCEPT_RANGES_VALUE, response.getHeaderString(HEADER_ACCEPT_RANGES));
-    assertEquals(CONTENT_DISPOSITION_VALUE, response.getHeaderString(HEADER_CONTENT_DISPOSITION));
-  }
-
-  @SuppressWarnings({"unchecked"})
-  private Response headTest(boolean local)
-      throws CatalogTransformerException, URISyntaxException, UnsupportedEncodingException,
-          UnsupportedQueryException, SourceUnavailableException, FederationException,
-          IngestException {
-
-    MetacardImpl metacard;
-    List<Result> list = new ArrayList<>();
-    Result result = mock(Result.class);
-    InputStream inputStream;
-    UriInfo uriInfo;
-    Response response;
-
-    CatalogFramework framework = givenCatalogFramework(SAMPLE_ID);
-
-    list.add(result);
-
-    QueryResponse queryResponse = mock(QueryResponse.class);
-
-    when(queryResponse.getResults()).thenReturn(list);
-
-    when(framework.query(isA(QueryRequest.class), isNull(FederationStrategy.class)))
-        .thenReturn(queryResponse);
-
-    metacard = new MetacardImpl();
-    metacard.setSourceId(GET_SITENAME);
-    when(result.getMetacard()).thenReturn(metacard);
-
-    Resource resource = mock(Resource.class);
-    inputStream = new ByteArrayInputStream(GET_STREAM.getBytes(GET_OUTPUT_TYPE));
-    when(resource.getInputStream()).thenReturn(inputStream);
-    when(resource.getMimeTypeValue()).thenReturn(GET_MIME_TYPE);
-    when(resource.getName()).thenReturn(GET_FILENAME);
-    when(framework.transform(isA(Metacard.class), anyString(), isA(Map.class)))
-        .thenReturn(resource);
-
-    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
-    restEndpoint.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
-    FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
-    restEndpoint.setFilterBuilder(filterBuilder);
-
-    uriInfo = createSpecificUriInfo(LOCAL_RETRIEVE_ADDRESS);
-
-    if (local) {
-      response = restEndpoint.getHeaders(GET_ID, uriInfo, null);
-    } else {
-      response = restEndpoint.getHeaders(null, GET_ID, uriInfo, null);
-    }
-
-    return response;
-  }
-
-  /**
-   * Creates a UriInfo with a user specified URL
-   *
-   * @param url
-   * @return
-   * @throws URISyntaxException
-   */
-  @SuppressWarnings({"unchecked"})
-  protected UriInfo createSpecificUriInfo(String url) throws URISyntaxException {
-
-    UriInfo uriInfo = mock(UriInfo.class);
-    URI uri = new URI(url);
-
-    when(uriInfo.getAbsolutePath()).thenReturn(uri);
-    when(uriInfo.getQueryParameters()).thenReturn(mock(MultivaluedMap.class));
-
-    return uriInfo;
-  }
-
-  /**
-   * Creates the mock setup for the GET tests above. Parameters provide the CatalogFramework, which
-   * will be setup for the test, and also specify which test case is being run.
-   *
-   * @param framework
-   * @param testType
-   * @return
-   * @throws Exception
-   */
-  @SuppressWarnings({"unchecked"})
-  protected String mockTestSetup(CatalogFramework framework, TestType testType) throws Exception {
-    String transformer = null;
-    QueryResponse queryResponse = mock(QueryResponse.class);
-    when(framework.query(isA(QueryRequest.class), isNull(FederationStrategy.class)))
-        .thenReturn(queryResponse);
-
-    List<Result> list = null;
-    MetacardImpl metacard = null;
-    Result result = mock(Result.class);
-    InputStream inputStream;
-
-    switch (testType) {
-      case QUERY_RESPONSE_TEST:
-        when(queryResponse.getResults()).thenReturn(list);
-        break;
-
-      case METACARD_TEST:
-        list = new ArrayList<>();
-        list.add(result);
-        when(queryResponse.getResults()).thenReturn(list);
-
-        when(result.getMetacard()).thenReturn(metacard);
-        break;
-
-      case RESOURCE_TEST:
-        transformer = "resource";
-        /* FALLTHRU */
-        // fall through
-      case SUCCESS_TEST:
-        list = new ArrayList<>();
-        list.add(result);
-        when(queryResponse.getResults()).thenReturn(list);
-
-        metacard = new MetacardImpl();
-        metacard.setSourceId(GET_SITENAME);
-        when(result.getMetacard()).thenReturn(metacard);
-
-        Resource resource = mock(Resource.class);
-        inputStream = new ByteArrayInputStream(GET_STREAM.getBytes(GET_OUTPUT_TYPE));
-        when(resource.getInputStream()).thenReturn(inputStream);
-        when(resource.getMimeTypeValue()).thenReturn(GET_MIME_TYPE);
-        when(resource.getName()).thenReturn(GET_FILENAME);
-        when(framework.transform(isA(Metacard.class), anyString(), isA(Map.class)))
-            .thenReturn(resource);
-        break;
-
-      case KML_TEST:
-        transformer = "kml";
-        list = new ArrayList<>();
-        list.add(result);
-        when(queryResponse.getResults()).thenReturn(list);
-
-        metacard = new MetacardImpl();
-        metacard.setSourceId(GET_SITENAME);
-        when(result.getMetacard()).thenReturn(metacard);
-
-        BinaryContent content = mock(BinaryContent.class);
-        inputStream = new ByteArrayInputStream(GET_STREAM.getBytes(GET_OUTPUT_TYPE));
-        when(content.getInputStream()).thenReturn(inputStream);
-        when(content.getMimeTypeValue()).thenReturn(GET_KML_MIME_TYPE);
-        when(framework.transform(isA(Metacard.class), anyString(), isA(Map.class)))
-            .thenReturn(content);
-        break;
-    }
-
-    return transformer;
-  }
-
-  private Response executeTest(
-      CatalogFramework framework, String transformer, boolean local, HttpServletRequest request)
-      throws URISyntaxException {
-
-    RESTEndpoint restEndpoint = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
-    restEndpoint.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
-    FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
-    restEndpoint.setFilterBuilder(filterBuilder);
-
-    UriInfo uriInfo;
-    Response response;
-    if (local) {
-      uriInfo = createSpecificUriInfo(LOCAL_RETRIEVE_ADDRESS);
-      response = restEndpoint.getDocument(GET_ID, transformer, uriInfo, request);
-    } else {
-      uriInfo = createSpecificUriInfo(FED_RETRIEVE_ADDRESS);
-      response = restEndpoint.getDocument(GET_SITENAME, GET_ID, transformer, uriInfo, request);
-    }
-
-    return response;
-  }
-
-  private Response mcardIdTest(Metacard metacard, UuidGenerator uuidGenerator) throws Exception {
+  private String mcardIdTest(Metacard metacard, UuidGenerator uuidGenerator) throws Exception {
     CatalogFramework framework = mock(CatalogFramework.class);
 
     when(framework.create(isA(CreateStorageRequest.class)))
@@ -1199,8 +897,8 @@ public class RestEndpointTest {
     when(bundleContext.getServiceReferences(InputTransformer.class, "(id=xml)"))
         .thenReturn(serviceReferences);
 
-    RESTEndpoint rest =
-        new RESTEndpoint(framework, attachmentParser, attributeRegistry) {
+    CatalogServiceImpl catalogService =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry) {
           @Override
           BundleContext getBundleContext() {
             return bundleContext;
@@ -1208,13 +906,11 @@ public class RestEndpointTest {
         };
     String generatedMcardId = UUID.randomUUID().toString();
     when(uuidGenerator.generateUuid()).thenReturn(generatedMcardId);
-    rest.setUuidGenerator(uuidGenerator);
+    catalogService.setUuidGenerator(uuidGenerator);
     when(attributeRegistry.lookup(Core.METADATA))
         .thenReturn(Optional.of(new CoreAttributes().getAttributeDescriptor(Core.METADATA)));
 
-    addMatchingService(rest, Collections.singletonList(inputTransformer));
-
-    UriInfo info = givenUriInfo(metacard.getId() == null ? generatedMcardId : metacard.getId());
+    addMatchingService(catalogService, Collections.singletonList(inputTransformer));
 
     List<Attachment> attachments = new ArrayList<>();
     ContentDisposition contentDisposition =
@@ -1234,18 +930,15 @@ public class RestEndpointTest {
 
     MultipartBody multipartBody = new MultipartBody(attachments);
 
-    return rest.addDocument(
-        headers,
-        info,
-        mock(HttpServletRequest.class),
+    return catalogService.addDocument(
+        headers.getRequestHeader(HttpHeaders.CONTENT_TYPE),
         multipartBody,
         null,
         new ByteArrayInputStream("".getBytes()));
   }
 
   @SuppressWarnings({"unchecked"})
-  protected void assertExceptionThrown(Class<? extends Throwable> klass)
-      throws IngestException, SourceUnavailableException, URISyntaxException {
+  private void assertExceptionThrown(Class<? extends Throwable> klass) throws Exception {
 
     CatalogFramework framework = mock(CatalogFramework.class);
 
@@ -1255,40 +948,37 @@ public class RestEndpointTest {
 
     HttpHeaders headers = createHeaders(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-    RESTEndpoint rest = new RESTEndpoint(framework, attachmentParser, attributeRegistry);
+    CatalogServiceImpl catalogService =
+        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry);
 
-    addMatchingService(rest, Collections.singletonList(getSimpleTransformer()));
-
-    UriInfo info = givenUriInfo(SAMPLE_ID);
+    addMatchingService(catalogService, Collections.singletonList(getSimpleTransformer()));
 
     try {
-      Response response =
-          rest.addDocument(
-              headers,
-              info,
-              mock(HttpServletRequest.class),
-              mock(MultipartBody.class),
-              null,
-              new ByteArrayInputStream("".getBytes()));
-      if (klass.getName().equals(IngestException.class.getName())) {
-        assertEquals(response.getStatus(), BAD_REQUEST);
-      } else {
-        fail();
-      }
+      catalogService.addDocument(
+          headers.getRequestHeader(HttpHeaders.CONTENT_TYPE),
+          mock(MultipartBody.class),
+          null,
+          new ByteArrayInputStream("".getBytes()));
     } catch (InternalServerErrorException e) {
       if (klass.getName().equals(SourceUnavailableException.class.getName())) {
         assertThat(e.getResponse().getStatus(), equalTo(INTERNAL_SERVER_ERROR));
       }
+    } catch (CatalogException e) {
+      if (klass.getName().equals(IngestException.class.getName())) {
+        assertEquals(e.getMessage(), "Error while storing entry in catalog: ");
+      } else {
+        fail();
+      }
     }
   }
 
-  protected CatalogFramework givenCatalogFramework(String returnId)
+  private CatalogFramework givenCatalogFramework()
       throws IngestException, SourceUnavailableException {
     CatalogFramework framework = mock(CatalogFramework.class);
 
     Metacard returnMetacard = mock(Metacard.class);
 
-    when(returnMetacard.getId()).thenReturn(returnId);
+    when(returnMetacard.getId()).thenReturn(CatalogServiceImplTest.SAMPLE_ID);
 
     when(framework.create(isA(CreateRequest.class)))
         .thenReturn(new CreateResponseImpl(null, null, Collections.singletonList(returnMetacard)));
@@ -1299,20 +989,17 @@ public class RestEndpointTest {
     return framework;
   }
 
-  protected UriInfo givenUriInfo(String metacardId) throws URISyntaxException {
-    UriInfo info = mock(UriInfo.class);
-
-    UriBuilder builder = mock(UriBuilder.class);
-
-    when(builder.path("/" + metacardId)).thenReturn(builder);
-
-    when(builder.build()).thenReturn(new URI(ENDPOINT_ADDRESS));
-
-    when(info.getAbsolutePathBuilder()).thenReturn(builder);
-    return info;
+  private Part createPart(String name, InputStream inputStream, String contentDisposition)
+      throws IOException {
+    Part part = mock(Part.class);
+    when(part.getName()).thenReturn(name);
+    when(part.getInputStream()).thenReturn(inputStream);
+    when(part.getHeader(HEADER_CONTENT_DISPOSITION)).thenReturn(contentDisposition);
+    when(part.getContentType()).thenReturn(MediaType.APPLICATION_OCTET_STREAM);
+    return part;
   }
 
-  protected Metacard getSimpleMetacard() {
+  private Metacard getSimpleMetacard() {
     MetacardImpl generatedMetacard = new MetacardImpl();
     generatedMetacard.setMetadata(getSample());
     generatedMetacard.setId(SAMPLE_ID);
@@ -1337,7 +1024,7 @@ public class RestEndpointTest {
 
   @SuppressWarnings({"unchecked"})
   private MimeTypeToTransformerMapper addMatchingService(
-      RESTEndpoint rest, List<InputTransformer> sortedListOfTransformers) {
+      CatalogServiceImpl rest, List<InputTransformer> sortedListOfTransformers) {
 
     MimeTypeToTransformerMapper matchingService = mock(MimeTypeToTransformerMapper.class);
 
@@ -1360,13 +1047,5 @@ public class RestEndpointTest {
 
   private String getSample() {
     return "<xml></xml>";
-  }
-
-  protected enum TestType {
-    QUERY_RESPONSE_TEST,
-    METACARD_TEST,
-    SUCCESS_TEST,
-    RESOURCE_TEST,
-    KML_TEST
   }
 }

--- a/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/action/AbstractActionProviderTest.java
+++ b/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/action/AbstractActionProviderTest.java
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.impl.action;
 
 import org.codice.ddf.configuration.SystemBaseUrl;
 

--- a/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/action/ActionProviderRegistryProxyTest.java
+++ b/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/action/ActionProviderRegistryProxyTest.java
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.impl.action;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/action/MetacardTransformerActionProviderTest.java
+++ b/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/action/MetacardTransformerActionProviderTest.java
@@ -11,10 +11,10 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.impl.action;
 
-import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
-import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
+import static org.codice.ddf.rest.impl.CatalogServiceImpl.CONTEXT_ROOT;
+import static org.codice.ddf.rest.impl.CatalogServiceImpl.SOURCES_PATH;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;

--- a/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/action/ViewMetacardActionProviderTest.java
+++ b/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/action/ViewMetacardActionProviderTest.java
@@ -11,10 +11,10 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.impl.action;
 
-import static org.codice.ddf.endpoints.rest.RESTService.CONTEXT_ROOT;
-import static org.codice.ddf.endpoints.rest.RESTService.SOURCES_PATH;
+import static org.codice.ddf.rest.impl.CatalogServiceImpl.CONTEXT_ROOT;
+import static org.codice.ddf.rest.impl.CatalogServiceImpl.SOURCES_PATH;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;

--- a/catalog/rest/catalog-rest-service/pom.xml
+++ b/catalog/rest/catalog-rest-service/pom.xml
@@ -24,7 +24,6 @@
     </parent>
 
     <artifactId>catalog-rest-service</artifactId>
-    <version>2.13.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>DDF :: Catalog :: REST :: Service</name>
 

--- a/catalog/rest/catalog-rest-service/pom.xml
+++ b/catalog/rest/catalog-rest-service/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ddf.catalog.rest</groupId>
+        <artifactId>catalog-rest-pom</artifactId>
+        <version>2.13.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>catalog-rest-service</artifactId>
+    <version>2.13.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>DDF :: Catalog :: REST :: Service</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/CatalogException.java
+++ b/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/CatalogException.java
@@ -11,12 +11,11 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.endpoints.rest.action;
+package org.codice.ddf.rest.service;
 
-public class MetacardTransformerActionProviderFactory {
+public class CatalogException extends Exception {
 
-  public MetacardTransformerActionProvider createActionProvider(
-      String id, String transformer, String attributeName) {
-    return new MetacardTransformerActionProvider(id, transformer, attributeName);
+  public CatalogException(String message) {
+    super(message);
   }
 }

--- a/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/CatalogService.java
+++ b/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/CatalogService.java
@@ -22,22 +22,25 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MultivaluedMap;
 import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
 
+/** Catalog service interface */
 public interface CatalogService {
 
-  String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
-
-  String HEADER_CONTENT_LENGTH = "Content-Length";
-
-  String HEADER_ACCEPT_RANGES = "Accept-Ranges";
-
-  String BYTES = "bytes";
-
+  /**
+   * Retrieves header information regarding the entry specified by the id such as the Accept-Ranges
+   * and Content-Range headers.
+   */
   BinaryContent getHeaders(
       String sourceid, String id, URI absolutePath, MultivaluedMap<String, String> queryParameters)
-      throws CatalogException;
+      throws CatalogServiceException;
 
-  BinaryContent getDocument();
+  /** Retrieves information regarding available sources. */
+  BinaryContent getSourcesInfo();
 
+  /**
+   * Retrieves the metadata entry specified by the id from the federated source specified by
+   * sourceid. Transformer argument is optional, but is used to specify what format the data should
+   * be returned.
+   */
   BinaryContent getDocument(
       String encodedSourceId,
       String encodedId,
@@ -45,45 +48,53 @@ public interface CatalogService {
       URI absolutePath,
       MultivaluedMap<String, String> queryParameters,
       HttpServletRequest httpRequest)
-      throws CatalogException, DataUsageLimitExceededException;
+      throws CatalogServiceException, DataUsageLimitExceededException;
 
+  /** Creates a new metacard. */
   BinaryContent createMetacard(MultipartBody multipartBody, String transformerParam)
-      throws CatalogException;
+      throws CatalogServiceException;
 
+  /** Creates a new metacard. */
   BinaryContent createMetacard(HttpServletRequest httpServletRequest, String transformerParam)
-      throws CatalogException;
+      throws CatalogServiceException;
 
+  /** Updates the specified metadata entry with the provided metadata. */
   void updateDocument(
       String id,
       List<String> contentTypeList,
       MultipartBody multipartBody,
       String transformerParam,
       InputStream message)
-      throws CatalogException;
+      throws CatalogServiceException;
 
+  /** Updates the specified metadata entry with the provided metadata. */
   void updateDocument(
       String id,
       List<String> contentTypeList,
       HttpServletRequest httpServletRequest,
       String transformerParam,
       InputStream message)
-      throws CatalogException;
+      throws CatalogServiceException;
 
+  /** Creates a new metadata entry in the catalog. */
   String addDocument(
       List<String> contentTypeList,
       MultipartBody multipartBody,
       String transformerParam,
       InputStream message)
-      throws CatalogException;
+      throws CatalogServiceException;
 
+  /** Creates a new metadata entry in the catalog. */
   String addDocument(
       List<String> contentTypeList,
       HttpServletRequest httpServletRequest,
       String transformerParam,
       InputStream message)
-      throws CatalogException;
+      throws CatalogServiceException;
 
-  void deleteDocument(String id) throws CatalogException;
+  /** Deletes a record from the catalog. */
+  void deleteDocument(String id) throws CatalogServiceException;
 
+  /** Retrieves the file extension fro the specified Mime Type. */
   String getFileExtensionForMimeType(String mimeType);
 }

--- a/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/CatalogService.java
+++ b/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/CatalogService.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.rest.service;
+
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.resource.DataUsageLimitExceededException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MultivaluedMap;
+import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
+
+public interface CatalogService {
+
+  String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
+
+  String HEADER_CONTENT_LENGTH = "Content-Length";
+
+  String HEADER_ACCEPT_RANGES = "Accept-Ranges";
+
+  String BYTES = "bytes";
+
+  BinaryContent getHeaders(
+      String sourceid, String id, URI absolutePath, MultivaluedMap<String, String> queryParameters)
+      throws CatalogException;
+
+  BinaryContent getDocument();
+
+  BinaryContent getDocument(
+      String encodedSourceId,
+      String encodedId,
+      String transformerParam,
+      URI absolutePath,
+      MultivaluedMap<String, String> queryParameters,
+      HttpServletRequest httpRequest)
+      throws CatalogException, DataUsageLimitExceededException;
+
+  BinaryContent createMetacard(MultipartBody multipartBody, String transformerParam)
+      throws CatalogException;
+
+  BinaryContent createMetacard(HttpServletRequest httpServletRequest, String transformerParam)
+      throws CatalogException;
+
+  void updateDocument(
+      String id,
+      List<String> contentTypeList,
+      MultipartBody multipartBody,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException;
+
+  void updateDocument(
+      String id,
+      List<String> contentTypeList,
+      HttpServletRequest httpServletRequest,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException;
+
+  String addDocument(
+      List<String> contentTypeList,
+      MultipartBody multipartBody,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException;
+
+  String addDocument(
+      List<String> contentTypeList,
+      HttpServletRequest httpServletRequest,
+      String transformerParam,
+      InputStream message)
+      throws CatalogException;
+
+  void deleteDocument(String id) throws CatalogException;
+
+  String getFileExtensionForMimeType(String mimeType);
+}

--- a/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/CatalogServiceException.java
+++ b/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/CatalogServiceException.java
@@ -13,9 +13,9 @@
  */
 package org.codice.ddf.rest.service;
 
-public class CatalogException extends Exception {
+public class CatalogServiceException extends Exception {
 
-  public CatalogException(String message) {
+  public CatalogServiceException(String message) {
     super(message);
   }
 }

--- a/catalog/rest/pom.xml
+++ b/catalog/rest/pom.xml
@@ -24,6 +24,8 @@
     <name>DDF Catalog REST</name>
     <packaging>pom</packaging>
     <modules>
+        <module>catalog-rest-service</module>
+        <module>catalog-rest-impl</module>
         <module>catalog-rest-endpoint</module>
     </modules>
 </project>

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -280,6 +280,11 @@
             <artifactId>jts-io</artifactId>
         </dependency>
         <dependency>
+            <groupId>ddf.catalog.rest</groupId>
+            <artifactId>catalog-rest-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.action.core</groupId>
             <artifactId>action-core-impl</artifactId>
             <version>${project.version}</version>
@@ -302,11 +307,6 @@
         <dependency>
             <groupId>ddf.security.servlet</groupId>
             <artifactId>security-servlet-logout-service</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.rest</groupId>
-            <artifactId>catalog-rest-service</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -304,6 +304,11 @@
             <artifactId>security-servlet-logout-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.rest</groupId>
+            <artifactId>catalog-rest-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/catalog/CatalogApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/catalog/CatalogApplication.java
@@ -1,0 +1,389 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.catalog;
+
+import static org.codice.ddf.rest.service.CatalogService.BYTES;
+import static org.codice.ddf.rest.service.CatalogService.HEADER_ACCEPT_RANGES;
+import static org.codice.ddf.rest.service.CatalogService.HEADER_CONTENT_DISPOSITION;
+import static org.codice.ddf.rest.service.CatalogService.HEADER_CONTENT_LENGTH;
+import static spark.Spark.delete;
+import static spark.Spark.get;
+import static spark.Spark.head;
+import static spark.Spark.post;
+import static spark.Spark.put;
+
+import com.google.common.collect.ImmutableList;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.resource.DataUsageLimitExceededException;
+import ddf.catalog.resource.Resource;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.cxf.jaxrs.impl.UriBuilderImpl;
+import org.apache.http.HttpStatus;
+import org.codice.ddf.rest.service.CatalogException;
+import org.codice.ddf.rest.service.CatalogService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+import spark.Response;
+import spark.servlet.SparkApplication;
+
+public class CatalogApplication implements SparkApplication {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CatalogApplication.class);
+
+  private static final String ECLIPSE_MULTIPART_CONFIG = "org.eclipse.jetty.multipartConfig";
+
+  private static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
+
+  private CatalogService catalogService;
+
+  public CatalogApplication(CatalogService catalogService) {
+    this.catalogService = catalogService;
+  }
+
+  @Override
+  public void init() {
+    head(
+        "/catalog/",
+        (req, res) -> {
+          res.status(HttpStatus.SC_OK);
+          return res;
+        });
+
+    head("/catalog/:id", (req, res) -> getHeaders(req, res, null, req.params(":id")));
+
+    head(
+        "/catalog/sources/:sourceid/:id",
+        (req, res) -> getHeaders(req, res, req.params(":sourceid"), req.params(":id")));
+
+    get(
+        "/catalog/sources",
+        (req, res) -> {
+          final BinaryContent content = catalogService.getDocument();
+
+          res.status(HttpStatus.SC_OK);
+          res.body(IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8));
+          res.type(content.getMimeTypeValue());
+
+          // Add the Accept-ranges header to let the client know that we accept ranges in bytes
+          res.header(HEADER_ACCEPT_RANGES, BYTES);
+          return res;
+        });
+
+    get(
+        "/catalog/:id",
+        (req, res) -> getDocument(req, res, null, req.params(":id"), req.queryParams("transform")));
+
+    get(
+        "/catalog/sources/:sourceid/:id",
+        (req, res) ->
+            getDocument(
+                req,
+                res,
+                req.params(":sourceid"),
+                req.params(":id"),
+                req.queryParams("transform")));
+
+    post(
+        "/catalog/metacard",
+        (req, res) -> {
+          try {
+            final BinaryContent content =
+                catalogService.createMetacard(req.raw(), req.queryParams("transform"));
+
+            res.status(HttpStatus.SC_OK);
+            res.body(IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8));
+            res.type(content.getMimeTypeValue());
+            return res;
+          } catch (CatalogException e) {
+            return createBadRequestResponse(res, e.getMessage());
+          }
+        });
+
+    post(
+        "/catalog/",
+        (req, res) -> {
+          if (req.contentType().startsWith("multipart/")) {
+            req.attribute(
+                ECLIPSE_MULTIPART_CONFIG,
+                new MultipartConfigElement(System.getProperty(JAVA_IO_TMPDIR)));
+
+            return addDocument(
+                res,
+                req.raw().getRequestURL(),
+                req.contentType(),
+                req.queryParams("transform"),
+                req.raw(),
+                new ByteArrayInputStream(req.bodyAsBytes()));
+          }
+
+          if (req.contentType().startsWith("text/")
+              || req.contentType().startsWith("application/")) {
+            return addDocument(
+                res,
+                req.raw().getRequestURL(),
+                req.contentType(),
+                req.queryParams("transform"),
+                null,
+                new ByteArrayInputStream(req.bodyAsBytes()));
+          }
+
+          res.status(HttpStatus.SC_NOT_FOUND);
+          return res;
+        });
+
+    put(
+        "/catalog/:id",
+        (req, res) -> {
+          if (req.contentType().startsWith("multipart/")) {
+            req.attribute(
+                ECLIPSE_MULTIPART_CONFIG,
+                new MultipartConfigElement(System.getProperty(JAVA_IO_TMPDIR)));
+
+            return updateDocument(
+                res,
+                req.params(":id"),
+                req.contentType(),
+                req.queryParams("transform"),
+                req.raw(),
+                new ByteArrayInputStream(req.bodyAsBytes()));
+          }
+
+          if (req.contentType().startsWith("text/")
+              || req.contentType().startsWith("application/")) {
+            return updateDocument(
+                res,
+                req.params(":id"),
+                req.contentType(),
+                req.queryParams("transform"),
+                null,
+                new ByteArrayInputStream(req.bodyAsBytes()));
+          }
+
+          res.status(HttpStatus.SC_NOT_FOUND);
+          return res;
+        });
+
+    delete(
+        "/catalog/:id",
+        (req, res) -> {
+          try {
+            String id = req.params(":id");
+            catalogService.deleteDocument(id);
+            return javax.ws.rs.core.Response.ok(id).build();
+
+          } catch (CatalogException e) {
+            return createBadRequestResponse(res, e.getMessage());
+          }
+        });
+  }
+
+  private Response getHeaders(Request req, Response res, String sourceid, String id) {
+    try {
+      String filename = null;
+
+      MultivaluedMap<String, String> queryParamsMap = getQueryParamsMap(req);
+      URI absolutePath = new URI(req.raw().getRequestURL().toString());
+
+      final BinaryContent content =
+          catalogService.getHeaders(sourceid, id, absolutePath, queryParamsMap);
+
+      if (content == null) {
+        res.status(HttpStatus.SC_NOT_FOUND);
+        res.body("<pre>Unable to retrieve requested metacard.</pre>");
+        res.type(MediaType.TEXT_HTML);
+        return res;
+      }
+
+      res.status(HttpStatus.SC_NO_CONTENT);
+
+      // Add the Accept-ranges header to let the client know that we accept ranges in bytes
+      res.header(HEADER_ACCEPT_RANGES, BYTES);
+
+      if (content instanceof Resource) {
+        // If we got a resource, we can extract the filename.
+        filename = ((Resource) content).getName();
+      } else {
+        String fileExtension =
+            catalogService.getFileExtensionForMimeType(content.getMimeTypeValue());
+        if (StringUtils.isNotBlank(fileExtension)) {
+          filename = id + fileExtension;
+        }
+      }
+
+      if (StringUtils.isNotBlank(filename)) {
+        LOGGER.debug("filename: {}", filename);
+        res.header(HEADER_CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"");
+      }
+
+      long size = content.getSize();
+      if (size > 0) {
+        res.header(HEADER_CONTENT_LENGTH, String.valueOf(size));
+      }
+      return res;
+    } catch (CatalogException | URISyntaxException e) {
+      return createBadRequestResponse(res, e.getMessage());
+    }
+  }
+
+  private Response getDocument(
+      Request req,
+      Response res,
+      String encodedSourceId,
+      String encodedId,
+      String transformerParam) {
+    try {
+      MultivaluedMap<String, String> queryParamsMap = getQueryParamsMap(req);
+      URI absolutePath = new URI(req.raw().getRequestURL().toString());
+      String id = URLDecoder.decode(encodedId, CharEncoding.UTF_8);
+
+      final BinaryContent content =
+          catalogService.getDocument(
+              encodedSourceId,
+              encodedId,
+              transformerParam,
+              absolutePath,
+              queryParamsMap,
+              req.raw());
+
+      if (content == null) {
+        res.status(HttpStatus.SC_NOT_FOUND);
+        res.body("<pre>Unable to retrieve requested metacard.</pre>");
+        res.type(MediaType.TEXT_HTML);
+        return res;
+      }
+
+      LOGGER.debug("Read and transform complete, preparing response.");
+      res.status(HttpStatus.SC_OK);
+      res.body(IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8));
+      res.type(content.getMimeTypeValue());
+
+      // Add the Accept-ranges header to let the client know that we accept ranges in bytes
+      res.header(HEADER_ACCEPT_RANGES, BYTES);
+
+      String filename = null;
+
+      if (content instanceof Resource) {
+        // If we got a resource, we can extract the filename.
+        filename = ((Resource) content).getName();
+      } else {
+        String fileExtension =
+            catalogService.getFileExtensionForMimeType(content.getMimeTypeValue());
+        if (StringUtils.isNotBlank(fileExtension)) {
+          filename = id + fileExtension;
+        }
+      }
+
+      if (StringUtils.isNotBlank(filename)) {
+        LOGGER.debug("filename: {}", filename);
+        res.header(HEADER_CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"");
+      }
+
+      long size = content.getSize();
+      if (size > 0) {
+        res.header(HEADER_CONTENT_LENGTH, String.valueOf(size));
+      }
+
+      return res;
+    } catch (CatalogException | URISyntaxException e) {
+      return createBadRequestResponse(res, e.getMessage());
+
+    } catch (DataUsageLimitExceededException e) {
+      res.status(HttpStatus.SC_REQUEST_TOO_LONG);
+      res.body("<pre>" + e.getMessage() + "</pre>");
+      res.type(MediaType.TEXT_HTML);
+      return res;
+    } catch (IOException e) {
+      String exceptionMessage = "Unknown error occurred while processing request: ";
+      LOGGER.info(exceptionMessage, e);
+      throw new InternalServerErrorException(exceptionMessage);
+    }
+  }
+
+  private Response updateDocument(
+      Response res,
+      String id,
+      String contentType,
+      String transformerParam,
+      HttpServletRequest httpServletRequest,
+      InputStream inputStream) {
+    try {
+      List<String> contentTypeList = ImmutableList.of(contentType);
+      catalogService.updateDocument(
+          id, contentTypeList, httpServletRequest, transformerParam, inputStream);
+
+      res.status(HttpStatus.SC_OK);
+      return res;
+
+    } catch (CatalogException e) {
+      return createBadRequestResponse(res, e.getMessage());
+    }
+  }
+
+  private Response addDocument(
+      Response res,
+      StringBuffer requestUrl,
+      String contentType,
+      String transformerParam,
+      HttpServletRequest httpServletRequest,
+      InputStream inputStream) {
+    try {
+      List<String> contentTypeList = ImmutableList.of(contentType);
+      String id =
+          catalogService.addDocument(
+              contentTypeList, httpServletRequest, transformerParam, inputStream);
+
+      URI uri = new URI(requestUrl.toString());
+      UriBuilder uriBuilder = new UriBuilderImpl(uri).path("/" + id);
+
+      res.redirect(uriBuilder.build().toString(), HttpStatus.SC_CREATED);
+      res.header(Metacard.ID, id);
+      return res;
+
+    } catch (CatalogException | URISyntaxException e) {
+      return createBadRequestResponse(res, e.getMessage());
+    }
+  }
+
+  private MultivaluedMap<String, String> getQueryParamsMap(Request request) {
+    MultivaluedMap<String, String> map = new MultivaluedHashMap<>();
+    request.queryParams().forEach(param -> map.addAll(param, request.queryMap(param).values()));
+    return map;
+  }
+
+  private Response createBadRequestResponse(Response response, String entityMessage) {
+    response.status(HttpStatus.SC_BAD_REQUEST);
+    response.type(MediaType.TEXT_HTML);
+    response.body("<pre>" + entityMessage + "</pre>");
+    return response;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -301,6 +301,12 @@
         <argument ref="catalogFramework"/>
     </bean>
 
+    <reference id="catalogService" interface="org.codice.ddf.rest.service.CatalogService"/>
+
+    <bean id="catalogApplication" class="org.codice.ddf.catalog.ui.catalog.CatalogApplication">
+        <argument ref="catalogService"/>
+    </bean>
+
     <reference id="csvQueryResponseTransformer"
                interface="ddf.catalog.transform.QueryResponseTransformer" filter="(id=csv)"/>
 
@@ -438,20 +444,14 @@
         <argument ref="logoutService"/>
     </bean>
 
-    <reference id="catalogService" interface="org.codice.ddf.rest.service.CatalogService"/>
-
-    <bean id="catalogApplication" class="org.codice.ddf.catalog.ui.catalog.CatalogApplication">
-        <argument ref="catalogService"/>
-    </bean>
-
     <bean id="rootReqSupplier" class="org.codice.ddf.catalog.ui.RootContextRequestSupplier"/>
     <bean id="sparkServlet" class="org.codice.ddf.catalog.ui.SparkServlet">
         <property name="sparkApplications">
             <list>
                 <ref component-id="queryApplication"/>
                 <ref component-id="metacardApplication"/>
-                <ref component-id="catalogApplication"/>
                 <ref component-id="userApplication"/>
+                <ref component-id="catalogApplication"/>
                 <ref component-id="logoutApplication"/>
                 <ref component-id="configurationApplication"/>
                 <ref component-id="feedbackApplication"/>

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -438,12 +438,19 @@
         <argument ref="logoutService"/>
     </bean>
 
+    <reference id="catalogService" interface="org.codice.ddf.rest.service.CatalogService"/>
+
+    <bean id="catalogApplication" class="org.codice.ddf.catalog.ui.catalog.CatalogApplication">
+        <argument ref="catalogService"/>
+    </bean>
+
     <bean id="rootReqSupplier" class="org.codice.ddf.catalog.ui.RootContextRequestSupplier"/>
     <bean id="sparkServlet" class="org.codice.ddf.catalog.ui.SparkServlet">
         <property name="sparkApplications">
             <list>
                 <ref component-id="queryApplication"/>
                 <ref component-id="metacardApplication"/>
+                <ref component-id="catalogApplication"/>
                 <ref component-id="userApplication"/>
                 <ref component-id="logoutApplication"/>
                 <ref component-id="configurationApplication"/>

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -200,7 +200,7 @@ grant codeBase "file:/security-sts-server/security-sts-realm/catalog-opensearch-
     permission java.lang.RuntimePermission "createClassLoader";
 }
 
-grant codeBase "file:/catalog-rest-endpoint/catalog-transformer-resource/ftp/org.apache.tika.core/org.codice.thirdparty.tika-bundle/tika-input-transformer/video-input-transformer" {
+grant codeBase "file:/catalog-rest-impl/catalog-transformer-resource/ftp/org.apache.tika.core/org.codice.thirdparty.tika-bundle/tika-input-transformer/video-input-transformer" {
     permission java.lang.RuntimePermission "createClassLoader";
     permission java.io.FilePermission "<<ALL FILES>>", "execute";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/builder/builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/builder/builder.view.js
@@ -205,7 +205,7 @@ module.exports = Marionette.LayoutView.extend({
 
         $.ajax({
             type: 'POST',
-            url: '/search/catalog/internal/catalog/?transform=geojson',
+            url: './internal/catalog/?transform=geojson',
             data: JSON.stringify(editedMetacard),
             contentType: 'application/json'
         }).then((response, status, xhr) => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/builder/builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/builder/builder.view.js
@@ -205,7 +205,7 @@ module.exports = Marionette.LayoutView.extend({
 
         $.ajax({
             type: 'POST',
-            url: '/services/catalog/?transform=geojson',
+            url: '/search/catalog/internal/catalog/?transform=geojson',
             data: JSON.stringify(editedMetacard),
             contentType: 'application/json'
         }).then((response, status, xhr) => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/ingest/ingest.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/ingest/ingest.view.js
@@ -53,7 +53,7 @@ module.exports = Marionette.LayoutView.extend({
             this.ingestEditor.show(new IngestEditor());
         }
         this.ingestDetails.show(new IngestDetails({
-            url: '/services/catalog/',
+            url: '/search/catalog/internal/catalog/',
             preIngestValidator: isEditorShown ? this.validateAttributes.bind(this) : null
         }));
     },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/ingest/ingest.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/ingest/ingest.view.js
@@ -53,7 +53,7 @@ module.exports = Marionette.LayoutView.extend({
             this.ingestEditor.show(new IngestEditor());
         }
         this.ingestDetails.show(new IngestDetails({
-            url: '/search/catalog/internal/catalog/',
+            url: './internal/catalog/',
             preIngestValidator: isEditorShown ? this.validateAttributes.bind(this) : null
         }));
     },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/metacard-overwrite/metacard-overwrite.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/metacard-overwrite/metacard-overwrite.view.js
@@ -50,7 +50,7 @@ module.exports = Marionette.ItemView.extend({
     },
     setupDropzone: function() {
         this.dropzone = new Dropzone(this.el.querySelector('.overwrite-dropzone'), {
-            url: '/search/catalog/internal/catalog/' + this.model.get('metacard').id,
+            url: './internal/catalog/' + this.model.get('metacard').id,
             maxFilesize: 5000000, //MB
             method: 'put'
         });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/metacard-overwrite/metacard-overwrite.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/metacard-overwrite/metacard-overwrite.view.js
@@ -50,7 +50,7 @@ module.exports = Marionette.ItemView.extend({
     },
     setupDropzone: function() {
         this.dropzone = new Dropzone(this.el.querySelector('.overwrite-dropzone'), {
-            url: '/services/catalog/' + this.model.get('metacard').id,
+            url: '/search/catalog/internal/catalog/' + this.model.get('metacard').id,
             maxFilesize: 5000000, //MB
             method: 'put'
         });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-feedback/test.json
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-feedback/test.json
@@ -13,55 +13,55 @@
         "relevance": 5.002892971038818,
         "actions": [
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda",
             "title": "Export Metacard XML",
             "description": "Provides a URL to the metacard",
             "id": "catalog.data.metacard.view"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform:resource",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform:resource",
             "title": "Export as resource",
             "description": "Provides a URL to the metacard that transforms the return value via the resource transformer",
             "id": "catalog.data.metacard.resource"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=xml",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=xml",
             "title": "Export as xml",
             "description": "Provides a URL to the metacard that transforms the return value via the xml transformer",
             "id": "catalog.data.metacard.xml"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=csw:Record",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=csw:Record",
             "title": "Export as csw:Record",
             "description": "Provides a URL to the metacard that transforms the return value via the csw:Record transformer",
             "id": "catalog.data.metacard.csw:Record"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=metadata",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=metadata",
             "title": "Export as metadata",
             "description": "Provides a URL to the metacard that transforms the return value via the metadata transformer",
             "id": "catalog.data.metacard.metadata"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=gmd:MD_Metadata",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=gmd:MD_Metadata",
             "title": "Export as gmd:MD_Metadata",
             "description": "Provides a URL to the metacard that transforms the return value via the gmd:MD_Metadata transformer",
             "id": "catalog.data.metacard.gmd:MD_Metadata"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=html",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=html",
             "title": "Export as html",
             "description": "Provides a URL to the metacard that transforms the return value via the html transformer",
             "id": "catalog.data.metacard.html"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=kml",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=kml",
             "title": "Export as kml",
             "description": "Provides a URL to the metacard that transforms the return value via the kml transformer",
             "id": "catalog.data.metacard.kml"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=geojson",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/fff1b066e0ef47379eae4fc482b1eeda?transform=geojson",
             "title": "Export as geojson",
             "description": "Provides a URL to the metacard that transforms the return value via the geojson transformer",
             "id": "catalog.data.metacard.geojson"
@@ -248,55 +248,55 @@
         "relevance": 6.000020980834961,
         "actions": [
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=html",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=html",
             "title": "Export as html",
             "description": "Provides a URL to the metacard that transforms the return value via the html transformer",
             "id": "catalog.data.metacard.html"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=xml",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=xml",
             "title": "Export as xml",
             "description": "Provides a URL to the metacard that transforms the return value via the xml transformer",
             "id": "catalog.data.metacard.xml"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=csw:Record",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=csw:Record",
             "title": "Export as csw:Record",
             "description": "Provides a URL to the metacard that transforms the return value via the csw:Record transformer",
             "id": "catalog.data.metacard.csw:Record"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=resource",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=resource",
             "title": "Export as resource",
             "description": "Provides a URL to the metacard that transforms the return value via the resource transformer",
             "id": "catalog.data.metacard.resource"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=gmd:MD_Metadata",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=gmd:MD_Metadata",
             "title": "Export as gmd:MD_Metadata",
             "description": "Provides a URL to the metacard that transforms the return value via the gmd:MD_Metadata transformer",
             "id": "catalog.data.metacard.gmd:MD_Metadata"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=metadata",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=metadata",
             "title": "Export as metadata",
             "description": "Provides a URL to the metacard that transforms the return value via the metadata transformer",
             "id": "catalog.data.metacard.metadata"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50",
             "title": "Export Metacard XML",
             "description": "Provides a URL to the metacard",
             "id": "catalog.data.metacard.view"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=kml",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=kml",
             "title": "Export as kml",
             "description": "Provides a URL to the metacard that transforms the return value via the kml transformer",
             "id": "catalog.data.metacard.kml"
           },
           {
-            "url": "https://localhost:8993/services/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=geojson",
+            "url": "https://localhost:8993/search/catalog/internal/catalog/sources/ddf.distribution/ff1c478c19a44c6f9165caad92b4ef50?transform=geojson",
             "title": "Export as geojson",
             "description": "Provides a URL to the metacard that transforms the return value via the geojson transformer",
             "id": "catalog.data.metacard.geojson"

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
@@ -64,7 +64,7 @@ require([
         if (jqxhr.getResponseHeader('content-type') === 'application/json' && jqxhr.responseText.startsWith('<') &&
             jqxhr.responseText.indexOf('ACSURL') > -1 && jqxhr.responseText.indexOf('SAMLRequest') > -1) {
             return {title: 'Logged out', message: 'Please refresh page to log in'};
-        } else if (settings.url.indexOf('/search/catalog/internal/catalog/sources') > -1 && settings.type === "GET") {
+        } else if (settings.url.indexOf('./internal/catalog/sources') > -1 && settings.type === "GET") {
             return {title: 'Error Polling Sources', message: 'Unable to query server for list of active sources'};
         } else if (settings.url.indexOf('/search/catalog/internal/workspaces') > -1 && settings.type === "PUT") {
             return {title: 'Error Saving Workspace', message: 'Unable to save workspace on server'};

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationSetup.js
@@ -64,7 +64,7 @@ require([
         if (jqxhr.getResponseHeader('content-type') === 'application/json' && jqxhr.responseText.startsWith('<') &&
             jqxhr.responseText.indexOf('ACSURL') > -1 && jqxhr.responseText.indexOf('SAMLRequest') > -1) {
             return {title: 'Logged out', message: 'Please refresh page to log in'};
-        } else if (settings.url.indexOf('/services/catalog/sources') > -1 && settings.type === "GET") {
+        } else if (settings.url.indexOf('/search/catalog/internal/catalog/sources') > -1 && settings.type === "GET") {
             return {title: 'Error Polling Sources', message: 'Unable to query server for list of active sources'};
         } else if (settings.url.indexOf('/search/catalog/internal/workspaces') > -1 && settings.type === "PUT") {
             return {title: 'Error Saving Workspace', message: 'Unable to save workspace on server'};

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Sources.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Sources.js
@@ -69,7 +69,7 @@ define([
     };
 
     return Backbone.Collection.extend({
-        url: "/search/catalog/internal/catalog/sources",
+        url: "./internal/catalog/sources",
         useAjaxSync: true,
         comparator: function(a, b) {
             const aName = a.id.toLowerCase();

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Sources.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Sources.js
@@ -69,7 +69,7 @@ define([
     };
 
     return Backbone.Collection.extend({
-        url: "/services/catalog/sources",
+        url: "/search/catalog/internal/catalog/sources",
         useAjaxSync: true,
         comparator: function(a, b) {
             const aName = a.id.toLowerCase();

--- a/ui/packages/standard/src/main/webapp/js/model/source.js
+++ b/ui/packages/standard/src/main/webapp/js/model/source.js
@@ -18,7 +18,7 @@ define([
 
         return  {
             Collection: Backbone.Collection.extend({
-                url: "/search/catalog/internal/catalog/sources",
+                url: "./internal/catalog/sources",
                 useAjaxSync: true
             }),
             Types: Backbone.Collection.extend({

--- a/ui/packages/standard/src/main/webapp/js/model/source.js
+++ b/ui/packages/standard/src/main/webapp/js/model/source.js
@@ -18,7 +18,7 @@ define([
 
         return  {
             Collection: Backbone.Collection.extend({
-                url: "/services/catalog/sources",
+                url: "/search/catalog/internal/catalog/sources",
                 useAjaxSync: true
             }),
             Types: Backbone.Collection.extend({

--- a/ui/packages/standard/test.js
+++ b/ui/packages/standard/test.js
@@ -32,7 +32,7 @@ app.use(express.static(__dirname + '/src/main/webapp'));
 
 //if we're mocking, it is being run by grunt
 console.log('setting up mock query endpoint');
-app.all('/services/catalog/sources', server.mockRequest);
+app.all('/search/catalog/internal/catalog/sources', server.mockRequest);
 app.all('/services/store/config', server.mockRequest);
 app.all('/services/platform/config/ui', server.mockRequest);
 app.all('/services/user', server.mockRequest);

--- a/ui/packages/standard/test.js
+++ b/ui/packages/standard/test.js
@@ -32,7 +32,7 @@ app.use(express.static(__dirname + '/src/main/webapp'));
 
 //if we're mocking, it is being run by grunt
 console.log('setting up mock query endpoint');
-app.all('/search/catalog/internal/catalog/sources', server.mockRequest);
+app.all('./internal/catalog/sources', server.mockRequest);
 app.all('/services/store/config', server.mockRequest);
 app.all('/services/platform/config/ui', server.mockRequest);
 app.all('/services/user', server.mockRequest);

--- a/ui/packages/ui/test.js
+++ b/ui/packages/ui/test.js
@@ -26,7 +26,7 @@ app.use(express.static(__dirname + '/src/main/webapp'));
 
 //if we're mocking, it is being run by grunt
 console.log('setting up mock query endpoint');
-app.all('/search/catalog/internal/catalog/sources', server.mockSources);
+app.all('./internal/catalog/sources', server.mockSources);
 app.all('/admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/listModules', server.mockRequest);
 app.all('/admin/jolokia/exec/org.codice.ddf.admin.insecure.defaults.service.InsecureDefaultsServiceBean:service=insecure-defaults-service/validate', server.mockRequest);
 app.all('/admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/InstallationProfiles/', server.mockInstallationProfiles);

--- a/ui/packages/ui/test.js
+++ b/ui/packages/ui/test.js
@@ -26,7 +26,7 @@ app.use(express.static(__dirname + '/src/main/webapp'));
 
 //if we're mocking, it is being run by grunt
 console.log('setting up mock query endpoint');
-app.all('/services/catalog/sources', server.mockSources);
+app.all('/search/catalog/internal/catalog/sources', server.mockSources);
 app.all('/admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/listModules', server.mockRequest);
 app.all('/admin/jolokia/exec/org.codice.ddf.admin.insecure.defaults.service.InsecureDefaultsServiceBean:service=insecure-defaults-service/validate', server.mockRequest);
 app.all('/admin/jolokia/read/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/InstallationProfiles/', server.mockInstallationProfiles);


### PR DESCRIPTION
#### What does this PR do?
**This is PR 1/7**
- Moved the implementation for the REST Endpoint to a service
- Created new endpoints under `/search/catalog/internal`
- Changed URLs under `catalog-search-ui` to use the new endpoints

#### Who is reviewing it? 
@brjeter @garrettfreibott @SmithJosh 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
@andrewkfiedler
@clockard
@coyotesqrl
@rzwiefel  

#### How should this be tested? (List steps with links to updated documentation)
- Making sure ingest, query, update workes from intrigue.
- Try using multiple sources.
- Making sure non-ui ingest works as well

#### What are the relevant tickets?
[DDF-3941](https://codice.atlassian.net/browse/DDF-3941)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
