### PR TITLE
DDF-4054 [WIP] [2.13.x] Permissions granted to profile:install command should be granted to other bundles

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommand.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/command/ProfileInstallCommand.java
@@ -21,6 +21,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -82,6 +85,24 @@ public class ProfileInstallCommand extends AbstractProfileCommand {
           "Profile Name must not start with '.', '/', or a windows drive letter");
     }
 
+    try {
+      AccessController.doPrivileged(
+          (PrivilegedExceptionAction<Void>)
+              () -> {
+                installProfile(applicationService, featuresService, bundleService, profileName);
+                return null;
+              });
+    } catch (PrivilegedActionException e) {
+      throw e.getException();
+    }
+  }
+
+  private void installProfile(
+      ApplicationService applicationService,
+      FeaturesService featuresService,
+      BundleService bundleService,
+      String profileName)
+      throws Exception {
     Optional<Feature> optionalProfile = getProfile(applicationService, profileName);
     Optional<Map<String, List<String>>> optionalExtraProfiles = getProfile(profileName);
 


### PR DESCRIPTION
#### What does this PR do?
Adds AccessController.doPrivilegedAction() call to ProfileInstallCommand's doExecute() method to grant same permissions to other bundles.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@brjeter 
@clockard 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/test

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@stustison

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4054](https://codice.atlassian.net/browse/DDF-4054)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
