### PR TITLE
DDF-4011 Adds minimum sizes to query-schedule and query-settings components

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.js
@@ -139,7 +139,9 @@ Behaviors.addBehavior('dropdown', Marionette.Behavior.extend({
     },
     updateWidth(dropdown){
         var clientRect = this.getDropdownElement(dropdown)[0].getBoundingClientRect();
-        dropdown._instance.$el.css('min-width', Math.min(clientRect.width, window.innerWidth - 20));
+        if (window.getComputedStyle(dropdown._instance.el)['min-width'] === '0px') {
+            dropdown._instance.$el.css('min-width', Math.min(clientRect.width, window.innerWidth - 20));
+        }
     },
     updatePosition (dropdown) {
         DropdownBehaviorUtility.updatePosition(

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-schedule/query-schedule.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-schedule/query-schedule.less
@@ -1,5 +1,6 @@
 @{customElementNamespace}query-schedule {
   .customElement;
+  min-width: @mobileScreenSize;
 
   overflow: hidden;
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.less
@@ -1,5 +1,6 @@
 @{customElementNamespace}query-settings {
   .customElement;
+  min-width: @mobileScreenSize;
 
   overflow: hidden;
 


### PR DESCRIPTION
#### What does this PR do?
 - Updates these components to have a minimum size.
 - Updates dropdown behavior to allow having a minimum size without using the !important keyword.

#### Who is reviewing it? 
@mcalcote 
@clockard 
@tbatie 
@rzwiefel 
@garrettfreibott 
@blen-desta 

#### How should this be tested?
Open the settings dropdown and the schedule dropdown and verify they aren't being sized super small.