### PR TITLE
[2.13.x] DDF-3941 Changed the new Spark endpoints to return Strings instead of Spark Responses

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/configuration/PlatformUiConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/configuration/PlatformUiConfigurationApplication.java
@@ -35,10 +35,9 @@ public class PlatformUiConfigurationApplication implements SparkApplication {
         APPLICATION_JSON,
         (req, res) -> {
           String response = platformUiConfigurationService.getConfigAsJsonString();
-          res.body(response);
           res.status(200);
           res.header(CONTENT_TYPE, APPLICATION_JSON);
-          return res;
+          return response;
         });
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/AuthenticationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/AuthenticationApplication.java
@@ -40,7 +40,7 @@ public class AuthenticationApplication implements SparkApplication {
 
           // Redirect to the previous url
           res.redirect(req.queryParams("prevurl"), HttpStatus.SC_SEE_OTHER);
-          return res;
+          return "";
         });
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/LogoutApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/LogoutApplication.java
@@ -37,8 +37,7 @@ public class LogoutApplication implements SparkApplication {
           res.status(HttpStatus.SC_OK);
           res.header("Cache-Control", "no-cache, no-store");
           res.header("Pragma", "no-cache");
-          res.body(jsonString);
-          return res;
+          return jsonString;
         });
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/session/SessionManagementApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/session/SessionManagementApplication.java
@@ -33,9 +33,8 @@ public class SessionManagementApplication implements SparkApplication {
         "/session/expiry",
         (req, res) -> {
           String body = sessionManagement.getExpiry(req.raw());
-          res.body(body);
           res.status(200);
-          return res;
+          return body;
         });
 
     get(
@@ -45,12 +44,11 @@ public class SessionManagementApplication implements SparkApplication {
 
           if (body == null) {
             res.status(500);
-            return res;
+            return "";
           }
 
-          res.body(body);
           res.status(200);
-          return res;
+          return body;
         });
 
     get(
@@ -58,8 +56,7 @@ public class SessionManagementApplication implements SparkApplication {
         (req, res) -> {
           URI uri = sessionManagement.getInvalidate(req.raw());
           res.status(200);
-          res.body(uri.toString());
-          return res;
+          return uri.toString();
         });
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/spatial/GeoCoderApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/spatial/GeoCoderApplication.java
@@ -42,11 +42,10 @@ public class GeoCoderApplication implements SparkApplication {
 
           if (jsonString != null) {
             res.status(HttpStatus.SC_OK);
-            res.body(jsonp + "(" + jsonString + ")");
-            return res;
+            return jsonp + "(" + jsonString + ")";
           } else {
             res.status(HttpStatus.SC_BAD_REQUEST);
-            return res;
+            return "";
           }
         });
 
@@ -60,17 +59,16 @@ public class GeoCoderApplication implements SparkApplication {
 
             if (jsonString != null) {
               res.status(HttpStatus.SC_OK);
-              res.body(jsonString);
-              return res;
+              return jsonString;
             } else {
               res.status(HttpStatus.SC_NO_CONTENT);
-              return res;
+              return "";
             }
 
           } catch (GeoEntryQueryException e) {
             LOGGER.debug("Error querying GeoNames resource with wkt:{}", wkt, e);
             res.status(HttpStatus.SC_BAD_REQUEST);
-            return res;
+            return "";
           }
         });
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/builder/builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/builder/builder.view.js
@@ -207,6 +207,7 @@ module.exports = Marionette.LayoutView.extend({
             type: 'POST',
             url: './internal/catalog/?transform=geojson',
             data: JSON.stringify(editedMetacard),
+            dataType: "text",
             contentType: 'application/json'
         }).then((response, status, xhr) => {
             const id = xhr.getResponseHeader('id');


### PR DESCRIPTION
#### What does this PR do?
Changed the new Spark endpoints to return Strings instead of Spark Responses.

#### Who is reviewing it? 
@Bdthomson @adimka 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@rzwiefel 

#### How should this be tested?
1. `CatalogApplication`
   - Verify ingest works
   - Verify in the metacard id is returned as a header on the response
   - Verify querying works
2. `PlatformUiConfigurationApplication`
   - Verify that configurations like the header, footer, color etc.. work on intrigue
   - Change the platform configurations in the Admin Console under 
`Platform -> Configuration -> Platform UI Configuration` and make 
sure they take effect in both the Admin Console and Intrigue
3. `AuthenticationApplication`
   - Set the authentication method for /search to GUEST
   - Go to Intrigue
   - Login from Intrigue
4. `LogoutApplication`
   - Verify that when from Intrigue that endpoint is called and that the response is a 200 with a json body
5. `SessionManagementApplication`
   - Verify sure that session renewal, expiry and invalidation works from both intrigue and the admin console.
6. `GeoCoderEndpoint`
   - Use curl commands or postman to hit that endpoint.

#### What are the relevant tickets?
[DDF-3941](https://codice.atlassian.net/browse/DDF-3941)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
