### PR TITLE
DDF-3968 Fix metrics report download and add itest to prevent regression

### DIFF
--- a/platform/metrics/platform-metrics-reporting/pom.xml
+++ b/platform/metrics/platform-metrics-reporting/pom.xml
@@ -101,7 +101,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Embed-Dependency>rrd4j,joda-time, commons-math, platform-util, poi-scratchpad
+                        <Embed-Dependency>rrd4j,joda-time, commons-math, platform-util, poi-scratchpad, poi
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Import-Package>


### PR DESCRIPTION
#### What does this PR do?
The metrics report download button was throwing an error into the admin ui due to a ClassNotFoundException. The missing jar was embedded in the metrics reporting bundle and an itest was added to ensure the download button will return a 200 in the future. 

#### Who is reviewing it? 
@austinsteffes @ahoffer 

#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
@brendan-hofmann @rzwiefel @shaundmorris 

#### How should this be tested? (List steps with links to updated documentation)
Go to the Admin Console in a browser
Select the Platform App (the metrics tab will appear)
Click the download button in the bottom left corner
The error shown in the screenshot will *NOT* appear!

#### What are the relevant tickets?
[DDF-3968](https://codice.atlassian.net/browse/DDF-3968)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
