### PR TITLE
DDF-3933 Fix attribute overrides in confluence source

### DIFF
--- a/catalog/confluence/catalog-confluence-source/pom.xml
+++ b/catalog/confluence/catalog-confluence-source/pom.xml
@@ -37,6 +37,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
         </dependency>
@@ -140,11 +144,11 @@
                             security-rest-cxfwrapper,
                             ddf-security-common,
                             catalog-core-api-impl;scope=!test,
+                            platform-util,
                             commons-lang3,
                             security-core-impl
                         </Embed-Dependency>
                         <Import-Package>
-                            !org.codice.ddf.platform.util,
                             !org.codice.ddf.platform.util.http,
                             !com.sun.management,
                             *

--- a/catalog/confluence/catalog-confluence-source/src/main/java/org/codice/ddf/confluence/source/ConfluenceInputTransformer.java
+++ b/catalog/confluence/catalog-confluence-source/src/main/java/org/codice/ddf/confluence/source/ConfluenceInputTransformer.java
@@ -78,7 +78,6 @@ public class ConfluenceInputTransformer implements InputTransformer {
   public Metacard transform(InputStream input, String id) throws CatalogTransformerException {
 
     Map<String, Object> json = getJsonObject(input);
-
     return transformConfluenceResult(json, null, id);
   }
 
@@ -199,12 +198,6 @@ public class ConfluenceInputTransformer implements InputTransformer {
     ArrayList<String> associations = new ArrayList<>();
     if (StringUtils.isNotEmpty(baseUrl)) {
       associations.add(String.format("%s%s", baseUrl, getString(links, "webui")));
-      associations.add(baseUrl);
-    }
-
-    String space = getStringOrDefault(json, null, "space", "_links", "webui");
-    if (space != null) {
-      associations.add(baseUrl + space);
     }
 
     if (!associations.isEmpty()) {

--- a/catalog/confluence/catalog-confluence-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/confluence/catalog-confluence-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,6 +28,15 @@
     <reference id="resourceReader" interface="ddf.catalog.resource.ResourceReader"
                filter="(id=URLResourceReader)" />
 
+    <reference-list id="attributeInjectors" interface="ddf.catalog.data.AttributeInjector"
+                    availability="optional">
+        <reference-listener bind-method="bindPlugin" unbind-method="unbindPlugin">
+            <bean class="org.codice.ddf.platform.util.SortedServiceList"/>
+        </reference-listener>
+    </reference-list>
+
+    <reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
+
     <bean id="confluenceMetacardType" class="ddf.catalog.data.impl.MetacardTypeImpl">
         <argument value="confluence"/>
         <argument>
@@ -44,6 +53,7 @@
     <bean id="confluenceTransformer"
           class="org.codice.ddf.confluence.source.ConfluenceInputTransformer">
         <argument ref="confluenceMetacardType"/>
+        <argument ref="attributeInjectors"/>
     </bean>
 
     <service ref="confluenceMetacardType" interface="ddf.catalog.data.MetacardType">
@@ -70,6 +80,7 @@
             <argument ref="encryptionService"/>
             <argument ref="confluenceTransformer"/>
             <argument ref="resourceReader"/>
+            <argument ref="attributeRegistry"/>
             <property name="username" value=""/>
             <property name="password" value=""/>
             <property name="includeArchivedSpaces" value="false"/>
@@ -103,6 +114,7 @@
             <argument ref="encryptionService"/>
             <argument ref="confluenceTransformer"/>
             <argument ref="resourceReader"/>
+            <argument ref="attributeRegistry"/>
             <property name="username" value=""/>
             <property name="password" value=""/>
             <property name="includeArchivedSpaces" value="false"/>

--- a/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceInputTransformerTest.java
+++ b/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceInputTransformerTest.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.confluence.source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -35,7 +36,6 @@ import ddf.catalog.transform.CatalogTransformerException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -86,7 +86,8 @@ public class ConfluenceInputTransformerTest {
   public void testPageTransformWithoutRestrictionInfo() throws Exception {
     String fileContent = getFileContent("confluence_page_no_restrictions.json");
     InputStream stream = new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8));
-    validatePageMetacard(transformer.transform(stream), null, "https://myconfluence/wiki", false);
+    validatePageMetacard(
+        transformer.transform(stream), null, "https://codice.atlassian.net/wiki", false);
   }
 
   @Test
@@ -108,8 +109,9 @@ public class ConfluenceInputTransformerTest {
     assertThat(mcard.getId(), equalTo("att1182017"));
     assertThat(mcard.getTitle(), equalTo("ddf-eclipse-code-formatter.xml"));
     assertThat(
-        mcard.getAttribute(Associations.EXTERNAL).getValues().get(0).toString(),
-        equalTo("/spaces/DDF"));
+        mcard.getAttribute(Associations.EXTERNAL).getValues(),
+        contains(
+            "https://codice.atlassian.net/wiki/display/DDF/Formatting+Source+Code?preview=%2F1179681%2F1182017%2Fddf-eclipse-code-formatter.xml"));
     assertThat(mcard.getCreatedDate(), is(getDate("2013-09-18T14:44:04.892-07:00")));
     assertThat(mcard.getModifiedDate(), is(getDate("2013-09-18T14:50:42.655-07:00")));
     assertThat(mcard.getAttribute(Contact.CREATOR_NAME).getValue().toString(), equalTo("user"));
@@ -117,7 +119,7 @@ public class ConfluenceInputTransformerTest {
     assertThat(
         mcard.getAttribute(Metacard.RESOURCE_URI).getValue().toString(),
         equalTo(
-            "/download/attachments/1179681/ddf-eclipse-code-formatter.xml?version=1&modificationDate=1379541042655&api=v2"));
+            "https://codice.atlassian.net/wiki/download/attachments/1179681/ddf-eclipse-code-formatter.xml?version=1&modificationDate=1379541042655&api=v2"));
     assertThat(mcard.getResourceSize(), equalTo("30895"));
   }
 
