### PR TITLE
DDF-3933 Add permission for catalog-core-resourcereader used by confluence

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -119,7 +119,7 @@ grant codeBase "file:/spatial-csw-source/spatial-csw-endpoint/org.apache.camel.c
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}issuer${/}-", "read";
 }
 
-grant codeBase "file:/org.apache.servicemix.bundles.commons-httpclient/org.apache.camel.camel-http/spatial-wfs-v1_0_0-source/spatial-wfs-v2_0_0-source/spatial-wfs-v1_1_0-source/org.apache.ws.xmlschema.core/security-rest-cxfwrapper" {
+grant codeBase "file:/org.apache.servicemix.bundles.commons-httpclient/org.apache.camel.camel-http/spatial-wfs-v1_0_0-source/spatial-wfs-v2_0_0-source/spatial-wfs-v1_1_0-source/org.apache.ws.xmlschema.core/security-rest-cxfwrapper/catalog-core-urlresourcereader" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";
 }
 


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: https://github.com/codice/ddf/pull/3545
____


#### What does this PR do?
Addes permission needed for downloading resources from confluence
#### Who is reviewing it? 

@coyotesqrl 
@shaundmorris

#### How should this be tested?
CI Build
#### What are the relevant tickets?
**[DDF-3933](https://codice.atlassian.net/browse/)**
