### PR TITLE
DDF-3818 Updated UrlResourceReader to include property allowing local…

### DIFF
--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -95,6 +95,8 @@ public class URLResourceReader implements ResourceReader {
   private static final Set<String> QUALIFIER_SET =
       ImmutableSet.of(URL_HTTP_SCHEME, URL_HTTPS_SCHEME, URL_FILE_SCHEME);
 
+  private static final String HTTP_REDIRECT_RELATIVE_URI = "http.redirect.relative.uri";
+
   /** Mapper for file extensions-to-mime types (and vice versa) */
   private MimeTypeMapper mimeTypeMapper;
 
@@ -594,6 +596,9 @@ public class URLResourceReader implements ResourceReader {
     }
 
     WebClient.getConfig(client).getHttpConduit().getClient().setAutoRedirect(getFollowRedirects());
+    WebClient.getConfig(client)
+        .getRequestContext()
+        .put(HTTP_REDIRECT_RELATIVE_URI, getFollowRedirects());
     return client;
   }
 

--- a/catalog/core/catalog-core-urlresourcereader/src/test/java/ddf/catalog/resource/impl/URLResourceReaderTest.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/test/java/ddf/catalog/resource/impl/URLResourceReaderTest.java
@@ -110,6 +110,7 @@ public class URLResourceReaderTest {
       "mydata?uri=63f30ff4dc85436ea507fceeb1396940_blahblahblah&this=that";
 
   private static final String BYTES_TO_SKIP = "BytesToSkip";
+  public static final String HTTP_REDIRECT_RELATIVE_URI = "http.redirect.relative.uri";
 
   @Rule
   public MethodRule watchman =
@@ -715,18 +716,24 @@ public class URLResourceReaderTest {
         resourceReader.getWebClient(
             HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH + JPEG_FILE_NAME_1, new HashMap<>());
     assertFalse(WebClient.getConfig(client).getHttpConduit().getClient().isAutoRedirect());
+    assertFalse(
+        (Boolean) WebClient.getConfig(client).getRequestContext().get(HTTP_REDIRECT_RELATIVE_URI));
 
     resourceReader.setFollowRedirects(true);
     client =
         resourceReader.getWebClient(
             HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH + JPEG_FILE_NAME_1, new HashMap<>());
     assertTrue(WebClient.getConfig(client).getHttpConduit().getClient().isAutoRedirect());
+    assertTrue(
+        (Boolean) WebClient.getConfig(client).getRequestContext().get(HTTP_REDIRECT_RELATIVE_URI));
 
     resourceReader.setFollowRedirects(false);
     client =
         resourceReader.getWebClient(
             HTTP_SCHEME_PLUS_SEP + HOST + TEST_PATH + JPEG_FILE_NAME_1, new HashMap<>());
     assertFalse(WebClient.getConfig(client).getHttpConduit().getClient().isAutoRedirect());
+    assertFalse(
+        (Boolean) WebClient.getConfig(client).getRequestContext().get(HTTP_REDIRECT_RELATIVE_URI));
   }
 
   private void verifyFile(


### PR DESCRIPTION
… redirects to be followed.

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Updates the WebClient with a CXF-specific header that allows it to follow local redirects in addition to the standard redirects.
#### Who is reviewing it? 
#### Select relevant component teams: 
@codice/security 
#### Ask 2 committers to review/merge the PR and tag them here.
@rzwiefel
@brendan-hofmann
#### How should this be tested?
CI Build
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-3818)
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
