### PR TITLE
DDF-3974 Updating security hardening documentation and default.policy to include securityBackup

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -42,3 +42,13 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
     // permission java.io.FilePermission "/test/some/monitored/directory", "read";
     // permission java.io.FilePermission "/test/some/monitored/directory${/}-", "read, write";
 }
+
+grant codeBase "file:/pax-logging-log4j2" {
+    //  Security-Hardening: Add permissions to another log file
+
+    //  Uncomment the following line and replace <PATH> with
+    //  the path to the new desired log file
+
+    //  permission java.io.FilePermission "<PATH>", "read,write";
+
+}

--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -43,12 +43,18 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
     // permission java.io.FilePermission "/test/some/monitored/directory${/}-", "read, write";
 }
 
+//                       Security-Hardening: Backup Log File Permissions
+//  Adding required permissions to the logger for read and write access to modified backup log files
+//
+//  If you want to change the default location of the backup security log files, add a new permission
+//  allowing the logger to create and modify the files within the new directory.
+//  If you haven't already done so, follow the Enabling Fallback Audit Logging steps in the security hardening
+//  checklist to finish configuring backup logging
+//
 grant codeBase "file:/pax-logging-log4j2" {
-    //  Security-Hardening: Add permissions to another log file
+    //  Add required permissions here.
 
-    //  Uncomment the following line and replace <PATH> with
-    //  the path to the new desired log file
-
-    //  permission java.io.FilePermission "<PATH>", "read,write";
-
+    //  Example:
+    //  permission java.io.FilePermission "/the/new/log/directory/-", "read, write";
+    //  permission java.io.FilePermission "/the/new/log/directory", "read, write";
 }

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -182,8 +182,16 @@ grant codeBase "file:/pax-logging-log4j2" {
     permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}ingest_error.log", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}artemis.log", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}security.log", "read,write";
+    permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}securityBackup.log", "read,write";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}log4j2.config.xml", "read";
     permission java.io.FilePermission "pax-logging.properties", "read";
     permission java.net.SocketPermission "*", "listen,resolve";
+
+    //  Security-Hardening: uncomment the following line and replace <PATH> with
+    //  the path to the new desired log file
+
+    //  permission java.io.FilePermission "<PATH>", "read,write";
+
 }
 
 grant codeBase "file:/woodstox-core/broker-topic-logger/platform-solr-server-standalone/catalog-core-downloadaction/platform-http-proxy/platform-scheduler/catalog-validator-metacardduplication" {

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -179,10 +179,6 @@ grant codeBase "file:/org.apache.karaf.jaas.modules" {
 
 grant codeBase "file:/pax-logging-log4j2" {
     permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}-", "read,write";
-    permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}ingest_error.log", "read,write";
-    permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}artemis.log", "read,write";
-    permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}security.log", "read,write";
-    permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}securityBackup.log", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}log4j2.config.xml", "read";
     permission java.io.FilePermission "pax-logging.properties", "read";
     permission java.net.SocketPermission "*", "listen,resolve";

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -186,12 +186,6 @@ grant codeBase "file:/pax-logging-log4j2" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}log4j2.config.xml", "read";
     permission java.io.FilePermission "pax-logging.properties", "read";
     permission java.net.SocketPermission "*", "listen,resolve";
