### PR TITLE
DDF-3987 Build offline gazetteer suggester index whenever gazetteer metacards are created, updated, or deleted

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -648,5 +648,10 @@
             <artifactId>catalog-core-attachment-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-gazetteer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -503,6 +503,12 @@
         <bundle>mvn:ddf.catalog.async/catalog-async-processingframework/${project.version}</bundle>
     </feature>
 
+    <feature name="catalog-plugin-gazetteer" version="${project.version}"
+      description="Post-ingest plugin for updating the offline gazetteer's suggester index when
+          gazetteer metacards are created, updated, or deleted.">
+        <bundle>mvn:ddf.catalog.plugin/catalog-plugin-gazetteer/${project.version}</bundle>
+    </feature>
+
     <feature name="catalog-app" version="${project.version}"
              description="The Catalog provides a framework for storing, searching, processing, and transforming information.\nClients typically perform query, create, read, update, and delete (QCRUD) operations against the Catalog.\nAt the core of the Catalog functionality is the Catalog Framework, which routes all requests and responses through the system, invoking additional processing per the system configuration.">
         <feature>admin-app</feature>
@@ -555,5 +561,6 @@
         <feature>catalog-transformer-thumbnail</feature>
         <feature>catalog-metacardingest-network</feature>
         <feature>catalog-core-attachment</feature>
+        <feature>catalog-plugin-gazetteer</feature>
     </feature>
 </features>

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/Constants.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/Constants.java
@@ -151,5 +151,7 @@ public final class Constants {
 
   public static final String SUGGESTION_RESULT_KEY = "suggestion-result";
 
+  public static final String SUGGESTION_BUILD_KEY = "suggestion-build";
+
   public static final String ADDITIONAL_SORT_BYS = "additional-sort-bys";
 }

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -16,11 +16,13 @@ package ddf.catalog.source.solr;
 import static ddf.catalog.Constants.ADDITIONAL_SORT_BYS;
 import static ddf.catalog.Constants.EXPERIMENTAL_FACET_PROPERTIES_KEY;
 import static ddf.catalog.Constants.EXPERIMENTAL_FACET_RESULTS_KEY;
+import static ddf.catalog.Constants.SUGGESTION_BUILD_KEY;
 import static ddf.catalog.Constants.SUGGESTION_CONTEXT_KEY;
 import static ddf.catalog.Constants.SUGGESTION_DICT_KEY;
 import static ddf.catalog.Constants.SUGGESTION_QUERY_KEY;
 import static ddf.catalog.Constants.SUGGESTION_RESULT_KEY;
 import static ddf.catalog.source.solr.DynamicSchemaResolver.FIRST_CHAR_OF_SUFFIX;
+import static org.apache.solr.spelling.suggest.SuggesterParams.SUGGEST_BUILD;
 import static org.apache.solr.spelling.suggest.SuggesterParams.SUGGEST_CONTEXT_FILTER_QUERY;
 import static org.apache.solr.spelling.suggest.SuggesterParams.SUGGEST_DICT;
 import static org.apache.solr.spelling.suggest.SuggesterParams.SUGGEST_Q;
@@ -164,16 +166,23 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       query.setFacetMinCount(textFacetProp.getMinFacetCount());
     }
 
-    Serializable suggestQueryProp = request.getPropertyValue(SUGGESTION_QUERY_KEY);
-    Serializable suggestContextProp = request.getPropertyValue(SUGGESTION_CONTEXT_KEY);
-    Serializable suggestDictProp = request.getPropertyValue(SUGGESTION_DICT_KEY);
+    Serializable suggestQuery = request.getPropertyValue(SUGGESTION_QUERY_KEY);
+    Serializable suggestContext = request.getPropertyValue(SUGGESTION_CONTEXT_KEY);
+    Serializable suggestDict = request.getPropertyValue(SUGGESTION_DICT_KEY);
 
