### PR TITLE
DDF-3985 Updated URL Resource Reader permissions/docs

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -62,5 +62,5 @@ grant codeBase "file:/catalog-core-urlresourcereader" {
 
     // Example:
     // permission java.io.FilePermission "/test/some/directory", "read";
-    // permission java.io.FilePermission "/test/some/directory${/}-", "read, write";
+    // permission java.io.FilePermission "/test/some/directory${/}-", "read";
 }

--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -41,3 +41,26 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
     // permission java.io.FilePermission "/test/some/monitored/directory", "read";
     // permission java.io.FilePermission "/test/some/monitored/directory${/}-", "read, write";
 }
+
+//                        URL Resource Reader Permissions
+// Adding required permissions for the URL Resource Reader to retrieve file resources.
+//
+//
+// Configuring URL Resource Reader requires adding read and write permissions to the directory being monitored.
+// For the following 2 permissions are required:
+//   1. permission java.io.FilePermission "<DIRECTORY_PATH>", "read";
+//   2. permission java.io.FilePermission "<DIRECTORY_PATH>${/}-", "read";
+// Replacing <DIRECTORY_PATH> with the path of the directory containing file resources.
+//
+// Line 1 gives the URL Resource Reader the permissions to read from the directory. Line 2 gives the
+// Resource Reader the permissions to recursively read from the directory path, specified
+// by the directory path's suffix "${/}-".
+//
+//
+grant codeBase "file:/catalog-core-urlresourcereader" {
+    // Add required URL Resource Reader permissions here.
+
+    // Example:
+    // permission java.io.FilePermission "/test/some/directory", "read";
+    // permission java.io.FilePermission "/test/some/directory${/}-", "read, write";
+}

--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -56,7 +56,6 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
 // Resource Reader the permissions to recursively read from the directory path, specified
 // by the directory path's suffix "${/}-".
 //
-//
 grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader" {
     // Add required URL Resource Reader permissions here.
 

--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -46,7 +46,7 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
 // Adding required permissions for the URL Resource Reader to retrieve file resources.
 //
 //
-// Configuring URL Resource Reader requires adding read and write permissions to the directory being monitored.
+// Configuring the URL Resource Reader requires adding read permissions to the directory being read from.
 // For the following 2 permissions are required:
 //   1. permission java.io.FilePermission "<DIRECTORY_PATH>", "read";
 //   2. permission java.io.FilePermission "<DIRECTORY_PATH>${/}-", "read";
@@ -57,7 +57,7 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
 // by the directory path's suffix "${/}-".
 //
 //
