### PR TITLE
DDF-4084 Intrigue fails to find results with Websockets enabled

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlQueryResponse.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlQueryResponse.java
@@ -51,7 +51,7 @@ public class CqlQueryResponse {
 
   private final Status status;
 
-  private final QueryResponse queryResponse;
+  @JsonIgnore private final QueryResponse queryResponse;
 
   public CqlQueryResponse(
       String id,
@@ -138,7 +138,6 @@ public class CqlQueryResponse {
     return searchTerms;
   }
 
-  @JsonIgnore
   public QueryResponse getQueryResponse() {
     return queryResponse;
   }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/JsonRpc.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/JsonRpc.java
@@ -47,7 +47,8 @@ public class JsonRpc implements WebSocket {
               .includeEmpty()
               .includeNulls()
               .includeDefaultValues()
-              .setJsonFormatForDates(false));
+              .setJsonFormatForDates(false)
+              .useAnnotations());
 
   public JsonRpc(Map<String, Function> methods) {
     this.methods = methods;


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
This is a bug fix for intrigue failing to find results when websockets are enabled. In a previous commit a `@JsonIgnore` annotation was added to the CqlQueryResponse class. Several classes use Boon to deserialize the response, but they need to specify that they include annotations. Since the JsonRpc mapper didn't include annotations the json failed to deserialize causing the `/wc` endpoint to fail.
#### Who is reviewing it? 
@bellcc 
@leo-sakh 
@peterhuffer 
@Schachte 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@bdeining
@millerw8
#### How should this be tested?
- Make sure websockets are enabled (System > Catalog Search UI)
- Inject one or more metacards and run a search query through intrigue, confirming that the metacards are found.
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4048](https://codice.atlassian.net/browse/DDF-4084)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
