### PR TITLE
DDF-3893 The IdP should account for the NameIDPolicy in AuthnRequests

### DIFF
--- a/features/security/pom.xml
+++ b/features/security/pom.xml
@@ -348,6 +348,11 @@
         </dependency>
         <dependency>
             <groupId>ddf.security.idp</groupId>
+            <artifactId>security-idp-plugin-nameidpolicy</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.idp</groupId>
             <artifactId>security-idp-client</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -563,6 +563,7 @@
         <feature>security-filter-login</feature>
         <bundle>mvn:ddf.security.idp/security-idp-server/${project.version}</bundle>
         <bundle>mvn:io.fastjson/boon/${boon.version}</bundle>
+        <bundle>mvn:ddf.security.idp/security-idp-plugin-nameidpolicy/${project.version}</bundle>
     </feature>
 
     <feature name="security-command-listener" version="${project.version}"

--- a/platform/security/idp/security-idp-plugin/pom.xml
+++ b/platform/security/idp/security-idp-plugin/pom.xml
@@ -31,6 +31,7 @@
         <module>security-idp-plugin-api</module>
         <module>security-idp-plugin-subjectconfirmation</module>
         <module>security-idp-plugin-audiencerestriction</module>
+        <module>security-idp-plugin-nameidpolicy</module>
     </modules>
 
 </project>

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/pom.xml
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>ddf.security.idp</groupId>
+    <artifactId>security-idp-plugin</artifactId>
+    <version>2.13.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>security-idp-plugin-nameidpolicy</artifactId>
+  <name>DDF :: Security :: IdP :: Plugin :: Name ID Policy</name>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>ddf.security.idp</groupId>
+      <artifactId>security-idp-plugin-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!--Spock dependencies-->
+    <dependency>
+      <groupId>ddf.lib</groupId>
+      <artifactId>spock-shaded</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Service>org.codice.ddf.security.idp.plugin.SamlPresignPlugin</Export-Service>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <haltOnFailure>true</haltOnFailure>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>1.00</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.95</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>COMPLEXITY</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.96</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/pom.xml
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/pom.xml
@@ -50,7 +50,6 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Export-Service>org.codice.ddf.security.idp.plugin.SamlPresignPlugin</Export-Service>
           </instructions>
         </configuration>
       </plugin>

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/pom.xml
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>ddf.security.idp</groupId>
     <artifactId>security-idp-plugin</artifactId>
-    <version>2.13.0-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
   </parent>
   <artifactId>security-idp-plugin-nameidpolicy</artifactId>
   <name>DDF :: Security :: IdP :: Plugin :: Name ID Policy</name>
@@ -39,6 +39,12 @@
       <artifactId>spock-shaded</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 
@@ -71,17 +77,17 @@
                     <limit implementation="org.codice.jacoco.LenientLimit">
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>1.00</minimum>
+                      <minimum>0.92</minimum>
                     </limit>
                     <limit implementation="org.codice.jacoco.LenientLimit">
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.95</minimum>
+                      <minimum>0.90</minimum>
                     </limit>
                     <limit implementation="org.codice.jacoco.LenientLimit">
                       <counter>COMPLEXITY</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.96</minimum>
+                      <minimum>0.92</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/main/java/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPlugin.java
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/main/java/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPlugin.java
@@ -48,7 +48,7 @@ public class NameIdPolicyPresignPlugin implements SamlPresignPlugin {
 
     if (nameIdPolicy == null
         || (StringUtils.isEmpty(nameIdPolicy.getFormat())
-            && StringUtils.isEmpty(nameIdPolicy.getSPNameQualifier()))) {
+        && StringUtils.isEmpty(nameIdPolicy.getSPNameQualifier()))) {
       return;
     }
 
