### PR TITLE
DDF-3945 Add missing jetty.websocket permissions to policy file (#3554)

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -121,7 +121,7 @@ grant codeBase "file:/org.apache.servicemix.bundles.wsdl4j" {
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 }
 
-grant codeBase "file:/org.apache.karaf.shell.core/registry-federation-admin-service-impl/catalog-core-commands/spatial-geocoding-offline-catalog/spatial-geocoding-geocoder/spatial-geocoding-plugin/spatial-wfs-v1_0_0-source/spatial-wfs-v2_0_0-source/spatial-wfs-v1_1_0-source/spatial-wfs-featuretransformer/spatial-wfs-featuretransformer-xstream/resourcemanagement-usage-ui/catalog-rest-endpoint" {
+grant codeBase "file:/org.apache.karaf.shell.core/registry-federation-admin-service-impl/catalog-core-commands/spatial-geocoding-offline-catalog/spatial-geocoding-geocoder/spatial-geocoding-plugin/spatial-wfs-v1_0_0-source/spatial-wfs-v2_0_0-source/spatial-wfs-v1_1_0-source/spatial-wfs-featuretransformer/spatial-wfs-featuretransformer-xstream/resourcemanagement-usage-ui/catalog-rest-endpoint/org.eclipse.jetty.websocket.server" {
     permission java.lang.RuntimePermission "createClassLoader";
 }
 
@@ -271,7 +271,7 @@ grant codeBase "file:/admin-core-impl/catalog-admin-poller-service/admin-core-jo
     permission java.io.FilePermission "${ddf.home.perm}etc${/}users.attributes", "read,write";
 }
 
-grant codeBase "file:/admin-core-jolokia/javax.servlet-api/org.apache.shiro.core/org.eclipse.jetty.io/org.eclipse.jetty.security/org.eclipse.jetty.server/org.eclipse.jetty.servlet/org.ops4j.pax.web.pax-web-extender-whiteboard/org.ops4j.pax.web.pax-web-jetty/org.ops4j.pax.web.pax-web-runtime/org.apache.cxf.cxf-rt-transports-http/org.eclipse.jetty.servlet/org.eclipse.jetty.util/platform-filter-clientinfo/platform-filter-delegate/platform-filter-response/security-certificate-generator/security-filter-authorization/security-filter-login/security-filter-web-sso" {
+grant codeBase "file:/admin-core-jolokia/javax.servlet-api/org.apache.shiro.core/org.eclipse.jetty.io/org.eclipse.jetty.security/org.eclipse.jetty.server/org.eclipse.jetty.servlet/org.ops4j.pax.web.pax-web-extender-whiteboard/org.ops4j.pax.web.pax-web-jetty/org.ops4j.pax.web.pax-web-runtime/org.apache.cxf.cxf-rt-transports-http/org.eclipse.jetty.servlet/org.eclipse.jetty.util/platform-filter-clientinfo/platform-filter-delegate/platform-filter-response/security-certificate-generator/security-filter-authorization/security-filter-login/security-filter-web-sso/org.eclipse.jetty.websocket.server" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}system.properties", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}users.properties", "read,write";
@@ -345,7 +345,7 @@ grant codeBase "file:/catalog-core-standardframework/platform-solr-server-standa
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}-", "read";
 }
 
-grant codeBase "file:/catalog-plugin-videothumbnail/catalog-rest-endpoint/catalog-core-standardframework/catalog-ui-search" {
+grant codeBase "file:/catalog-plugin-videothumbnail/catalog-rest-endpoint/catalog-core-standardframework/catalog-ui-search/org.eclipse.jetty.websocket.server" {
     permission java.io.FilePermission "${ddf.home.perm}bin_third_party", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}bin_third_party${/}-", "read,write,execute";
     permission java.io.FilePermission "${ddf.home.perm}bin_third_party${/}ffmpeg${/}-", "read,write,execute";


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #3554 
____

#### What does this PR do?
Adds missing permissions that were causing itests to fail

#### Who is reviewing it?

@bakejeyner @peterhuffer @kcover @mcalcote 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann
@coyotesqrl
@rzwiefel
@shaundmorris
@tbatie
@vinamartin
#### How should this be tested?
CI Build
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3945](https://codice.atlassian.net/browse/DDF-3945)