### PR TITLE
DDF-4089 Change to Guava Cache implementation for in memory token cache

### DIFF
--- a/distribution/test/itests/pom.xml
+++ b/distribution/test/itests/pom.xml
@@ -129,6 +129,11 @@
             <artifactId>rest-assured</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
@@ -97,6 +97,8 @@ public class TestPlatform extends AbstractIntegrationTest {
             .auth()
             .preemptive()
             .basic(ADMIN, ADMIN)
+            .header("X-Requested-With", "XMLHttpRequest")
+            .header("Origin", REPORT_GENERATION_URL.getUrl())
             .expect()
             .statusCode(200)
             .when()

--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -31,6 +31,7 @@
         <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore.version}</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient.version}</bundle>
         <bundle>mvn:ddf.thirdparty/rest-assured/${project.version}</bundle>
+        <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>
 
         <bundle>
             wrap:mvn:ddf.security/ddf-security-common/${project.version}$Bundle-SymbolicName=itest-test-security-common

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -277,6 +277,7 @@
     <feature name="security-sts-server" version="${project.version}"
              description="Security STS.">
         <feature>sts-prereqs</feature>
+        <feature>guava</feature>
         <configfile finalname="${ddf.etc}/ws-security/attributeMap.properties">
             mvn:ddf.security.sts/security-sts-ldapclaimshandler/${project.version}/properties/attributeMap
         </configfile>

--- a/platform/security/sts/security-sts-server/pom.xml
+++ b/platform/security/sts/security-sts-server/pom.xml
@@ -109,6 +109,10 @@
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
         </dependency>
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/MemoryTokenStore.java
+++ b/platform/security/sts/security-sts-server/src/main/java/ddf/security/sts/MemoryTokenStore.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.sts;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.apache.cxf.buslifecycle.BusLifeCycleListener;
+import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.apache.cxf.ws.security.tokenstore.TokenStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MemoryTokenStore implements TokenStore, Closeable, BusLifeCycleListener {
+
+  private static final Cache<String, SecurityToken> CACHE =
+      CacheBuilder.newBuilder().expireAfterWrite(15, TimeUnit.MINUTES).maximumSize(1000).build();
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MemoryTokenStore.class);
+
+  @Override
+  public void close() {
+    LOGGER.trace("Cleaning up token cache");
+    CACHE.invalidateAll();
+    CACHE.cleanUp();
+  }
+
+  @Override
+  public void initComplete() {
+    // No-Op
+  }
+
+  @Override
+  public void preShutdown() {
+    close();
+  }
+
+  @Override
+  public void postShutdown() {
+    close();
+  }
+
+  @Override
+  public void add(SecurityToken securityToken) {
+    LOGGER.trace("Adding token: {}", securityToken.getId());
+    CACHE.put(securityToken.getId(), securityToken);
+  }
+
+  @Override
+  public void add(String identifier, SecurityToken securityToken) {
+    LOGGER.trace("Adding token by id: {}", identifier);
+    CACHE.put(identifier, securityToken);
+  }
+
+  @Override
+  public void remove(String identifier) {
+    LOGGER.trace("Removing token: {}", identifier);
+    CACHE.invalidate(identifier);
+  }
+
+  @Override
+  public Collection<String> getTokenIdentifiers() {
+    return Collections.unmodifiableCollection(CACHE.asMap().keySet());
+  }
+
+  @Override
+  public SecurityToken getToken(String identifier) {
+    return CACHE.getIfPresent(identifier);
+  }
+}

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/tokenstore.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/tokenstore.xml
@@ -16,7 +16,11 @@
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
         http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
         
-    <bean id="defaultTokenStore" class="ddf.security.sts.DefaultInMemoryTokenStore"
+    <bean id="defaultTokenStore" class="ddf.security.sts.MemoryTokenStore"
           scope="singleton"/>
+
+    <!-- Required for CXF -->
+    <bean id="ehCacheTokenStore" class="ddf.security.sts.DefaultInMemoryTokenStore"
+        scope="singleton"/>
     
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
Updates InMemoryTokenStore to use Guava instead of ehCache. 
This cleans up a problem with growing .data files in <ddf.home>/data/tmp

#### Who is reviewing it? 
@adimka 
@Bdthomson 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@stustison

#### How should this be tested?
Full build with tests
1. Login/Logout to admin UI and search UI a couple of times.
Verify no data is stored in the <ddf.home>/data/tmp/*cxf*/*.data file

#### Any background context you want to provide?
Will backport to 2.13.x once this PR is approved. 

#### What are the relevant tickets?
[DDF-4089](https://codice.atlassian.net/browse/DDF-4089)

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