-
-    //  Security-Hardening: uncomment the following line and replace <PATH> with
-    //  the path to the new desired log file
-
-    //  permission java.io.FilePermission "<PATH>", "read,write";
-
 }
 
 grant codeBase "file:/woodstox-core/broker-topic-logger/platform-solr-server-standalone/catalog-core-downloadaction/platform-http-proxy/platform-scheduler/catalog-validator-metacardduplication" {

--- a/distribution/docs/src/main/resources/content/_securing/auditing.adoc
+++ b/distribution/docs/src/main/resources/content/_securing/auditing.adoc
@@ -48,14 +48,14 @@ In the event the system is unable to write to the `security.log` file, ${brandin
 ** uncomment the line (remove the `#` from the beginning of the line) for `log4j2` (`org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml`)
 ** delete all subsequent lines
 
-If you want to change the location of your systems security backup log from the default: `${home_directory}/data/log/securityBackup.log`, follow the next two steps:
+If you want to change the location of your systems security backup log from the default location: `${home_directory}/data/log/securityBackup.log`, follow the next two steps:
 
 * edit `${home_directory}/security/configurations.policy`
-** find `//  permission java.io.FilePermission "<PATH>", "read,write";` under Security-Hardening
-** uncomment that line and change the value of <PATH> to the absolute path of <NEW_FILE_NAME> (described below)
+** find "Security-Hardening: Backup Log File Permissions"
+** below `grant codeBase "file:/pax-logging-log4j2"` add the path to the directory containing the new log file you will create in the next step.
 * edit `${home_directory}/etc/log4j2.config.xml`
 ** find the entry for the `securityBackup` appender. (see example)
-** change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs (<NEW_FILE_NAME>)
+** change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs
 
 .`securityBackup` Appender Before
 [source,xml,linenums]
@@ -69,8 +69,8 @@ If you want to change the location of your systems security backup log from the 
 [source,xml,linenums]
 ----
 <RollingFile name="securityBackup" append="true" ignoreExceptions="false"
-                     fileName="${sys:karaf.data}/log/<NEW_FILE_NAME>"
-                     filePattern="${sys:karaf.data}/log/<NEW_FILE_NAME>-%d{yyyy-MM-dd-HH}-%i.log.gz">
+                     fileName="${sys:karaf.data}/log/<NEW_LOG_FILE>"
+                     filePattern="${sys:karaf.data}/log/<NEW_LOG_FILE>-%d{yyyy-MM-dd-HH}-%i.log.gz">
 ----
 
 [WARNING]

--- a/distribution/docs/src/main/resources/content/_securing/auditing.adoc
+++ b/distribution/docs/src/main/resources/content/_securing/auditing.adoc
@@ -47,6 +47,12 @@ In the event the system is unable to write to the `security.log` file, ${brandin
 * edit `${home_directory}/etc/org.ops4j.pax.logging.cfg`
 ** uncomment the line (remove the `#` from the beginning of the line) for `log4j2` (`org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml`)
 ** delete all subsequent lines
+
+If you want to change the location of your systems security backup log from the default: `${home_directory}/data/log/securityBackup.log`, follow the next two steps:
+
+* edit `${home_directory}/security/default.policy`
+** find `//  permission java.io.FilePermission "<PATH>", "read,write";` under Security-Hardening
+** uncomment that line and change the value of <PATH> to the absolute path of <NEW_FILE_NAME> (described below)
 * edit `${home_directory}/etc/log4j2.config.xml`
 ** find the entry for the `securityBackup` appender. (see example)
 ** change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs (<NEW_FILE_NAME>)

--- a/distribution/docs/src/main/resources/content/_securing/auditing.adoc
+++ b/distribution/docs/src/main/resources/content/_securing/auditing.adoc
@@ -50,7 +50,7 @@ In the event the system is unable to write to the `security.log` file, ${brandin
 
 If you want to change the location of your systems security backup log from the default: `${home_directory}/data/log/securityBackup.log`, follow the next two steps:
 
-* edit `${home_directory}/security/default.policy`
+* edit `${home_directory}/security/configurations.policy`
 ** find `//  permission java.io.FilePermission "<PATH>", "read,write";` under Security-Hardening
 ** uncomment that line and change the value of <PATH> to the absolute path of <NEW_FILE_NAME> (described below)
 * edit `${home_directory}/etc/log4j2.config.xml`


### PR DESCRIPTION
#### What does this PR do?
Fixing a minor security-manager bug that occurs when setting up security hardening for DDF.
#### Who is reviewing it? 
@bakejeyner 
@blen-desta 
@ricklarsen 
@paouelle
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here. If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
@clockard
@coyotesqrl 
#### How should this be tested? (List steps with links to updated documentation)

Step 1:
Install and build DDF

Step 2:
```
edit <DDF_HOME>/etc/org.ops4j.pax.logging.cfg

uncomment the line (remove the # from the beginning of the line) for log4j2 (org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml)

delete all other lines
```
Run DDF and there should be no security-manager errors.

#### Edited for rolling logs

Step 3:
* edit `<DDF_HOME>/security/configurations.policy`
  * find `//  permission java.io.FilePermission "/path/to/directory/", "read,write";` under Security-Hardening
  * uncomment both lines and change the value of /path/to/directory to a new directory for the rolling logs (described below)
* edit `${home_directory}/etc/log4j2.config.xml`
  * find the entry for the `securityBackup` appender. (see example)
  * change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs (I used slog and gave it permissions 750)

##### `securityBackup` Appender Before
```xml
<RollingFile name="securityBackup" append="true" ignoreExceptions="false"
                     fileName="${sys:karaf.data}/log/securityBackup.log"
                     filePattern="${sys:karaf.data}/log/securityBackup.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
```

##### `securityBackup` Appender After
```xml
<RollingFile name="securityBackup" append="true" ignoreExceptions="false"
                     fileName="${sys:karaf.data}/log/<NEW_FILE_NAME>"
                     filePattern="${sys:karaf.data}/log/<NEW_FILE_NAME>-%d{yyyy-MM-dd-HH}-%i.log.gz">
```
Step 4: (mac instructions)
* Create a [small hard drive partition](http://osxdaily.com/2011/04/26/partition-hard-drive-mac-os-x/) (10 MB max?) 
  * Go to `finder` > `applications` > `utilities` > `disk utilities`
  * at the top there should be a Pie, click it and make either a volume or partition (I did volume)
  * Name it, and set the size to 10 MB (for volume set both to 10MB)
* From there create a symbolic link in <DDF_HOME>/data/
  * `ln -s /Volumes/${partition name}/ && mv ${partition name} log`
  * This will set up a symbolic link so you log to the partition. (You will need to give the logger permissions to write here. Add it in config.policy from step 3)
* Fill up the partition, either from running the logs for a bit or following these commands Vina supplied (https://www.skorks.com/2010/03/how-to-quickly-generate-a-large-file-on-the-command-line-with-linux/)

Run DDF and see the securityFallback logs be written to.

Fill the securityBackup log by running a command similar to `dd if=/dev/zero of=securityBackup.log count=1024 bs=12448576`. It should rollover after DDF tries to write to it a few times. 

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3974](https://codice.atlassian.net/browse/DDF-3974)
#### Screenshots (if appropriate)
#### Checklist:
- [:+1:] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