-    if (suggestQueryProp instanceof String && suggestContextProp instanceof String) {
+    if (suggestQuery instanceof String
+        && suggestContext instanceof String
+        && suggestDict instanceof String) {
       query = new SolrQuery();
       query.setRequestHandler("/suggest");
-      query.setParam(SUGGEST_Q, (String) suggestQueryProp);
-      query.setParam(SUGGEST_CONTEXT_FILTER_QUERY, (String) suggestContextProp);
-      query.setParam(SUGGEST_DICT, (String) suggestDictProp);
+      query.setParam(SUGGEST_Q, (String) suggestQuery);
+      query.setParam(SUGGEST_CONTEXT_FILTER_QUERY, (String) suggestContext);
+      query.setParam(SUGGEST_DICT, (String) suggestDict);
+
+      Serializable buildSuggesterIndex = request.getPropertyValue(SUGGESTION_BUILD_KEY);
+      if (buildSuggesterIndex instanceof Boolean) {
+        query.setParam(SUGGEST_BUILD, (Boolean) buildSuggesterIndex);
+      }
     }
 
     long totalHits = 0;

--- a/catalog/plugin/catalog-plugin-gazetteer/pom.xml
+++ b/catalog/plugin/catalog-plugin-gazetteer/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>plugin</artifactId>
+    <groupId>ddf.catalog.plugin</groupId>
+    <version>2.14.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>catalog-plugin-gazetteer</artifactId>
+  <packaging>bundle</packaging>
+  <name>DDF :: Catalog :: Plugin :: Gazetteer :: Build Suggester Index</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.platform.util</groupId>
+      <artifactId>platform-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codice.ddf.spatial</groupId>
+      <artifactId>spatial-geocoding-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>ddf.lib</groupId>
+      <artifactId>spock-shaded</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Embed-Dependency>
+              catalog-core-api-impl,
+              platform-util
+            </Embed-Dependency>
+            <Export-Package/>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <haltOnFailure>true</haltOnFailure>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.99</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.91</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>COMPLEXITY</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.95</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/catalog/plugin/catalog-plugin-gazetteer/src/main/java/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndex.java
+++ b/catalog/plugin/catalog-plugin-gazetteer/src/main/java/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndex.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.gazetteer;
+
+import static ddf.catalog.Constants.SUGGESTION_BUILD_KEY;
+import static ddf.catalog.Constants.SUGGESTION_CONTEXT_KEY;
+import static ddf.catalog.Constants.SUGGESTION_DICT_KEY;
+import static ddf.catalog.Constants.SUGGESTION_QUERY_KEY;
+import static ddf.catalog.data.types.Core.METACARD_TAGS;
+import static org.codice.ddf.spatial.geocoding.GeoCodingConstants.GAZETTEER_METACARD_TAG;
+import static org.codice.ddf.spatial.geocoding.GeoCodingConstants.SUGGEST_PLACE_KEY;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BuildSuggesterIndex implements Runnable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BuildSuggesterIndex.class);
+
+  private final CatalogFramework catalogFramework;
+
+  private final FilterBuilder filterBuilder;
+
+  public BuildSuggesterIndex(
+      final CatalogFramework catalogFramework, final FilterBuilder filterBuilder) {
+    this.catalogFramework = catalogFramework;
+    this.filterBuilder = filterBuilder;
+  }
+
+  @Override
+  public void run() {
+    LOGGER.trace("Building the suggester index.");
+    final QueryRequest buildSuggesterIndex = getQueryBuildSuggesterIndex();
+    requestBuildSuggesterIndex(buildSuggesterIndex);
+  }
+
+  private void requestBuildSuggesterIndex(final QueryRequest buildSuggesterIndex) {
+    try {
+      catalogFramework.query(buildSuggesterIndex);
+      LOGGER.trace("Finished building the suggester index.");
+    } catch (SourceUnavailableException | FederationException | UnsupportedQueryException e) {
+      LOGGER.info(
+          "The offline gazetteer's suggester index could not be built automatically. It may have "
+              + "to be built manually with the 'gazetteer:build-suggester-index' command.",
+          e);
+    }
+  }
+
+  private QueryRequest getQueryBuildSuggesterIndex() {
+    // The filter provided here isn't used since this query goes to the suggest handler.
+    final Query suggestionQuery =
+        new QueryImpl(filterBuilder.attribute(METACARD_TAGS).text(GAZETTEER_METACARD_TAG));
+
+    return new QueryRequestImpl(suggestionQuery, getPropertiesBuildSuggesterIndex());
+  }
+
+  private Map<String, Serializable> getPropertiesBuildSuggesterIndex() {
+    final Map<String, Serializable> suggestQueryProperties = new HashMap<>();
+    // Query string must be included but we don't care about the result
+    suggestQueryProperties.put(SUGGESTION_QUERY_KEY, "anything");
+    suggestQueryProperties.put(SUGGESTION_CONTEXT_KEY, GAZETTEER_METACARD_TAG);
+    suggestQueryProperties.put(SUGGESTION_DICT_KEY, SUGGEST_PLACE_KEY);
+    suggestQueryProperties.put(SUGGESTION_BUILD_KEY, true);
+    return suggestQueryProperties;
+  }
+}

