### PR TITLE
[2.13.x] DDF-3739: Ensure filter delegate runs before any context paths are registered with Jetty

### DIFF
--- a/features/apps/src/main/feature/feature.xml
+++ b/features/apps/src/main/feature/feature.xml
@@ -41,10 +41,10 @@
              description="Features that will be started on container startup.">
         <!--Added prerequisite to kernel since it starts up features that must be started before others such as wrap and blueprint -->
         <feature prerequisite="true">kernel</feature>
-        <feature>secure-boot</feature>
+        <!--Added prerequisite to make sure the security filter injector is running before any other contexts get registered-->
+        <feature prerequisite="true">security-services-app</feature>
         <feature>ddf-branding</feature>
         <feature>platform-app</feature>
-        <feature>security-services-app</feature>
         <feature>admin-app</feature>
     </feature>
 
@@ -82,6 +82,7 @@
              description="The Security Application provides Authentication, Authorization, and Auditing services.\nThey comprise both a framework that developers and integrators can extend and also a reference implementation that can be used which meets security requirements.::Security">
         <!--Added prerequisite to make sure the security filter injector is running before any other contexts get registered-->
         <feature prerequisite="true">web-container</feature>
+        <feature>secure-boot</feature>
         <feature>security-core</feature>
         <feature>security-policy-context</feature>
         <feature>security-web-sso-defaults</feature>


### PR DESCRIPTION
#### What does this PR do?
Ensures the filter delegate is running in jetty before any contexts paths are registered.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@ryeats 
@clockard 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
@figliold
@stustison
@coyotesqrl 

#### How should this be tested?
Distribution successfully starts up.

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
