### PR TITLE
[2.13.x] DDF-3984 Fixed resetting search forms

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
@@ -89,8 +89,8 @@ module.exports = Marionette.LayoutView.extend({
         'change:choice',
         function(confirmation) {
             if (confirmation.get('choice')) {
-                const filterTree = this.model.get('filterTree');
-                this.model.resetToDefaults({filterTree});
+                const defaults = this.model.get('type') === 'custom' ? this.model.toJSON(): undefined;
+                this.model.resetToDefaults({...defaults});
                 this.triggerCloseDropdown();
             }
         }.bind(this));

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
@@ -89,7 +89,8 @@ module.exports = Marionette.LayoutView.extend({
         'change:choice',
         function(confirmation) {
             if (confirmation.get('choice')) {
-                this.model.resetToDefaults();
+                const filterTree = this.model.get('filterTree');
+                this.model.resetToDefaults({filterTree});
                 this.triggerCloseDropdown();
             }
         }.bind(this));

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.view.js
@@ -90,7 +90,7 @@ module.exports = Marionette.LayoutView.extend({
         function(confirmation) {
             if (confirmation.get('choice')) {
                 const defaults = this.model.get('type') === 'custom' ? this.model.toJSON(): undefined;
-                this.model.resetToDefaults({...defaults});
+                this.model.resetToDefaults(defaults);
                 this.triggerCloseDropdown();
             }
         }.bind(this));

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -93,8 +93,8 @@ define([
                     'detail-level': undefined
                 }, user.getQuerySettings().toJSON());
             },
-            resetToDefaults: function (defaults) {
-                this.set(_.omit(_merge(this.defaults(), defaults), ['type', 'isLocal', 'serverPageIndex', 'result']));
+            resetToDefaults: function (overridenDefaults) {
+                this.set(_.omit(_merge(this.defaults(), overridenDefaults), ['type', 'isLocal', 'serverPageIndex', 'result']));
                 this.trigger('resetToDefaults');
             },
             applyDefaults: function () {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -93,8 +93,8 @@ define([
                     'detail-level': undefined
                 }, user.getQuerySettings().toJSON());
             },
-            resetToDefaults: function () {
-                this.set(_.omit(this.defaults(), ['type', 'isLocal', 'serverPageIndex', 'result']));
+            resetToDefaults: function (defaults) {
+                this.set(_.omit(_merge(this.defaults(), defaults), ['type', 'isLocal', 'serverPageIndex', 'result']));
                 this.trigger('resetToDefaults');
             },
             applyDefaults: function () {


### PR DESCRIPTION
#### What does this PR do?
Fixes the issue of when resetting a search form it clears the values instead of defaulting to anyText.
#### Who is reviewing it? 
@djblue @mackncheesiest 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?

1. Extract built DDF
2. Create a `/etc/forms` directory
3. Start DDF
4. Enable experimental features in the catalog-ui-search config
5. Create a search form in the catalog search ui and save it.
6. Click the reset button from the three button dropdown and verify your form is the same.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3984](https://codice.atlassian.net/browse/DDF-3984)
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
