### PR TITLE
DDF-3929 Updated search-redirect to be installed with search-ui-app

### DIFF
--- a/catalog/ui/search-ui-app/src/main/resources/features.xml
+++ b/catalog/ui/search-ui-app/src/main/resources/features.xml
@@ -17,7 +17,8 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="catalog-ui-search-api" version="${project.version}" description="API for interacting with Catalog UI">
+    <feature name="catalog-ui-search-api" version="${project.version}"
+             description="API for interacting with Catalog UI">
         <bundle>mvn:ddf.ui/catalog-ui-search-api/${project.version}</bundle>
     </feature>
 
@@ -40,7 +41,6 @@
         <feature>camel-http</feature>
         <feature>javax-inject</feature>
         <bundle>mvn:ddf.ui.search/standard/${project.version}</bundle>
-        <bundle>mvn:ddf.ui.search/search-redirect/${project.version}</bundle>
         <bundle>mvn:ddf.ui.search/search-htmltransformer/${project.version}</bundle>
         <bundle>mvn:ddf.ui.search/search-endpoint/${project.version}</bundle>
         <bundle>mvn:io.fastjson/boon/${boon.version}</bundle>
@@ -50,14 +50,22 @@
         <bundle>mvn:ddf.ui.search/simple/${project.version}</bundle>
     </feature>
 
+    <feature name="search-redirect" version="${project.version}"
+             description="Configuration to redirect /search to another endpoint">
+        <bundle>mvn:ddf.ui.search/search-redirect/${project.version}</bundle>
+    </feature>
+
     <feature name="search-ui-app" version="${project.version}"
-             description="The Search UI is an application that not only provides results in a html format but also provides a convenient, simple querying user interface.\nThe left pane of the SearchUI contains basic fields to query the Catalog and other Sources. The right pane consists of a map.\nIt includes both standard (3d globe) and simple (text page) versions.">
-        <configfile finalname="${ddf.etc}/org.codice.ddf.ui.searchui.filter.RedirectServlet.config" override="false">mvn:ddf.ui/search-ui-app/${project.version}/config/redirect</configfile>
+             description="The Search UI is an application that not only provides results in a html format but also provides a convenient, simple querying user interface.\nThe left pane of the Search UI contains basic fields to query the Catalog and other Sources. The right pane consists of a map.\nIt includes both the Catalog UI (3d globe) and Simple Search UI (text page) versions.">
+        <configfile finalname="${ddf.etc}/org.codice.ddf.ui.searchui.filter.RedirectServlet.config" override="false">
+            mvn:ddf.ui/search-ui-app/${project.version}/config/redirect
+        </configfile>
         <feature>catalog-app</feature>
         <feature>catalog-versioning-plugin</feature>
         <feature>catalog-core-validator</feature>
         <feature>catalog-ui</feature>
         <feature>simple-search-ui</feature>
+        <feature>search-redirect</feature>
     </feature>
 
 </features>


### PR DESCRIPTION
#### What does this PR do?
The Simple Search UI was deprecated in 8ab5e702fa73f64e5bb3b5176737e387828e845e. This PR moves the `search-redirect` bundle under the `search-ui-app` feature so that it is started by default regardless of what search UI is installed.
#### Who is reviewing it? 
@peterhuffer
@austinsteffes
#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@vinamartin
#### How should this be tested?
- Confirm that /search redirects to /search/catalog.
- Confirm that the redirect can be configured in the Admin Console.
#### What are the relevant tickets?
[DDF-3929](https://codice.atlassian.net/browse/DDF-3929)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.