### PR TITLE
DDF-4037 Added input-time.view to Intrigue

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/component.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/component.less
@@ -41,6 +41,7 @@
 @import 'input/input';
 @import 'input/boolean/input-boolean';
 @import 'input/date/input-date';
+@import 'input/time/input-time';
 @import 'input/color/input-color';
 @import 'input/bulk/input-bulk';
 @import 'input/enum/input-enum';

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/bulk/input-bulk.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/bulk/input-bulk.view.js
@@ -102,7 +102,7 @@ define([
                             valueInfo.value[0] = 'No Value';
                         } else {
                             valueInfo.value = valueInfo.value.map(function(value){
-                                return user.getUserReadableDate(value);
+                                return user.getUserReadableDateTime(value);
                             });
                             return valueInfo;
                         }
@@ -156,7 +156,7 @@ define([
                     switch(type){
                         case 'date':
                             label = label.map(function(text){
-                            return user.getUserReadableDate(text);
+                            return user.getUserReadableDateTime(text);
                             });
                             value = value.map(function(text){
                                 return moment(text);

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
@@ -27,7 +27,7 @@ define([
 ], function (Marionette, _, $, template, CustomElements, moment, InputView, Common, user) {
 
     function getDateFormat() {
-        return user.get('user').get('preferences').get('timeFormat');
+        return user.get('user').get('preferences').get('dateTimeFormat')['datetimefmt'];
     }
 
     function getTimeZone() {
@@ -45,11 +45,11 @@ define([
         serializeData: function () {
             return _.extend(this.model.toJSON(), {
                 cid: this.cid,
-                humanReadableDate: this.model.getValue() ? user.getUserReadableDate(this.model.getValue()) : this.model.getValue()
+                humanReadableDate: this.model.getValue() ? user.getUserReadableDateTime(this.model.getValue()) : this.model.getValue()
             });
         },
         initialize: function() {
-            this.listenTo(user.get('user').get('preferences'), 'change:timeZone change:timeFormat', this.initializeDatepicker);
+            this.listenTo(user.get('user').get('preferences'), 'change:timeZone change:dateTimeFormat', this.initializeDatepicker);
             InputView.prototype.initialize.call(this);
         },
         onRender: function () {
@@ -69,7 +69,7 @@ define([
             this.$el.toggleClass('is-readOnly', this.model.isReadOnly());
         },
         handleValue: function(){
-            this.$el.find('.input-group.date').data('DateTimePicker').date(user.getUserReadableDate(this.model.getValue()));
+            this.$el.find('.input-group.date').data('DateTimePicker').date(user.getUserReadableDateTime(this.model.getValue()));
         },
         focus: function(){
             this.$el.find('input').select();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/date/input-date.view.js
@@ -48,11 +48,16 @@ define([
                 humanReadableDate: this.model.getValue() ? user.getUserReadableDate(this.model.getValue()) : this.model.getValue()
             });
         },
+        initialize: function() {
+            this.listenTo(user.get('user').get('preferences'), 'change:timeZone change:timeFormat', this.initializeDatepicker);
+            InputView.prototype.initialize.call(this);
+        },
         onRender: function () {
             this.initializeDatepicker();
             InputView.prototype.onRender.call(this);
         },
         initializeDatepicker: function(){
+            this.onDestroy();
             this.$el.find('.input-group.date').datetimepicker({
                 format: getDateFormat(),
                 timeZone: getTimeZone(),
@@ -101,8 +106,8 @@ define([
         listenForChange: function(){
             this.$el.on('dp.change click input change keyup', function(){
                 this.model.set('value', this.getCurrentValue());
+                this.validate();
             }.bind(this));
-
         },
         isValid: function(){
             var currentValue = this.$el.find('input').val();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/enum/input-enum.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/enum/input-enum.view.js
@@ -33,10 +33,10 @@ define([
         if (value !== undefined && model.get('property').get('type') === 'DATE'){
             if (multivalued && value.map){
                 value = value.map(function(subvalue){
-                    return user.getUserReadableDate(subvalue);
+                    return user.getUserReadableDateTime(subvalue);
                 });
             } else {
-                value = user.getUserReadableDate(value);
+                value = user.getUserReadableDateTime(value);
             }
         }
         if (!multivalued){

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/time/input-time.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/time/input-time.less
@@ -1,0 +1,25 @@
+@{customElementNamespace}input.is-time {
+  .input-group {
+    margin: 0px;
+    padding: 0px;
+  }
+  
+  input {
+    height: @minimumButtonSize;
+    width: 100%;
+  }
+  
+  label {
+    padding-left: ~'calc(2px + .5*@{minimumFontSize})';
+    line-height: @minimumButtonSize;
+    margin: 0px;
+    white-space: normal;
+    word-break: break-all;
+    min-height: @minimumButtonSize;
+  }
+  
+  .input-group > span.input-group-addon {
+    background: @primary-color !important;
+    color: contrast(@primary-color) !important;
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/time/input-time.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/time/input-time.view.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+import React from 'react'
+const _ = require('lodash')
+const $ = require('jquery')
+const InputView = require('../input.view')
+const user = require('component/singletons/user-instance')
+const moment = require('moment-timezone')
+require('eonasdan-bootstrap-datetimepicker')
+
+module.exports = InputView.extend({
+    template(data) {
+        return (
+            <React.Fragment>
+                <div className="if-editing">
+                    <div className="input-group time">
+                        <input type="text" placeholder={data.property.placeholder}/>
+                        <span className="input-group-addon">
+                            <span className="fa fa-clock-o"/>
+                        </span>
+                    </div>
+                </div>
+                <div className="if-viewing">
+                    <label>{data.humanReadableTime}</label>
+                </div>
+            </React.Fragment>
+        )
+    },
+    events: {
+        'click .input-revert': 'revert',
+        'dp.change .input-group.time': 'handleRevert',
+        'dp.show .input-group.time': 'handleOpen',
+        'dp.hide .input-group.time': 'removeResizeHandler'
+    },
+    serializeData() {
+        return _.extend(this.model.toJSON(), {
+            cid: this.cid,
+            humanReadableTime: this.model.getValue() ? 
+                this.getUserReadableTime(this.model.getValue()) : this.model.getValue()
+        })
+    },
+    initialize() {
+        this.listenTo(user.get('user').get('preferences'), 'change:timeZone change:timeFormat', this.initializeTimePicker)
+        InputView.prototype.initialize.call(this)
+    },
+    onRender() {
+        this.initializeTimePicker()
+        InputView.prototype.onRender.call(this)
+    },
+    initializeTimePicker() {
+        this.onDestroy()
+        this.$el.find('.input-group.time').datetimepicker({
+            format: this.getTimeFormat(),
+            timeZone: this.getTimeZone(),
+            widgetParent: 'body',
+            keyBinds: null
+        })
+    },
+    handleValue() {
+        this.$el.find('.input-group.time').data('DateTimePicker').date(this.getUserReadableTime(this.model.getValue()))
+    },
+    handleOpen() {
+        this.updatePosition()
+        this.addResizeHandler()
+    },
+    updatePosition() {
+        const datepicker = $('body').find('.bootstrap-datetimepicker-widget:last')
+        const inputCoordinates = this.$el.find('.input-group.time')[0].getBoundingClientRect()
+        const top = datepicker.hasClass('bottom') ? inputCoordinates.top + inputCoordinates.height : inputCoordinates.top - datepicker.outerHeight()
+        datepicker.css({
+            'top': top + 'px',
+            'bottom': 'auto',
+            'left': inputCoordinates.left + 'px',
+            'width': inputCoordinates.width + 'px'
+        })
+    },
+    addResizeHandler() {
+        $(window).on('resize.datePicker', this.updatePosition.bind(this))
+    },
+    removeResizeHandler() {
+        $(window).off('resize.datePicker')
+    },
+    getCurrentValue() {
+        const currentValue = this.$el.find('input').val()
+        if (currentValue) {
+            return (moment.tz(currentValue, this.getTimeFormat(), this.getTimeZone())).toISOString()
+        } else {
+            return null
+        }
+    },
+    listenForChange() {
+        this.$el.on('dp.change click input change keyup', function(){
+            this.model.set('value', this.getCurrentValue());
+            this.validate();
+        }.bind(this));
+    },
+    isValid() {
+        const currentValue = this.$el.find('input').val()
+        return currentValue != null && currentValue !== ''
+    },
+    onDestroy() {
+        const datetimepicker = this.$el.find('.input-group.time').data('DateTimePicker')
+        if (datetimepicker) {
+            datetimepicker.destroy()
+        }
+    },
+    //TODO: Refactor most other `timeFormat` codebase refererences to `dateTimeFormat` and move this logic to `Common.js`
+    getTimeFormat() {
+        const format = user.get('user').get('preferences').get('timeFormat')
+        if (format === 'YYYY-MM-DD[T]HH:mm:ss.SSSZ' || format === 'DD MMM YYYY HH:mm:ss.SSS Z') {
+            return 'HH:mm:ss Z'
+        } else if (format === 'DD MMM YYYY h:mm:ss.SSS a Z') {
+            return 'hh:mm:ss a Z'
+        }
+    },
+    getTimeZone() { 
+        return user.get('user').get('preferences').get('timeZone') 
+    },
+    getUserReadableTime(time) {
+        return moment.tz(time, this.getTimeZone()).format(this.getTimeFormat())
+    }
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/time/input-time.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/time/input-time.view.js
@@ -53,7 +53,7 @@ module.exports = InputView.extend({
         })
     },
     initialize() {
-        this.listenTo(user.get('user').get('preferences'), 'change:timeZone change:timeFormat', this.initializeTimePicker)
+        this.listenTo(user.get('user').get('preferences'), 'change:timeZone change:dateTimeFormat', this.initializeTimePicker)
         InputView.prototype.initialize.call(this)
     },
     onRender() {
@@ -117,14 +117,8 @@ module.exports = InputView.extend({
             datetimepicker.destroy()
         }
     },
-    //TODO: Refactor most other `timeFormat` codebase refererences to `dateTimeFormat` and move this logic to `Common.js`
     getTimeFormat() {
-        const format = user.get('user').get('preferences').get('timeFormat')
-        if (format === 'YYYY-MM-DD[T]HH:mm:ss.SSSZ' || format === 'DD MMM YYYY HH:mm:ss.SSS Z') {
-            return 'HH:mm:ss Z'
-        } else if (format === 'DD MMM YYYY h:mm:ss.SSS a Z') {
-            return 'hh:mm:ss a Z'
-        }
+        return user.get('user').get('preferences').get('dateTimeFormat')['timefmt']
     },
     getTimeZone() { 
         return user.get('user').get('preferences').get('timeZone') 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.js
@@ -198,6 +198,9 @@ define([
                 case 'DATE':
                     calculatedType = 'date';
                     break;
+                case 'TIME':
+                    calculatedType = 'time';
+                    break;
                 case 'BINARY':
                     calculatedType = 'thumbnail';
                     break;

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.view.js
@@ -20,10 +20,9 @@ define([
     './property.hbs',
     'js/CustomElements',
     'component/input/bulk/input-bulk.view',
-    'component/multivalue/multivalue.view',
     'js/Common',
     './property'
-], function (Marionette, _, $, template, CustomElements, BulkInputView, MultivalueView, Common, Property) {
+], function (Marionette, _, $, template, CustomElements, BulkInputView, Common, Property) {
 
     return Marionette.LayoutView.extend({
         template: template,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
@@ -87,7 +87,7 @@
               let d = new Date(0)
               d.setUTCSeconds(utcSeconds)
               this.addResultForm(new ResultForm({
-                createdOn: Common.getHumanReadableDate(d),
+                createdOn: Common.getHumanReadableDateTime(d),
                 id: element.id,
                 name: element.label,
                 type: 'result',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
@@ -65,7 +65,7 @@ let bootstrapPromise = sharedSearchFormPromise();
                     let d = new Date(0);
                     d.setUTCSeconds(utcSeconds);
                     this.addSearchForm(new SearchForm({
-                        createdOn: Common.getHumanReadableDate(d),
+                        createdOn: Common.getHumanReadableDateTime(d),
                         id: value.id,
                         name: value.title,
                         description: value.description,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
@@ -94,7 +94,7 @@ module.exports = Backbone.AssociatedModel.extend({
                     var d = new Date(0);
                     d.setUTCSeconds(utcSeconds);
                     this.addSearchForm(new SearchForm({
-                        createdOn: Common.getHumanReadableDate(d),
+                        createdOn: Common.getHumanReadableDateTime(d),
                         id: value.id,
                         name: value.title,
                         description: value.description,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/time-settings/time-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/time-settings/time-settings.view.js
@@ -147,7 +147,7 @@ module.exports = Marionette.LayoutView.extend({
         this.listenTo(this.propertyTimeZone.currentView.model, 'change:value', this.save);
     },
     setupResultCount: function () {
-        var timeFormat = user.get('user').get('preferences').get('timeFormat');
+        var timeFormat = user.get('user').get('preferences').get('dateTimeFormat');
 
         this.propertyTimeFormat.show(new PropertyView({
             model: new Property({
@@ -155,13 +155,13 @@ module.exports = Marionette.LayoutView.extend({
                 value: [timeFormat],
                 enum: [{
                     label: 'ISO 8601',
-                    value: Common.getTimeFormats()['ISO']
+                    value: Common.getDateTimeFormats()['ISO']
                 }, {
                     label: '24 Hour Standard',
-                    value: Common.getTimeFormats()['24']
+                    value: Common.getDateTimeFormats()['24']
                 }, {
                     label: '12 Hour Standard',
-                    value: Common.getTimeFormats()['12']
+                    value: Common.getDateTimeFormats()['12']
                 }]
             })
         }));
@@ -172,7 +172,7 @@ module.exports = Marionette.LayoutView.extend({
     save: function () {
         var preferences = user.get('user').get('preferences');
         preferences.set({
-            timeFormat: this.propertyTimeFormat.currentView.model.getValue()[0],
+            dateTimeFormat: this.propertyTimeFormat.currentView.model.getValue()[0],
             timeZone: this.propertyTimeZone.currentView.model.getValue()[0]
         });
         preferences.savePreferences();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/value/value.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/value/value.view.js
@@ -22,6 +22,7 @@ define([
     'component/input/input.view',
     'component/input/thumbnail/input-thumbnail.view',
     'component/input/date/input-date.view',
+    'component/input/time/input-time.view',
     'component/input/location/input-location.view',
     'component/input/enum/input-enum.view',
     'component/input/radio/input-radio.view',
@@ -33,7 +34,7 @@ define([
     'component/input/autocomplete/input-autocomplete.view',
     'component/input/color/input-color.view',
     'component/input/with-param/input-with-param.view'
-], function (Marionette, _, $, template, CustomElements, InputView, InputThumbnailView, InputDateView,
+], function (Marionette, _, $, template, CustomElements, InputView, InputThumbnailView, InputDateView, InputTimeView,
              InputLocationView, InputEnumView, InputRadioView, InputNumberView, InputBooleanView, InputRangeView, InputTextareaView,
              InputGeometryView, InputAutocompleteView, InputColorView, InputWithParamView) {
 
@@ -66,6 +67,11 @@ define([
                 switch (this.model.get('property').get('calculatedType')) {
                     case 'date':
                         this.input.show(new InputDateView({
+                            model: this.model
+                        }));
+                        break;
+                    case 'time':
+                        this.input.show(new InputTimeView({
                             model: this.model
                         }));
                         break;

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -105,7 +105,7 @@ module.exports = Marionette.LayoutView.extend({
                     switch (metacardDefinitions.metacardTypes[property].type) {
                         case 'DATE':
                             value = value.map(function(val) {
-                                return val !== undefined && val !== '' ? user.getUserReadableDate(val) : '';
+                                return val !== undefined && val !== '' ? user.getUserReadableDateTime(val) : '';
                             });
                             break;
                         default:

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/input-guide/input-guide.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/input-guide/input-guide.hbs
@@ -252,6 +252,15 @@
             </div>
             <div class="editor" data-js="showExample25"></div>
         </div>
+        <div class="example">
+            <div class="title">
+                Time without Date
+            </div>
+            <div class="instance">
+            
+            </div>
+            <div class="editor" data-js="showExample26"></div>
+        </div>
     </div>
 </div>
 <div class="section">

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/input-guide/input-guide.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/input-guide/input-guide.view.js
@@ -38,7 +38,8 @@ module.exports = BaseGuideView.extend({
         example22: '.example:nth-of-type(22) .instance',
         example23: '.example:nth-of-type(23) .instance',
         example24: '.example:nth-of-type(24) .instance',
-        example25: '.example:nth-of-type(25) .instance'
+        example25: '.example:nth-of-type(25) .instance',
+        example26: '.example:nth-of-type(26) .instance'
     },
     showComponents() {
         this.showExampleOne();
@@ -66,6 +67,7 @@ module.exports = BaseGuideView.extend({
         this.showExample23();
         this.showExample24();
         this.showExample25();
+        this.showExample26();
     },
     showExampleOne() {
         this.exampleOne.show(new PropertyView({
@@ -592,6 +594,17 @@ module.exports = BaseGuideView.extend({
                 ],
                 showLabel: false,
                 showValidationIssues: false,
+                isEditing: true
+            })
+        }))
+    },
+    showExample26() {
+        this.example26.show(new PropertyView({
+            model: new Property({
+                label: 'Time Input',
+                placeholder: 'This input only likes times, not dates (or any fruit, really)',
+                value: [(new Date()).toISOString()],
+                type: 'TIME',
                 isEditing: true
             })
         }))

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/Common.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/Common.js
@@ -18,7 +18,7 @@ define([
     'js/requestAnimationFramePolyfill'
 ], function ($, moment, _) {
 
-    var timeZones = {
+    const timeZones = {
         UTC: 'Etc/UTC',
         '-12': 'Etc/GMT+12',
         '-11': 'Etc/GMT+11',
@@ -46,10 +46,10 @@ define([
         '12' : 'Etc/GMT-12'
     };
 
-    var timeFormats = {
-        ISO: 'YYYY-MM-DD[T]HH:mm:ss.SSSZ',
-        24: 'DD MMM YYYY HH:mm:ss.SSS Z',
-        12: 'DD MMM YYYY h:mm:ss.SSS a Z'
+    const dateTimeFormats = {
+        ISO: { datetimefmt: 'YYYY-MM-DD[T]HH:mm:ss.SSSZ', timefmt: 'HH:mm:ssZ' },
+        24: { datetimefmt: 'DD MMM YYYY HH:mm:ss.SSS Z', timefmt: 'HH:mm:ss Z' },
+        12: { datetimefmt: 'DD MMM YYYY h:mm:ss.SSS a Z', timefmt: 'h:mm:ss a Z' }
     };
 
     return {
@@ -190,11 +190,11 @@ define([
             return size + ' ' + type[index];
         },
         //can be deleted once histogram changes are merged
-        getHumanReadableDate: function(date) {
-            return moment(date).format(timeFormats['24']);
+        getHumanReadableDateTime: function(date) {
+            return moment(date).format(dateTimeFormats['24']['datetimefmt']);
         },
-        getTimeFormats(){
-            return timeFormats;
+        getDateTimeFormats(){
+            return dateTimeFormats;
         },
         getTimeZones(){
             return timeZones;

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -136,7 +136,7 @@ define([
                 uploads: [],
                 fontSize: ThemeUtils.getFontSize(_get(properties, 'zoomPercentage', 100)),
                 resultCount: properties.resultCount,
-                timeFormat: Common.getTimeFormats()['ISO'],
+                dateTimeFormat: Common.getDateTimeFormats()['ISO'],
                 timeZone: Common.getTimeZones()['UTC'],
                 coordinateFormat: 'degrees',
                 goldenLayout: undefined,
@@ -351,8 +351,8 @@ define([
         getSummaryShown: function(){
             return this.get('user').getSummaryShown();
         },
-        getUserReadableDate: function(date){
-            return moment.tz(date, this.get('user').get('preferences').get('timeZone')).format(this.get('user').get('preferences').get('timeFormat'));
+        getUserReadableDateTime: function(date){
+            return moment.tz(date, this.get('user').get('preferences').get('timeZone')).format(this.get('user').get('preferences').get('dateTimeFormat')['datetimefmt']);
         },
         getHoverPreview: function() {
             return this.get('user').getHoverPreview();


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Adds a separate time input (doesn't have a date component) to Intrigue that is accessible through a PropertyView with `type: 'TIME'` 

- First commit is base component functionality
- Second commit is refactoring overall usages of `timeFormat` to `dateTimeFormat` and refactoring code out of `input-time.view`
- Third commit is adding a demonstration usage in the Intrigue `/#dev` route

Feedback would be appreciated [around this change](https://github.com/codice/ddf/pull/3574/commits/23ccc4deb33d3c7d125455f769c08a0749ee46ee#diff-2c47d09316e732de2725104cbd2aa7d9L49) comparing it to the alternative of maintaining a separate `Common.timeFormats` object and then either (i) storing a new entry in user prefs that stays in sync with the user's `dateTimeFormat` (ii) including tedious logic to reverse the `dateTimeFormat` mapping and using that same key in the `timeFormat` map as needed or (iii) changing the user prefs entry to be the key itself and then changing `user.getUserPrefs().get('dateTimeFormat')` calls to `Common.getDateTimeFormats()[user.getUserPrefs().get('dateTimeFormat')]` (potentially through a helper method on Common). 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@adimka @djblue 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler @bdeining 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Load Intrigue with the dev server and navigate to the `Inputs` section of the dev guide (`/#dev`). Test out the `input-time` component down near the bottom with various user timezone settings
- Verify (within a reasonable level of certainty) no regressions in the `input-date` component
- Verify input-date has no regressions in query formation and such

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4037](https://codice.atlassian.net/browse/DDF-4037)
#### Screenshots
<!--(if appropriate)-->
![image](https://user-images.githubusercontent.com/8922497/43879766-54e9eaf6-9b5a-11e8-96bb-832ad7d94c82.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
