### PR TITLE
[2.13.x] DDF-3933 Add external links dropdown to Intrigue

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/component.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/component.less
@@ -225,6 +225,7 @@
 @import 'list-editor/list-editor';
 @import 'dropdown/popout/dropdown.popout.less';
 @import 'result-add/result-add';
+@import 'result-link/result-link';
 @import 'list-create/list-create';
 @import 'list-interactions/list-interactions';
 @import 'notfound/notfound';

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.hbs
@@ -82,6 +82,8 @@
             <button class="result-download fa fa-download is-button is-neutral" title="Downloads the results associated product directly to your machine." data-help="Downloads
             the results associated product directly to your machine.">
             </button>
+            <div class="result-link is-button is-neutral composed-button" title="Follow external links" data-help="Follow external links.">
+            </div>
             <div class="result-add is-button is-neutral composed-button" title="Add or remove the result from a list, or make a new list with this result." data-help="Add or remove the result from a list, or make a new list with this result.">
             </div>
             <div class="result-actions is-button" title="Provides a list of actions to take on the result." data-help="Provides a list

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.less
@@ -61,6 +61,10 @@
     display: none;
   }
 
+  .result-link {
+    display: none;
+  }
+
   .details-property {
     height: @minimumLineSize;
     line-height: @minimumLineSize;
@@ -152,6 +156,14 @@
 @{customElementNamespace}result-item.is-downloadable {
   .content-footer {
     > .result-download {
+      display: inline-block;
+    }
+  }
+}
+
+@{customElementNamespace}result-item.is-link {
+  .content-footer {
+    > .result-link {
       display: inline-block;
     }
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.view.js
@@ -34,11 +34,12 @@ define([
     'component/singletons/sources-instance',
     'component/dropdown/hover-preview/dropdown.hover-preview.view',
     'component/result-add/result-add.view',
+    'component/result-link/result-link.view',
     'component/dropdown/popout/dropdown.popout.view',
     'behaviors/button.behavior'
 ], function (Backbone, Marionette, _, $, template, CustomElements, IconHelper, store, Common, DropdownModel,
              MetacardInteractionsView, ResultIndicatorView, properties, router, user,
-             metacardDefinitions, moment, sources, HoverPreviewDropdown, ResultAddView, PopoutView) {
+             metacardDefinitions, moment, sources, HoverPreviewDropdown, ResultAddView, ResultLinkView, PopoutView) {
 
     return Marionette.LayoutView.extend({
         template: template,
@@ -57,7 +58,8 @@ define([
             resultActions: '.result-actions',
             resultIndicator: '.container-indicator',
             resultThumbnail: '.detail-thumbnail',
-            resultAdd: '.result-add'
+            resultAdd: '.result-add',
+            resultLink: '.result-link'
         },
         behaviors: {
             button: {}
@@ -70,6 +72,7 @@ define([
             this.checkTags();
             this.checkIsInWorkspace();
             this.checkIfDownloadable();
+            this.checkIfLinks();
             this.checkIfBlacklisted();
             this.listenTo(this.model, 'change:metacard>properties change:metacard', this.handleMetacardUpdate);
             this.listenTo(user.get('user').get('preferences'), 'change:resultDisplay', this.checkDisplayType);
@@ -92,6 +95,7 @@ define([
             this.checkIsInWorkspace();
             this.checkIfBlacklisted();
             this.checkIfDownloadable();
+            this.checkIfLinks();
         },
         onBeforeShow: function(){
             this.resultActions.show(PopoutView.createSimpleDropdown({
@@ -110,6 +114,13 @@ define([
                 modelForComponent: new Backbone.Collection([this.model]),
                 leftIcon: 'fa fa-plus'
             }));
+            if (this.model.get('metacard').get('properties').get('associations.external')) {
+                this.resultLink.show(PopoutView.createSimpleDropdown({
+                    componentToShow: ResultLinkView,
+                    modelForComponent: this.model,
+                    leftIcon: 'fa fa-external-link'
+                }));
+            }
             this.handleResultThumbnail();
         },
         handleResultThumbnail: function() {
@@ -196,6 +207,9 @@ define([
         },
         checkIfDownloadable: function() {
             this.$el.toggleClass('is-downloadable', this.model.get('metacard').get('properties').get('resource-download-url') !== undefined);
+        },
+        checkIfLinks: function() {
+            this.$el.toggleClass('is-link', this.model.get('metacard').get('properties').get('associations.external') !== undefined);
         },
         checkDisplayType: function() {
             var displayType = user.get('user').get('preferences').get('resultDisplay');

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-link/result-link.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-link/result-link.hbs
@@ -1,0 +1,23 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<div class="is-header">
+    Follow External Link(s)
+</div>
+<div class="is-divider"></div>
+{{#each this}}
+    <div title="{{this}}">
+        <a href="{{this}}" target="_blank" class="is-link">{{this}}</a>
+    </div>
+{{/each}}
+</div>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-link/result-link.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-link/result-link.less
@@ -1,0 +1,13 @@
+@{customElementNamespace}result-link {
+    .customElement;
+    padding: @minimumSpacing;
+
+    .is-link {
+        line-height: @minimumButtonSize;
+        display: block;
+        max-width: @minimumScreenSize;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-link/result-link.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-link/result-link.view.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define, require, module*/
+var Marionette = require('marionette');
+var template = require('./result-link.hbs');
+var CustomElements = require('js/CustomElements');
+
+
+module.exports = Marionette.LayoutView.extend({
+  tagName: CustomElements.register('result-link'),
+  template: template,
+
+  serializeData: function() {
+    return this.model.get('metacard').get('properties').get('associations.external');
+  }
+});

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -59,6 +59,7 @@ module.exports = Marionette.LayoutView.extend({
     },
     onRender: function() {
         this.checkIfDownloadable();
+        this.checkIfLinks();
         this.$el.attr(this.attributes());
         this.handleResultThumbnail();
     },
@@ -74,6 +75,9 @@ module.exports = Marionette.LayoutView.extend({
     },
     checkIfDownloadable: function(){
         this.$el.toggleClass('is-downloadable', this.model.get('metacard').get('properties').get('resource-download-url') !== undefined);
+    },
+    checkIfLinks: function() {
+        this.$el.toggleClass('is-links', this.model.get('metacard').get('properties').get('associations.external') !== undefined);
     },
     triggerDownload: function(){
         window.open(this.model.get('metacard').get('properties').get('resource-download-url'));


### PR DESCRIPTION
#### What does this PR do?
This PR adds a dropdown menu displaying all `associations.external` URL's for metacards in Intrigue that have any `associations.external` attributes. 
#### Who is reviewing it? 
@clockard 
@kcover 
@emmberk 
@peterhuffer 
@oconnormi 

#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@clockard

#### How should this be tested?

- Ingest a metacard.
- In the inspector's details tab, add an associations.external attribute. 
- Edit the associations.external attribute, add URL(s) with a valid protocol.
- In the Intrigue search, verify that the new external links button appears and is usable. Verify that other buttons attached to the metacard were not negatively impacted. 


#### What are the relevant tickets?
[DDF-3933](https://codice.atlassian.net/browse/DDF-3933)


#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