-grant codeBase "file:/catalog-core-urlresourcereader" {
+grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader" {
     // Add required URL Resource Reader permissions here.
 
     // Example:

--- a/distribution/docs/src/main/resources/content/_architectures/url-resource-reader.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/url-resource-reader.adoc
@@ -31,6 +31,25 @@ Configure the URL Resource Reader from the ${admin-console}.
 
 See <<ddf.catalog.resource.impl.URLResourceReader,URL Resource Reader configurations>> for all possible configurations.
 
+=== Configuring Permissions for the URL Resource Reader
+
+Configuring the URL Resource Reader to retrieve files requires adding permissions to the Security Manager.
+
+Configuring the URL Resource Reader requires adding read permissions to the directory containing the resources. The following permissions, replacing <DIRECTORY_PATH> with the path of the directory containing resources should be placed in the URL Resource Reader section inside ${home_directory}/security/configurations.policy.
+
+.Adding New Permissions
+[WARNING]
+====
+After adding permissions, a system restart is required for them to take effect.
+====
+
+. permission java.io.FilePermission "<DIRECTORY_PATH>", "read";
+. permission java.io.FilePermission "<DIRECTORY_PATH>${/}-", "read";
+
+Trailing slashes after <DIRECTORY_PATH> have no effect on the permissions granted. For example, adding a permission for "/test/path" and "/test/path/" are equivalent. The recursive forms "/test/path${/}-", and "/test/path/${/}-" are also equivalent.
+
+Line 1 gives the URL Resource Reader the permissions to read from directory. Line 2 gives the URL Resource Reader the permissions to recursively read from the directory, specified by the directory path's suffix "${/}-".
+
 ===== Using the URL Resource Reader
 
 `URLResourceReader` will be used by the Catalog Framework to obtain a resource whose metacard is cataloged in the local data store.

--- a/distribution/docs/src/main/resources/content/_architectures/url-resource-reader.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/url-resource-reader.adoc
@@ -33,9 +33,7 @@ See <<ddf.catalog.resource.impl.URLResourceReader,URL Resource Reader configurat
 
 === Configuring Permissions for the URL Resource Reader
 
-Configuring the URL Resource Reader to retrieve files requires adding permissions to the Security Manager.
-
-Configuring the URL Resource Reader requires adding read permissions to the directory containing the resources. The following permissions, replacing <DIRECTORY_PATH> with the path of the directory containing resources should be placed in the URL Resource Reader section inside ${home_directory}/security/configurations.policy.
+Configuring the URL Resource Reader to retrieve files requires adding Security Manager read permissions to the directory containing the resources. The following permissions, replacing <DIRECTORY_PATH> with the path of the directory containing resources should be placed in the URL Resource Reader section inside ${home_directory}/security/configurations.policy.
 
 .Adding New Permissions
 [WARNING]
@@ -48,7 +46,7 @@ After adding permissions, a system restart is required for them to take effect.
 
 Trailing slashes after <DIRECTORY_PATH> have no effect on the permissions granted. For example, adding a permission for "/test/path" and "/test/path/" are equivalent. The recursive forms "/test/path${/}-", and "/test/path/${/}-" are also equivalent.
 
-Line 1 gives the URL Resource Reader the permissions to read from directory. Line 2 gives the URL Resource Reader the permissions to recursively read from the directory, specified by the directory path's suffix "${/}-".
+Line 1 gives the URL Resource Reader the permissions to read from the directory. Line 2 gives the URL Resource Reader the permissions to recursively read from the directory, specified by the directory path's suffix "${/}-".
 
 ===== Using the URL Resource Reader
 

--- a/distribution/docs/src/main/resources/content/_running/ingest-command.adoc
+++ b/distribution/docs/src/main/resources/content/_running/ingest-command.adoc
@@ -12,7 +12,7 @@ The ${command-console} has a command-line option for ingesting data.
 [NOTE]
 ====
 Ingesting with the console ingest command creates a metacard in the catalog, but does not copy the resource to the content store.
-See the URL Resource Reader documentation for more information on retrieving the resource from a directory.
+The Ingest Command requires read access to the directory being ingested from, see the <<_url_resource_reader, URL Resource Reader>> for configuring read permissions on the directory.
 ====
 
 The syntax for the ingest command is

--- a/distribution/docs/src/main/resources/content/_running/ingest-command.adoc
+++ b/distribution/docs/src/main/resources/content/_running/ingest-command.adoc
@@ -12,6 +12,7 @@ The ${command-console} has a command-line option for ingesting data.
 [NOTE]
 ====
 Ingesting with the console ingest command creates a metacard in the catalog, but does not copy the resource to the content store.
+See the URL Resource Reader documentation for more information on retrieving the resource from a directory.
 ====
 
 The syntax for the ingest command is


### PR DESCRIPTION
#### What does this PR do?
Document how an administrator can add permissions for the URL Resource Reader to retrieve resources from directories
#### Who is reviewing it? 
@jhunzik @peterhuffer @ricklarsen 
#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@lessarderic
@stustison

#### How should this be tested?
1) Ingest a metacard with a link to a resource located in an external directory
2) Read the docs to update the configurations.policy
3) restart DDF
4) Retrieve the resource the external directory (via URL Resource Reader)

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3985](https://codice.atlassian.net/browse/DDF-3985)

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/ddf/3456)
<!-- Reviewable:end -->
