### PR TITLE
DDF-3962 Resolve IE10 compatibility issue

### DIFF
--- a/ui/packages/ace/lib/webpack.config.js
+++ b/ui/packages/ace/lib/webpack.config.js
@@ -46,7 +46,10 @@ const babelLoader = (plugins = []) => ({
 })
 
 const base = ({ alias = {}, env }) => ({
-  entry: [nodeResolve('babel-polyfill')],
+  entry: [
+    nodeResolve('babel-polyfill'),
+    nodeResolve('whatwg-fetch')
+  ],
   output: {
     path: resolve('./target/webapp'),
     filename: 'bundle.[hash].js',

--- a/ui/packages/ace/package.json
+++ b/ui/packages/ace/package.json
@@ -60,6 +60,7 @@
     "webpack-bundle-analyzer": "2.13.1",
     "webpack-dev-server": "3.1.1",
     "webpack-merge": "4.1.2",
+    "whatwg-fetch": "2.0.4",
     "worker-loader": "1.1.1"
   },
   "devDependencies": {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/router/routes-loader.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/router/routes-loader.js
@@ -48,8 +48,8 @@ module.exports = function (source, map) {
     }).join(',');
     this.callback(null, [
       `
-      const $ = require('jquery')
-      const onComponentResolution = function(deferred, options, component) {
+      var $ = require('jquery')
+      var onComponentResolution = function(deferred, options, component) {
         this.component = this.component || new component(options);
         deferred.resolve(this.component);
       }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15642,7 +15642,7 @@ whatwg-fetch@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz#fe294d1d89e36c5be8b3195057f2e4bc74fc980e"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@2.0.4, whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 


### PR DESCRIPTION
#### What does this PR do?

The code the `routes-loader` generates doesn't get passed through babel,
so we cannot use ES6 features. We could figure out a way to pass the
code through babel, but it is sufficient to simply not use the features
for now.

The fetch api is unavailable in IE10, we can address this issue by using
a polyfill.

#### Who is reviewing it? 

@mackncheesiest 
@Schachte 

#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@rzwiefel

#### How should this be tested?

- Full build of the ui directory
- Load catalog-ui-search module in IE10 browser
- Ensure functionality is restored

#### What are the relevant tickets?

[DDF-3962](https://codice.atlassian.net/browse/DDF-3962)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
