### PR TITLE
DDF-3915 Updating Solr Memory Default and Docs

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/system.properties
@@ -89,6 +89,7 @@ solr.data.dir=_DO_NOT_EXPAND_${karaf.home}/solr/server/solr
 solr.client=HttpSolrClient
 solr.http.port=8994
 solr.http.protocol=https
+solr.max.heap.size=2g
 
 # Do NOT update the solr.http.url when quick installing on a remote headless server.
 solr.http.url=_DO_NOT_EXPAND_${solr.http.protocol}://_DO_NOT_EXPAND_${org.codice.ddf.system.hostname}:_DO_NOT_EXPAND_${solr.http.port}/solr

--- a/distribution/ddf-common/src/main/resources/bin/ddf.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddf.bat
@@ -24,6 +24,8 @@ REM Start Solr if needed
 IF "%start.solr%" == "true" (
 	CALL %GET_PROPERTY% solr.http.port 8994
 	CALL %GET_PROPERTY% solr.http.protocol https
+	CALL %GET_PROPERTY% solr.max.heap.size 2g
+	CALL SET SOLR_JAVA_MEM=-Xmx!solr.max.heap.size!
 
 	IF NOT "!solr.http.protocol!"=="http" IF NOT "!solr.http.protocol!"=="https" (
 		ECHO Unkown Solr protocol %solr.http.protocol% found in system.properties file

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -61,6 +61,7 @@ set_security_properties() {
 
 
 start_solr() {
+    export SOLR_JAVA_MEM=-Xmx$($GET solr.max.heap.size)
     if [ "$SOLR_UNSECURE" != "true" ]; then
         set_security_properties
     fi

--- a/distribution/docs/src/main/resources/content/_configuring/global-settings.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/global-settings.adoc
@@ -477,6 +477,13 @@ Thumbs.db
 |zookeeperhost1:2181,zookeeperhost2:2181,zookeeperhost3:2181
 |No
 
+|Solr max heap size
+|solr.max.heap.size
+|String
+|Memory settings for the Solr server
+|2g
+|Yes
+
 |===
 
 These properties are available to be used as variable parameters in input url fields within the ${admin-console}.

--- a/distribution/docs/src/main/resources/content/_running/starting-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_running/starting-intro.adoc
@@ -28,6 +28,12 @@ Update the wrapper.java.additional -Xmx value
 ----
 ====
 
+.Solr Memory Considerations
+[NOTE]
+====
+If the ${branding} will be ingesting many records at a time, consider increasing the `solr.max.heap.size` in the `system.properties` file. More information can be found in the https://lucene.apache.org/solr/guide/7_4/taking-solr-to-production.html[Solr documentation].
+====
+
 .JMX Connectivity Considerations
 [NOTE]
 ====

--- a/distribution/docs/src/main/resources/content/_sources/solr-catalog-provider.adoc
+++ b/distribution/docs/src/main/resources/content/_sources/solr-catalog-provider.adoc
@@ -37,6 +37,7 @@ No configuration.
  start.solr=true
  solr.client=HttpSolrClient
  solr.http.port=8994
+ solr.max.heap.size=2g
  ----
 
 .[[_solr_cloud]]Solr Cloud


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #3591
____
#### What does this PR do?
Update the docs and start scripts to reference a non-default heap max for Solr that is configurable.

#### Who is reviewing it? 
@clockard @lessarderic @kcrowe01 @taz77 @austinsteffes @garrettfreibott @ahoffer @ricklarsen 

#### How should this be tested?
Ensure Solr starts and operates as expected. Try ingesting a large dataset (like a million records) through the command line with `ingest -t format path/to/records` and make sure the ingest is successful.
Read through the docs changes and make sure they are adequate. 

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
