### PR TITLE
DDF-3998 Fix CAS client redirects

### DIFF
--- a/platform/security/cas/security-cas-client/pom.xml
+++ b/platform/security/cas/security-cas-client/pom.xml
@@ -129,17 +129,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.47</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.30</minimum>
+                                            <minimum>0.43</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.29</minimum>
+                                            <minimum>0.41</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/cas/security-cas-client/src/main/java/org/codice/ddf/security/handler/cas/filter/FilteredRequest.java
+++ b/platform/security/cas/security-cas-client/src/main/java/org/codice/ddf/security/handler/cas/filter/FilteredRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.handler.cas.filter;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A wrapped HttpServletRequest that is aware of the system root context, and returns the correct
+ * paths for both internal and external requests.
+ */
+public class FilteredRequest extends HttpServletRequestWrapper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FilteredRequest.class);
+
+  private final String contextPath;
+  private final String requestUri;
+  private final String requestUrl;
+
+  public FilteredRequest(HttpServletRequest request, String serverName) {
+    super(request);
+
+    // Wrapping FilteredRequests will result in repeated root contexts since the original request
+    // is already wrapped. Instead, just copy the wrapped request and systemBaseUrl references
+    if (request instanceof FilteredRequest) {
+      FilteredRequest filteredRequest = (FilteredRequest) request;
+      contextPath = filteredRequest.contextPath;
+      requestUri = filteredRequest.requestUri;
+      requestUrl = filteredRequest.requestUrl;
+    } else {
+      URL baseUrl = toBaseUrl(serverName);
+      contextPath =
+          isExternalRequest(baseUrl)
+              ? SystemBaseUrl.EXTERNAL.getRootContext().replaceFirst("/$", "")
+              : "";
+      requestUri = contextPath + request.getRequestURI();
+      requestUrl =
+          (baseUrl == null)
+              ? serverName.replaceFirst("/$", "") + requestUri
+              : baseUrl.toString() + requestUri;
+    }
+  }
+
+  @Override
+  public String getContextPath() {
+    return contextPath;
+  }
+
+  @Override
+  public String getRequestURI() {
+    return requestUri;
+  }
+
+  @Override
+  public StringBuffer getRequestURL() {
+    return new StringBuffer(requestUrl);
+  }
+
+  private URL toBaseUrl(String serverName) {
+    try {
+      URL url = new URL(serverName);
+      return new URI(url.getProtocol(), url.getAuthority(), null, null, null).toURL();
+    } catch (MalformedURLException | URISyntaxException e) {
+      LOGGER.warn("Error parsing CAS client server name config. Is it a valid URL?");
+      return null;
+    }
+  }
+
+  private boolean isExternalRequest(URL url) {
+    if (url == null) {
+      return false;
+    }
+
+    String protocol = SystemBaseUrl.EXTERNAL.getProtocol().replaceFirst("://$", "");
+    return SystemBaseUrl.EXTERNAL.getHost().equals(url.getHost())
+        && SystemBaseUrl.EXTERNAL.getPort().equals(Integer.toString(url.getPort()))
+        && protocol.equals(url.getProtocol());
+  }
+}

--- a/platform/security/cas/security-cas-client/src/main/java/org/codice/ddf/security/handler/cas/filter/ProxyFilter.java
+++ b/platform/security/cas/security-cas-client/src/main/java/org/codice/ddf/security/handler/cas/filter/ProxyFilter.java
@@ -22,6 +22,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import org.jasig.cas.client.util.AbstractCasFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,12 +46,14 @@ import org.slf4j.LoggerFactory;
 public class ProxyFilter implements Filter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProxyFilter.class);
 
-  private List<Filter> filters;
+  private List<AbstractCasFilter> filters;
 
   private boolean initialized;
 
+  private String serverName = "";
+
   /** @param filters The CAS filters to add to the filter chain. */
-  public ProxyFilter(List<Filter> filters) {
+  public ProxyFilter(List<AbstractCasFilter> filters) {
     this.filters = filters;
     initialized = false;
   }
@@ -89,7 +92,7 @@ public class ProxyFilter implements Filter {
         filterProxyChain.getClass().getName(),
         servletRequest,
         servletResponse);
-    filterProxyChain.doFilter(servletRequest, servletResponse);
+    filterProxyChain.doFilter(new FilteredRequest(httpServletRequest, serverName), servletResponse);
   }
 
   /** @see javax.servlet.Filter#init(javax.servlet.FilterConfig) */
@@ -102,5 +105,9 @@ public class ProxyFilter implements Filter {
 
       initialized = true;
     }
