### PR TITLE
DDF-3915 Add os agnostic path separator to solr itest policy

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -694,8 +694,12 @@ public abstract class AbstractIntegrationTest {
               getClass().getResource("/etc/forms/contact-name.xml"), "/etc/forms/contact-name.xml"),
           installStartupFile(
               String.format(
-                  "priority \"grant\"; grant {permission java.io.FilePermission \"%s/-\", \"read, write\"; }",
-                  new File("target" + File.separator + "solr").getAbsolutePath()),
+                  "priority \"grant\"; grant {permission java.io.FilePermission \"%s%s-\", \"read, write\"; };",
+                  new File("target" + File.separator + "solr")
+                      .getAbsolutePath()
+                      .replace("/", "${/}")
+                      .replace("\\", "${/}"),
+                  "${/}"),
               "/security/itests-solr.policy"));
     } catch (IOException e) {
       LoggingUtils.failWithThrowableStacktrace(e, "Failed to deploy configuration files: ");


### PR DESCRIPTION
#### What does this PR do?
Fixes path separator character
#### Who is reviewing it? 
@stustison 
`@anyone`

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3915
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
