### PR TITLE
DDF-3915 Fix for itest on Windows

### DIFF
--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -308,6 +308,39 @@
                 <solr.script.file>solr</solr.script.file>
                 <solr.force>-force</solr.force>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <!--Do not run this plugin execution if the we are skipping tests-->
+                            <skip>${skipTests}</skip>
+                            <longModulepath>false</longModulepath>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-solr-executable</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>chmod</executable>
+                                    <arguments>
+                                        <argument>+x</argument>
+                                        <argument>
+                                            ${solr.script.dir}${solr.script.file}
+                                        </argument>
+                                    </arguments>
+                                    <async>true</async>
+                                    <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 
@@ -346,29 +379,11 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <configuration>
-                    <!--Do not run this plugin exection if the we are skipping tests-->
+                    <!--Do not run this plugin execution if the we are skipping tests-->
                     <skip>${skipTests}</skip>
                     <longModulepath>false</longModulepath>
                 </configuration>
                 <executions>
-                    <execution>
-                        <id>make-solr-executable</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>chmod</executable>
-                            <arguments>
-                                <argument>+x</argument>
-                                <argument>
-                                    ${solr.script.dir}${solr.script.file}
-                                </argument>
-                            </arguments>
-                            <async>true</async>
-                            <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>ensure-solr-is-stopped</id>
                         <phase>pre-clean</phase>


### PR DESCRIPTION
#### What does this PR do?
Fix for Windows itests. Itest POM executes chmod, which causes an error on Windows. Sam Chu created a fix by moved the chmod execution to the unix-only profile.

UPDATE: Moved from 2.13.x to mater per conversation with Chris

#### Who is reviewing it? 
@samuelechu 
@mcalcote  
@vinamartin 

#### Ask 2 committers to review/merge the PR and tag them here.
@rzwiefel 
@clockard
@pklinef

#### How should this be tested?
Build and run an itest on windows.

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an inline code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
