### PR TITLE
2.13.X DDF-3915 Update file permission access in itest

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -148,6 +148,9 @@ public abstract class AbstractIntegrationTest {
 
   private static final String KARAF_HOME = "{karaf.home}";
 
+  protected static final String FILE_PERMISSIONS =
+      "priority \"grant\"; grant {permission java.io.FilePermission \"%s%s-\", \"read, write\"; };";
+
   protected static ServerSocket placeHolderSocket;
 
   protected static Integer basePort;
@@ -692,19 +695,23 @@ public abstract class AbstractIntegrationTest {
               getClass().getResource("/etc/forms/imagery.xml"), "/etc/forms/imagery.xml"),
           installStartupFile(
               getClass().getResource("/etc/forms/contact-name.xml"), "/etc/forms/contact-name.xml"),
-          installStartupFile(
-              String.format(
-                  "priority \"grant\"; grant {permission java.io.FilePermission \"%s%s-\", \"read, write\"; };",
-                  new File("target" + File.separator + "solr")
-                      .getAbsolutePath()
-                      .replace("/", "${/}")
-                      .replace("\\", "${/}"),
-                  "${/}"),
-              "/security/itests-solr.policy"));
+          getFilePermissionsOption());
     } catch (IOException e) {
       LoggingUtils.failWithThrowableStacktrace(e, "Failed to deploy configuration files: ");
     }
     return new Option[0];
+  }
+
+  protected Option getFilePermissionsOption() throws IOException {
+    return installStartupFile(
+        String.format(
+            FILE_PERMISSIONS,
+            new File("target" + File.separator + "solr")
+                .getAbsolutePath()
+                .replace("/", "${/}")
+                .replace("\\", "${/}"),
+            "${/}"),
+        "/security/itests-solr.policy");
   }
 
   private Option[] configureSolr() {


### PR DESCRIPTION
#### What does this PR do?
Update file permission access in itest, allow downstream projects that extend the abstract class to reference the getFilePermissionsOption method. 

#### Who is reviewing it? 
@austinsteffes @garrettfreibott @ahoffer @rzwiefel @clockard @oconnormi @vinamartin

#### How should this be tested?
Inspect changes. Run itests.

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
