### PR TITLE
DDF-4046 Update PollingPolicyFinderModule to use custom file observer

### DIFF
--- a/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/PollingPolicyFinderModule.java
+++ b/platform/security/pdp/security-pdp-authzrealm/src/main/java/ddf/security/pdp/realm/xacml/processor/PollingPolicyFinderModule.java
@@ -65,7 +65,7 @@ public class PollingPolicyFinderModule extends FileBasedPolicyFinderModule
     for (String xacmlPolicyDirectory : xacmlPolicyDirectories) {
       File directoryToMonitor = new File(xacmlPolicyDirectory);
       FileAlterationObserver observer =
-          new FileAlterationObserver(directoryToMonitor, getXmlFileFilter());
+          new PrivilegedFileAlterationObserver(directoryToMonitor, getXmlFileFilter());
       observer.addListener(this);
       monitor.addObserver(observer);
       LOGGER.debug("Monitoring directory: {}", directoryToMonitor);
@@ -204,5 +204,21 @@ public class PollingPolicyFinderModule extends FileBasedPolicyFinderModule
   public void reloadPolicies() {
     LOGGER.debug("Reloading XACML policies");
     this.loadPolicies();
+  }
+
+  private static class PrivilegedFileAlterationObserver extends FileAlterationObserver {
+    public PrivilegedFileAlterationObserver(final File directory, final FileFilter fileFilter) {
+      super(directory, fileFilter, null);
+    }
+
+    @Override
+    public void checkAndNotify() {
+      AccessController.doPrivileged(
+          (PrivilegedAction)
+              () -> {
+                super.checkAndNotify();
+                return null;
+              });
+    }
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Switches the FileAlterationObserver used in PollingPolicyFinderModule to a custom one that override and wraps method in an AccessController.doPrivileged to fix an access control exception.
#### Who is reviewing it? 
@peterhuffer @emmberk @kcover 

#### Ask 2 committers to review/merge the PR and tag them here.
@stustison
@tbatie
#### How should this be tested?
See me for instructions.
#### What are the relevant tickets?
[DDF-4046](https://codice.atlassian.net/browse/DDF-4046)
