### PR TITLE
[2.13.x] DDF-3938 Replace anyText:* with *:* to use optimized MatchAllDocsQuery

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -290,6 +290,11 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
     }
 
     String searchPhrase = escapeSpecialCharacters(pattern);
+
+    if (Metacard.ANY_TEXT.equals(propertyName) && SOLR_WILDCARD_CHAR.equals(searchPhrase)) {
+      return new SolrQuery("*:*");
+    }
+
     if (searchPhrase.contains(SOLR_WILDCARD_CHAR)
         || searchPhrase.contains(SOLR_SINGLE_WILDCARD_CHAR)) {
       searchPhrase = "(" + searchPhrase + ")";

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
@@ -277,6 +277,20 @@ public class SolrFilterDelegateTest {
     stub(mockResolver.anyTextFields()).toReturn(Collections.singletonList("metadata_txt").stream());
     stub(mockResolver.getWhitespaceTokenizedField("metadata_txt")).toReturn("metadata_txt_ws");
 
+    String searchPhrase = "*";
+    String expectedQuery = "*:*";
+    boolean isCaseSensitive = false;
+
+    SolrQuery isLikeQuery = toTest.propertyIsLike(Metacard.ANY_TEXT, searchPhrase, isCaseSensitive);
+
+    assertThat(isLikeQuery.getQuery(), is(expectedQuery));
+  }
+
+  @Test
+  public void testPropertyIsLikeTermAndWildcard() {
+    stub(mockResolver.anyTextFields()).toReturn(Collections.singletonList("metadata_txt").stream());
+    stub(mockResolver.getWhitespaceTokenizedField("metadata_txt")).toReturn("metadata_txt_ws");
+
     String searchPhrase = "abc-123*";
     String expectedQuery = "(" + WHITESPACE_TOKENIZED_METADATA_FIELD + ":(abc\\-123*))";
     boolean isCaseSensitive = false;


### PR DESCRIPTION
#### What does this PR do?
Replaces `anyText:*` queries with `*:*` Solr queries.  This avoids `anyText` being expanded to all attributes when the query value is only a wildcard.  Instead a Solr `MatchAllDocsQuery` is used which is optimized for this use case.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@paouelle 
@troymohl 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/solr

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@clockard
@rzwiefel

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Install and ingest data into DDF.  From Intrigue, do an advance search and search for "*" on `anyText`.  A default basic search on "*" should have the same result.

Verify in the Solr log files that the `q` parameter looks like `q=+(++(*:*+-validation-errors_txt:[*+TO+*])++AND++(++(+metacard-tags_txt_tokenized:%22resource%22+OR++(*:*+-metacard-tags_txt:[*+TO+*])++)++AND+*:*+)++)+`

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3938](https://codice.atlassian.net/browse/DDF-3938)

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ n/a ] Documentation Updated
- [ n/a ] Update / Add Unit Tests
- [ n/a ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
