### PR TITLE
DDF-3988 Give the third-party FFmpeg library permissions to create thumbnails

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -347,7 +347,7 @@ grant codeBase "file:/catalog-core-standardframework/platform-solr-server-standa
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}-", "read";
 }
 
-grant codeBase "file:/catalog-plugin-videothumbnail/catalog-rest-endpoint/catalog-core-standardframework" {
+grant codeBase "file:/catalog-plugin-videothumbnail/catalog-rest-endpoint/catalog-core-standardframework/catalog-ui-search" {
     permission java.io.FilePermission "${ddf.home.perm}bin_third_party", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}bin_third_party${/}-", "read,write,execute";
     permission java.io.FilePermission "${ddf.home.perm}bin_third_party${/}ffmpeg${/}-", "read,write,execute";


### PR DESCRIPTION
#### What does this PR do?
Gives `catalog-ui-search` permissions to read, write, and execute the Codice Third Party executables.

#### Who is reviewing it? 
@Kjames5269 
@emmberk 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@coyotesqrl 

#### How should this be tested?
1. Install DDF
2. Ingest a video file (message me if you need one)
3. Verify that the DDF logs don't throw any exceptions and that there is a thumbnail on the ingested resource.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3988](https://codice.atlassian.net/browse/DDF-3988)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
