### PR TITLE
DDF-4099 UI should autocomplete based on labels, not underlying field…

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
@@ -161,7 +161,10 @@ define([
                     }).length > 1))) {
                 return false;
             }
-            if (this.getAppropriateString(child.get('label')).indexOf(filterValue) === -1) {
+            if (child.get('label') !== undefined && this.getAppropriateString(child.get('label')).indexOf(filterValue) === -1) {
+                return false;
+            }
+            if (child.get('label') === undefined && this.getAppropriateString(child.get('value')).indexOf(filterValue) === -1) {
                 return false;
             }
             return true;

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
@@ -161,7 +161,7 @@ define([
                     }).length > 1))) {
                 return false;
             }
-            if (this.getAppropriateString(child.get('value')).indexOf(filterValue) === -1) {
+            if (this.getAppropriateString(child.get('label')).indexOf(filterValue) === -1) {
                 return false;
             }
             return true;


### PR DESCRIPTION
… names

`select.collection.view` is used in multiple locations; I believe this is safe change, but it would be good to receive some reviews from experienced UI engineers. 

#### Who is reviewing it? 
@gjvera 
@djblue 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@djblue
#### How should this be tested?
Search on partial field data name ('ext.') -> get no results
Search on a partial field alias name (e.g. 'created') -> get relevant results
#### What are the relevant tickets?
[DDF-4099](https://codice.atlassian.net/browse/DDF-4099)
#### Screenshots
<img width="411" alt="screen shot 2018-08-27 at 6 28 08 pm" src="https://user-images.githubusercontent.com/37838624/44689880-fa52a700-aa26-11e8-843c-aacd5b190414.png">

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