@@ -77,14 +77,14 @@ public class NameIdPolicyPresignPlugin implements SamlPresignPlugin {
 
     if (StringUtils.isNotEmpty(nameIdFormatPolicy)) {
       switch (nameIdFormatPolicy) {
-          // supported NameIDFormats
+        // supported NameIDFormats
         case NameID.UNSPECIFIED:
           return; // avoid changing the Format later
         case NameID.PERSISTENT:
           // TODO DDF-3965
           break;
 
-          // partially supported NameIDFormats
+        // partially supported NameIDFormats
         case NameID.X509_SUBJECT:
           LOGGER.warn("Specifying the \"X509Subject\" NameIDPolicy Format is not fully supported.");
           if (!NameID.X509_SUBJECT.equals(assertionNameId.getFormat())) {
@@ -97,7 +97,7 @@ public class NameIdPolicyPresignPlugin implements SamlPresignPlugin {
           assertionNameId.setValue(resolveEmail(response));
           break;
 
-          // not supported NameIDFormats
+        // not supported NameIDFormats
         case NameID.TRANSIENT:
         case NameID.WIN_DOMAIN_QUALIFIED:
         case NameID.KERBEROS:
@@ -111,6 +111,13 @@ public class NameIdPolicyPresignPlugin implements SamlPresignPlugin {
     }
   }
 
+  /**
+   * Attempts to find an email identifier in a given Response. More specifically, this method looks
+   * in a Response's AttributeStatements for the email identifier. Throws an error if not found.
+   *
+   * @param response Response object
+   * @return Email identifier
+   */
   private String resolveEmail(Response response) {
     return response
         .getAssertions()

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/main/java/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPlugin.java
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/main/java/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPlugin.java
@@ -83,9 +83,6 @@ public class NameIdPolicyPresignPlugin implements SamlPresignPlugin {
         case NameID.PERSISTENT:
           // TODO DDF-3965
           break;
-        case NameID.TRANSIENT:
-          // TODO DDF-3965
-          break;
 
           // partially supported NameIDFormats
         case NameID.X509_SUBJECT:
@@ -101,6 +98,7 @@ public class NameIdPolicyPresignPlugin implements SamlPresignPlugin {
           break;
 
           // not supported NameIDFormats
+        case NameID.TRANSIENT:
         case NameID.WIN_DOMAIN_QUALIFIED:
         case NameID.KERBEROS:
         case NameID.ENTITY:

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/main/java/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPlugin.java
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/main/java/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPlugin.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.plugin.nameidpolicy;
+
+import ddf.security.samlp.SamlProtocol.Binding;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.security.idp.plugin.SamlPresignPlugin;
+import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
+import org.opensaml.saml.saml2.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This plugin is responsible for setting the NameID Format/SPNameQualifier on the outgoing Response
+ * according to the values found in the NameIDPolicy of the passed in AuthnRequest.
+ */
+public class NameIdPolicyPresignPlugin implements SamlPresignPlugin {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(NameIdPolicyPresignPlugin.class);
+
+  private static final String EMAIL_ATTRIBUTE_NAME =
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+
+  @Override
+  public void processPresign(
+      Response response,
+      AuthnRequest authnRequest,
+      List<String> spMetadata,
+      Set<Binding> supportedBindings) {
+    NameIDPolicy nameIdPolicy = authnRequest.getNameIDPolicy();
+
+    if (nameIdPolicy == null
+        || (StringUtils.isEmpty(nameIdPolicy.getFormat())
+        && StringUtils.isEmpty(nameIdPolicy.getSPNameQualifier()))) {
+      return;
+    }
+
+    response
+        .getAssertions()
+        .stream()
+        .map(assertion -> assertion.getSubject().getNameID())
+        .forEach(
+            assertionNameId ->
+                setAssertionNameIdQualifierAndFormat(
+                    assertionNameId,
+                    nameIdPolicy.getFormat(),
+                    nameIdPolicy.getSPNameQualifier(),
+                    response));
+  }
+
+  private void setAssertionNameIdQualifierAndFormat(
+      NameID assertionNameId,
+      @Nullable String nameIdFormatPolicy,
+      @Nullable String spNameQualifierPolicy,
+      Response response) {
+
+    if (StringUtils.isNotEmpty(spNameQualifierPolicy)) {
+      assertionNameId.setSPNameQualifier(spNameQualifierPolicy);
+    }
+
+    if (StringUtils.isNotEmpty(nameIdFormatPolicy)) {
+      switch (nameIdFormatPolicy) {
+        // supported NameIDFormats
+        case NameID.UNSPECIFIED:
+          break;
+        case NameID.PERSISTENT:
+          // TODO DDF-3965
+          break;
+        case NameID.TRANSIENT:
+          // TODO DDF-3965
+          break;
+
+        // partially supported NameIDFormats
+        case NameID.X509_SUBJECT:
+          LOGGER.warn("Specifying the \"X509Subject\" NameIDPolicy Format is not fully supported.");
+          if (!NameID.X509_SUBJECT.equals(assertionNameId.getFormat())) {
+            throw new UnsupportedOperationException(
+                "The \"X509Subject\" NameID could not be retrieved.");
+          }
+          break;
+        case NameID.EMAIL:
+          LOGGER.warn("Specifying the \"Email\" NameIDPolicy Format is not fully supported.");
+          assertionNameId.setValue(resolveEmail(response));
+          break;
+
+        // not supported NameIDFormats
+        case NameID.WIN_DOMAIN_QUALIFIED:
+        case NameID.KERBEROS:
+        case NameID.ENTITY:
+        default:
+          throw new UnsupportedOperationException(
+              String.format(
+                  "The NameIDPolicy Format of value %s is not supported.", nameIdFormatPolicy));
+      }
+    }
+
+    assertionNameId.setFormat(nameIdFormatPolicy);
+  }
+
+  private String resolveEmail(Response response) {
+    return response
+        .getAssertions()
+        .stream()
+        .flatMap(assertion -> assertion.getAttributeStatements().stream())
+        .flatMap(statement -> statement.getAttributes().stream())
+        .filter(attribute ->
+            EMAIL_ATTRIBUTE_NAME.equals(attribute.getName())
+                || NameID.EMAIL.equals(attribute.getNameFormat()))
+        .flatMap(attribute -> attribute.getAttributeValues().stream())
+        .filter(attributeValue -> attributeValue instanceof XSString)
+        .map(attributeValue -> (XSString) attributeValue)
+        .map(XSString::getValue)
+        .filter(StringUtils::isNotBlank)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new UnsupportedOperationException("The \"Email\" NameID could not be retrieved."));
+  }
+}

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.0.0"
+  xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+  <bean id="nameIdPresignPlugin"
+    class="org.codice.ddf.security.idp.plugin.nameidpolicy.NameIdPolicyPresignPlugin"/>
+
+  <service ref="nameIdPresignPlugin"
+    interface="org.codice.ddf.security.idp.plugin.SamlPresignPlugin"/>
+
+</blueprint>

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/test/groovy/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPluginSpec.groovy
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/test/groovy/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPluginSpec.groovy
@@ -65,163 +65,137 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         authnRequestMock.getNameIDPolicy() >> nameIdPolicyMock
     }
 
-    @Unroll("null NameIDPolicy Format tests for Format #format")
+    @Unroll("test a null NameIDPolicy Format against an original NameID Format of #format")
     def 'null NameIDPolicy Format tests'() {
         setup:
         nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
+        nameIdPolicyMock.getFormat() >> null
 
         when:
         plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
 
         then:
-        if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE)
-            return
-        }
-        thrown(UnsupportedOperationException)
+        assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == format)
 
         where:
-        policyFormat | format              | isError
-        null         | null                | false
-        null         | NameID.UNSPECIFIED  | false
-        null         | NameID.PERSISTENT   | false
-        null         | NameID.TRANSIENT    | false
-        null         | NameID.X509_SUBJECT | false
-        null         | NameID.EMAIL        | false
+        format << [null,
+                   NameID.UNSPECIFIED,
+                   NameID.PERSISTENT,
+                   NameID.X509_SUBJECT]
     }
 
-    @Unroll("unspecified NameIDPolicy Format tests for Format #format")
+    @Unroll("test an unspecified NameIDPolicy Format against an original NameID Format of #format")
     def 'unspecified NameIDPolicy Format tests'() {
         setup:
         nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
+        nameIdPolicyMock.getFormat() >> NameID.UNSPECIFIED
 
         when:
         plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
 
         then:
-        if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE)
-            return
-        }
-        thrown(UnsupportedOperationException)
+        assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == format)
 
         where:
