### PR TITLE
DDF-3943 Default timeout option in platform UI config

### DIFF
--- a/distribution/docs/src/main/resources/content/_tables/platform.ui.config.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/platform.ui.config.adoc
@@ -19,58 +19,65 @@
 |Enable System Usage Message
 |systemUsageEnabled
 |Boolean
-|Turns on a system usage message, which is shown when the Search Application is opened
+|Turns on a system usage message, which is shown when the Search Application is opened.
 |false
 |true
 
 |System Usage Message Title
 |systemUsageTitle
 |String
-|A title for the system usage Message when the application is opened
-|true
+|A title for the system usage Message when the application is opened.
 |
+|false
 
 |System Usage Message
 |systemUsageMessage
 |String
-|A system usage message to be displayed to the user each time the user opens the application
-|true
+|A system usage message to be displayed to the user each time the user opens the application.
 |
+|false
 
 |Show System Usage Message once per session
 |systemUsageOncePerSession
-|With this selected, the system usage message will be shown once for each browser session. Uncheck this to have the usage message appear every time the search window is opened or refreshed.
 |Boolean
+|With this selected, the system usage message will be shown once for each browser session. Uncheck this to have the usage message appear every time the search window is opened or refreshed.
 |true
 |true
 
 |Header
 |header
-|Specifies the header text to be rendered on all pages.
 |String
-|true
+|Specifies the header text to be rendered on all pages.
 |
+|false
 
 |Footer
 |footer
-|Specifies the footer text to be rendered on all pages.
 |String
-|true
+|Specifies the footer text to be rendered on all pages.
 |
+|false
 
 |Text Color
 |color
-|Specifies the Text Color of the Header and Footer. Use html css colors or `#rrggbb`.
 |String
-|true
+|Specifies the Text Color of the Header and Footer. Use html css colors or `#rrggbb`.
 |
+|false
 
 |Background Color
 |background
-|Specifies the Background Color of the Header and Footer. Use html css colors or `#rrggbb`.
 |String
-|true
+|Specifies the Background Color of the Header and Footer. Use html css colors or `#rrggbb`.
 |
+|false
+
+|Session Timeout
+|timeout
+|Integer
+|Specifies the length of inactivity (in minutes) that will cause a user to be logged out automatically. This value must be 2 minutes or greater, as users are warned when only 1 minute remains. If a value of less than 2 minutes is used, the timeout is set to the default time of 15 minutes.
+|15
+|true
 
 |===
 

--- a/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/PlatformUiConfiguration.java
+++ b/platform/platform-configuration/src/main/java/org/codice/ddf/configuration/PlatformUiConfiguration.java
@@ -20,6 +20,8 @@ import javax.ws.rs.Produces;
 import net.minidev.json.JSONObject;
 import org.codice.ddf.branding.BrandingPlugin;
 import org.codice.ddf.branding.BrandingRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Configuration class for pid=ddf.platform.ui.config.
@@ -28,6 +30,8 @@ import org.codice.ddf.branding.BrandingRegistry;
  */
 @Path("/")
 public class PlatformUiConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PlatformUiConfiguration.class);
 
   public static final String SYSTEM_USAGE_TITLE_CONFIG_KEY = "systemUsageTitle";
 
