### PR TITLE
DDF-3855: External Hostname Support for CSRF Filter

### DIFF
--- a/platform/security/filter/security-filter-csrf/pom.xml
+++ b/platform/security/filter/security-filter-csrf/pom.xml
@@ -70,17 +70,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.91</minimum>
+                                            <minimum>0.96</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.91</minimum>
+                                            <minimum>1.00</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.84</minimum>
+                                            <minimum>0.94</minimum>
                                         </limit>
                                     </limits>
                                 </rule>


### PR DESCRIPTION
#### What does this PR do?
CSRF filter now compares the origin or referer header for incoming requests to the hostname and port specified in system.properties for local and external authorities. This allows the CSRF to operate properly when behind a proxy that does not modify origin or referer headers so long as the system.properties is correctly configured to include the proxy's hostname + port.

#### Who is reviewing it? 
@adimka 
@austinsteffes 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann
@andrewkfiedler 

#### How should this be tested?
The main addition is the ability to run DDF behind a proxy without CSRF Filter violations, so set up DDF with a proxy with proper settings in system.properties and ensure everything still works. Also see testing section of previous PR here: https://github.com/codice/ddf/pull/3297 for a more detailed list of contexts to test.

#### What are the relevant tickets?
Addition to [DDF-3855](https://codice.atlassian.net/browse/DDF-3855) from proxy compatibility

#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [X] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
