### PR TITLE
DDF-3960 Update SecurityPlugin to not override POC attribute

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/resources/json/record/UpdatedSimpleGeoJsonRecord
+++ b/distribution/test/itests/test-itests-common/src/main/resources/json/record/UpdatedSimpleGeoJsonRecord
@@ -1,0 +1,20 @@
+{
+    "properties": {
+        "title": "myTitle",
+        "thumbnail": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=",
+        "created": "2012-09-01T00:09:19.368+0000",
+        "metadata-content-type-version": "myVersion",
+        "metadata-content-type": "myType",
+        "metadata": "<xml>text</xml>",
+        "modified": "2012-09-01T00:09:19.368+0000",
+        "point-of-contact": "updated-admin@local"
+    },
+    "type": "Feature",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            30.0,
+            10.0
+        ]
+    }
+}

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -130,9 +130,11 @@ import org.w3c.dom.Node;
 @ExamReactorStrategy(PerSuite.class)
 public class TestCatalog extends AbstractIntegrationTest {
 
-  public static final String ADMIN = "admin";
+  private static final String ADMIN = "admin";
 
-  public static final String ADMIN_EMAIL = "admin@localhost.local";
+  private static final String ADMIN_EMAIL = "admin@localhost.local";
+
+  private static final String JSON_RECORD_POC = "admin@local";
 
   private static final String METACARD_X_PATH = "/metacards/metacard[@id='%s']";
 
@@ -318,7 +320,9 @@ public class TestCatalog extends AbstractIntegrationTest {
         .body(hasXPath("/metacard[@id='" + id + "']"))
         .body(
             hasXPath(
-                "/metacard/string[@name='point-of-contact']/value[text()='" + ADMIN_EMAIL + "']"));
+                "/metacard/string[@name='point-of-contact']/value[text()='"
+                    + JSON_RECORD_POC
+                    + "']"));
 
     deleteMetacard(id);
   }
@@ -348,7 +352,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .preemptive()
         .basic(ADMIN, ADMIN)
         .header(HttpHeaders.CONTENT_TYPE, "application/json")
-        .body(getFileContent(JSON_RECORD_RESOURCE_PATH + "/SimpleGeoJsonRecord"))
+        .body(getFileContent(JSON_RECORD_RESOURCE_PATH + "/UpdatedSimpleGeoJsonRecord"))
         .expect()
         .log()
         .all()


### PR DESCRIPTION
#### What does this PR do?
- Don't override POC attribute in SecurityPlugin if it is already present.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@emmberk @kcover @brjeter 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams


#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@clockard
@stustison

#### How should this be tested? (List steps with links to updated documentation)
Unit tests.

#### Any background context you want to provide?
When a Metacard created on one system is sent over to another system, it rewrites the POC. Then if the original system sends an update, the PointOfContactPolicyPlugin sees 2 different POCs and rejects the update.

#### What are the relevant tickets?
[DDF-3960](https://codice.atlassian.net/browse/DDF-3960)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