-        policyFormat       | format              | isError
-        NameID.UNSPECIFIED | null                | false
-        NameID.UNSPECIFIED | NameID.UNSPECIFIED  | false
-        NameID.UNSPECIFIED | NameID.PERSISTENT   | false
-        NameID.UNSPECIFIED | NameID.TRANSIENT    | false
-        NameID.UNSPECIFIED | NameID.X509_SUBJECT | false
-        NameID.UNSPECIFIED | NameID.EMAIL        | false
+        format << [null,
+                   NameID.UNSPECIFIED,
+                   NameID.PERSISTENT,
+                   NameID.TRANSIENT,
+                   NameID.X509_SUBJECT,
+                   NameID.EMAIL]
     }
 
-    @Unroll("persistent NameIDPolicy Format tests for Format #format")
+    @Unroll("test a persistent NameIDPolicy Format against an original NameID Format of #format")
     def 'persistent NameIDPolicy Format tests'() {
         setup:
         nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
+        nameIdPolicyMock.getFormat() >> NameID.PERSISTENT
 
         when:
         plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
 
         then:
-        if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
-            return
-        }
-        thrown(UnsupportedOperationException)
+        assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == NameID.PERSISTENT)
 
         where:
-        policyFormat      | format              | isError
-        NameID.PERSISTENT | null                | false
-        NameID.PERSISTENT | NameID.UNSPECIFIED  | false
-        NameID.PERSISTENT | NameID.PERSISTENT   | false
-        NameID.PERSISTENT | NameID.TRANSIENT    | false
-        NameID.PERSISTENT | NameID.X509_SUBJECT | false
-        NameID.PERSISTENT | NameID.EMAIL        | false
+        format << [null,
+                   NameID.UNSPECIFIED,
+                   NameID.PERSISTENT,
+                   NameID.TRANSIENT,
+                   NameID.X509_SUBJECT,
+                   NameID.EMAIL]
     }
 
-    @Unroll("transient NameIDPolicy Format tests for Format #format")
+    @Unroll("test a transient NameIDPolicy Format against an original NameID Format of #format")
     def 'transient NameIDPolicy Format tests'() {
         setup:
         nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
+        nameIdPolicyMock.getFormat() >> NameID.TRANSIENT
 
         when:
         plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
 
         then:
-        if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
-            return
-        }
-        thrown(UnsupportedOperationException)
+        assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == NameID.TRANSIENT)
 
         where:
-        policyFormat     | format              | isError
-        NameID.TRANSIENT | null                | false
-        NameID.TRANSIENT | NameID.UNSPECIFIED  | false
-        NameID.TRANSIENT | NameID.PERSISTENT   | false
-        NameID.TRANSIENT | NameID.TRANSIENT    | false
-        NameID.TRANSIENT | NameID.X509_SUBJECT | false
-        NameID.TRANSIENT | NameID.EMAIL        | false
+        format  << [null,
+                    NameID.UNSPECIFIED,
+                    NameID.PERSISTENT,
+                    NameID.TRANSIENT,
+                    NameID.X509_SUBJECT,
+                    NameID.EMAIL]
     }
 
-    @Unroll("x509 NameIDPolicy Format tests for Format #format")
+    @Unroll("test a null NameIDPolicy Format against an original NameID Format of #format")
     def 'x509 NameIDPolicy Format tests'() {
         setup:
         nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
+        nameIdPolicyMock.getFormat() >> NameID.X509_SUBJECT
 
         when:
         plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
 
         then:
         if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE
+                    && nameIdMock.format == NameID.X509_SUBJECT)
             return
         }
         thrown(UnsupportedOperationException)
 
         where:
