### PR TITLE
DDF-2824 Cleanup usages of ddf.home in docs

### DIFF
--- a/distribution/docs/src/main/resources/content/_configuring/global-settings.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/global-settings.adoc
@@ -439,7 +439,7 @@ Thumbs.db
 |solr.data.dir
 |String
 |Solr Data Directory
-|${ddf.home}/data/solr
+|${home_directory}/data/solr
 |Yes
 
 |Solr Catalog Provider Url

--- a/distribution/docs/src/main/resources/content/_tables/CatalogBackupPlugin.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/CatalogBackupPlugin.adoc
@@ -19,7 +19,7 @@
 |Root backup directory path
 |rootBackupDir
 |String
-|Root backup directory for Metacards. A relative path is relative to ddf.home.
+|Root backup directory for Metacards. A relative path is relative to ${home_directory}.
 |data/backup
 |true
 

--- a/distribution/docs/src/main/resources/content/_tables/URLResourceReader.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/URLResourceReader.adoc
@@ -25,7 +25,7 @@
 |Root Resource Directories
 |rootResourceDirectories
 |String
-|List of root resource directories. A relative path is relative to ddf.home. Specifies the only directories the URLResourceReader has access to when attempting to download resources linked using file-based URLs.
+|List of root resource directories. A relative path is relative to ${home_directory}. Specifies the only directories the URLResourceReader has access to when attempting to download resources linked using file-based URLs.
 |data/products
 
 |===

--- a/distribution/docs/src/main/resources/content/_tables/sts.client.configuration.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/sts.client.configuration.adoc
@@ -68,21 +68,21 @@
 |Signature Properties
 |signatureProperties
 |String
-|Path to Signature crypto properties. This path can be part of the classpath, relative to ddf.home, or an absolute path on the system.
+|Path to Signature crypto properties. This path can be part of the classpath, relative to ${home_directory}, or an absolute path on the system.
 |etc/ws-security/server/signature.properties
 |true
 
 |Encryption Properties
 |encryptionProperties
 |String
-|Path to Encryption crypto properties file. This path can be part of the classpath, relative to ddf.home, or an absolute path on the system.
+|Path to Encryption crypto properties file. This path can be part of the classpath, relative to ${home_directory}, or an absolute path on the system.
 |etc/ws-security/server/encryption.properties
 |true
 
 |STS Properties
 |tokenProperties
 |String
-|Path to STS crypto properties file. This path can be part of the classpath, relative to ddf.home, or an absolute path on the system.
+|Path to STS crypto properties file. This path can be part of the classpath, relative to ${home_directory}, or an absolute path on the system.
 |etc/ws-security/server/signature.properties
 |true
 

--- a/distribution/docs/src/main/resources/content/_tables/sts.wss.configuration.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/sts.wss.configuration.adoc
@@ -68,21 +68,21 @@
 |Signature Properties
 |signatureProperties
 |String
-|Path to Signature crypto properties. This path can be part of the classpath, relative to ddf.home, or an absolute path on the system.
+|Path to Signature crypto properties. This path can be part of the classpath, relative to ${home_directory}, or an absolute path on the system.
 |etc/ws-security/server/signature.properties
 |true
 
 |Encryption Properties
 |encryptionProperties
 |String
-|Path to Encryption crypto properties file. This path can be part of the classpath, relative to ddf.home, or an absolute path on the system.
+|Path to Encryption crypto properties file. This path can be part of the classpath, relative to ${home_directory}, or an absolute path on the system.
 |etc/ws-security/server/encryption.properties
 |true
 
 |STS Properties
 |tokenProperties
 |String
-|Path to STS crypto properties file. This path can be part of the classpath, relative to ddf.home, or an absolute path on the system.
+|Path to STS crypto properties file. This path can be part of the classpath, relative to ${home_directory}, or an absolute path on the system.
 |etc/ws-security/server/signature.properties
 |true
 


### PR DESCRIPTION
#### What does this PR do?
- Replaces usages of ddf.home with home_directory

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)
@kcover @clockard @emmberk 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@shaundmorris 
@ricklarsen - Documentation

#### How should this be tested? (List steps with links to updated documentation)
Build docs and verify ddf.home is now DDF_HOME.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)

#### Screenshots (if appropriate)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
