### PR TITLE
[2.13.x] DDF-4057 Adding metadata back into metacard for federation caching

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CachedResourceMetacardComparator.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CachedResourceMetacardComparator.java
@@ -60,6 +60,10 @@ class CachedResourceMetacardComparator {
           Metacard::getExpirationDate,
           Metacard::getContentTypeName);
 
+  /**
+   * These are attributes we are going to ignore because they are already being compared or extra
+   * ones that are to be ignored
+   */
   private static final Set<String> ATTRIBUTES_TO_IGNORE =
       ImmutableSet.of(
           Metacard.CHECKSUM,

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
@@ -161,9 +161,7 @@ public class CqlRequest {
     }
 
     if (excludeUnnecessaryAttributes) {
-      queryRequest
-          .getProperties()
-          .put("excludeAttributes", Sets.newHashSet(Metacard.METADATA, "lux"));
+      queryRequest.getProperties().put("excludeAttributes", Sets.newHashSet("lux"));
     }
 
     if (sortBys.size() > 1) {


### PR DESCRIPTION
Backport of this PR: https://github.com/codice/ddf/pull/3611

#### What does this PR do?
Fixes deletion of cached metacards when cachedMetacard == updatedMetacard under federated environments
#### Who is reviewing it? 
@ahoffer 
@garrettfreibott 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->

@lessarderic
@pklinef
@ricklarsen - Documentation
@rzwiefel
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
set up a federation
ingest a word document or something with metadata
query and download it
re-search query and make sure product is still in the product/cache -> good
then
download -> edit metadata -> requery -> make sure product is not cached since cached metadata != updated metadata
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4057](https://codice.atlassian.net/browse/DDF-4057)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