-        policyFormat        | format              | isError
-        NameID.X509_SUBJECT | null                | true
-        NameID.X509_SUBJECT | NameID.UNSPECIFIED  | true
-        NameID.X509_SUBJECT | NameID.PERSISTENT   | true
-        NameID.X509_SUBJECT | NameID.TRANSIENT    | true
-        NameID.X509_SUBJECT | NameID.X509_SUBJECT | false
-        NameID.X509_SUBJECT | NameID.EMAIL        | true
+        format              | isError
+        null                | true
+        NameID.UNSPECIFIED  | true
+        NameID.PERSISTENT   | true
+        NameID.TRANSIENT    | true
+        NameID.X509_SUBJECT | false
+        NameID.EMAIL        | true
     }
 
-    @Unroll("email NameIDPolicy Format tests for Format #format")
+    @Unroll("test an email NameIDPolicy Format against an original NameID Format of #format")
     def 'email NameIDPolicy Format tests'() {
         setup:
         nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
+        nameIdPolicyMock.getFormat() >> NameID.EMAIL
 
         when:
         plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
 
         then:
-        if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_EMAIL && nameIdMock.format == policyFormat)
-            return
-        }
-        thrown(UnsupportedOperationException)
+        assert (nameIdMock.value == EXAMPLE_EMAIL && nameIdMock.format == NameID.EMAIL)
 
         where:
-        policyFormat | format              | isError
-        NameID.EMAIL | null                | false
-        NameID.EMAIL | NameID.UNSPECIFIED  | false
-        NameID.EMAIL | NameID.PERSISTENT   | false
-        NameID.EMAIL | NameID.TRANSIENT    | false
-        NameID.EMAIL | NameID.X509_SUBJECT | false
-        NameID.EMAIL | NameID.EMAIL        | false
+        format << [null,
+                   NameID.UNSPECIFIED,
+                   NameID.PERSISTENT,
+                   NameID.TRANSIENT,
+                   NameID.X509_SUBJECT,
+                   NameID.EMAIL]
     }
 
