### PR TITLE
[2.13.x] DDF-4051 Permissions granted to ApplicationService to install new features should be granted to other bundles

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
@@ -207,8 +207,13 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
     LOGGER.trace("Uninstalling feature {}", feature);
 
     try {
-      featuresService.uninstallFeature(
-          feature, EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
+      AccessController.doPrivileged(
+          (PrivilegedExceptionAction<Void>)
+              () -> {
+                featuresService.uninstallFeature(
+                    feature, EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
+                return null;
+              });
     } catch (VirtualMachineError e) {
       throw e;
     } catch (PrivilegedActionException e) {

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SimpleSign.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/samlp/SimpleSign.java
@@ -13,8 +13,8 @@
  */
 package ddf.security.samlp;
 
-import static com.sun.org.apache.xml.internal.security.signature.XMLSignature.ALGO_ID_SIGNATURE_DSA_SHA256;
 import static org.apache.commons.lang.CharEncoding.UTF_8;
+import static org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA256;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;


### PR DESCRIPTION
#### What does this PR do?
Adds AccessController.doPrivilegedAction() call to ApplicationServiceBean's installFeature() method to grant same feature install permissions to other bundles.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@brjeter 
@clockard

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/security
#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@stustison

#### How should this be tested?
Unzip the distribution (or any downstream distribution), start karaf and make sure that the installer UI works as expected, especially when the profile selected contains a feature that needs to install a file or files under `/etc`.

Since this is an intermittent problem, the test should be repeated multiple times on both Windows and Linux.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-4051](https://codice.atlassian.net/browse/DDF-4051)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
