### PR TITLE
[2.13.x] DDF-3941 Fix Metacard ID not being set in CatalogApplication

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/catalog/CatalogApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/catalog/CatalogApplication.java
@@ -372,7 +372,8 @@ public class CatalogApplication implements SparkApplication {
       URI uri = new URI(requestUrl.toString());
       UriBuilder uriBuilder = new UriBuilderImpl(uri).path("/" + id);
 
-      res.redirect(uriBuilder.build().toString(), HttpStatus.SC_CREATED);
+      res.status(HttpStatus.SC_CREATED);
+      res.header("Location", uriBuilder.build().toString());
       res.header(Metacard.ID, id);
       return res;
 


### PR DESCRIPTION
#### What does this PR do?
Fixes Metacard ID not being set as a header in the CatalogApplication.

#### Who is reviewing it? 
@garrettfreibott  @brjeter 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@rzwiefel

#### How should this be tested?
Ingest data from Intrigue with the network tab open and verify that a location header is returned in the response.

#### What are the relevant tickets?
[DDF-3941](https://codice.atlassian.net/browse/DDF-3941)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