-    def 'email NameIDPolicy Format null email attribute'() {
+    def 'test an email NameIDPolicy Format against an assertion with no attribute statements'() {
         setup:
         nameIdPolicyMock.getFormat() >> NameID.EMAIL
         responseMock.assertions.first().attributeStatements.first().attributes.clear()
@@ -233,7 +207,7 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         thrown(UnsupportedOperationException)
     }
 
-    def 'email NameIDPolicy Format empty email attribute'() {
+    def 'test an email NameIDPolicy Format against an assertion with no email attribute statement'() {
         setup:
         nameIdPolicyMock.getFormat() >> NameID.EMAIL
         emailAttribute.getAttributeValues().clear()
@@ -247,20 +221,7 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         thrown(UnsupportedOperationException)
     }
 
-    def 'email NameIDPolicy Format incorrect email attribute name/format'() {
-        setup:
-        nameIdPolicyMock.getFormat() >> NameID.EMAIL
-        emailAttribute.setName(INCORRECT_VALUE)
-        emailAttribute.setNameFormat(INCORRECT_VALUE)
-
-        when:
-        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
-
-        then:
-        thrown(UnsupportedOperationException)
-    }
-
-    def 'email NameIDPolicy Format correct email attribute name'() {
+    def 'test an email NameIDPolicy Format against an assertion with a correctly named email attribute statement'() {
         setup:
         nameIdPolicyMock.getFormat() >> NameID.EMAIL
         emailAttribute.setNameFormat(INCORRECT_VALUE)
@@ -272,7 +233,7 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         assert (nameIdMock.value == EXAMPLE_EMAIL && nameIdMock.format == nameIdPolicyMock.format)
     }
 
-    def 'email NameIDPolicy Format correct email attribute format'() {
+    def 'test an email NameIDPolicy Format against an assertion with a correctly name formatted email attribute statement'() {
         setup:
         nameIdPolicyMock.getFormat() >> NameID.EMAIL
         emailAttribute.setName(INCORRECT_VALUE)
@@ -284,84 +245,7 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         assert (nameIdMock.value == EXAMPLE_EMAIL && nameIdMock.format == nameIdPolicyMock.format)
     }
 
-    @Unroll("windows domain qualified NameIDPolicy Format tests for Format #format")
-    def 'windows domain qualified NameIDPolicy Format tests'() {
-        setup:
-        nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
-
-        when:
-        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
-
-        then:
-        if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
-            return
-        }
-        thrown(UnsupportedOperationException)
-
-        where:
-        policyFormat                | format              | isError
-        NameID.WIN_DOMAIN_QUALIFIED | null                | true
-        NameID.WIN_DOMAIN_QUALIFIED | NameID.UNSPECIFIED  | true
-        NameID.WIN_DOMAIN_QUALIFIED | NameID.PERSISTENT   | true
-        NameID.WIN_DOMAIN_QUALIFIED | NameID.TRANSIENT    | true
-        NameID.WIN_DOMAIN_QUALIFIED | NameID.X509_SUBJECT | true
-        NameID.WIN_DOMAIN_QUALIFIED | NameID.EMAIL        | true
-    }
-
-    @Unroll("kerberos NameIDPolicy Format tests for Format #format")
-    def 'kerberos NameIDPolicy Format tests'() {
-        setup:
-        nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
-
-        when:
-        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
-
-        then:
-        if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
-            return
-        }
-        thrown(UnsupportedOperationException)
-
-        where:
-        policyFormat    | format              | isError
-        NameID.KERBEROS | null                | true
-        NameID.KERBEROS | NameID.UNSPECIFIED  | true
-        NameID.KERBEROS | NameID.PERSISTENT   | true
-        NameID.KERBEROS | NameID.TRANSIENT    | true
-        NameID.KERBEROS | NameID.X509_SUBJECT | true
-        NameID.KERBEROS | NameID.EMAIL        | true
-    }
-
-    @Unroll("entity NameIDPolicy Format tests for Format #format")
-    def 'entity NameIDPolicy Format tests'() {
-        setup:
-        nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> policyFormat
-
-        when:
-        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
-
-        then:
-        if (!isError) {
-            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
-            return
-        }
-        thrown(UnsupportedOperationException)
-
-        where:
-        policyFormat  | format              | isError
-        NameID.ENTITY | null                | true
-        NameID.ENTITY | NameID.UNSPECIFIED  | true
-        NameID.ENTITY | NameID.PERSISTENT   | true
-        NameID.ENTITY | NameID.TRANSIENT    | true
-        NameID.ENTITY | NameID.X509_SUBJECT | true
-        NameID.ENTITY | NameID.EMAIL        | true
-    }
-
+    @Unroll('test a #policySpNameQualifier NameIDPolicy SPNameQualifier against an original #spNameQualifier NameID SPNameQualifier')
     def 'SPNameQualifier tests'() {
         setup:
         nameIdMock.setSPNameQualifier(spNameQualifier)
@@ -385,7 +269,7 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         EXAMPLE_SP_NAME_QUALIFIER | EXAMPLE_SP_NAME_QUALIFIER
     }
 
-    def 'null NameIDPolicy'() {
+    def 'null NameIDPolicy test'() {
         setup:
         authnRequestMock.getNameIDPolicy() >> null
 
@@ -396,7 +280,7 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         0 * responseMock.any()
     }
 
-    def 'null/empty NameIDPolicy Format/SpNameQualifier'() {
+    def 'null/empty NameIDPolicy Format/SpNameQualifier test'() {
         setup:
         nameIdPolicyMock.getFormat() >> policyFormat
         nameIdPolicyMock.getSPNameQualifier() >> policySpNameQualifier

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/test/groovy/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPluginSpec.groovy
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/test/groovy/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPluginSpec.groovy
@@ -1,0 +1,417 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.security.idp.plugin.nameidpolicy
+
+import org.apache.cxf.staxutils.StaxUtils
+import org.apache.wss4j.common.saml.OpenSAMLUtil
+import org.opensaml.core.xml.XMLObject
+import org.opensaml.saml.saml2.core.Attribute
+import org.opensaml.saml.saml2.core.AuthnRequest
+import org.opensaml.saml.saml2.core.NameID
+import org.opensaml.saml.saml2.core.NameIDPolicy
+import org.opensaml.saml.saml2.core.Response
+import org.w3c.dom.Document
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NameIdPolicyPresignPluginSpec extends Specification {
+    def static INCORRECT_VALUE = "incorrect"
+    def static EXAMPLE_SP_NAME_QUALIFIER = "https://example-ddf-sp.com"
+    def static EXAMPLE_NAME_ID_VALUE = "admin"
+    def static EXAMPLE_EMAIL = "admin@localhost"
+
+    def static NAME_IDENTIFIER_URI =
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+    def static EMAIL_URI = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+
+    def plugin = new NameIdPolicyPresignPlugin()
+
+    Response responseMock
+    NameID nameIdMock
+    Attribute emailAttribute
+
+    def authnRequestMock = Mock(AuthnRequest)
+    def nameIdPolicyMock = Mock(NameIDPolicy)
+    def spMetadataMock = new ArrayList<>()
+    def supportedBindingsMock = new HashSet<>()
+
+    def setupSpec() {
+        OpenSAMLUtil.initSamlEngine()
+    }
+
+    def setup() {
+        def cannedResponse = this.getClass().getResource('/sampleResponse.xml').text
+        Document responseDoc = StaxUtils.read(new ByteArrayInputStream(cannedResponse.getBytes()))
+        XMLObject responseXmlObject = OpenSAMLUtil.fromDom(responseDoc.getDocumentElement())
+        responseMock = (Response) responseXmlObject
+        nameIdMock = responseMock.assertions.first().subject.nameID
+        nameIdMock.setValue(EXAMPLE_NAME_ID_VALUE)
+        nameIdMock.setFormat(NameID.UNSPECIFIED)
+
+        emailAttribute =
+                responseMock.assertions.first().attributeStatements.first().attributes.first()
+
+        authnRequestMock.getNameIDPolicy() >> nameIdPolicyMock
+    }
+
+    @Unroll("null NameIDPolicy Format tests for Format #format")
+    def 'null NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat | format              | isError
+        null         | null                | false
+        null         | NameID.UNSPECIFIED  | false
+        null         | NameID.PERSISTENT   | false
+        null         | NameID.TRANSIENT    | false
+        null         | NameID.X509_SUBJECT | false
+        null         | NameID.EMAIL        | false
+    }
+
+    @Unroll("unspecified NameIDPolicy Format tests for Format #format")
+    def 'unspecified NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat       | format              | isError
+        NameID.UNSPECIFIED | null                | false
+        NameID.UNSPECIFIED | NameID.UNSPECIFIED  | false
+        NameID.UNSPECIFIED | NameID.PERSISTENT   | false
+        NameID.UNSPECIFIED | NameID.TRANSIENT    | false
+        NameID.UNSPECIFIED | NameID.X509_SUBJECT | false
+        NameID.UNSPECIFIED | NameID.EMAIL        | false
+    }
+
+    @Unroll("persistent NameIDPolicy Format tests for Format #format")
+    def 'persistent NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat      | format              | isError
+        NameID.PERSISTENT | null                | false
+        NameID.PERSISTENT | NameID.UNSPECIFIED  | false
+        NameID.PERSISTENT | NameID.PERSISTENT   | false
+        NameID.PERSISTENT | NameID.TRANSIENT    | false
+        NameID.PERSISTENT | NameID.X509_SUBJECT | false
+        NameID.PERSISTENT | NameID.EMAIL        | false
+    }
+
+    @Unroll("transient NameIDPolicy Format tests for Format #format")
+    def 'transient NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat     | format              | isError
+        NameID.TRANSIENT | null                | false
+        NameID.TRANSIENT | NameID.UNSPECIFIED  | false
+        NameID.TRANSIENT | NameID.PERSISTENT   | false
+        NameID.TRANSIENT | NameID.TRANSIENT    | false
+        NameID.TRANSIENT | NameID.X509_SUBJECT | false
+        NameID.TRANSIENT | NameID.EMAIL        | false
+    }
+
+    @Unroll("x509 NameIDPolicy Format tests for Format #format")
+    def 'x509 NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat        | format              | isError
+        NameID.X509_SUBJECT | null                | true
+        NameID.X509_SUBJECT | NameID.UNSPECIFIED  | true
+        NameID.X509_SUBJECT | NameID.PERSISTENT   | true
+        NameID.X509_SUBJECT | NameID.TRANSIENT    | true
+        NameID.X509_SUBJECT | NameID.X509_SUBJECT | false
+        NameID.X509_SUBJECT | NameID.EMAIL        | true
+    }
+
+    @Unroll("email NameIDPolicy Format tests for Format #format")
+    def 'email NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_EMAIL && nameIdMock.format == policyFormat)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat | format              | isError
+        NameID.EMAIL | null                | false
+        NameID.EMAIL | NameID.UNSPECIFIED  | false
+        NameID.EMAIL | NameID.PERSISTENT   | false
+        NameID.EMAIL | NameID.TRANSIENT    | false
+        NameID.EMAIL | NameID.X509_SUBJECT | false
+        NameID.EMAIL | NameID.EMAIL        | false
+    }
+
+    def 'email NameIDPolicy Format null email attribute'() {
+        setup:
+        nameIdPolicyMock.getFormat() >> NameID.EMAIL
+        responseMock.assertions.first().attributeStatements.first().attributes.clear()
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def 'email NameIDPolicy Format empty email attribute'() {
+        setup:
+        nameIdPolicyMock.getFormat() >> NameID.EMAIL
+        emailAttribute.getAttributeValues().clear()
+        emailAttribute.name = null
+        emailAttribute.nameFormat = null
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def 'email NameIDPolicy Format incorrect email attribute name/format'() {
+        setup:
+        nameIdPolicyMock.getFormat() >> NameID.EMAIL
+        emailAttribute.setName(INCORRECT_VALUE)
+        emailAttribute.setNameFormat(INCORRECT_VALUE)
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def 'email NameIDPolicy Format correct email attribute name'() {
+        setup:
+        nameIdPolicyMock.getFormat() >> NameID.EMAIL
+        emailAttribute.setNameFormat(INCORRECT_VALUE)
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        assert (nameIdMock.value == EXAMPLE_EMAIL && nameIdMock.format == nameIdPolicyMock.format)
+    }
+
+    def 'email NameIDPolicy Format correct email attribute format'() {
+        setup:
+        nameIdPolicyMock.getFormat() >> NameID.EMAIL
+        emailAttribute.setName(INCORRECT_VALUE)
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        assert (nameIdMock.value == EXAMPLE_EMAIL && nameIdMock.format == nameIdPolicyMock.format)
+    }
+
+    @Unroll("windows domain qualified NameIDPolicy Format tests for Format #format")
+    def 'windows domain qualified NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat                | format              | isError
+        NameID.WIN_DOMAIN_QUALIFIED | null                | true
+        NameID.WIN_DOMAIN_QUALIFIED | NameID.UNSPECIFIED  | true
+        NameID.WIN_DOMAIN_QUALIFIED | NameID.PERSISTENT   | true
+        NameID.WIN_DOMAIN_QUALIFIED | NameID.TRANSIENT    | true
+        NameID.WIN_DOMAIN_QUALIFIED | NameID.X509_SUBJECT | true
+        NameID.WIN_DOMAIN_QUALIFIED | NameID.EMAIL        | true
+    }
+
+    @Unroll("kerberos NameIDPolicy Format tests for Format #format")
+    def 'kerberos NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat    | format              | isError
+        NameID.KERBEROS | null                | true
+        NameID.KERBEROS | NameID.UNSPECIFIED  | true
+        NameID.KERBEROS | NameID.PERSISTENT   | true
+        NameID.KERBEROS | NameID.TRANSIENT    | true
+        NameID.KERBEROS | NameID.X509_SUBJECT | true
+        NameID.KERBEROS | NameID.EMAIL        | true
+    }
+
+    @Unroll("entity NameIDPolicy Format tests for Format #format")
+    def 'entity NameIDPolicy Format tests'() {
+        setup:
+        nameIdMock.setFormat(format)
+        nameIdPolicyMock.getFormat() >> policyFormat
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (!isError) {
+            assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == policyFormat)
+            return
+        }
+        thrown(UnsupportedOperationException)
+
+        where:
+        policyFormat  | format              | isError
+        NameID.ENTITY | null                | true
+        NameID.ENTITY | NameID.UNSPECIFIED  | true
+        NameID.ENTITY | NameID.PERSISTENT   | true
+        NameID.ENTITY | NameID.TRANSIENT    | true
+        NameID.ENTITY | NameID.X509_SUBJECT | true
+        NameID.ENTITY | NameID.EMAIL        | true
+    }
+
+    def 'SPNameQualifier tests'() {
+        setup:
+        nameIdMock.setSPNameQualifier(spNameQualifier)
+        nameIdPolicyMock.getSPNameQualifier() >> policySpNameQualifier
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        if (policySpNameQualifier == null) {
+            nameIdMock.getSPNameQualifier() == spNameQualifier
+        } else {
+            nameIdMock.getSPNameQualifier() == policySpNameQualifier
+        }
+
+        where:
+        policySpNameQualifier     | spNameQualifier
+        null                      | null
+        null                      | EXAMPLE_SP_NAME_QUALIFIER
+        EXAMPLE_SP_NAME_QUALIFIER | null
+        EXAMPLE_SP_NAME_QUALIFIER | EXAMPLE_SP_NAME_QUALIFIER
+    }
+
+    def 'null NameIDPolicy'() {
+        setup:
+        authnRequestMock.getNameIDPolicy() >> null
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        0 * responseMock.any()
+    }
+
+    def 'null/empty NameIDPolicy Format/SpNameQualifier'() {
+        setup:
+        nameIdPolicyMock.getFormat() >> policyFormat
+        nameIdPolicyMock.getSPNameQualifier() >> policySpNameQualifier
+
+        when:
+        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
+
+        then:
+        0 * responseMock.any()
+
+        where:
+        policyFormat | policySpNameQualifier
+        null         | null
+        ""           | ""
+        null         | ""
+        ""           | null
+    }
+}

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/test/groovy/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPluginSpec.groovy
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/test/groovy/org/codice/ddf/security/idp/plugin/nameidpolicy/NameIdPolicyPresignPluginSpec.groovy
@@ -100,7 +100,6 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         format << [null,
                    NameID.UNSPECIFIED,
                    NameID.PERSISTENT,
-                   NameID.TRANSIENT,
                    NameID.X509_SUBJECT,
                    NameID.EMAIL]
     }