--- a/catalog/plugin/catalog-plugin-gazetteer/src/main/java/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndexPlugin.java
+++ b/catalog/plugin/catalog-plugin-gazetteer/src/main/java/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndexPlugin.java
@@ -95,7 +95,7 @@ public class BuildSuggesterIndexPlugin implements PostIngestPlugin {
     try {
       future = executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES);
     } catch (RejectedExecutionException e) {
-      LOGGER.info(
+      LOGGER.warn(
           "The offline gazetteer's suggester index could not be built automatically. It may have "
               + "to be built manually with the 'gazetteer:build-suggester-index' command.");
       throw new PluginExecutionException(e);

--- a/catalog/plugin/catalog-plugin-gazetteer/src/main/java/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndexPlugin.java
+++ b/catalog/plugin/catalog-plugin-gazetteer/src/main/java/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndexPlugin.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.gazetteer;
+
+import static org.codice.ddf.spatial.geocoding.GeoCodingConstants.GAZETTEER_METACARD_TAG;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.Update;
+import ddf.catalog.operation.UpdateResponse;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.PostIngestPlugin;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BuildSuggesterIndexPlugin implements PostIngestPlugin {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BuildSuggesterIndexPlugin.class);
+
+  private final ScheduledThreadPoolExecutor executor;
+
+  private final BuildSuggesterIndex buildSuggesterIndex;
+
+  private ScheduledFuture<?> future;
+
+  public BuildSuggesterIndexPlugin(
+      final ScheduledThreadPoolExecutor executor, final BuildSuggesterIndex buildSuggesterIndex) {
+    this.executor = executor;
+    this.buildSuggesterIndex = buildSuggesterIndex;
+  }
+
+  @Override
+  public CreateResponse process(final CreateResponse input) throws PluginExecutionException {
+    final List<Metacard> metacards = input.getCreatedMetacards();
+    if (containsGazetteerMetacards(metacards)) {
+      LOGGER.trace("Create response contains gazetteer metacards. Building suggester index.");
+      scheduleSuggesterIndexBuild();
+    }
+    return input;
+  }
+
+  @Override
+  public UpdateResponse process(final UpdateResponse input) throws PluginExecutionException {
+    if (containsGazetteerMetacards(input)) {
+      LOGGER.trace("Update response contains gazetteer metacards. Building suggester index.");
+      scheduleSuggesterIndexBuild();
+    }
+    return input;
+  }
+
+  @Override
+  public DeleteResponse process(final DeleteResponse input) throws PluginExecutionException {
+    final List<Metacard> metacards = input.getDeletedMetacards();
+    if (containsGazetteerMetacards(metacards)) {
+      LOGGER.trace("Delete response contains gazetteer metacards. Building suggester index.");
+      scheduleSuggesterIndexBuild();
+    }
+    return input;
+  }
+
+  private boolean containsGazetteerMetacards(final List<Metacard> metacards) {
+    return metacards.stream().anyMatch(m -> m.getTags().contains(GAZETTEER_METACARD_TAG));
+  }
+
+  private boolean containsGazetteerMetacards(final UpdateResponse updateResponse) {
+    return updateResponse.getUpdatedMetacards().stream().anyMatch(this::containsGazetteerMetacard);
+  }
+
+  private boolean containsGazetteerMetacard(final Update update) {
+    return update.getOldMetacard().getTags().contains(GAZETTEER_METACARD_TAG)
+        || update.getNewMetacard().getTags().contains(GAZETTEER_METACARD_TAG);
+  }
+
+  private synchronized void scheduleSuggesterIndexBuild() throws PluginExecutionException {
+    if (future != null) {
+      future.cancel(false);
+    }
+
+    try {
+      future = executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES);
+    } catch (RejectedExecutionException e) {
+      LOGGER.info(
+          "The offline gazetteer's suggester index could not be built automatically. It may have "
+              + "to be built manually with the 'gazetteer:build-suggester-index' command.");
+      throw new PluginExecutionException(e);
+    }
+  }
+}

