### PR TITLE
DDF-3963 Added access to keystore for Registry Federation Admin

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -102,6 +102,7 @@ grant codeBase "file:/registry-api-impl/catalog-plugin-metacardbackup-filestorag
 
 grant codeBase "file:/registry-federation-admin-impl" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}registry${/}-", "read";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";
 }
 
 grant codeBase "file:/spatial-csw-source/spatial-csw-endpoint/org.apache.camel.camel-core/com.google.guava/ddf-pubsub/registry-source-configuration-handler/registry-api-impl/org.apache.camel.camel-blueprint/fabric8-karaf-checks" {


### PR DESCRIPTION
#### What does this PR do?
Give access to the keystore file for the Registry Federation Admin Impl, which allows for an admin to save the local node description and save/modify a contact.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@emmberk @peterhuffer 
#### Select relevant component teams: 
@codice/security 
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@clockard 
@stustison
#### How should this be tested? (List steps with links to updated documentation)
Apply the policy change to a DDF
Verify the local node description can be updated
Verify the contact can be saved
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3963](https://codice.atlassian.net/browse/DDF-3963)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
