### PR TITLE
[2.13.x] DDF-3974 Updating security hardening documentation and default.policy to include securityBackup

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -63,3 +63,19 @@ grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader" {
     // permission java.io.FilePermission "/test/some/directory", "read";
     // permission java.io.FilePermission "/test/some/directory${/}-", "read";
 }
+
+//                       Security-Hardening: Backup Log File Permissions
+//  Adding required permissions to the logger for read and write access to modified backup log files
+//
+//  If you want to change the default location of the backup security log files, add a new permission
+//  allowing the logger to create and modify the files within the new directory.
+//  If you haven't already done so, follow the Enabling Fallback Audit Logging steps in the security hardening
+//  checklist to finish configuring backup logging
+//
+grant codeBase "file:/pax-logging-log4j2" {
+    //  Add required permissions here.
+
+    //  Example:
+    //  permission java.io.FilePermission "/the/new/log/directory/-", "read, write";
+    //  permission java.io.FilePermission "/the/new/log/directory", "read, write";
+}

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -183,9 +183,7 @@ grant codeBase "file:/org.apache.karaf.jaas.command" {
 
 grant codeBase "file:/pax-logging-log4j2" {
     permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}-", "read,write";
-    permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}ingest_error.log", "read,write";
-    permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}artemis.log", "read,write";
-    permission java.io.FilePermission "${ddf.home.perm}data${/}log${/}security.log", "read,write";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}log4j2.config.xml", "read";
     permission java.io.FilePermission "pax-logging.properties", "read";
     permission java.net.SocketPermission "*", "listen,resolve";
 }

--- a/distribution/docs/src/main/resources/content/_securing/auditing.adoc
+++ b/distribution/docs/src/main/resources/content/_securing/auditing.adoc
@@ -47,9 +47,15 @@ In the event the system is unable to write to the `security.log` file, ${brandin
 * edit `${home_directory}/etc/org.ops4j.pax.logging.cfg`
 ** uncomment the line (remove the `#` from the beginning of the line) for `log4j2` (`org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml`)
 ** delete all subsequent lines
+
+If you want to change the location of your systems security backup log from the default location: `${home_directory}/data/log/securityBackup.log`, follow the next two steps:
+
+* edit `${home_directory}/security/configurations.policy`
+** find "Security-Hardening: Backup Log File Permissions"
+** below `grant codeBase "file:/pax-logging-log4j2"` add the path to the directory containing the new log file you will create in the next step.
 * edit `${home_directory}/etc/log4j2.config.xml`
 ** find the entry for the `securityBackup` appender. (see example)
-** change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs (<NEW_FILE_NAME>)
+** change value of `filename` and prefix of `filePattern` to the name/path of the desired failover security logs
 
 .`securityBackup` Appender Before
 [source,xml,linenums]
@@ -63,8 +69,8 @@ In the event the system is unable to write to the `security.log` file, ${brandin
 [source,xml,linenums]
 ----
 <RollingFile name="securityBackup" append="true" ignoreExceptions="false"
-                     fileName="${sys:karaf.data}/log/<NEW_FILE_NAME>"
-                     filePattern="${sys:karaf.data}/log/<NEW_FILE_NAME>-%d{yyyy-MM-dd-HH}-%i.log.gz">
+                     fileName="${sys:karaf.data}/log/<NEW_LOG_FILE>"
+                     filePattern="${sys:karaf.data}/log/<NEW_LOG_FILE>-%d{yyyy-MM-dd-HH}-%i.log.gz">
 ----
 
 [WARNING]


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
[Link to master PR: #3419](https://github.com/codice/ddf/pull/3419)
____

#### Who is reviewing it? 
Who is reviewing it?
@bakejeyner
@blen-desta
@ricklarsen

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@coyotesqrl

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