@@ -55,6 +59,10 @@ public class PlatformUiConfiguration {
 
   public static final String TIMEOUT_CONFIG_KEY = "timeout";
 
+  private static final int DEFAULT_TIMEOUT_MINUTES = 15;
+
+  private static final int MINIMUM_TIMEOUT_MINUTES = 2;
+
   private boolean systemUsageEnabled;
 
   private String systemUsageTitle;
@@ -71,7 +79,7 @@ public class PlatformUiConfiguration {
 
   private String background;
 
-  private int timeout;
+  private int timeout = DEFAULT_TIMEOUT_MINUTES;
 
   private Optional<BrandingRegistry> branding = Optional.empty();
 
@@ -182,7 +190,16 @@ public class PlatformUiConfiguration {
   }
 
   public void setTimeout(int timeout) {
-    this.timeout = timeout;
+    if (timeout >= MINIMUM_TIMEOUT_MINUTES) {
+      this.timeout = timeout;
+    } else {
+      LOGGER.warn(
+          "Received a timeout of {} minutes, which is less than the minimum timeout allowed of {}. Defaulting to {}.",
+          timeout,
+          MINIMUM_TIMEOUT_MINUTES,
+          DEFAULT_TIMEOUT_MINUTES);
+      this.timeout = DEFAULT_TIMEOUT_MINUTES;
+    }
   }
 
   public String getProductImage() {

--- a/platform/platform-configuration/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/platform-configuration/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -64,7 +64,7 @@
                 default=""
         />
         <AD
-                description="Specifies the length of inactivity (in minutes) that will cause a user to be logged out automatically. This value should be 2 minutes or greater, as users are warned when only 1 minute remains."
+                description="Specifies the length of inactivity (in minutes) that will cause a user to be logged out automatically. This value must be 2 minutes or greater, as users are warned when only 1 minute remains. If a value of less than 2 minutes is used, the timeout is set to the default time of 15 minutes."
                 name="Session Timeout" id="timeout" required="true" type="Integer"
                 default="15"
         />

--- a/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/PlatformUiConfigurationTest.java
+++ b/platform/platform-configuration/src/test/java/org/codice/ddf/configuration/PlatformUiConfigurationTest.java
@@ -13,7 +13,9 @@
  */
 package org.codice.ddf.configuration;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -26,14 +28,23 @@ import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
 import org.codice.ddf.branding.BrandingPlugin;
 import org.codice.ddf.branding.impl.BrandingRegistryImpl;
+import org.junit.Before;
 import org.junit.Test;
 
 public class PlatformUiConfigurationTest {
 
+  private static final int DEFAULT_TIMEOUT_MINUTES = 15;
+
+  private PlatformUiConfiguration configuration;
+
+  @Before
+  public void setup() {
+    configuration = new PlatformUiConfiguration();
+  }
+
   @Test
   public void testConfig() throws IOException {
     int timeout = 1234;
-    PlatformUiConfiguration configuration = new PlatformUiConfiguration();
     String wsOutput = configuration.getConfig();
     Object obj = JSONValue.parse(wsOutput); // throws JSON Parse exception if not valid json.
     if (!(obj instanceof JSONObject)) {
@@ -87,5 +98,19 @@ public class PlatformUiConfigurationTest {
             Base64.getMimeDecoder()
                 .decode((String) jsonObject.get(PlatformUiConfiguration.FAV_ICON_CONFIG_KEY))));
     assertEquals(timeout, jsonObject.get(PlatformUiConfiguration.TIMEOUT_CONFIG_KEY));
+  }
+
+  @Test
+  public void testOutOfBoundsTimeoutConfig() {
+    int outOfBoundsTimeout = 1;
+    configuration.setTimeout(outOfBoundsTimeout);
+    assertThat(configuration.getTimeout(), is(DEFAULT_TIMEOUT_MINUTES));
+  }
+
+  @Test
+  public void testLowerBoundsTimeoutConfig() {
+    int lowerBoundTimeout = 2;
+    configuration.setTimeout(lowerBoundTimeout);
+    assertThat(configuration.getTimeout(), is(lowerBoundTimeout));
   }
 }


### PR DESCRIPTION
#### What does this PR do?
- Disallows setting platform UI configuration timeout to below 2

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@emmberk @SmithJosh @mackncheesiest 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@clockard
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
Unit tests.
Manually test setting timeout below 2 defaults to 15.

#### Any background context you want to provide?
Even though the bean will have the correct timeout value, the actual value saved in the configuration file will be whatever the admin puts in the UI. For example, if the admin set a timeout of 1, the configuration will have a value of 1, but the platform ui configuration endpoint will return 15.

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
