### PR TITLE
DDF-3992 won't start local solr if not configured as HttpSolrClient

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddf
+++ b/distribution/ddf-common/src/main/resources/bin/ddf
@@ -32,7 +32,7 @@ SOLR_EXEC=${HOME_DIR}/solr/bin/solr
 get_property() {
 
     value=""
-    value=`grep ^$1= "$PROPERTIES_FILE" | cut -d = -f2`
+    value=`grep ^$1 "$PROPERTIES_FILE" | cut -d = -f2`
 
     if [ $value ]; then
         echo $value
@@ -59,7 +59,7 @@ refresh_properties() {
 # Return 0 (success/true) if the Solr lifecycle should be managed by this script
 is_managing_solr() {
   local RC=1
-  if [ $SOLR_CLIENT = HttpSolrClient  ]; then
+  if [ $SOLR_CLIENT = "HttpSolrClient"  ]; then
     RC=0
   fi
   return $RC
@@ -169,8 +169,10 @@ start_karaf() {
 }
 
 attempt_startup() {
+    if is_managing_solr; then
         set_solr_memory
         start_solr;
+    fi
 
     # Process suspended while Karaf is running
     start_karaf

--- a/distribution/ddf-common/src/main/resources/bin/ddf.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddf.bat
@@ -49,14 +49,18 @@ SET RC=%ERRORLEVEL%
 REM Check if restart was requested by ddf_on_error.bat
 IF EXIST "%DIRNAME%\restart.jvm" (
     ECHO Restarting JVM...
-    IF "%SOLR_CLIENT%" == "HttpSolrClient" (
-      CALL %DDF_HOME%/solr/bin/solr.cmd stop -p %SOLR_PORT%
-    )
+    CALL :STOP_SOLR
     GOTO :RESTART
 ) ELSE (
-    IF "%SOLR_CLIENT%" == "HttpSolrClient" (
-      ECHO Stopping Solr process on port %SOLR_PORT%
-      CALL %DDF_HOME%/solr/bin/solr.cmd stop -p %SOLR_PORT%
-    )
+    CALL :STOP_SOLR
     EXIT /B %RC%
 )
+
+EXIT /B
+
+:STOP_SOLR
+IF "%SOLR_CLIENT%" == "HttpSolrClient" (
+  ECHO Stopping Solr process on port %SOLR_PORT%
+  CALL %DDF_HOME%/solr/bin/solr.cmd stop -p %SOLR_PORT%
+)
+GOTO :EOF

--- a/distribution/ddf-common/src/main/resources/bin/ddf.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddf.bat
@@ -49,10 +49,14 @@ SET RC=%ERRORLEVEL%
 REM Check if restart was requested by ddf_on_error.bat
 IF EXIST "%DIRNAME%\restart.jvm" (
     ECHO Restarting JVM...
-    CALL %DDF_HOME%/solr/bin/solr.cmd stop -p %SOLR_PORT%
+    IF "%SOLR_CLIENT%" == "HttpSolrClient" (
+      CALL %DDF_HOME%/solr/bin/solr.cmd stop -p %SOLR_PORT%
+    )
     GOTO :RESTART
 ) ELSE (
-    ECHO Stopping Solr process on port %SOLR_PORT%
-    CALL %DDF_HOME%/solr/bin/solr.cmd stop -p %SOLR_PORT%
+    IF "%SOLR_CLIENT%" == "HttpSolrClient" (
+      ECHO Stopping Solr process on port %SOLR_PORT%
+      CALL %DDF_HOME%/solr/bin/solr.cmd stop -p %SOLR_PORT%
+    )
     EXIT /B %RC%
 )


### PR DESCRIPTION
#### What does this PR do?
Won't start local solr if not configured as HttpSolrClient
Parse solr port and client properly even with spaces between = 

#### Who is reviewing it? 
@ahoffer 
@millerw8 
@bdeining 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8

#### How should this be tested?
Test in both Linux and Windows
by default. start up DDF should start solr
`Started Solr server on port 8994 (pid=46296). Happy searching!`
Modify etc/system.properties `solr.client` value any else but `HttpSolrClient`
Verify solr is not started

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-3992
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
