### PR TITLE
DDF-3719 Adds defaultConfig to `disable-idp` command

### DIFF
--- a/ui/packages/ace/lib/default-wcpm-config.json
+++ b/ui/packages/ace/lib/default-wcpm-config.json
@@ -1,0 +1,36 @@
+{
+  "traversalDepth": [
+    "20"
+  ],
+  "realms": [
+    "/=karaf"
+  ],
+  "authenticationTypes": [
+    "/=IDP|GUEST",
+    "/solr=SAML|PKI|BASIC"
+  ],
+  "requiredAttributes": [
+    "/=",
+    "/admin={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=system-admin}",
+    "/solr={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=system-admin}",
+    "/system={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=system-admin}",
+    "/security-config={http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=system-admin}"
+  ],
+  "whiteListContexts": [
+    "${org.codice.ddf.system.rootContext}/SecurityTokenService",
+    "${org.codice.ddf.system.rootContext}/internal/metrics",
+    "/proxy",
+    "${org.codice.ddf.system.rootContext}/saml",
+    "${org.codice.ddf.system.rootContext}/idp",
+    "/idp",
+    "${org.codice.ddf.system.rootContext}/platform/config/ui",
+    "/login",
+    "/logout",
+    "${org.codice.ddf.system.rootContext}/internal/session",
+    "/error",
+    "/webjars",
+    "/health-check",
+    "/readiness-check"
+  ],
+  "service.pid": "org.codice.ddf.security.policy.context.impl.PolicyManager"
+}

--- a/ui/packages/ace/lib/disable-idp.js
+++ b/ui/packages/ace/lib/disable-idp.js
@@ -34,6 +34,8 @@ const createClient = ({ auth, hostname, port }) =>
     req.end()
   })
 
+const defaultConfig = [{ properties: require('./default-wcpm-config.json') }]
+
 module.exports = async ({ args }) => {
   const auth = process.env.AUTH || args.auth || 'admin:admin'
   const hostname = process.env.HOST || args.host || 'localhost'
@@ -43,7 +45,7 @@ module.exports = async ({ args }) => {
   const pid = 'org.codice.ddf.security.policy.context.impl.PolicyManager'
 
   const { value } = JSON.parse(await exec('listServices'))
-  const [{ configurations }] = value.filter(({ id }) => id === pid)
+  const [{ configurations = defaultConfig }] = value.filter(({ id }) => id === pid)
   const [{ properties }] = configurations
 
   properties.authenticationTypes.shift()


### PR DESCRIPTION
#### What does this PR do?

Previously, the `disable-idp` command would:

- fetch the existing web context policy configuration
- apply a minimal change to the policy (remove IDP from authentication types)
- save the altered policy back into configuration admin

An issue would occur if there was no existing configuration, but this is
easily fixed by embedding the default config into the script.

#### Who is reviewing it? 

@mackncheesiest 
@tbatie 


#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@brendan-hofmann

#### How should this be tested?

#### What are the relevant tickets?

[DDF-3719](https://codice.atlassian.net/browse/DDF-3719)

#### Checklist:

- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