@@ -165,8 +167,9 @@ public class ConfluenceInputTransformerTest {
     }
     assertThat(mcard.getId(), equalTo(id));
     assertThat(mcard.getTitle(), equalTo("Formatting Source Code"));
-    List<Serializable> associations = mcard.getAttribute(Associations.EXTERNAL).getValues();
-    assertThat(associations.get(associations.size() - 1).toString(), equalTo(url + "/spaces/DDF"));
+    assertThat(
+        mcard.getAttribute(Associations.EXTERNAL).getValues(),
+        contains("https://codice.atlassian.net/wiki/display/DDF/Formatting+Source+Code"));
     assertThat(mcard.getCreatedDate(), is(getDate("2013-09-18T14:50:42.616-07:00")));
     assertThat(mcard.getModifiedDate(), is(getDate("2015-06-16T19:21:39.141-07:00")));
     assertThat(mcard.getAttribute(Contact.CREATOR_NAME).getValue().toString(), equalTo("another"));

--- a/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceSourceTest.java
+++ b/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceSourceTest.java
@@ -493,10 +493,7 @@ public class ConfluenceSourceTest {
     assertThat(mcard.getTitle(), is("Formatting Source Code"));
     assertThat(
         mcard.getAttribute(Associations.EXTERNAL).getValues(),
-        contains(
-            "https://codice.atlassian.net/wiki/display/DDF/Formatting+Source+Code",
-            "https://codice.atlassian.net/wiki",
-            "https://codice.atlassian.net/wiki/spaces/DDF"));
+        contains("https://codice.atlassian.net/wiki/display/DDF/Formatting+Source+Code"));
     assertThat(mcard.getAttribute(Contact.CREATOR_NAME).getValue(), is("another"));
     assertThat(mcard.getAttribute(Contact.CONTRIBUTOR_NAME).getValue(), is("first.last"));
     assertThat(mcard.getAttribute(Media.TYPE).getValue(), is("text/html"));

--- a/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceSourceTest.java
+++ b/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceSourceTest.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.confluence.source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -26,9 +27,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ddf.catalog.data.AttributeRegistry;
+import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.types.Associations;
+import ddf.catalog.data.types.Contact;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Media;
+import ddf.catalog.data.types.Security;
+import ddf.catalog.data.types.Topic;
 import ddf.catalog.filter.FilterAdapter;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.filter.impl.SortByImpl;
