### PR TITLE
[2.13.x] DDF-4016 the response will close the output stream when it's ready

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/catalog/CatalogApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/catalog/CatalogApplication.java
@@ -300,8 +300,6 @@ public class CatalogApplication implements SparkApplication {
         res.raw().setContentLength(bytesCopied);
         res.raw()
             .flushBuffer(); // Flashing buffer so Spark won't set the body based on the return value
-
-        res.raw().getOutputStream().close();
       }
       // Add the Accept-ranges header to let the client know that we accept ranges in bytes
       res.header(HEADER_ACCEPT_RANGES, BYTES);


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do? 
I closed a stream that shouldn't have been closed and it was caught in the forward port #3588 
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Closes input streams in Catalog Application
#### Who is reviewing it? 
@bakejeyner @blen-desta @brjeter 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@coyotesqrl
@stustison 
@rzwiefel 
#### How should this be tested?
<!--(List steps with links to updated documentation)-->

1) Install DDF
2) hit https://localhost:8993/search/catalog/internal/catalog/:id
    I did this through postman with the following headers: 
``` 
  Host: localhost:8993
  Referer: https://localhost:8993/admin/
  X-Requested-With: XMLHttpRequest
```
  You can get an id by navigating to details in intrigue:
  Nothing should break. 👍 

3) hit https://localhost:8993/search/catalog/internal/catalog/:sourceid/:id with the same postman headers

  Nothing should break. 👍 


#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4016](https://codice.atlassian.net/browse/DDF-4016)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
