### PR TITLE
[2.13.x] DDF-3982 Updated the spatial-geocoding-feature bundle to start with the offline-gazetteer feature

### DIFF
--- a/catalog/spatial/spatial-app/src/main/resources/features.xml
+++ b/catalog/spatial/spatial-app/src/main/resources/features.xml
@@ -143,6 +143,7 @@
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-create/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-extract/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-offline-catalog/${project.version}</bundle>
+        <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-feature/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-commands/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-admin-module/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-plugin/${project.version}</bundle>
@@ -188,11 +189,6 @@
         <feature>spatial-wfs-v1_0_0</feature>
         <feature>spatial-wfs-v1_1_0</feature>
         <feature>spatial-wfs-v2_0_0</feature>
-    </feature>
-
-    <feature name="feature-index" version="${project.version}"
-             description="Offline gazetteer service storing geographic features in the catalog">
-        <bundle>mvn:org.codice.ddf.spatial/spatial-geocoding-feature/${project.version}</bundle>
     </feature>
 
 </features>


### PR DESCRIPTION
#### What does this PR do?
The `gazetteer` commands were not starting for default because they were waiting on services started by the `spatial-geocoding-feature`. The `spatial-geocoding-feature` should be started with the `offline-gazetteer` because it only contains services that are used by the offline gazetteer.
#### Who is reviewing it? 
@peterhuffer @vinamartin @kcover 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@clockard
#### How should this be tested?
Confirm that the `gazetteer` commands are available after a default install.
#### What are the relevant tickets?
[DDF-3982](https://codice.atlassian.net/browse/DDF-3982)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.