### PR TITLE
[2.13.x] DDF-3989 Exclude unused libraries from the distribution

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -40,6 +40,11 @@
                 <exclude>etc/system.properties</exclude>
                 <exclude>etc/shell.init.script</exclude>
                 <exclude>etc/org.apache.karaf.kar.cfg</exclude>
+                <exclude>system/**/org.ops4j.pax.tipi.tomcat*</exclude>
+                <exclude>system/**/pax-web-jsp*</exclude>
+                <exclude>system/**/*elasticsearch*</exclude>
+                <exclude>system/**/*kibana*</exclude>
+                <exclude>system/**/pax-web-tomcat*</exclude>
                 <!--
                 Since Karaf v2.2.9, Karaf includes a default user "karaf" with its own authentication key in it, thus
                 when running client script it logs in as "karaf" user without requiring a password.
@@ -71,16 +76,6 @@
                 -->
                 <exclude>
                     **/org/apache/cxf/cxf-rt-transports-http-netty-server/3.1.4/cxf-rt-transports-http-netty-server-3.1.4.jar
-                </exclude>
-                <!--
-                Excluding this unused jar, as we don't use it (TO BE CONFIRMED)
-                and it's associated with CVE-2013-2185, CVE-2002-0493
-                -->
-                <exclude>
-                    **/org/ops4j/pax/tipi/org.ops4j.pax.tipi.tomcat-embed-core/8.0.14.1/org.ops4j.pax.tipi.tomcat-embed-core-8.0.14.1.jar
-                </exclude>
-                <exclude>
-                    **/org/ops4j/pax/tipi/org.ops4j.pax.tipi.tomcat-embed-websocket/8.0.14.1/org.ops4j.pax.tipi.tomcat-embed-websocket-8.0.14.1.jar
                 </exclude>
                 <!-- 3.2.2 is binary compatibles and we want to exclude this since it has vulnerabilities -->
                 <exclude>
@@ -282,6 +277,9 @@
         <fileSet>
             <directory>${setup.folder}/solr</directory>
             <outputDirectory>/solr</outputDirectory>
+          <excludes>
+            <exclude>**/derby*</exclude>
+          </excludes>
         </fileSet>
     </fileSets>
 


### PR DESCRIPTION
#### What does this PR do?
Port of https://github.com/codice/ddf/pull/3461
Excludes unused libraries from the distribution to reduce Sonatype findings.

#### Who is reviewing it? 

@peterhuffer @emmberk @oconnormi

#### Ask 2 committers to review/merge the PR and tag them here.

@bdeining
@clockard

#### How should this be tested?

The excluded files should not be included in the distribution after building the ddf-common and ddf modules.

#### What are the relevant tickets?

[DDF-3989](https://codice.atlassian.net/browse/DDF-3989)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
