### PR TITLE
DDF-2824 Fixes typo "provides contains" in Admin UI

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/admin.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/admin.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-app",
-  "description": "Administration application for installation and management.\nIncludes the Admin UI and the underlying application service that supports the user interface.\nThe Admin UI provides contains modules allowing the administrator to access configuration pages to tailor system services and properties.::Admin",
+  "description": "Administration application for installation and management.\nIncludes the Admin UI and the underlying application service that supports the user interface.\nThe Admin UI provides modules allowing the administrator to access configuration pages to tailor system services and properties.::Admin",
   "bundleLocations": [
     "mvn:ddf.admin.core/admin-core-configpolicy/${project.version}",
     "mvn:ddf.admin.core/admin-core-insecuredefaults/${project.version}",

--- a/features/apps/src/main/feature/feature.xml
+++ b/features/apps/src/main/feature/feature.xml
@@ -102,7 +102,7 @@
     </feature>
 
     <feature name="admin-app" version="${project.version}"
-             description="Administration application for installation and management.\nIncludes the Admin UI and the underlying application service that supports the user interface.\nThe Admin UI provides contains modules allowing the administrator to install/remove applications and their dependencies and to access configuration pages to customize and tailor system services and properties.\nThe application service provides the supporting operations allowing the Admin UI to add, remove, start, stop, and obtain status information about all applications on the system.">
+             description="Administration application for installation and management.\nIncludes the Admin UI and the underlying application service that supports the user interface.\nThe Admin UI provides modules allowing the administrator to install/remove applications and their dependencies and to access configuration pages to customize and tailor system services and properties.\nThe application service provides the supporting operations allowing the Admin UI to add, remove, start, stop, and obtain status information about all applications on the system.">
         <feature>admin-core</feature>
         <feature>admin-ui</feature>
         <feature>admin-core-migration-commands</feature>

--- a/platform/admin/modules/admin-modules-application/src/test/resources/application-service-array.json
+++ b/platform/admin/modules/admin-modules-application/src/test/resources/application-service-array.json
@@ -30,7 +30,7 @@
         "platform-app"
       ],
       "dependencies": [],
-      "description": "Administration application for installation and management.\\nIncludes the Admin UI and the underlying application service that supports the user interface.\\nThe Admin UI provides contains modules allowing the administrator to install/remove applications and their dependencies and to access configuration pages to customize and tailor system services and properties.\\nThe application service provides the supporting operations allowing the Admin UI to add, remove, start, stop, and obtain status information about all applications on the system.::Admin",
+      "description": "Administration application for installation and management.\\nIncludes the Admin UI and the underlying application service that supports the user interface.\\nThe Admin UI provides modules allowing the administrator to install/remove applications and their dependencies and to access configuration pages to customize and tailor system services and properties.\\nThe application service provides the supporting operations allowing the Admin UI to add, remove, start, stop, and obtain status information about all applications on the system.::Admin",
       "name": "admin-app",
       "state": "ACTIVE",
       "uri": "mvn:ddf.admin/admin-app/1.1.0-SNAPSHOT/xml/features",


### PR DESCRIPTION
#### What does this PR do?
Fixes typo in Admin UI which read "Admin UI **provides contains** modules allowing the administrator to access ..."
#### Who is reviewing it? 
@ethantmanns @tbatie 
#### Ask 2 committers to review/merge the PR and tag them here.
@ricklarsen - Documentation
@shaundmorris 
#### How should this be tested?
Verify hovering over the Admin description box in the UI shows the typo is no longer there

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