--- a/catalog/plugin/catalog-plugin-gazetteer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-gazetteer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+  <bean id="buildSuggesterIndexThreadFactory"
+    class="org.codice.ddf.platform.util.StandardThreadFactoryBuilder"
+    factory-method="newThreadFactory">
+    <argument value="buildSuggesterIndexThread"/>
+  </bean>
+
+  <bean id="singleThreadScheduledExecutor" class="java.util.concurrent.ScheduledThreadPoolExecutor">
+    <argument value="1"/>
+    <argument ref="buildSuggesterIndexThreadFactory"/>
+    <property name="removeOnCancelPolicy" value="true"/>
+  </bean>
+
+  <bean id="buildSuggesterIndex"
+    class="org.codice.ddf.catalog.plugin.gazetteer.BuildSuggesterIndex">
+    <argument>
+      <reference interface="ddf.catalog.CatalogFramework"/>
+    </argument>
+    <argument>
+      <reference interface="ddf.catalog.filter.FilterBuilder"/>
+    </argument>
+  </bean>
+
+  <service interface="ddf.catalog.plugin.PostIngestPlugin">
+    <bean class="org.codice.ddf.catalog.plugin.gazetteer.BuildSuggesterIndexPlugin">
+      <argument ref="singleThreadScheduledExecutor"/>
+      <argument ref="buildSuggesterIndex"/>
+    </bean>
+  </service>
+</blueprint>

