### PR TITLE
DDF-3946 Add supported NameIdFormats to SP metadata

### DIFF
--- a/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
+++ b/platform/security/idp/security-idp-client/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
@@ -29,8 +29,10 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import javax.servlet.Filter;
 import javax.servlet.ServletException;
@@ -59,6 +61,7 @@ import org.apache.wss4j.common.crypto.Crypto;
 import org.apache.wss4j.common.crypto.CryptoType;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
+import org.apache.wss4j.common.saml.builder.SAML2Constants;
 import org.apache.wss4j.common.util.DOM2Writer;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.security.common.HttpUtils;
@@ -402,6 +405,10 @@ public class AssertionConsumerService {
   @Path("/metadata")
   @Produces("application/xml")
   public Response retrieveMetadata() throws WSSecurityException, CertificateEncodingException {
+    List<String> nameIdFormats = new ArrayList<>();
+    nameIdFormats.add(SAML2Constants.NAMEID_FORMAT_PERSISTENT);
+    nameIdFormats.add(SAML2Constants.NAMEID_FORMAT_UNSPECIFIED);
+    nameIdFormats.add(SAML2Constants.NAMEID_FORMAT_X509_SUBJECT_NAME);
     X509Certificate issuerCert =
         findCertificate(systemCrypto.getSignatureAlias(), systemCrypto.getSignatureCrypto());
     X509Certificate encryptionCert =
@@ -423,6 +430,7 @@ public class AssertionConsumerService {
             entityId,
             Base64.getEncoder().encodeToString(issuerCert.getEncoded()),
             Base64.getEncoder().encodeToString(encryptionCert.getEncoded()),
+            nameIdFormats,
             logoutLocation,
             assertionConsumerServiceLocation,
             assertionConsumerServiceLocation,

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SamlProtocol.java
@@ -377,6 +377,7 @@ public class SamlProtocol {
       String entityId,
       String signingCert,
       String encryptionCert,
+      List<String> nameIds,
       String singleLogOutLocation,
       String assertionConsumerServiceLocationRedirect,
       String assertionConsumerServiceLocationPost,
@@ -408,6 +409,12 @@ public class SamlProtocol {
     encKeyInfo.getX509Datas().add(encX509Data);
     encKeyDescriptor.setKeyInfo(encKeyInfo);
     spSsoDescriptor.getKeyDescriptors().add(encKeyDescriptor);
+
+    for (String nameId : nameIds) {
+      NameIDFormat nameIDFormat = nameIdFormatBuilder.buildObject();
+      nameIDFormat.setFormat(nameId);
+      spSsoDescriptor.getNameIDFormats().add(nameIDFormat);
+    }
 
     addSingleLogoutLocation(singleLogOutLocation, spSsoDescriptor.getSingleLogoutServices());
 

--- a/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/SamlProtocolTest.java
+++ b/platform/security/platform-security-core-api/src/test/java/ddf/security/samlp/SamlProtocolTest.java
@@ -145,6 +145,7 @@ public class SamlProtocolTest {
             "myid",
             "mysigningcert",
             "myencryptioncert",
+            Arrays.asList("mynameid"),
             "logoutlocation",
             "redirectlocation",
             "postlocation",
@@ -174,6 +175,13 @@ public class SamlProtocolTest {
             .getX509Certificates()
             .get(0)
             .getValue());
+    assertEquals(
+        "mynameid",
+        entityDescriptor
+            .getSPSSODescriptor(SamlProtocol.SUPPORTED_PROTOCOL)
+            .getNameIDFormats()
+            .get(0)
+            .getFormat());
     assertEquals(
         "logoutlocation",
         entityDescriptor


### PR DESCRIPTION
#### What does this PR do?
Adds all supported NameIdFormats to the SP metadata so it is clear which formats we do and do not support.

#### Who is reviewing it? 
@bakejeyner @vinamartin @alexaabrd 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@brendan-hofmann
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Verify that the SP metadata contains the three supported NameIdFormats:
```
urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName
```
The SP metadata can be found at https://localhost:8993/services/saml/sso/metadata
#### Any background context you want to provide?
CAS 5 can be used as an IdP, but fails authentication if the requested NameIdFormat is not listed as supported by the SP. Being more explicit about the formats we support will increase interoperability with external IdPs.

#### What are the relevant tickets?
[DDF-3946](https://codice.atlassian.net/browse/DDF-3946)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
