### PR TITLE
DDF-4053 Change FilterInjector to only warn when filters could not be injected

### DIFF
--- a/features/apps/src/main/feature/feature.xml
+++ b/features/apps/src/main/feature/feature.xml
@@ -41,6 +41,7 @@
              description="Features that will be started on container startup.">
         <!--Added prerequisite to kernel since it starts up features that must be started before others such as wrap and blueprint -->
         <feature prerequisite="true">kernel</feature>
+        <feature prerequisite="true">platform-filter-delegate</feature>
         <!--Added prerequisite to make sure the security filter injector is running before any other contexts get registered-->
         <feature prerequisite="true">security-services-app</feature>
         <feature>ddf-branding</feature>

--- a/platform/platform-filter-delegate/src/main/java/org/codice/ddf/platform/filter/delegate/FilterInjector.java
+++ b/platform/platform-filter-delegate/src/main/java/org/codice/ddf/platform/filter/delegate/FilterInjector.java
@@ -33,7 +33,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHandler;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceEvent;
@@ -117,19 +116,14 @@ public class FilterInjector implements EventListenerHook {
 
         if (service.getFilterRegistration(DELEGATING_FILTER) == null) {
           LOGGER.error(
-              "Platform filter delegate failed to start in time to inject itself into {} {}. This means the {} servlet will not properly attach the user subject to requests. Attempting to resolve the issue by restarting the bundle.",
+              "Platform filter delegate failed to start in time to inject itself into {} {}. This means the {} servlet will not properly attach the user subject to requests. A system restart is recommended.",
               refBundle.getSymbolicName(),
               refBundle.getBundleId(),
               refBundle.getSymbolicName());
-
-          // Restarting the missed servlet context bundle so the injector will be able to perform
-          // its job.
-          refBundle.stop();
-          refBundle.start();
         }
       }
 
-    } catch (InvalidSyntaxException | BundleException e) {
+    } catch (InvalidSyntaxException e) {
       LOGGER.error(
           "Problem checking ServletContexts for DelegateServletFilter injections. One of the servlets running might not have all of the needed filters injected. A system restart is recommended. See debug logs for additional details.");
       LOGGER.debug("Additional Details:", e);


### PR DESCRIPTION
#### What does this PR do?
Instead of trying to restart bundles that didn't get the injections just log a message. Trying to restart some bundles can cause the system to get into an even worse state. 
#### Who is reviewing it? 
@emmberk @peterhuffer 

#### Ask 2 committers to review/merge the PR and tag them here.
@lessarderic
@stustison

#### How should this be tested?
CI build
#### What are the relevant tickets?
[DDF-4053](https://codice.atlassian.net/browse/DDF-4053)