--- a/catalog/plugin/catalog-plugin-gazetteer/src/test/groovy/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndexPluginSpec.groovy
+++ b/catalog/plugin/catalog-plugin-gazetteer/src/test/groovy/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndexPluginSpec.groovy
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.gazetteer
+
+import ddf.catalog.data.Metacard
+import ddf.catalog.operation.CreateResponse
+import ddf.catalog.operation.DeleteResponse
+import ddf.catalog.operation.Update
+import ddf.catalog.operation.UpdateResponse
+import ddf.catalog.plugin.PluginExecutionException
+import spock.lang.Specification
+
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+import static org.codice.ddf.spatial.geocoding.GeoCodingConstants.GAZETTEER_METACARD_TAG
+
+class BuildSuggesterIndexPluginSpec extends Specification {
+    def future = Mock(ScheduledFuture)
+    def buildSuggesterIndex = Stub(BuildSuggesterIndex)
+    def executor = Mock(ScheduledThreadPoolExecutor)
+    def buildSuggesterIndexPlugin = new BuildSuggesterIndexPlugin(executor, buildSuggesterIndex)
+
+    def gazetteerMetacard = Stub(Metacard) {
+        getTags() >> (Set) [GAZETTEER_METACARD_TAG]
+    }
+
+    def "schedules a suggester index build when gazetteer metacards are created"() {
+        setup:
+        def createResponse = Stub(CreateResponse) {
+            getCreatedMetacards() >> [gazetteerMetacard]
+        }
+
+        when:
+        buildSuggesterIndexPlugin.process(createResponse)
+
+        then:
+        1 * executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES) >> future
+    }
+
+    def "schedules a suggester index build when gazetteer metacards are updated"() {
+        setup:
+        def update = Stub(Update) {
+            getOldMetacard() >> gazetteerMetacard
+        }
+        def updateResponse = Stub(UpdateResponse) {
+            getUpdatedMetacards() >> [update]
+        }
+
+        when:
+        buildSuggesterIndexPlugin.process(updateResponse)
+
+        then:
+        1 * executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES) >> future
+    }
+
+    def "schedules a suggester index build when metacards are updated to gazetteer metacards"() {
+        setup:
+        def update = Stub(Update) {
+            getOldMetacard() >> Stub(Metacard)
+            getNewMetacard() >> gazetteerMetacard
+        }
+        def updateResponse = Stub(UpdateResponse) {
+            getUpdatedMetacards() >> [update]
+        }
+
+        when:
+        buildSuggesterIndexPlugin.process(updateResponse)
+
+        then:
+        1 * executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES) >> future
+    }
+
+    def "schedules a suggester index build when gazetteer metacards are deleted"() {
+        setup:
+        def deleteResponse = Stub(DeleteResponse) {
+            getDeletedMetacards() >> [gazetteerMetacard]
+        }
+
+        when:
+        buildSuggesterIndexPlugin.process(deleteResponse)
+
+        then:
+        1 * executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES) >> future
+    }
+
+    def "does nothing when no gazetteer metacards are created"() {
+        setup:
+        def createResponse = Stub(CreateResponse)
+
+        when:
+        buildSuggesterIndexPlugin.process(createResponse)
+
+        then:
+        0 * _
+    }
+
+    def "does nothing when no gazetteer metacards are updated"() {
+        setup:
+        def updateResponse = Stub(UpdateResponse)
+
+        when:
+        buildSuggesterIndexPlugin.process(updateResponse)
+
+        then:
+        0 * _
+    }
+
+    def "does nothing when no gazetteer metacards are deleted"() {
+        setup:
+        def deleteResponse = Stub(DeleteResponse)
+
+        when:
+        buildSuggesterIndexPlugin.process(deleteResponse)
+
+        then:
+        0 * _
+    }
+
+    def "cancels last scheduled task before scheduling another"() {
+        setup:
+        def createResponse = Stub(CreateResponse) {
+            getCreatedMetacards() >> [gazetteerMetacard]
+        }
+
+        when:
+        buildSuggesterIndexPlugin.process(createResponse)
+
+        then:
+        1 * executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES) >> future
+
+        when:
+        buildSuggesterIndexPlugin.process(createResponse)
+
+        then:
+        1 * future.cancel(false)
+        1 * executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES) >> future
+    }
+
+    def "throws a PluginExecutionException when the task cannot be scheduled"() {
+        setup:
+        def createResponse = Stub(CreateResponse) {
+            getCreatedMetacards() >> [gazetteerMetacard]
+        }
+
+        when:
+        buildSuggesterIndexPlugin.process(createResponse)
+
+        then:
+        1 * executor.schedule(buildSuggesterIndex, 1, TimeUnit.MINUTES) >> {
+            throw new RejectedExecutionException()
+        }
+        PluginExecutionException e = thrown()
+        e.cause instanceof RejectedExecutionException
+    }
+}

