### PR TITLE
DDF-4098 Low bandwidth map buttons should be more clear

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
@@ -16,7 +16,10 @@
     Low-bandwidth mode is enabled. Please confirm that you want this component to load despite potential bandwidth implications. Choosing to continue may cause available connection resources to be exhausted, and you or other users on your network may experience slowdowns or extended periods of waiting while necessary resources are fetched. 
     </h3>
     <button class="low-bandwidth-button is-positive" align="center">
-        <span>Continue</span>
+        <span>Continue to Map Anyway</span>
+    </button>
+    <button class="low-bandwidth-button-close is-negative" align="center">
+        <span>Close Map</span>
     </button>
 </div>
 <div class="map-container">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.view.js
@@ -30,7 +30,8 @@ module.exports = Marionette.LayoutView.extend({
     },
 
     events: {
-        'click .low-bandwidth-button' : 'continueLoading'
+        'click .low-bandwidth-button' : 'continueLoading',
+        'click .low-bandwidth-button-close' : 'closeMap'
     },
 
     initialize: function(options) {
@@ -50,5 +51,9 @@ module.exports = Marionette.LayoutView.extend({
         } else {
             this.mapContainer.show(new OpenlayersView(this.options));
         }
+    },
+
+    closeMap: function() {
+        this.options.container.close();
     }
 });


### PR DESCRIPTION
#### What does this PR do?
Currently low bandwidth mode brings up the map visuals with a large green continue button.  This is a little vague in purpose, (does it continue low band-width?  does it continue to the map?) Perhaps a "continue to map anyway" and "close map" options would be better so it is clear to what the user wants to do.

https://localhost:8993/search/catalog/?lowBandwidth

#### Who is reviewing it? 
@GabrielFabian  
@gjvera 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### What are the relevant tickets?
[DDF-4098](https://codice.atlassian.net/browse/DDF-4098)
#### Screenshots
<img width="810" alt="screen shot 2018-08-27 at 5 32 09 pm" src="https://user-images.githubusercontent.com/37838624/44687424-2f5afb80-aa1f-11e8-9ac6-e8b8a100ac3e.png">

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