@@ -46,13 +58,17 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.ws.rs.core.Response;
+import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.io.IOUtils;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.codice.ddf.confluence.api.SearchResource;
@@ -77,6 +93,8 @@ public class ConfluenceSourceTest {
 
   private ResourceReader reader;
 
+  private AttributeRegistry registry;
+
   private SearchResource client;
 
   private Response clientResponse;
@@ -86,13 +104,15 @@ public class ConfluenceSourceTest {
   @Before
   public void setup() {
 
-    MetacardType type = new MetacardTypeImpl("confluence", (List) null);
-    transformer = new ConfluenceInputTransformer(type);
+    MetacardType type =
+        new MetacardTypeImpl("confluence", MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
+    transformer = new ConfluenceInputTransformer(type, Collections.emptyList());
 
     encryptionService = mock(EncryptionService.class);
     reader = mock(ResourceReader.class);
     factory = mock(SecureCxfClientFactory.class);
     client = mock(SearchResource.class);
+    registry = mock(AttributeRegistry.class);
     clientResponse = mock(Response.class);
     when(factory.getClient()).thenReturn(client);
     doReturn(clientResponse)
@@ -100,7 +120,19 @@ public class ConfluenceSourceTest {
         .search(
             anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyBoolean());
     when(encryptionService.decryptValue(anyString())).thenReturn("decryptedPass");
-    confluence = new TestConfluenceSource(adapter, encryptionService, transformer, reader, factory);
+    when(registry.lookup("attrib1"))
+        .thenReturn(
+            Optional.of(
+                new AttributeDescriptorImpl(
+                    "attrib1", true, true, true, false, BasicTypes.STRING_TYPE)));
+    when(registry.lookup("attrib2"))
+        .thenReturn(
+            Optional.of(
+                new AttributeDescriptorImpl(
+                    "attrib2", true, true, true, true, BasicTypes.STRING_TYPE)));
+    confluence =
+        new TestConfluenceSource(
+            adapter, encryptionService, transformer, reader, registry, factory);
     confluence.setAvailabilityPollInterval(1);
     confluence.setConfigurationPid("configPid");
     confluence.setEndpointUrl("https://confluence/rest/api/content");
@@ -352,11 +384,136 @@ public class ConfluenceSourceTest {
 
   @Test
   public void testInitNoEndpointUrl() throws Exception {
-    ConfluenceSource source = new ConfluenceSource(adapter, encryptionService, transformer, reader);
+    ConfluenceSource source =
+        new ConfluenceSource(adapter, encryptionService, transformer, reader, registry);
     source.setUsername("myname");
     source.setPassword("mypass");
     source.init();
     assertThat(source.getClientFactory(), is(nullValue()));
+  }
+
+  @Test
+  public void testAttributeOverrides() throws Exception {
+    QueryRequest request =
+        new QueryRequestImpl(
+            new QueryImpl(
+                builder.attribute("anyText").is().like().text("searchValue"),
+                1,
+                1,
+                new SortByImpl("title", SortOrder.DESCENDING),
+                false,
+                1000));
+    InputStream entity = new ByteArrayInputStream(JSON_RESPONSE.getBytes(StandardCharsets.UTF_8));
+    when(clientResponse.getEntity()).thenReturn(entity);
+    when(clientResponse.getStatus()).thenReturn(Response.Status.OK.getStatusCode());
+
+    setupRegistryEntry("dateAttribute", BasicTypes.DATE_TYPE);
+    setupRegistryEntry("boolAttribute", BasicTypes.BOOLEAN_TYPE);
+    setupRegistryEntry("longAttribute", BasicTypes.LONG_TYPE);
+    setupRegistryEntry("intAttribute", BasicTypes.INTEGER_TYPE);
+    setupRegistryEntry("shortAttribute", BasicTypes.SHORT_TYPE);
+    setupRegistryEntry("floatAttribute", BasicTypes.FLOAT_TYPE);
+    setupRegistryEntry("doubleAttribute", BasicTypes.DOUBLE_TYPE);
+    setupRegistryEntry("binaryAttribute", BasicTypes.BINARY_TYPE);
+    setupRegistryEntry("badAttribute", BasicTypes.INTEGER_TYPE);
+    when(registry.lookup("missingAttribute")).thenReturn(Optional.empty());
+
+    Instant now = Instant.now();
+
+    List<String> additionalAttributes = new ArrayList<>();
+    additionalAttributes.add("attrib1=val1");
+    additionalAttributes.add("attrib2=val1,val2,val3");
+    additionalAttributes.add("dateAttribute=2018-06-28T10:44:00+07:00");
+    additionalAttributes.add("boolAttribute=true");
+    additionalAttributes.add("longAttribute=12345678900000");
+    additionalAttributes.add("intAttribute=1234");
+    additionalAttributes.add("shortAttribute=1");
+    additionalAttributes.add("floatAttribute=1.1");
+    additionalAttributes.add("doubleAttribute=1.23456");
+    additionalAttributes.add("binaryAttribute=binaryString");
+    additionalAttributes.add("badAttribute=1.23456");
+    additionalAttributes.add("missingAttribute=something");
+
+    confluence.setAttributeOverrides(additionalAttributes);
+
+    SourceResponse response = confluence.query(request);
+    assertThat(response.getHits(), is(1L));
+    Metacard mcard = response.getResults().get(0).getMetacard();
+    assertThat(mcard, notNullValue());
+    assertThat(mcard.getAttribute("attrib1").getValue(), is("val1"));
+    assertThat(mcard.getAttribute("attrib2").getValues().size(), is(3));
+    assertThat(
+        mcard.getAttribute("dateAttribute").getValue(),
+        is(DatatypeConverter.parseDateTime("2018-06-28T10:44:00+07:00").getTime()));
+    assertThat(mcard.getAttribute("boolAttribute").getValue(), is(true));
+    assertThat(mcard.getAttribute("longAttribute").getValue(), is(12345678900000L));
+    assertThat(mcard.getAttribute("intAttribute").getValue(), is(1234));
+    assertThat(mcard.getAttribute("shortAttribute").getValue(), is((short) 1));
+    assertThat(mcard.getAttribute("floatAttribute").getValue(), is(1.1f));
+    assertThat(mcard.getAttribute("doubleAttribute").getValue(), is(1.23456));
+    assertThat(
+        mcard.getAttribute("binaryAttribute").getValue(),
+        is("binaryString".getBytes(Charset.forName("UTF-8"))));
+    assertThat(mcard.getAttribute("badAttribute"), is(nullValue()));
+    assertThat(mcard.getAttribute("missingAttribute"), is(nullValue()));
+  }
+
+  @Test
+  public void verifyAllMappings() throws Exception {
+    QueryRequest request =
+        new QueryRequestImpl(
+            new QueryImpl(
+                builder.attribute("anyText").is().like().text("searchValue"),
+                1,
+                1,
+                new SortByImpl("title", SortOrder.DESCENDING),
+                false,
+                1000));
+    InputStream entity = new ByteArrayInputStream(JSON_RESPONSE.getBytes(StandardCharsets.UTF_8));
+    when(clientResponse.getEntity()).thenReturn(entity);
+    when(clientResponse.getStatus()).thenReturn(Response.Status.OK.getStatusCode());
+
+    SourceResponse response = confluence.query(request);
+    assertThat(response.getHits(), is(1L));
+    Metacard mcard = response.getResults().get(0).getMetacard();
+    assertThat(
+        mcard.getCreatedDate(),
+        is(DatatypeConverter.parseDateTime("2013-09-18T14:50:42.616-07:00").getTime()));
+    assertThat(
+        mcard.getModifiedDate(),
+        is(DatatypeConverter.parseDateTime("2015-06-16T19:21:39.141-07:00").getTime()));
+    assertThat(
+        mcard.getAttribute(Core.METACARD_CREATED).getValue(),
+        is(DatatypeConverter.parseDateTime("2013-09-18T14:50:42.616-07:00").getTime()));
+    assertThat(
+        mcard.getAttribute(Core.METACARD_MODIFIED).getValue(),
+        is(DatatypeConverter.parseDateTime("2015-06-16T19:21:39.141-07:00").getTime()));
+    assertThat(mcard.getTags(), contains("confluence", "resource"));
+    assertThat(mcard.getId(), is("1179681"));
+    assertThat(mcard.getTitle(), is("Formatting Source Code"));
+    assertThat(
+        mcard.getAttribute(Associations.EXTERNAL).getValues(),
+        contains(
+            "https://codice.atlassian.net/wiki/display/DDF/Formatting+Source+Code",
+            "https://codice.atlassian.net/wiki",
+            "https://codice.atlassian.net/wiki/spaces/DDF"));
+    assertThat(mcard.getAttribute(Contact.CREATOR_NAME).getValue(), is("another"));
+    assertThat(mcard.getAttribute(Contact.CONTRIBUTOR_NAME).getValue(), is("first.last"));
+    assertThat(mcard.getAttribute(Media.TYPE).getValue(), is("text/html"));
+    assertThat(mcard.getAttribute(Security.ACCESS_GROUPS).getValue(), is("ddf-developers"));
+    assertThat(mcard.getAttribute(Security.ACCESS_INDIVIDUALS).getValue(), is("first.last"));
+    assertThat(mcard.getAttribute(Topic.CATEGORY).getValue(), is("page"));
+    assertThat(
+        mcard.getAttribute(Topic.VOCABULARY).getValue(),
+        is(
+            "https://developer.atlassian.com/confdev/confluence-server-rest-api/advanced-searching-using-cql/cql-field-reference#CQLFieldReference-titleTitleType"));
+    assertThat(mcard.getAttribute(Topic.KEYWORD).getValue(), is("testlabel"));
+  }
+
+  private void setupRegistryEntry(String attributeName, AttributeType type) {
+    when(registry.lookup(attributeName))
+        .thenReturn(
+            Optional.of(new AttributeDescriptorImpl(attributeName, true, true, true, false, type)));
   }
 
   class TestConfluenceSource extends ConfluenceSource {
@@ -367,8 +524,9 @@ public class ConfluenceSourceTest {
         EncryptionService encryptionService,
         ConfluenceInputTransformer transformer,
         ResourceReader reader,
+        AttributeRegistry registry,
         SecureCxfClientFactory<SearchResource> mockFactory) {
-      super(adapter, encryptionService, transformer, reader);
+      super(adapter, encryptionService, transformer, reader, registry);
       this.mockFactory = mockFactory;
     }
 

--- a/catalog/confluence/catalog-confluence-source/src/test/resources/confluence_attachment.json
+++ b/catalog/confluence/catalog-confluence-source/src/test/resources/confluence_attachment.json
@@ -3,6 +3,7 @@
   "type": "attachment",
   "status": "current",
   "title": "ddf-eclipse-code-formatter.xml",
+  "baseUrl": "https://codice.atlassian.net/wiki",
   "space": {
     "id": 1277953,
     "key": "DDF",
@@ -150,7 +151,8 @@
   "_links": {
     "webui": "/display/DDF/Formatting+Source+Code?preview=%2F1179681%2F1182017%2Fddf-eclipse-code-formatter.xml",
     "download": "/download/attachments/1179681/ddf-eclipse-code-formatter.xml?version=1&modificationDate=1379541042655&api=v2",
-    "self": "https://codice.atlassian.net/wiki/rest/api/content/att1182017"
+    "self": "https://codice.atlassian.net/wiki/rest/api/content/att1182017",
+    "base": "https://codice.atlassian.net/wiki"
   },
   "_expandable": {
     "childTypes": "",

--- a/catalog/confluence/catalog-confluence-source/src/test/resources/confluence_page.json
+++ b/catalog/confluence/catalog-confluence-source/src/test/resources/confluence_page.json
@@ -3,6 +3,7 @@
   "type": "page",
   "status": "current",
   "title": "Formatting Source Code",
+  "baseUrl": "https://codice.atlassian.net/wiki",
   "space": {
     "id": 1277953,
     "key": "DDF",
@@ -218,7 +219,8 @@
   "_links": {
     "webui": "/display/DDF/Formatting+Source+Code",
     "tinyui": "/x/IQAS",
-    "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681"
+    "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681",
+    "base": "https://codice.atlassian.net/wiki"
   },
   "_expandable": {
     "childTypes": "",

--- a/catalog/confluence/catalog-confluence-source/src/test/resources/confluence_page_no_restrictions.json
+++ b/catalog/confluence/catalog-confluence-source/src/test/resources/confluence_page_no_restrictions.json
@@ -3,7 +3,7 @@
   "type": "page",
   "status": "current",
   "title": "Formatting Source Code",
-  "baseUrl": "https://myconfluence/wiki",
+  "baseUrl": "https://codice.atlassian.net/wiki",
   "space": {
     "id": 1277953,
     "key": "DDF",
@@ -133,6 +133,7 @@
   "_links": {
     "webui": "/display/DDF/Formatting+Source+Code",
     "tinyui": "/x/IQAS",
+    "base": "https://codice.atlassian.net/wiki",
     "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681"
   },
   "_expandable": {

--- a/catalog/confluence/catalog-confluence-source/src/test/resources/full_response.json
+++ b/catalog/confluence/catalog-confluence-source/src/test/resources/full_response.json
@@ -183,6 +183,15 @@
         "tinyui": "/x/IQAS",
         "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681"
       },
+      "metadata": {
+        "labels": {
+          "results": [
+            {
+              "name": "testlabel"
+            }
+          ]
+        }
+      },
       "_expandable": {
         "childTypes": "",
         "container": "/rest/api/space/DDF",


### PR DESCRIPTION
#### What does this PR do?
Injects attribute descriptors into confluence metacards and fixes attribute overrides so they are the correct type. Address some sonarqube findings as well.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@peterhuffer @emmberk @kcover 
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@shaundmorris 
@figliold
#### How should this be tested? (List steps with links to updated documentation)
Install DDF and create a confluence source.
Add overrides that are in the common taxonomy but not in the confluence type. (I used `datetime.start=2018-06-28`)
Perform a query via Intrigue using the confluence source and verify the overrides show up as expected.
#### What are the relevant tickets?
[DDF-3933](https://codice.atlassian.net/browse/DDF-3933)
