### PR TITLE
DDF-4068 Removed unused ApplicationServiceImpl managed-properties

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceImpl.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceImpl.java
@@ -66,7 +66,7 @@ public class ApplicationServiceImpl implements ApplicationService {
 
   private static final Map<Long, String> BUNDLE_LOCATIONS = new ConcurrentHashMap<>();
 
-  private FeaturesService featuresService = null;
+  private final FeaturesService featuresService;
 
   private static final Path APPLICATION_DEFINITIONS_FOLDER =
       Paths.get("etc", "application-definitions");
@@ -137,6 +137,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     return profiles;
   }
 
+  @Override
   public List<FeatureDetails> getAllFeatures() {
     List<FeatureDetails> features = new ArrayList<>();
     try {

--- a/platform/admin/core/admin-core-appservice/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/core/admin-core-appservice/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,16 +10,12 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/ -->
-<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+<blueprint xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <ext:property-placeholder/>
 
     <bean id="appService" class="org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl">
-        <cm:managed-properties
-            persistent-id="org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl"
-            update-strategy="container-managed"/>
         <argument ref="featuresService"/>
     </bean>
 


### PR DESCRIPTION
#### What does this PR do?
This PR removes a leftover managed-properties section in a blueprint for a config that was removed in https://github.com/codice/ddf/pull/2986 (https://github.com/codice/ddf/commit/5b30f47b61db9df4372c3b8b658c4bb5b20798a1#diff-3e2a721ab8acfb851595af59df747ee9 and https://github.com/codice/ddf/commit/5b30f47b61db9df4372c3b8b658c4bb5b20798a1#diff-6fde67309bea545bb05f0addffbc2d1eL258).
#### Who is reviewing it? 
@peterhuffer @kcover 
#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@vinamartin
#### How should this be tested?
CI build
#### What are the relevant tickets?
[DDF-4068](https://codice.atlassian.net/browse/DDF-4068)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.