### PR TITLE
DDF-3941 - Moved intrigue from using the LogoutService endpoint under /services

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -295,6 +295,11 @@
             <artifactId>catalog-ui-search-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.servlet</groupId>
+            <artifactId>security-servlet-logout-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/LogoutApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/LogoutApplication.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.security;
+
+import static spark.Spark.get;
+
+import org.apache.http.HttpStatus;
+import org.codice.ddf.security.logout.service.LogoutService;
+import spark.servlet.SparkApplication;
+
+public class LogoutApplication implements SparkApplication {
+
+  private LogoutService logoutService;
+
+  public LogoutApplication(LogoutService logoutService) {
+    this.logoutService = logoutService;
+  }
+
+  @Override
+  public void init() {
+    get(
+        "/logout/actions",
+        (req, res) -> {
+          String jsonString = logoutService.getActionProviders(req.raw());
+
+          res.status(HttpStatus.SC_OK);
+          res.header("Cache-Control", "no-cache, no-store");
+          res.header("Pragma", "no-cache");
+          res.body(jsonString);
+          return res;
+        });
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -432,6 +432,12 @@
         <argument ref="endpointUtil"/>
     </bean>
 
+    <reference id="logoutService" interface="org.codice.ddf.security.logout.service.LogoutService"/>
+
+    <bean id="logoutApplication" class="org.codice.ddf.catalog.ui.security.LogoutApplication">
+        <argument ref="logoutService"/>
+    </bean>
+
     <bean id="rootReqSupplier" class="org.codice.ddf.catalog.ui.RootContextRequestSupplier"/>
     <bean id="sparkServlet" class="org.codice.ddf.catalog.ui.SparkServlet">
         <property name="sparkApplications">
@@ -439,6 +445,7 @@
                 <ref component-id="queryApplication"/>
                 <ref component-id="metacardApplication"/>
                 <ref component-id="userApplication"/>
+                <ref component-id="logoutApplication"/>
                 <ref component-id="configurationApplication"/>
                 <ref component-id="feedbackApplication"/>
                 <ref component-id="searchFormsApplication"/>

--- a/features/security/pom.xml
+++ b/features/security/pom.xml
@@ -303,7 +303,17 @@
         </dependency>
         <dependency>
             <groupId>ddf.security.servlet</groupId>
+            <artifactId>security-servlet-logout-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.servlet</groupId>
             <artifactId>security-servlet-logout</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.servlet</groupId>
+            <artifactId>security-servlet-logout-endpoint</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -503,7 +503,9 @@
         <feature>cxf-jaxrs</feature>
         <feature>security-handler-api</feature>
         <feature>security-core</feature>
+        <bundle>mvn:ddf.security.servlet/security-servlet-logout-service/${project.version}</bundle>
         <bundle>mvn:ddf.security.servlet/security-servlet-logout/${project.version}</bundle>
+        <bundle>mvn:ddf.security.servlet/security-servlet-logout-endpoint/${project.version}</bundle>
         <bundle>mvn:io.fastjson/boon/${boon.version}</bundle>
     </feature>
 

--- a/platform/security/servlet/pom.xml
+++ b/platform/security/servlet/pom.xml
@@ -24,7 +24,9 @@
     <name>DDF Security Servlet</name>
     <packaging>pom</packaging>
     <modules>
+        <module>security-servlet-logout-service</module>
         <module>security-servlet-logout</module>
+        <module>security-servlet-logout-endpoint</module>
         <module>security-servlet-whoami</module>
         <module>security-servlet-session-expiry</module>
     </modules>

--- a/platform/security/servlet/security-servlet-logout-endpoint/pom.xml
+++ b/platform/security/servlet/security-servlet-logout-endpoint/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>ddf.security.servlet</groupId>
+        <artifactId>security-servlet</artifactId>
+        <version>2.13.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>security-servlet-logout-endpoint</artifactId>
+    <name>DDF :: Security :: Servlet :: Logout :: Endpoint</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.security.servlet</groupId>
+            <artifactId>security-servlet-logout-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/security/servlet/security-servlet-logout-endpoint/src/main/java/org/codice/ddf/security/logout/endpoint/LogoutEndpoint.java
+++ b/platform/security/servlet/security-servlet-logout-endpoint/src/main/java/org/codice/ddf/security/logout/endpoint/LogoutEndpoint.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.logout.endpoint;
+
+import ddf.security.service.SecurityServiceException;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import org.codice.ddf.security.logout.service.LogoutService;
+
+@Path("/")
+public class LogoutEndpoint {
+
+  private LogoutService logoutService;
+
+  public LogoutEndpoint(LogoutService logoutService) {
+    this.logoutService = logoutService;
+  }
+
+  @GET
+  @Path("/actions")
+  public Response getActionProviders(@Context HttpServletRequest request)
+      throws SecurityServiceException {
+
+    String jsonString = logoutService.getActionProviders(request);
+
+    return Response.ok(new ByteArrayInputStream(jsonString.getBytes(StandardCharsets.UTF_8)))
+        .header("Cache-Control", "no-cache, no-store")
+        .header("Pragma", "no-cache")
+        .build();
+  }
+}

--- a/platform/security/servlet/security-servlet-logout-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/servlet/security-servlet-logout-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+
+    <reference id="logoutService" interface="org.codice.ddf.security.logout.service.LogoutService"/>
+
+    <bean id="logoutServiceEndpoint" class="org.codice.ddf.security.logout.endpoint.LogoutEndpoint">
+        <argument ref="logoutService"/>
+    </bean>
+
+    <jaxrs:server id="restService" address="/logout">
+        <jaxrs:serviceBeans>
+            <ref component-id="logoutServiceEndpoint"/>
+        </jaxrs:serviceBeans>
+    </jaxrs:server>
+
+</blueprint>

--- a/platform/security/servlet/security-servlet-logout-service/pom.xml
+++ b/platform/security/servlet/security-servlet-logout-service/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>ddf.security.servlet</groupId>
+        <artifactId>security-servlet</artifactId>
+        <version>2.13.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>security-servlet-logout-service</artifactId>
+    <name>DDF :: Security :: Servlet :: Logout :: Service</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/security/servlet/security-servlet-logout-service/src/main/java/org/codice/ddf/security/logout/service/LogoutService.java
+++ b/platform/security/servlet/security-servlet-logout-service/src/main/java/org/codice/ddf/security/logout/service/LogoutService.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.logout.service;
+
+import ddf.security.service.SecurityServiceException;
+import javax.servlet.http.HttpServletRequest;
+
+public interface LogoutService {
+
+  String getActionProviders(HttpServletRequest request) throws SecurityServiceException;
+}

--- a/platform/security/servlet/security-servlet-logout/pom.xml
+++ b/platform/security/servlet/security-servlet-logout/pom.xml
@@ -110,6 +110,11 @@
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.servlet</groupId>
+            <artifactId>security-servlet-logout-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutServiceImpl.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LogoutServiceImpl.java
@@ -23,24 +23,18 @@ import ddf.security.common.SecurityTokenHolder;
 import ddf.security.http.SessionFactory;
 import ddf.security.service.SecurityManager;
 import ddf.security.service.SecurityServiceException;
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.shiro.subject.Subject;
+import org.codice.ddf.security.logout.service.LogoutService;
 
-@Path("/")
-public class LogoutService {
+public class LogoutServiceImpl implements LogoutService {
 
   private List<ActionProvider> logoutActionProviders;
 
@@ -48,10 +42,8 @@ public class LogoutService {
 
   private SecurityManager securityManager;
 
-  @GET
-  @Path("/actions")
-  public Response getActionProviders(@Context HttpServletRequest request)
-      throws SecurityServiceException {
+  @Override
+  public String getActionProviders(HttpServletRequest request) throws SecurityServiceException {
 
     HttpSession session = httpSessionFactory.getOrCreateSession(request);
     Map<String, SecurityToken> realmTokenMap =
@@ -84,11 +76,7 @@ public class LogoutService {
       }
     }
 
-    return Response.ok(
-            new ByteArrayInputStream(toJson(realmToPropMaps).getBytes(StandardCharsets.UTF_8)))
-        .header("Cache-Control", "no-cache, no-store")
-        .header("Pragma", "no-cache")
-        .build();
+    return toJson(realmToPropMaps);
   }
 
   public void setHttpSessionFactory(SessionFactory httpSessionFactory) {

--- a/platform/security/servlet/security-servlet-logout/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/servlet/security-servlet-logout/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,8 +13,8 @@
 <blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.2.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
-           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
 
     <service interface="ddf.action.ActionProvider">
@@ -36,21 +36,18 @@
     <reference-list id="logoutActionProvidersList" interface="ddf.action.ActionProvider"
                     filter="(id=security.logout.*)" availability="optional"/>
 
-    <bean id="logoutService" class="org.codice.ddf.security.servlet.logout.LogoutService">
-        <cm:managed-properties persistent-id="org.codice.ddf.security.servlet.logout.LogoutService"
-                               update-strategy="container-managed"/>
-        <property name="logoutActionProviders" ref="logoutActionProvidersList"></property>
+    <bean id="logoutService" class="org.codice.ddf.security.servlet.logout.LogoutServiceImpl">
+        <cm:managed-properties
+                persistent-id="org.codice.ddf.security.servlet.logout.LogoutServiceImpl"
+                update-strategy="container-managed"/>
+        <property name="logoutActionProviders" ref="logoutActionProvidersList"/>
         <property name="securityManager" ref="securityManager"/>
         <property name="httpSessionFactory">
             <reference interface="ddf.security.http.SessionFactory" filter="(id=http)"/>
         </property>
     </bean>
 
-    <jaxrs:server id="restService" address="/logout">
-        <jaxrs:serviceBeans>
-            <ref component-id="logoutService"/>
-        </jaxrs:serviceBeans>
-    </jaxrs:server>
+    <service ref="logoutService" interface="org.codice.ddf.security.logout.service.LogoutService"/>
 
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
 

--- a/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/LogoutServiceImplTest.java
+++ b/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/LogoutServiceImplTest.java
@@ -23,8 +23,6 @@ import ddf.security.common.SecurityTokenHolder;
 import ddf.security.http.SessionFactory;
 import ddf.security.service.SecurityManager;
 import ddf.security.service.SecurityServiceException;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,11 +32,10 @@ import net.minidev.json.JSONObject;
 import net.minidev.json.parser.JSONParser;
 import net.minidev.json.parser.ParseException;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
-import org.apache.tika.io.IOUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class LogoutServiceTest {
+public class LogoutServiceImplTest {
 
   private static SessionFactory sessionFactory;
 
@@ -63,20 +60,19 @@ public class LogoutServiceTest {
   }
 
   @Test
-  public void testLogout() throws IOException, ParseException, SecurityServiceException {
+  public void testLogout() throws ParseException, SecurityServiceException {
     KarafLogoutAction karafLogoutActionProvider = new KarafLogoutAction();
     LdapLogoutAction ldapLogoutActionProvider = new LdapLogoutAction();
     Action karafLogoutAction = karafLogoutActionProvider.getAction(null);
     Action ldapLogoutAction = ldapLogoutActionProvider.getAction(null);
 
-    LogoutService logoutService = new LogoutService();
-    logoutService.setHttpSessionFactory(sessionFactory);
-    logoutService.setSecurityManager(sm);
-    logoutService.setLogoutActionProviders(
+    LogoutServiceImpl logoutServiceImpl = new LogoutServiceImpl();
+    logoutServiceImpl.setHttpSessionFactory(sessionFactory);
+    logoutServiceImpl.setSecurityManager(sm);
+    logoutServiceImpl.setLogoutActionProviders(
         Arrays.asList(karafLogoutActionProvider, ldapLogoutActionProvider));
 
-    String responseMessage =
-        IOUtils.toString((ByteArrayInputStream) logoutService.getActionProviders(null).getEntity());
+    String responseMessage = logoutServiceImpl.getActionProviders(null);
 
     JSONArray actionProperties = (JSONArray) new JSONParser().parse(responseMessage);
     assertEquals(2, actionProperties.size());

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/logout-actions.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/logout-actions.js
@@ -26,7 +26,7 @@ var LogoutAction = Backbone.AssociatedModel.extend({
 
 var LogoutActions = Backbone.Collection.extend({
     model: LogoutAction,
-    url: '/services/logout/actions'
+    url: '/search/catalog/internal/logout/actions'
 });
 
 var logoutModel = new (Backbone.AssociatedModel.extend({
@@ -41,7 +41,7 @@ var logoutModel = new (Backbone.AssociatedModel.extend({
             collectionType: LogoutActions
         }
     ],
-    url: '/services/logout/actions',
+    url: '/search/catalog/internal/logout/actions',
     initialize: function() {
         this.listenTo(this, 'sync:actions', this.setFetched);
         this.get('actions').fetch();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/logout-actions.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/logout-actions.js
@@ -26,7 +26,7 @@ var LogoutAction = Backbone.AssociatedModel.extend({
 
 var LogoutActions = Backbone.Collection.extend({
     model: LogoutAction,
-    url: '/search/catalog/internal/logout/actions'
+    url: './internal/logout/actions'
 });
 
 var logoutModel = new (Backbone.AssociatedModel.extend({
@@ -41,7 +41,7 @@ var logoutModel = new (Backbone.AssociatedModel.extend({
             collectionType: LogoutActions
         }
     ],
-    url: '/search/catalog/internal/logout/actions',
+    url: './internal/logout/actions',
     initialize: function() {
         this.listenTo(this, 'sync:actions', this.setFetched);
         this.get('actions').fetch();


### PR DESCRIPTION
#### What does this PR do?
**This is PR 5/7**
- Moved endpoint for the LogoutService into a new module
- Added new endpoint under /search/catalog/internal
- Changed Intrigue code to use new endpoint

#### Who is reviewing it? 
@brjeter @bakejeyner 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
- Look at the network activity in intrigue and verify that `/search/catalog/internal/logout/action` is called and that the response is a 200 with a json body

#### What are the relevant tickets?
[DDF-3941](https://codice.atlassian.net/browse/DDF-3941)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
