### PR TITLE
DDF-3855: Update CSRF filter to be case insensitive for hostnames

### DIFF
--- a/platform/security/filter/security-filter-csrf/src/main/java/org/codice/ddf/security/filter/csrf/CsrfFilter.java
+++ b/platform/security/filter/security-filter-csrf/src/main/java/org/codice/ddf/security/filter/csrf/CsrfFilter.java
@@ -159,7 +159,7 @@ public class CsrfFilter implements SecurityFilter {
         } else {
           sourceAuthority = url.getAuthority();
         }
-        return (trustedAuthorities.stream().anyMatch(sourceAuthority::equals));
+        return (trustedAuthorities.stream().anyMatch(sourceAuthority::equalsIgnoreCase));
       } catch (MalformedURLException e) {
         LOGGER.debug("Could not extract hostname and port from the request URL", e);
         return false;

--- a/platform/security/filter/security-filter-csrf/src/test/groovy/org/codice/ddf/security/filter/csrf/CsrfFilterSpec.groovy
+++ b/platform/security/filter/security-filter-csrf/src/test/groovy/org/codice/ddf/security/filter/csrf/CsrfFilterSpec.groovy
@@ -39,6 +39,10 @@ class CsrfFilterSpec extends Specification {
     static final String PROXY_HTTPS_NOPORT = "https://" + PROXY_HOST
     static final String EXTERNAL_SITE = "https://example.com"
 
+    static final String DDF_UPPER = "https://" + DDF_HOST.toUpperCase() + ":" + DDF_HTTPS_PORT
+    static final String PROXY_UPPER = "https://" + PROXY_HOST.toUpperCase() + ":" + PROXY_HTTPS_PORT
+    static final String EXTERNAL_UPPER = "https://EXAMPLE.COM"
+
     static final String DDF_BADPORT = "https://" + DDF_HOST + ":9999"
     static final String PROXY_BADPORT = "https://" + PROXY_HOST + ":" + "9999"
 
@@ -85,40 +89,40 @@ class CsrfFilterSpec extends Specification {
         [requestContext, originHeader, refererHeader, hasCsrfHeader] << [
                 // Non-protected contexts
                 ["/", "/subdirectory"],
-                [null, "", EXTERNAL_SITE, DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT, DDF_BADPORT, PROXY_BADPORT],
-                [null, "", EXTERNAL_SITE, DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT, DDF_BADPORT, PROXY_BADPORT],
+                [null, "", EXTERNAL_SITE, EXTERNAL_UPPER, DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT, DDF_BADPORT, PROXY_BADPORT],
+                [null, "", EXTERNAL_SITE, EXTERNAL_UPPER, DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT, DDF_BADPORT, PROXY_BADPORT],
                 [true, false]
         ].combinations() + [
                 // Websockets - same origin OR same referer, with/without CSRF header
                 ["/search/catalog/ws", "/search/catalog/ws/subdirectory"],
-                [DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
-                [DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
+                [DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
+                [DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
                 [true, false]
         ].combinations() + [
                 ["/search/catalog/ws", "/search/catalog/ws/subdirectory"],
                 [null, ""],
-                [DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
+                [DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
                 [true, false]
         ].combinations() + [
                 ["/search/catalog/ws", "/search/catalog/ws/subdirectory"],
-                [DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
+                [DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
                 [null, ""],
                 [true, false]
         ].combinations() + [
                 //  Protected Contexts - same origin OR referer, with CSRF header
                 ["/admin/jolokia", "/admin/jolokia/subdirectory", "/search/catalog/internal", "/search/catalog/internal/subdirectory"],
-                [DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
-                [DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
+                [DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
+                [DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
                 [true]
         ].combinations() + [
                 ["/admin/jolokia", "/admin/jolokia/subdirectory", "/search/catalog/internal", "/search/catalog/internal/subdirectory"],
-                [DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
+                [DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
                 [null, ""],
                 [true]
         ].combinations() + [
                 ["/admin/jolokia", "/admin/jolokia/subdirectory", "/search/catalog/internal", "/search/catalog/internal/subdirectory"],
                 [null, ""],
-                [DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
+                [DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT],
                 [true]
         ].combinations()
     }
@@ -157,20 +161,20 @@ class CsrfFilterSpec extends Specification {
         [requestContext, originHeader, refererHeader, hasCsrfHeader] << [
                 // Protected Contexts - no CSRF Header
                 ["/admin/jolokia", "/admin/jolokia/subdirectory", "/search/catalog/internal", "/search/catalog/internal/subdirectory"],
-                [null, "", EXTERNAL_SITE, DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT, DDF_BADPORT, PROXY_BADPORT],
-                [null, "", EXTERNAL_SITE, DDF_HTTP, DDF_HTTPS, PROXY_HTTP, PROXY_HTTPS, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT, DDF_BADPORT, PROXY_BADPORT],
+                [null, "", EXTERNAL_SITE, EXTERNAL_UPPER, DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT, DDF_BADPORT, PROXY_BADPORT],
+                [null, "", EXTERNAL_SITE, EXTERNAL_UPPER, DDF_HTTP, DDF_HTTPS, DDF_UPPER, PROXY_HTTP, PROXY_HTTPS, PROXY_UPPER, PROXY_HTTP_NOPORT, PROXY_HTTPS_NOPORT, DDF_BADPORT, PROXY_BADPORT],
                 [false]
         ].combinations() + [
                 // Protected Contexts - different or no origin/referer, with CSRF header
                 ["/admin/jolokia", "/admin/jolokia/subdirectory", "/search/catalog/internal", "/search/catalog/internal/subdirectory"],
-                [null, "", EXTERNAL_SITE, DDF_BADPORT, PROXY_BADPORT],
-                [null, "", EXTERNAL_SITE, DDF_BADPORT, PROXY_BADPORT],
+                [null, "", EXTERNAL_SITE, EXTERNAL_UPPER, DDF_BADPORT, PROXY_BADPORT],
+                [null, "", EXTERNAL_SITE, EXTERNAL_UPPER, DDF_BADPORT, PROXY_BADPORT],
                 [true]
         ].combinations() + [
                 // Websockets - different or no origin/referer, with/without CSRF header
                 ["/search/catalog/ws", "/search/catalog/ws/subdirectory"],
-                [null, "", EXTERNAL_SITE, DDF_BADPORT, PROXY_BADPORT],
-                [null, "", EXTERNAL_SITE, DDF_BADPORT, PROXY_BADPORT],
+                [null, "", EXTERNAL_SITE, EXTERNAL_UPPER, DDF_BADPORT, PROXY_BADPORT],
+                [null, "", EXTERNAL_SITE, EXTERNAL_UPPER, DDF_BADPORT, PROXY_BADPORT],
                 [true, false]
         ].combinations() + [
                 // Corrupted origin/referer headers


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
____

#### What does this PR do?
Master port of https://github.com/codice/ddf/pull/3448

Updates the CSRF Filter to match hostnames without case sensitivity to account for non-lowercased hostnames in system.properties

#### Who is reviewing it? 
@emmberk  @peterhuffer @kcover

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@vinamartin

#### How should this be tested?
Using a hostname that is not lowercase:

Install DDF using the Quick Install of DDF on a remote headless server section of the documentation. Confirm that the Admin Console is functional after install.
Install DDF with ?dev=true. Confirm that the Admin Console is functional after install.

#### What are the relevant tickets?
[DDF-3855](https://codice.atlassian.net/browse/DDF-3855)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
