### PR TITLE
DDF-3979 Modified to migrate all policy files

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -30,7 +30,7 @@ deny {
 }
 
 grant
-  codeBase "file:/platform-migration" {
+  codeBase "file:/platform-migration/platform-migratable-api" {
     permission java.io.FilePermission "<<ALL FILES>>", "read, readlink";
     permission java.io.FilePermission "${ddf.home}", "write, delete";
     permission java.io.FilePermission "${ddf.home.perm}-", "write, delete";

--- a/platform/platform-migratable/src/main/java/org/codice/ddf/platform/migratable/impl/PlatformMigratable.java
+++ b/platform/platform-migratable/src/main/java/org/codice/ddf/platform/migratable/impl/PlatformMigratable.java
@@ -49,7 +49,6 @@ public class PlatformMigratable implements Migratable {
 
   private static final List<Path> REQUIRED_SYSTEM_PATHS =
       ImmutableList.of( //
-          Paths.get("security", "default.policy"),
           Paths.get("etc", "ws-security"),
           Paths.get("etc", "system.properties"),
           Paths.get("etc", "startup.properties"),

--- a/platform/platform-migratable/src/test/java/org/codice/ddf/platform/migratable/impl/PlatformMigratableTest.java
+++ b/platform/platform-migratable/src/test/java/org/codice/ddf/platform/migratable/impl/PlatformMigratableTest.java
@@ -123,7 +123,6 @@ public class PlatformMigratableTest {
 
   private static final List<Path> REQUIRED_SYSTEM_FILES =
       ImmutableList.of(
-          Paths.get("security", "default.policy"),
           Paths.get("etc", "system.properties"),
           Paths.get("etc", "startup.properties"),
           Paths.get("etc", "custom.properties"),

--- a/platform/security/security-migratable/src/main/java/org/codice/ddf/security/migratable/impl/SecurityMigratable.java
+++ b/platform/security/security-migratable/src/main/java/org/codice/ddf/security/migratable/impl/SecurityMigratable.java
@@ -42,6 +42,8 @@ public class SecurityMigratable implements Migratable {
 
   private static final Path PDP_POLICIES_DIR = Paths.get("etc", "pdp");
 
+  private static final Path SECURITY_POLICIES_DIR = Paths.get("security");
+
   private static final List<Path> PROPERTIES_FILES =
       ImmutableList.of( //
           Paths.get("etc", SecurityMigratable.WS_SECURITY, "server", "encryption.properties"),
@@ -97,6 +99,9 @@ public class SecurityMigratable implements Migratable {
         .forEach(ExportMigrationEntry::store);
     LOGGER.debug("Exporting PDP files from [{}]...", SecurityMigratable.PDP_POLICIES_DIR);
     context.getEntry(SecurityMigratable.PDP_POLICIES_DIR).store();
+    LOGGER.debug(
+        "Exporting security policy files from [{}]...", SecurityMigratable.SECURITY_POLICIES_DIR);
+    context.getEntry(SecurityMigratable.SECURITY_POLICIES_DIR).store();
   }
 
   @Override
@@ -116,5 +121,8 @@ public class SecurityMigratable implements Migratable {
         .forEach(ImportMigrationEntry::restore);
     LOGGER.debug("Importing PDP Directory at [{}]...", SecurityMigratable.PDP_POLICIES_DIR);
     context.getEntry(SecurityMigratable.PDP_POLICIES_DIR).restore();
+    LOGGER.debug(
+        "Importing security policy Directory at [{}]...", SecurityMigratable.SECURITY_POLICIES_DIR);
+    context.getEntry(SecurityMigratable.SECURITY_POLICIES_DIR).restore();
   }
 }


### PR DESCRIPTION
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
##### Backport of [PR 3465](https://github.com/codice/ddf/pull/3465)
____

#### What does this PR do?
It moves the policy files migration from the platform migratable to the security migratable and ensures to migrate the whole security directory and not just the default.policy file. It also fixes a permission issue where default interface methods from the API are called and thus require the same privileges as the implementation.

#### Who is reviewing it? 
@ethantmanns 
@tyler30clemens 
@jhunzik 
@tbatie

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/security

#### Ask 2 committers to review/merge the PR and tag them here.
@figliold
@stustison
@tbatie

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
