### PR TITLE
[2.13.x] DDF-4019 Fixed deleting search forms

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -242,7 +242,14 @@ module.exports = Marionette.LayoutView.extend({
         .done((data, textStatus, jqxhr) => {
             _this.model.set({
                 type: 'custom'
-            })
+            });
+            const preferences = _user.getQuerySettings();
+            if (preferences.get('template')) {
+                preferences.set('type', 'custom');
+            } else {
+                preferences.set('type', 'text');
+            }
+            _user.savePreferences();
         })
         .fail((jqxhr, textStatus, errorThrown) => {
             announcement.announce({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -82,8 +82,13 @@ module.exports =  Marionette.ItemView.extend({
                                 }.bind(this)
                             });
                         loadingview.remove();
+                        if (!user.getQuerySettings().get('template')) {
+                            user.getQuerySettings().set('type', 'text');
+                            user.savePreferences();
+                        }
+                        this.options.queryModel.resetToDefaults();
                     }
-                }.bind(this));                        
+                }.bind(this));
             }
             else{
                 this.messageNotifier(

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -94,7 +94,8 @@ define([
                 }, user.getQuerySettings().toJSON());
             },
             resetToDefaults: function (overridenDefaults) {
-                this.set(_.omit(_merge(this.defaults(), overridenDefaults), ['type', 'isLocal', 'serverPageIndex', 'result']));
+                const defaults = _.omit(this.defaults(),  ['isLocal', 'serverPageIndex', 'result']);
+                this.set(_merge(defaults, overridenDefaults));
                 this.trigger('resetToDefaults');
             },
             applyDefaults: function () {


### PR DESCRIPTION
#### What does this PR do?
Fixes the UI when deleting a search form, it resets to the default search form or basic text search.
#### Who is reviewing it? 
@Bdthomson @lamhuy @mackncheesiest @hayleynorton
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/ui
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?
1. Extract built DDF
2. Create a /etc/forms directory
3. Start DDF
4. Enable experimental features in the catalog-ui-search config
5. Create a search form in the catalog search ui and save it.
6. Select the search form.
7. Delete the search form.
8. Verify that when you open a new search, it is a basic text search.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4019](https://codice.atlassian.net/browse/DDF-4019)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