@@ -121,30 +120,8 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         format << [null,
                    NameID.UNSPECIFIED,
                    NameID.PERSISTENT,
-                   NameID.TRANSIENT,
                    NameID.X509_SUBJECT,
                    NameID.EMAIL]
-    }
-
-    @Unroll("test a transient NameIDPolicy Format against an original NameID Format of #format")
-    def 'transient NameIDPolicy Format tests'() {
-        setup:
-        nameIdMock.setFormat(format)
-        nameIdPolicyMock.getFormat() >> NameID.TRANSIENT
-
-        when:
-        plugin.processPresign(responseMock, authnRequestMock, spMetadataMock, supportedBindingsMock)
-
-        then:
-        assert (nameIdMock.value == EXAMPLE_NAME_ID_VALUE && nameIdMock.format == NameID.TRANSIENT)
-
-        where:
-        format  << [null,
-                    NameID.UNSPECIFIED,
-                    NameID.PERSISTENT,
-                    NameID.TRANSIENT,
-                    NameID.X509_SUBJECT,
-                    NameID.EMAIL]
     }
 
     @Unroll("test a null NameIDPolicy Format against an original NameID Format of #format")
@@ -169,7 +146,6 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         null                | true
         NameID.UNSPECIFIED  | true
         NameID.PERSISTENT   | true