--- a/catalog/plugin/catalog-plugin-gazetteer/src/test/groovy/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndexSpec.groovy
+++ b/catalog/plugin/catalog-plugin-gazetteer/src/test/groovy/org/codice/ddf/catalog/plugin/gazetteer/BuildSuggesterIndexSpec.groovy
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.plugin.gazetteer
+
+import ddf.catalog.CatalogFramework
+import ddf.catalog.data.types.Core
+import ddf.catalog.filter.AttributeBuilder
+import ddf.catalog.filter.FilterBuilder
+import ddf.catalog.operation.QueryRequest
+import ddf.catalog.source.SourceUnavailableException
+import spock.lang.Specification
+
+import static ddf.catalog.Constants.SUGGESTION_BUILD_KEY
+import static ddf.catalog.Constants.SUGGESTION_CONTEXT_KEY
+import static ddf.catalog.Constants.SUGGESTION_DICT_KEY
+import static ddf.catalog.Constants.SUGGESTION_QUERY_KEY
+import static org.codice.ddf.spatial.geocoding.GeoCodingConstants.GAZETTEER_METACARD_TAG
+import static org.codice.ddf.spatial.geocoding.GeoCodingConstants.SUGGEST_PLACE_KEY
+
+class BuildSuggesterIndexSpec extends Specification {
+    def catalogFramework = Mock(CatalogFramework)
+    def filterBuilder = Stub(FilterBuilder) {
+        attribute(Core.METACARD_TAGS) >> Stub(AttributeBuilder)
+    }
+    def buildSuggesterIndex = new BuildSuggesterIndex(catalogFramework, filterBuilder)
+
+    def "sends a query request with the parameters needed to build the suggester index"() {
+        when:
+        buildSuggesterIndex.run()
+
+        then:
+        1 * catalogFramework.query((QueryRequest) {
+            it.getPropertyValue(SUGGESTION_QUERY_KEY) == "anything"
+            it.getPropertyValue(SUGGESTION_CONTEXT_KEY) == GAZETTEER_METACARD_TAG
+            it.getPropertyValue(SUGGESTION_DICT_KEY) == SUGGEST_PLACE_KEY
+            it.getPropertyValue(SUGGESTION_BUILD_KEY) == true
+        })
+    }
+
+    def "does not propagate exceptions thrown by the catalog framework"() {
+        when:
+        buildSuggesterIndex.run()
+
+        then:
+        1 * catalogFramework.query(_ as QueryRequest) >> { throw new SourceUnavailableException() }
+    }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -40,5 +40,6 @@
         <module>catalog-plugin-metacardbackup-filestorage</module>
         <module>catalog-plugin-metacardbackup-s3storage</module>
         <module>catalog-plugin-security-audit</module>
+        <module>catalog-plugin-gazetteer</module>
     </modules>
 </project>

--- a/catalog/spatial/spatial-commands/pom.xml
+++ b/catalog/spatial/spatial-commands/pom.xml
@@ -24,6 +24,18 @@
     <packaging>bundle</packaging>
     <dependencies>
         <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.codice.ddf.spatial</groupId>
             <artifactId>spatial-geocoding-api</artifactId>
             <version>${project.version}</version>
@@ -53,10 +65,51 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Karaf-Commands>*</Karaf-Commands>
+                        <Karaf-Commands>org.codice.ddf.commands.spatial.gazetteer</Karaf-Commands>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
                         <Export-Package/>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.87</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.83</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.91</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/catalog/spatial/spatial-commands/src/main/java/org/codice/ddf/commands/spatial/gazetteer/GazetteerBuildSuggesterIndexCommand.java
+++ b/catalog/spatial/spatial-commands/src/main/java/org/codice/ddf/commands/spatial/gazetteer/GazetteerBuildSuggesterIndexCommand.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.spatial.gazetteer;
+
+import static ddf.catalog.Constants.SUGGESTION_BUILD_KEY;
+import static ddf.catalog.Constants.SUGGESTION_CONTEXT_KEY;
+import static ddf.catalog.Constants.SUGGESTION_DICT_KEY;
+import static ddf.catalog.Constants.SUGGESTION_QUERY_KEY;
+import static ddf.catalog.data.types.Core.METACARD_TAGS;
+import static org.codice.ddf.spatial.geocoding.GeoCodingConstants.GAZETTEER_METACARD_TAG;
+import static org.codice.ddf.spatial.geocoding.GeoCodingConstants.SUGGEST_PLACE_KEY;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.codice.ddf.commands.catalog.SubjectCommands;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Service
+@Command(
+  scope = "gazetteer",
+  name = "build-suggester-index",
+  description =
+      "Builds the Solr suggest index used for placename autocompletion in Intrigue when using "
+          + "the offline gazetteer. This index is built automatically whenever gazetteer "
+          + "metacards are created, updated, or deleted, but if those builds fail then this "
+          + "command can be used to attempt to build the index again."
+)
+public class GazetteerBuildSuggesterIndexCommand extends SubjectCommands {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(GazetteerBuildSuggesterIndexCommand.class);
+
+  @Reference private CatalogFramework catalogFramework;
+
+  @Reference private FilterBuilder filterBuilder;
+
+  public void setCatalogFramework(final CatalogFramework catalogFramework) {
+    this.catalogFramework = catalogFramework;
+  }
+
+  public void setFilterBuilder(final FilterBuilder filterBuilder) {
+    this.filterBuilder = filterBuilder;
+  }
+
+  @Override
+  protected Object executeWithSubject() {
+    console.println("Building the gazetteer suggester index.");
+    console.println(
+        "This will take a few seconds or longer depending on how many gazetteer entries there are.");
+
+    buildSuggesterIndex();
+
+    console.println("Done.");
+
+    return null;
+  }
+
+  private void buildSuggesterIndex() {
+    final QueryRequest buildSuggesterIndex = getQueryBuildSuggesterIndex();
+
+    requestBuildSuggesterIndex(buildSuggesterIndex);
+  }
+
+  private void requestBuildSuggesterIndex(final QueryRequest buildSuggesterIndex) {
+    try {
+      catalogFramework.query(buildSuggesterIndex);
+    } catch (SourceUnavailableException | FederationException | UnsupportedQueryException e) {
+      printErrorMessage(
+          "Could not build the Solr suggestion index. Try running this command again after resolving the following error.");
+      printErrorMessage("Error: " + e.getMessage());
+      console.println("The stacktrace can be viewed in the log.");
+      LOGGER.info("The gazetteer:build-suggester-index command failed.", e);
+    }
+  }
+
+  private QueryRequest getQueryBuildSuggesterIndex() {
+    // The filter provided here isn't used since this query goes to the suggest handler.
+    final Query suggestionQuery =
+        new QueryImpl(filterBuilder.attribute(METACARD_TAGS).text(GAZETTEER_METACARD_TAG));
+
+    return new QueryRequestImpl(suggestionQuery, getPropertiesBuildSuggesterIndex());
+  }
+
+  private Map<String, Serializable> getPropertiesBuildSuggesterIndex() {
+    final Map<String, Serializable> suggestQueryProperties = new HashMap<>();
+    // Query string must be included but we don't care about the result
+    suggestQueryProperties.put(SUGGESTION_QUERY_KEY, "anything");
+    suggestQueryProperties.put(SUGGESTION_CONTEXT_KEY, GAZETTEER_METACARD_TAG);
+    suggestQueryProperties.put(SUGGESTION_DICT_KEY, SUGGEST_PLACE_KEY);
+    suggestQueryProperties.put(SUGGESTION_BUILD_KEY, true);
+    return suggestQueryProperties;
+  }
+}

--- a/catalog/spatial/spatial-commands/src/test/java/org/codice/ddf/commands/spatial/gazetteer/GazetteerBuildSuggesterIndexCommandTest.java
+++ b/catalog/spatial/spatial-commands/src/test/java/org/codice/ddf/commands/spatial/gazetteer/GazetteerBuildSuggesterIndexCommandTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.spatial.gazetteer;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.source.SourceUnavailableException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GazetteerBuildSuggesterIndexCommandTest {
+  @Mock private CatalogFramework catalogFramework;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private FilterBuilder filterBuilder;
+
+  private ConsoleInterceptor consoleInterceptor;
+
+  private GazetteerBuildSuggesterIndexCommand command;
+
+  @Before
+  public void setUp() {
+    consoleInterceptor = new ConsoleInterceptor();
+    consoleInterceptor.interceptSystemOut();
+    command = new GazetteerBuildSuggesterIndexCommand();
+    command.setFilterBuilder(filterBuilder);
+    command.setCatalogFramework(catalogFramework);
+  }
+
+  @After
+  public void tearDown() {
+    consoleInterceptor.resetSystemOut();
+  }
+
+  @Test
+  public void successfulRunPrintsNoErrors() {
+    command.executeWithSubject();
+
+    final String output = consoleInterceptor.getOutput();
+    assertThat(output, not(containsString("Error:")));
+  }
+
+  @Test
+  public void unsuccessfulRunPrintsErrors() throws Exception {
+    final String exceptionMessage = "The source is unavailable.";
+    doThrow(new SourceUnavailableException(exceptionMessage)).when(catalogFramework).query(any());
+
+    command.executeWithSubject();
+
+    final String output = consoleInterceptor.getOutput();
+    assertThat(output, containsString("Error: " + exceptionMessage));
+  }
+}

--- a/distribution/docs/src/main/resources/content/_appReferences/mg-spatial.adoc
+++ b/distribution/docs/src/main/resources/content/_appReferences/mg-spatial.adoc
@@ -32,6 +32,13 @@ The `gazetteer` commands provide the ability to interact with the local GeoNames
 The `-c` or `--create` flag can be used to clear out the existing gazetteer metacards before adding new entries.
 |gazetteer:update
 
+|`build-suggester-index`
+|Builds the Solr suggester index used for placename autocompletion in Intrigue when using the
+offline gazetteer. This index is built automatically whenever gazetteer metacards are created,
+updated, or deleted, but if those builds fail then this command can be used to attempt to build the
+index again.
+|`gazetteer:build-suggester-index`
+
 |===
 
 ===  ${ddf-spatial} Prerequisites

--- a/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/solrconfig-inmemory.xml
+++ b/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/solrconfig-inmemory.xml
@@ -1153,15 +1153,15 @@
     <searchComponent name="suggest" class="solr.SuggestComponent">
         <lst name="suggester">
             <str name="name">suggestPlace</str>
-            <str name="storeDir">place_suggest_index</str>
             <str name="lookupImpl">BlendedInfixLookupFactory</str>
+            <str name="indexPath">place_suggest_index</str>
             <str name="dictionaryImpl">DocumentDictionaryFactory</str>
             <str name="suggestAnalyzerFieldType">lowercase</str>
             <str name="field">title_txt</str>
             <str name="contextField">metacard-tags_txt</str>
             <str name="weightField">ext.population_lng</str>
-            <str name="payloadField">description_txt</str>
-            <str name="buildOnStartup">true</str>
+            <str name="payloadField">id_txt</str>
+            <str name="buildOnStartup">false</str>
         </lst>
     </searchComponent>
 

--- a/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/solrconfig.xml
+++ b/platform/solr/platform-solr-server-standalone/src/main/resources/solr/conf/solrconfig.xml
@@ -1149,15 +1149,15 @@
     <searchComponent name="suggest" class="solr.SuggestComponent">
         <lst name="suggester">
             <str name="name">suggestPlace</str>
-            <str name="storeDir">place_suggest_index</str>
             <str name="lookupImpl">BlendedInfixLookupFactory</str>
+            <str name="indexPath">place_suggest_index</str>
             <str name="dictionaryImpl">DocumentDictionaryFactory</str>
             <str name="suggestAnalyzerFieldType">lowercase</str>
             <str name="field">title_txt</str>
             <str name="contextField">metacard-tags_txt</str>
             <str name="weightField">ext.population_lng</str>
             <str name="payloadField">id_txt</str>
-            <str name="buildOnStartup">true</str>
+            <str name="buildOnStartup">false</str>
         </lst>
     </searchComponent>
 


### PR DESCRIPTION
#### What does this PR do?
- Changes when the Solr gazetteer suggester index is built. Currently the index is built on every Solr restart and `catalog ` core reload, regardless of whether the gazetteer entries have changed. This PR sets `buildOnStartup=false` and adds a new `PostIngestPlugin` that builds the suggester index when new gazetteer metacards are created, updated, or deleted.
- Adds a `gazetteer:build-suggester-index` command for manually issuing requests to build the suggester index (useful if the request submitted after the gazetteer update fails).
- Changes `storeDir` to `indexPath` in the suggest component in `solrconfig.xml`. `BlendedInfixLookupFactory` uses `indexPath` to store the suggester index. This change prevents Solr from printing a bogus failure message in its log and ensures the suggester index will be stored in the `place_suggest_index` directory.

#### Who is reviewing it? 
@adimka 
@bdeining 
@troymohl 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@millerw8 
@pklinef

#### How should this be tested?
- Start DDF and run through the installer. Restart DDF, open Intrigue, and create an advanced search. Select the `anyGeo` field then click the `Keyword` box. Click `Enter a region, country, or city` and type a few characters. Verify that matching suggestions are provided below. Also try searching for "Omaha" and verify that there are no results (this is relevant to step 3).
- Check Solr's log file `<DDF_INSTALL_LOCATION>/solr/server/logs/solr.log` and verify that `SolrSuggester.build(suggestPlace)` only appears once. This is printed every time the suggester index is built.
- Add more entries to the gazetteer using the `gazetteer:update` command and a dump file obtained from [GeoNames](http://download.geonames.org/export/dump/), such as `cities15000.zip`. Wait one minute (how long it takes for the suggester index to be built after ingesting new gazetteer entries), then go back to Intrigue and try searching for `Omaha` in the box you typed in in step 1 (Omaha is not included in the default geonames zip included with DDF but is included in `cities15000.zip`). Verify that you get at least one result back, which means the suggester index was updated after you added gazetteer entries.

#### What are the relevant tickets?
[DDF-3987](https://codice.atlassian.net/browse/DDF-3987)

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
