### PR TITLE
[2.13.x] DDF-3915 Added a note in the documentation to not update the solr.http.url in system.properties

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
@@ -86,6 +86,7 @@ org.codice.ddf.system.registry-id=
 solr.client=HttpSolrClient
 solr.http.port=8994
 # Use "https" in the URL to configure the Solr server for TLS
+# Do NOT update the solr.http.url when quick installing on a remote headless server.
 solr.http.url=http://localhost:_DO_NOT_EXPAND_${solr.http.port}/solr
 solr.data.dir=_DO_NOT_EXPAND_${karaf.home}/solr/server/solr
 

--- a/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc
+++ b/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc
@@ -148,7 +148,7 @@ ${branding-lowercase}${at-symbol}local>
 If ${branding} is being installed on a remote server that has no user interface some additional steps must be taken prior to starting the system.
 
 . Update any references to localhost in the following files. These references to localhost should be updated to match either the hostname or IP of the system.
-** `${home_directory}/etc/system.properties`
+** `${home_directory}/etc/system.properties` (Do not update the value for `solr.http.url`.)
 ** `${home_directory}/etc/users.properties`
 ** `${home_directory}/etc/users.attributes`
 . From the console go to ${home_directory}/etc/certs.


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the `Quick Install of DDF on a remote headless server` section of the documentation. Changing the solr.http.url from `http://localhost:_DO_NOT_EXPAND_${solr.http.port}/solr` to `http://<hostname>:_DO_NOT_EXPAND_${solr.http.port}/solr` causes issues.
#### Who is reviewing it? 
@ahoffer @mcalcote @peterhuffer @oconnormi 
#### Ask 2 committers to review/merge the PR and tag them here.
@ricklarsen - Documentation
@rzwiefel
#### How should this be tested?
There are no testable changes for this PR.
#### What are the relevant tickets?
[DDF-3915](https://codice.atlassian.net/browse/DDF-3915)
#### Screenshots
![image](https://user-images.githubusercontent.com/8041246/43166464-7c1c94ea-8f4b-11e8-9e07-b2d03b8c484e.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.