-        NameID.TRANSIENT    | true
         NameID.X509_SUBJECT | false
         NameID.EMAIL        | true
     }
@@ -190,7 +166,6 @@ class NameIdPolicyPresignPluginSpec extends Specification {
         format << [null,
                    NameID.UNSPECIFIED,
                    NameID.PERSISTENT,
-                   NameID.TRANSIENT,
                    NameID.X509_SUBJECT,
                    NameID.EMAIL]
     }

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/test/resources/sampleResponse.xml
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-nameidpolicy/src/test/resources/sampleResponse.xml
@@ -1,0 +1,117 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<saml2p:Response Destination="https://localhost:8993/services/saml/sso"
+  ID="_8273f583-d326-45ff-8b70-3f8384c06c7b" InResponseTo="_cae17689-0c8c-4f95-9c0e-283e7a3c0731"
+  IssueInstant="2017-12-06T18:05:50.156Z" Version="2.0"
+  xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
+  <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
+    https://localhost:8993/services/idp/login
+  </saml2:Issuer>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml2:Assertion ID="_a59b84bd-ecea-4926-bdd9-0eaad46059b8"
+    IssueInstant="2017-12-06T18:05:50.137Z" Version="2.0"
+    xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="saml2:AssertionType">
+    <saml2:Issuer>localhost</saml2:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference URI="#_a59b84bd-ecea-4926-bdd9-0eaad46059b8">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+              <ec:InclusiveNamespaces PrefixList="xsd"
+                xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+            </ds:Transform>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>vyE/KNTbTMTcV696hkCiTNZ3RqTTdE4mNVuoeyPGsa4=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>
+        KDZwApMfNgW9lkWUp65dulh5k7jz7FMsE8WEalnfs7G3x1PAEbL7pIwT2LWWUcXjRpV7cjxBqeysoTXDBaVZYIXeFUG5wNQKn4lXjBkGk1Rhq5Bjymkf4bzMOHhFvQ7sL/tCdXpHm5AF88k/ys2pv4LuRM7unJzTblbZ/odrnnU=
+      </ds:SignatureValue>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>
+            MIIC8DCCAlmgAwIBAgIJAIzc4FYrIp9pMA0GCSqGSIb3DQEBCwUAMIGEMQswCQYDVQQGEwJVUzEL
+            MAkGA1UECBMCQVoxDDAKBgNVBAoTA0RERjEMMAoGA1UECxMDRGV2MRkwFwYDVQQDExBEREYgRGVt
+            byBSb290IENBMTEwLwYJKoZIhvcNAQkBFiJlbWFpbEFkZHJlc3M9ZGRmcm9vdGNhQGV4YW1wbGUu
+            b3JnMCAXDTE1MTIxMTE1NDMyM1oYDzIxMTUxMTE3MTU0MzIzWjBwMQswCQYDVQQGEwJVUzELMAkG
+            A1UECBMCQVoxDDAKBgNVBAoTA0RERjEMMAoGA1UECxMDRGV2MRIwEAYDVQQDEwlsb2NhbGhvc3Qx
+            JDAiBgkqhkiG9w0BCQEWFWxvY2FsaG9zdEBleGFtcGxlLm9yZzCBnzANBgkqhkiG9w0BAQEFAAOB
+            jQAwgYkCgYEAx4LI1lsJNmmEdB8HmDwWuAGrVFjNXuKRXD+lUaTPyDHeXcD32zxa0DiZEB5vqfS9
+            NH3I0E56Rbidg6IQ6r/9hOL9+sjWTPRBsQfWzZwjmcUG61psPc9gbFRK5qltz4BLv4+SWvRMMjgx
+            HM8+SROnjCU5FD9roJ9Ww2v+ZWAvYJ8CAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0E
+            HxYdT3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFID3lAgzIEAdGx3RHizs
+            LcGt4WuwMB8GA1UdIwQYMBaAFOFUx5ffCsK/qV94XjsLK+RIF73GMA0GCSqGSIb3DQEBCwUAA4GB
+            ACWWsi4WusO5/u1O91obGn8ctFnxVlogBQ/tDZ+neQDxy8YB2J28tztELrRHkaGiCPT4CCKdy0hx
+            /bG/jSM1ypJnPKrPVrCkYL3Y68pzxvrFNq5NqAFCcBOCNsDNfvCSZ/XHvFyGHIuso5wNVxJyvTdh
+            Q+vWbnpiX8qr6vTx2Wgw
+          </ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </ds:Signature>
+    <saml2:Subject>
+      <saml2:NameID
+        Format="urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified"
+        SPNameQualifier="DDF-SP"
+        NameQualifier="http://cxf.apache.org/sts">admin
+      </saml2:NameID>
+      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>
+    </saml2:Subject>
+    <saml2:Conditions NotBefore="2017-12-06T18:05:50.138Z" NotOnOrAfter="2017-12-06T18:35:50.138Z">
+      <saml2:AudienceRestriction>
+        <saml2:Audience>https://localhost:8993/services/SecurityTokenService?wsdl</saml2:Audience>
+      </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AuthnStatement AuthnInstant="2017-12-06T18:05:50.137Z" SessionIndex="702700499">
+      <saml2:AuthnContext>
+        <saml2:AuthnContextClassRef>
+          urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+        </saml2:AuthnContextClassRef>
+      </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+      <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+        NameFormat="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">
+        <saml2:AttributeValue xsi:type="xsd:string">admin@localhost</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role"
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml2:AttributeValue xsi:type="xsd:string">group</saml2:AttributeValue>
+        <saml2:AttributeValue xsi:type="xsd:string">admin</saml2:AttributeValue>
+        <saml2:AttributeValue xsi:type="xsd:string">manager</saml2:AttributeValue>
+        <saml2:AttributeValue xsi:type="xsd:string">viewer</saml2:AttributeValue>
+        <saml2:AttributeValue xsi:type="xsd:string">system-admin</saml2:AttributeValue>
+        <saml2:AttributeValue xsi:type="xsd:string">systembundles</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml2:AttributeValue xsi:type="xsd:string">guest</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role"
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml2:AttributeValue xsi:type="xsd:string">guest</saml2:AttributeValue>
+      </saml2:Attribute>
+      <saml2:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role"
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
+        <saml2:AttributeValue xsi:type="xsd:string">guest</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+  </saml2:Assertion>
+</saml2p:Response>


### PR DESCRIPTION
#### What does this PR do?
Adds support for `NameIDPolicy`s on the `AuthnRequest` in DDF's IdP.

#### Who is reviewing it? 
@blen-desta
@brjeter

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@stustison

#### How should this be tested? (List steps with links to updated documentation)
1. Build and install DDF
2. Run [this branch of the SAML CTK](https://github.com/bakejeyner/saml-conformance/tree/DDF-3893), and verify that there are no errors.

#### What are the relevant tickets?
[DDF-3893](https://codice.atlassian.net/browse/DDF-3893)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