+  }
+
+  public void setServerName(String serverName) {
+    this.serverName = serverName;
   }
 }

--- a/platform/security/cas/security-cas-client/src/main/java/org/codice/ddf/security/handler/cas/filter/ProxyFilterChain.java
+++ b/platform/security/cas/security-cas-client/src/main/java/org/codice/ddf/security/handler/cas/filter/ProxyFilterChain.java
@@ -17,12 +17,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import org.jasig.cas.client.util.AbstractCasFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,9 +32,9 @@ public class ProxyFilterChain implements FilterChain {
 
   private FilterChain filterChain;
 
-  private List<Filter> filters;
+  private List<AbstractCasFilter> filters;
 
-  private Iterator<Filter> iterator;
+  private Iterator<AbstractCasFilter> iterator;
 
   /**
    * @param filterChain The filter chain from the web container. If null, no other filters will be
@@ -46,7 +46,7 @@ public class ProxyFilterChain implements FilterChain {
   }
 
   /** @param filter The servlet filter to add. */
-  public void addFilter(Filter filter) {
+  public void addFilter(AbstractCasFilter filter) {
     if (iterator != null) {
       throw new IllegalStateException();
     }
@@ -56,7 +56,7 @@ public class ProxyFilterChain implements FilterChain {
   }
 
   /** @param filters The servlet filters to add. */
-  public void addFilters(List<Filter> filters) {
+  public void addFilters(List<AbstractCasFilter> filters) {
     if (iterator != null) {
       throw new IllegalStateException();
     }
@@ -64,7 +64,7 @@ public class ProxyFilterChain implements FilterChain {
     this.filters.addAll(filters);
 
     if (LOGGER.isDebugEnabled()) {
-      for (Filter filter : filters) {
+      for (AbstractCasFilter filter : filters) {
         LOGGER.debug("Added filter {} to filter chain.", filter.getClass().getName());
       }
     }
@@ -83,7 +83,7 @@ public class ProxyFilterChain implements FilterChain {
     }
 
     if (iterator.hasNext()) {
-      Filter filter = iterator.next();
+      AbstractCasFilter filter = iterator.next();
       LOGGER.debug(
           "Calling filter {}.doFilter({},{},{})",
           filter.getClass().getName(),

--- a/platform/security/cas/security-cas-client/src/main/resources/OSGI-INF/blueprint/casfilters.xml
+++ b/platform/security/cas/security-cas-client/src/main/resources/OSGI-INF/blueprint/casfilters.xml
@@ -73,6 +73,10 @@
                 <ref component-id="casAuthenticationFilter"/>
             </list>
         </argument>
+        <cm:managed-properties persistent-id="ddf.security.cas"
+          update-strategy="container-managed"/>
+        <property name="serverName"
+                  value="${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.external.context}" />
     </bean>
 
     <reference id="stsClientConfig"

--- a/platform/security/cas/security-cas-client/src/test/java/org/codice/ddf/security/handler/cas/CasHandlerTest.java
+++ b/platform/security/cas/security-cas-client/src/test/java/org/codice/ddf/security/handler/cas/CasHandlerTest.java
@@ -23,8 +23,7 @@ import static org.mockito.Mockito.when;
 
 import ddf.security.sts.client.configuration.STSClientConfiguration;
 import java.io.IOException;
-import java.util.Arrays;
-import javax.servlet.Filter;
+import java.util.Collections;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -94,8 +93,8 @@ public class CasHandlerTest {
   @Test
   public void testNoPrincipalResolve() throws ServletException, IOException {
     CasHandler handler = createHandler();
-    Filter testFilter = mock(Filter.class);
-    handler.setProxyFilter(new ProxyFilter(Arrays.asList(testFilter)));
+    AbstractCasFilter testFilter = mock(AbstractCasFilter.class);
+    handler.setProxyFilter(new ProxyFilter(Collections.singletonList(testFilter)));
     HandlerResult result =
         handler.getNormalizedToken(
             createServletRequest(false),
@@ -159,8 +158,8 @@ public class CasHandlerTest {
     STSClientConfiguration clientConfiguration = mock(STSClientConfiguration.class);
     when(clientConfiguration.getAddress()).thenReturn(STS_ADDRESS);
     handler.setClientConfiguration(clientConfiguration);
-    Filter testFilter = mock(Filter.class);
-    handler.setProxyFilter(new ProxyFilter(Arrays.asList(testFilter)));
+    AbstractCasFilter testFilter = mock(AbstractCasFilter.class);
+    handler.setProxyFilter(new ProxyFilter(Collections.singletonList(testFilter)));
     return handler;
   }
 

--- a/platform/security/cas/security-cas-client/src/test/java/org/codice/ddf/security/handler/cas/FilteredRequestTest.java
+++ b/platform/security/cas/security-cas-client/src/test/java/org/codice/ddf/security/handler/cas/FilteredRequestTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.handler.cas;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.security.handler.cas.filter.FilteredRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FilteredRequestTest {
+
+  private HttpServletRequest httpServletRequest;
+
+  private String https = "https://";
+  private String internalHost = "localhost";
+  private String internalPort = "8993";
+  private String internalBaseUrl = String.format("https://%s:%s", internalHost, internalPort);
+  private String externalHost = "reverse.proxy";
+  private String externalPort = "443";
+  private String externalBaseUrl = String.format("https://%s:%s", externalHost, externalPort);
+  private String externalContext = "/ddf";
+  private String servicePath = "/path/to/service";
+
+  public void defaultConfig() {
+    System.setProperty(SystemBaseUrl.INTERNAL_PROTOCOL, https);
+    System.setProperty(SystemBaseUrl.INTERNAL_HOST, internalHost);
+    System.setProperty(SystemBaseUrl.INTERNAL_PORT, internalPort);
+    System.setProperty(SystemBaseUrl.EXTERNAL_PROTOCOL, https);
+    System.setProperty(SystemBaseUrl.EXTERNAL_HOST, internalHost);
+    System.setProperty(SystemBaseUrl.EXTERNAL_PORT, internalPort);
+    System.setProperty(SystemBaseUrl.EXTERNAL_CONTEXT, "");
+  }
+
+  public void reverseProxyConfig() {
+    System.setProperty(SystemBaseUrl.INTERNAL_PROTOCOL, https);
+    System.setProperty(SystemBaseUrl.INTERNAL_HOST, internalHost);
+    System.setProperty(SystemBaseUrl.INTERNAL_PORT, internalPort);
+    System.setProperty(SystemBaseUrl.EXTERNAL_PROTOCOL, https);
+    System.setProperty(SystemBaseUrl.EXTERNAL_HOST, externalHost);
+    System.setProperty(SystemBaseUrl.EXTERNAL_PORT, externalPort);
+    System.setProperty(SystemBaseUrl.EXTERNAL_CONTEXT, externalContext);
+  }
+
+  @Before
+  public void initialize() {
+    httpServletRequest = mock(HttpServletRequest.class);
+    when(httpServletRequest.getRequestURI()).thenReturn(servicePath);
+  }
+
+  @Test
+  public void testDefaultConfig() {
+    defaultConfig();
+    FilteredRequest filteredRequest = new FilteredRequest(httpServletRequest, internalBaseUrl);
+
+    assertEquals(filteredRequest.getContextPath(), "");
+    assertEquals(filteredRequest.getRequestURI(), servicePath);
+    assertEquals(filteredRequest.getRequestURL().toString(), internalBaseUrl + servicePath);
+  }
+
+  @Test
+  public void testProxyConfigUnmatchedServerName() {
+    reverseProxyConfig();
+    FilteredRequest filteredRequest =
+        new FilteredRequest(httpServletRequest, "https://example.com/");
+
+    assertEquals(filteredRequest.getRequestURL().toString(), "https://example.com" + servicePath);
+  }
+
+  @Test
+  public void testDefaultConfigMalformedServerName() {
+    defaultConfig();
+    String invalidUri = "not^a^valid^uri";
+    FilteredRequest filteredRequest = new FilteredRequest(httpServletRequest, invalidUri);
+
+    assertEquals(filteredRequest.getRequestURL().toString(), invalidUri + servicePath);
+  }
+
+  @Test
+  public void testProxyConfigInternalRequest() {
+    reverseProxyConfig();
+    FilteredRequest filteredRequest = new FilteredRequest(httpServletRequest, internalBaseUrl);
+
+    assertEquals(filteredRequest.getContextPath(), "");
+    assertEquals(filteredRequest.getRequestURI(), servicePath);
+    assertEquals(filteredRequest.getRequestURL().toString(), internalBaseUrl + servicePath);
+  }
+
+  @Test
+  public void testProxyConfigExternalRequest() {
+    reverseProxyConfig();
+    FilteredRequest filteredRequest = new FilteredRequest(httpServletRequest, externalBaseUrl);
+
+    assertEquals(filteredRequest.getContextPath(), externalContext);
+    assertEquals(filteredRequest.getRequestURI(), externalContext + servicePath);
+    assertEquals(
+        filteredRequest.getRequestURL().toString(),
+        externalBaseUrl + externalContext + servicePath);
+  }
+
+  @Test
+  public void testProxyConfigNestedWrapping() {
+    reverseProxyConfig();
+    FilteredRequest filteredRequest = new FilteredRequest(httpServletRequest, externalBaseUrl);
+    FilteredRequest filteredRequest1 = new FilteredRequest(filteredRequest, externalBaseUrl);
+
+    assertEquals(filteredRequest1.getContextPath(), externalContext);
+    assertEquals(filteredRequest1.getRequestURI(), externalContext + servicePath);
+    assertEquals(
+        filteredRequest1.getRequestURL().toString(),
+        externalBaseUrl + externalContext + servicePath);
+  }
+}

--- a/platform/security/cas/security-cas-client/src/test/java/org/codice/ddf/security/handler/cas/FilteredRequestTest.java
+++ b/platform/security/cas/security-cas-client/src/test/java/org/codice/ddf/security/handler/cas/FilteredRequestTest.java
@@ -74,15 +74,6 @@ public class FilteredRequestTest {
   }
 
   @Test
-  public void testProxyConfigUnmatchedServerName() {
-    reverseProxyConfig();
-    FilteredRequest filteredRequest =
-        new FilteredRequest(httpServletRequest, "https://example.com/");
-
-    assertEquals(filteredRequest.getRequestURL().toString(), "https://example.com" + servicePath);
-  }
-
-  @Test
   public void testDefaultConfigMalformedServerName() {
     defaultConfig();
     String invalidUri = "not^a^valid^uri";
@@ -111,6 +102,27 @@ public class FilteredRequestTest {
     assertEquals(
         filteredRequest.getRequestURL().toString(),
         externalBaseUrl + externalContext + servicePath);
+  }
+
+  @Test
+  public void testProxyConfigExternalRequestDefaultPort() {
+    reverseProxyConfig();
+    String externalBaseUrlImpliedPort = String.format("https://%s", externalHost);
+    FilteredRequest filteredRequest =
+        new FilteredRequest(httpServletRequest, externalBaseUrlImpliedPort);
+
+    assertEquals(
+        filteredRequest.getRequestURL().toString(),
+        externalBaseUrlImpliedPort + externalContext + servicePath);
+  }
+
+  @Test
+  public void testProxyConfigUnmatchedServerName() {
+    reverseProxyConfig();
+    FilteredRequest filteredRequest =
+        new FilteredRequest(httpServletRequest, "https://example.com/");
+
+    assertEquals(filteredRequest.getRequestURL().toString(), "https://example.com" + servicePath);
   }
 
   @Test


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Wraps incoming ServletRequests so they use the correct context paths behind a proxy. 
#### Who is reviewing it? 

#### Select relevant component teams: 
@codice/security 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@brendan-hofmann 
@vinamartin 
#### How should this be tested?
### Set up DDF behind a reverse proxy
* Checkout this repo and follow the ReadMe to deploy a reverse proxy: https://github.com/brendan-hofmann/nginx-reverse-proxy/tree/context
* Install DDF with ?dev=true to generate certs for your ip/hostname
* Install the public key of the reverse proxy in the keystore and truststore under the alias localhost by running this command in `etc/keystores`: `openssl s_client -showcerts -connect localhost:YOUR_PORT_80_PORT_ASSIGNED_BY_DOCKER< /dev/null | openssl x509 -outform DER > derp.der; keytool -delete -alias localhost -keystore serverKeystore.jks -storepass changeit; keytool -import -alias localhost -keystore serverKeystore.jks -file derp.der -storepass changeit -noprompt; keytool -delete -alias localhost -keystore serverTruststore.jks -storepass changeit; keytool -import -alias localhost -keystore serverTruststore.jks -file derp.der -storepass changeit -noprompt`
* Configure web context policy. Set `SAML|BASIC` for /admin and `SAML|CAS` for /
* Shutdown DDF
* Configure the external properties in system.properties
* Access DDF at https://localhost:DOCKER_PORT/LOCAL_CONTEXT.

### Verification
Verify you can log into DDF given the reverse proxy setup above. Also, verify, that CAS auth still works with a normal installation.

#### Any background context you want to provide?
DDF's CAS client constructs redirect urls based on the ServletRequests it receives. However, ServletRequests are not aware of the external context that may be used when DDF is deployed behind a proxy, and so CAS will generate incorrect redirect urls.

#### What are the relevant tickets?
[DDF-3998](https://codice.atlassian.net/browse/DDF-3998)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
