### PR TITLE
DDF-4087 Suppressing jetty CVEs that don't apply to DDF

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -513,6 +513,16 @@
         <cve>CVE-2018-1270</cve>
         <cve>CVE-2018-1275</cve>
     </suppress>
+
+    <suppress>
+        <notes>
+            These CVEs affect Jetty 9.3.x up to 9.3.23 and 9.4.x up to 9.4.10. DDF is using a
+            version of jetty that does not fall within those ranges.
+        </notes>
+        <cve>CVE-2017-7658</cve>
+        <cve>CVE-2017-7657</cve>
+    </suppress>
+
     <suppress>
         <notes><![CDATA[
         Nearly all of these are not an issue because either we are not using those features entirely or (and in addition to the fact) that solr is now running as an external process and completely locked down, so no one could access solr to take advantage of these vulnerabilites. All communication is controlled by DDF.


### PR DESCRIPTION
#### What does this PR do?
Suppresses two CVEs.

Getting OWASP failures on CVE-2017-7658 and CVE-2017-7657, but these don't actually apply to the version of Jetty that DDF is using.

#### Who is reviewing it? 
@Kjames5269 @blen-desta 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@stustison 
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4087](https://codice.atlassian.net/browse/DDF-4087)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
