### PR TITLE
DDF-3939 Search templates fail to search if date or anyGeo fields are left unfilled

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -262,8 +262,14 @@ define([
             }
         },
         deleteInvalidFilters: function(){
-            var currentValue = this.filterInput.currentView.model.getValue()[0];
-            if (currentValue === null){
+            const multiValueView = this.filterInput.currentView;
+            const valueCollectionView = multiValueView.values.currentView;
+            let allValid = valueCollectionView.children.every(function (valueView){
+                  const inputView = valueView.input.currentView;
+                  return inputView.isValid();
+            });
+
+            if (!allValid){
                 this.delete();
             }
         },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
@@ -104,6 +104,10 @@ define([
             }.bind(this));
 
         },
+        isValid: function(){
+            var currentValue = this.$el.find('input').val();
+            return currentValue != null && currentValue !== '';
+        },
         onDestroy: function(){
             var datetimepicker = this.$el.find('.input-group.date').data('DateTimePicker');
             if (datetimepicker) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/enum/input-enum.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/enum/input-enum.view.js
@@ -134,9 +134,6 @@ define([
             }
         },
         isValid: function(){
-            if (!this.model.showValidationIssues()){
-                return true;
-            }
             var value = getValue(this.model);
             var choice = this.model.get('property').get('enum').filter(function(choice){
                 return value.filter(function(subvalue){

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/input.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/input.view.js
@@ -70,7 +70,9 @@ define([
             }
         },
         handleValidation: function(){
-            this.$el.toggleClass('has-validation-issues', !this.model.isValid());
+            if (this.model.showValidationIssues()){
+                this.$el.toggleClass('has-validation-issues', !this.model.isValid());
+            }
         },
         isValid: function(){
             return true; //overwrite on a per input basis   

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/location/input-location.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/location/input-location.view.js
@@ -44,6 +44,9 @@ define([
         listenForChange: function(){
              this.listenTo(this.locationRegion.currentView.model, 'change', this.triggerChange);   
         },
+        isValid: function(){
+             return this.locationRegion.currentView.isValid();
+        },
         initializeRadio: function(){
             this.locationRegion.show(new LocationView({
                 model: this.model

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/number/input-number.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/number/input-number.view.js
@@ -28,9 +28,6 @@ module.exports = InputView.extend({
             }
         },
         isValid: function(){
-            if (!this.model.showValidationIssues()){
-                return true;
-            }
             return this.getCurrentValue() !== '';
         }
 });

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -229,5 +229,8 @@ module.exports = Marionette.LayoutView.extend({
     },
     onDestroy: function() {
         wreqr.vent.trigger('search:drawend', this.model);
+    },
+    isValid: function(){
+        return this.getCurrentValue().type != undefined;
     }
 });


### PR DESCRIPTION
Search templates fail to search if date or anyGeo fields are left unfilled
Note: this change impacts all search filters (not just templates). Any filter containing an input where isValid() returns false will be removed from the search. 

* modify isValid implementation for several input views
* remove all invalid filters at search time

#### Who is reviewing it? 
@andrewkfiedler
@djblue 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@bdeining
@millerw8 
#### How should this be tested? (List steps with links to updated documentation
Create searches (advanced, basic, and template) with invalid fields and confirm that the fields are removed.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3939](https://codice.atlassian.net/browse/DDF-3939)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
(if this behavior is accepted I will update the documentation and add unit tests)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
