### PR TITLE
DDF-3933 Add permission for catalog-core-resourcereader used by confluence

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -113,7 +113,7 @@ grant codeBase "file:/spatial-csw-source/spatial-csw-endpoint/org.apache.camel.c
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}issuer${/}-", "read";
 }
 
-grant codeBase "file:/org.apache.servicemix.bundles.commons-httpclient/org.apache.camel.camel-http/spatial-wfs-v1_0_0-source/spatial-wfs-v2_0_0-source/spatial-wfs-v1_1_0-source/org.apache.ws.xmlschema.core/catalog-rest-endpoint" {
+grant codeBase "file:/org.apache.servicemix.bundles.commons-httpclient/org.apache.camel.camel-http/spatial-wfs-v1_0_0-source/spatial-wfs-v2_0_0-source/spatial-wfs-v1_1_0-source/org.apache.ws.xmlschema.core/catalog-rest-endpoint/catalog-core-urlresourcereader" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";
 }
 


### PR DESCRIPTION
#### What does this PR do?
Addes permission needed for downloading resources from confluence
#### Who is reviewing it? 
@peterhuffer @kcover @JGatley 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@shaundmorris

#### How should this be tested?
Install DDF and add a confluence federated source (https://codice.atlassian.net/wiki/rest/api/content) 
Enable Catalog->Configuration->URL Resource Reader->Follow Server Redirects
In intrigue search the confluence source for "security_manager_tech_codice.pptx"
Verify the ppt can be downloaded via the download button

#### What are the relevant tickets?
[DDF-3933](https://codice.atlassian.net/browse/DDF-3933)
