### PR TITLE
[2.13.x] DDF-4090 - Remove LDAP structure assumptions

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -385,11 +385,7 @@ grant codeBase "file:/admin-core-migration-commands/catalog-core-solrcommands/se
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}*", "read";
 }
 
-grant codeBase "file:/security-sts-attributequeryclaimshandler/security-sts-ldapclaimshandler" {
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}attributeMap.properties", "read";
-}
-
-grant codeBase "file:/security-core-api/security-sts-ldapclaimshandler" {
+grant codeBase "file:/security-core-api/security-sts-attributequeryclaimshandler/security-sts-ldapclaimshandler" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}-", "read";
 }
 

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -389,6 +389,10 @@ grant codeBase "file:/security-sts-attributequeryclaimshandler/security-sts-ldap
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}attributeMap.properties", "read";
 }
 
+grant codeBase "file:/security-core-api/security-sts-ldapclaimshandler" {
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}-", "read";
+}
+
 //
 // itest specific perms
 //

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -221,7 +221,7 @@ public class ClaimsHandlerManager {
     }
 
     Options options = Options.defaultOptions();
-    if (loadBalancingAlgorithm != null && loadBalancingAlgorithm.equalsIgnoreCase(FAILOVER)) {
+    if (FAILOVER.equalsIgnoreCase(loadBalancingAlgorithm)) {
       return Connections.newFailoverLoadBalancer(connectionFactories, options);
     } else {
       return Connections.newRoundRobinLoadBalancer(connectionFactories, options);

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -118,13 +118,7 @@ public class ClaimsHandlerManager {
       return;
     }
     LOGGER.debug("Received an updated set of configurations for the LDAP/Role Claims Handlers.");
-    List<String> urls = new ArrayList<>();
-    Object urlObj = props.get(ClaimsHandlerManager.URL);
-    if (urlObj instanceof String[]) {
-      urls.addAll(Arrays.asList((String[]) urlObj));
-    } else {
-      urls.add(urlObj.toString());
-    }
+    List<String> urls = getUrls(props, ClaimsHandlerManager.URL);
     String loadBalancingAlgorithm = (String) props.get(ClaimsHandlerManager.LOAD_BALANCING);
     Boolean startTls;
     if (props.get(ClaimsHandlerManager.START_TLS) instanceof String) {
@@ -207,6 +201,18 @@ public class ClaimsHandlerManager {
           "Experienced error while configuring claims handlers. Handlers are NOT configured and claim retrieval will not work. Check LDAP configuration.",
           e);
     }
+  }
+
+  private List<String> getUrls(Map<String, Object> props, String key) {
+    List<String> urls = new ArrayList<>();
+    Object urlProperty = props.get(key);
+    if (urlProperty instanceof String[]) {
+      urls.addAll(Arrays.asList((String[]) urlProperty));
+    } else {
+      urls.add(urlProperty.toString());
+    }
+
+    return urls;
   }
 
   public void destroy() {}

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -56,6 +56,8 @@ public class ClaimsHandlerManager {
 
   public static final String LOAD_BALANCING = "ldapLoadBalancing";
 
+  public static final String FAILOVER = "failover";
+
   public static final String START_TLS = "startTls";
 
   public static final String OVERRIDE_CERT_DN = "overrideCertDn";
@@ -219,7 +221,7 @@ public class ClaimsHandlerManager {
     }
 
     Options options = Options.defaultOptions();
-    if (loadBalancingAlgorithm != null && loadBalancingAlgorithm.equalsIgnoreCase("failover")) {
+    if (loadBalancingAlgorithm != null && loadBalancingAlgorithm.equalsIgnoreCase(FAILOVER)) {
       return Connections.newFailoverLoadBalancer(connectionFactories, options);
     } else {
       return Connections.newRoundRobinLoadBalancer(connectionFactories, options);

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -387,7 +387,7 @@ public class ClaimsHandlerManager {
     return null;
   }
 
-  public void setUrl(String url) {
+  public void setUrl(String... url) {
     LOGGER.trace("Setting url: {}", url);
     ldapProperties.put(URL, url);
   }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
@@ -26,7 +26,7 @@ import org.apache.cxf.sts.claims.ProcessedClaimCollection;
 import org.forgerock.opendj.ldap.Attribute;
 import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.opendj.ldap.Connection;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.ConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.SearchResultReferenceIOException;
 import org.forgerock.opendj.ldap.SearchScope;
@@ -44,7 +44,7 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
 
   private String propertyFileLocation;
 
-  private LDAPConnectionFactory connectionFactory;
+  private ConnectionFactory connectionFactory;
 
   private String bindUserCredentials;
 
@@ -62,11 +62,11 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
     super();
   }
 
-  public LDAPConnectionFactory getLdapConnectionFactory() {
+  public ConnectionFactory getLdapConnectionFactory() {
     return connectionFactory;
   }
 
-  public void setLdapConnectionFactory(LDAPConnectionFactory connection) {
+  public void setLdapConnectionFactory(ConnectionFactory connection) {
     this.connectionFactory = connection;
   }
 
@@ -169,6 +169,7 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
             } else {
               // Got a continuation reference
               LOGGER.debug("Referral ignored while searching for user {}", user);
+              entryReader.readReference();
             }
           }
         } else {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
@@ -254,7 +254,7 @@ public class RoleClaimsHandler implements ClaimsHandler {
             SearchResultEntry entry = entryReader.readEntry();
 
             userDN = entry.getName().toString();
-            specificUserBaseDN = userDN.substring(userDN.indexOf(",") + 1);
+            specificUserBaseDN = userDN.substring(userDN.indexOf(',') + 1);
             if (!membershipUserAttribute.equals(loginUserAttribute)) {
               Attribute attr = entry.getAttribute(membershipUserAttribute);
               if (attr != null) {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
@@ -247,7 +247,7 @@ public class RoleClaimsHandler implements ClaimsHandler {
         ConnectionEntryReader entryReader =
             connection.search(
                 baseDN, SearchScope.WHOLE_SUBTREE, filter.toString(), membershipUserAttribute);
-        String userDN = loginUserAttribute + "=" + user + "," + baseDN;
+        String userDN = String.format("%s=%s,%s", loginUserAttribute, user, baseDN);
         String specificUserBaseDN = baseDN;
         while (entryReader.hasNext()) {
           if (entryReader.isEntry()) {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -53,6 +53,7 @@
                     <value>ldaps://${org.codice.ddf.system.hostname}:1636</value>
                 </list>
             </property>
+            <property name="loadBalancing" value="round_robin"/>
             <property name="startTls" value="false"/>
             <property name="ldapBindUserDn" value="cn=admin"/>
             <property name="password" value="secret"/>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -48,7 +48,11 @@
                               init-method="configure" destroy-method="destroy">
             <argument ref="encryptionService"/>
             <!-- Default properties -->
-            <property name="url" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
+            <property name="url">
+                <list>
+                    <value>ldaps://${org.codice.ddf.system.hostname}:1636</value>
+                </list>
+            </property>
             <property name="startTls" value="false"/>
             <property name="ldapBindUserDn" value="cn=admin"/>
             <property name="password" value="secret"/>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
 	<OCD description="STS Ldap and Roles Claims Handler Configuration. WARNING: The server must be restarted for these updates to take affect."
          name="Security STS LDAP and Roles Claims Handler" id="Claims_Handler_Manager">
 
-	    <AD name="LDAP URL:" id="url" required="true" type="String"
+	    <AD name="LDAP URL:" id="url" required="true" type="String" cardinality="10"
             default="ldaps://${org.codice.ddf.system.hostname}:1636"
             description="LDAP or LDAPS server and port">
 	    </AD>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -23,6 +23,11 @@
             description="LDAP or LDAPS server and port">
 	    </AD>
 
+		<AD name="LDAP Load Balancing:" id="loadBalancing" required="false" type="String"
+			default="round_robin"
+			description="Load balancing algorithm to use when multiple LDAP urls are provided (round_robin, failover)">
+		</AD>
+
 		<AD name="LDAP Bind Method" id="bindMethod" required="true" type="String"
 			default="Simple">
 			<Option label="Digest MD5 SASL" value="Digest MD5 SASL" />

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
@@ -34,6 +34,7 @@ import org.apache.cxf.sts.claims.ProcessedClaim;
 import org.apache.cxf.sts.claims.ProcessedClaimCollection;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.forgerock.opendj.ldap.Connection;
+import org.forgerock.opendj.ldap.DN;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.LinkedAttribute;
@@ -76,6 +77,7 @@ public class RoleClaimsHandlerTest {
     ProcessedClaimCollection processedClaims;
     RoleClaimsHandler claimsHandler;
     SearchResultEntry membershipSearchResult = mock(SearchResultEntry.class);
+    DN resultDN = DN.valueOf("uid=tstark,");
     SearchResultEntry groupNameSearchResult = mock(SearchResultEntry.class);
     String groupName = "avengers";
 
@@ -89,6 +91,8 @@ public class RoleClaimsHandlerTest {
     when(membershipReader.isEntry()).thenReturn(true);
     when(membershipReader.readEntry()).thenReturn(membershipSearchResult);
 
+    when(membershipSearchResult.getName()).thenReturn(resultDN);
+
     groupNameAttribute.add(groupName);
     when(groupNameSearchResult.getAttribute(anyString())).thenReturn(groupNameAttribute);
 
@@ -100,7 +104,7 @@ public class RoleClaimsHandlerTest {
     when(connection.search(
             anyObject(),
             anyObject(),
-            eq("(&(objectClass=groupOfNames)(member=uid=tstark,))"),
+            eq("(&(objectClass=groupOfNames)(|(member=uid=tstark,)(member=uid=tstark,)))"),
             anyVararg()))
         .thenReturn(groupNameReader);
     when(connection.search(anyString(), anyObject(), anyString(), matches("uid")))
@@ -113,6 +117,75 @@ public class RoleClaimsHandlerTest {
     claimsHandler.setBindMethod("Simple");
     claimsHandler.setBindUserCredentials("foo");
     claimsHandler.setBindUserDN("bar");
+
+    claimsParameters = new ClaimsParameters();
+    claimsParameters.setPrincipal(new UserPrincipal(USER_CN));
+    ClaimCollection claimCollection = new ClaimCollection();
+    processedClaims = claimsHandler.retrieveClaimValues(claimCollection, claimsParameters);
+    assertThat(processedClaims, hasSize(1));
+    ProcessedClaim claim = processedClaims.get(0);
+    assertThat(claim.getPrincipal(), equalTo(new UserPrincipal(USER_CN)));
+    assertThat(claim.getValues(), hasSize(1));
+    assertThat(claim.getValues().get(0), equalTo(groupName));
+  }
+
+  @Test
+  public void testRetrieveClaimsValuesNestedUserOU()
+      throws LdapException, SearchResultReferenceIOException {
+    BindResult bindResult = mock(BindResult.class);
+    ClaimsParameters claimsParameters;
+    Connection connection = mock(Connection.class);
+    ConnectionEntryReader membershipReader = mock(ConnectionEntryReader.class);
+    ConnectionEntryReader groupNameReader = mock(ConnectionEntryReader.class);
+    LDAPConnectionFactory connectionFactory = PowerMockito.mock(LDAPConnectionFactory.class);
+    LinkedAttribute membershipAttribute = new LinkedAttribute("cn");
+    LinkedAttribute groupNameAttribute = new LinkedAttribute("cn");
+    ProcessedClaimCollection processedClaims;
+    RoleClaimsHandler claimsHandler;
+    SearchResultEntry membershipSearchResult = mock(SearchResultEntry.class);
+    DN resultDN = DN.valueOf("uid=tstark,OU=nested,");
+    SearchResultEntry groupNameSearchResult = mock(SearchResultEntry.class);
+    String groupName = "avengers";
+
+    when(bindResult.isSuccess()).thenReturn(true);
+
+    membershipAttribute.add("tstark");
+    when(membershipSearchResult.getAttribute(anyString())).thenReturn(membershipAttribute);
+
+    // hasNext() returns 'true' the first time, then 'false' every time after.
+    when(membershipReader.hasNext()).thenReturn(true, false);
+    when(membershipReader.isEntry()).thenReturn(true);
+    when(membershipReader.readEntry()).thenReturn(membershipSearchResult);
+
+    when(membershipSearchResult.getName()).thenReturn(resultDN);
+
+    groupNameAttribute.add(groupName);
+    when(groupNameSearchResult.getAttribute(anyString())).thenReturn(groupNameAttribute);
+
+    when(groupNameReader.hasNext()).thenReturn(true, false);
+    when(groupNameReader.isEntry()).thenReturn(true);
+    when(groupNameReader.readEntry()).thenReturn(groupNameSearchResult);
+
+    when(connection.bind(anyObject())).thenReturn(bindResult);
+    when(connection.search(
+            anyObject(),
+            anyObject(),
+            eq(
+                "(&(objectClass=groupOfNames)(|(member=cn=tstark,OU=nested,)(member=uid=tstark,OU=nested,)))"),
+            anyVararg()))
+        .thenReturn(groupNameReader);
+    when(connection.search(anyString(), anyObject(), anyString(), matches("cn")))
+        .thenReturn(membershipReader);
+
+    when(connectionFactory.getConnection()).thenReturn(connection);
+
+    claimsHandler = new RoleClaimsHandler();
+    claimsHandler.setLdapConnectionFactory(connectionFactory);
+    claimsHandler.setBindMethod("Simple");
+    claimsHandler.setBindUserCredentials("foo");
+    claimsHandler.setBindUserDN("bar");
+    claimsHandler.setMembershipUserAttribute("cn");
+    claimsHandler.setLoginUserAttribute("uid");
 
     claimsParameters = new ClaimsParameters();
     claimsParameters.setPrincipal(new UserPrincipal(USER_CN));
@@ -139,6 +212,7 @@ public class RoleClaimsHandlerTest {
     ProcessedClaimCollection processedClaims;
     RoleClaimsHandler claimsHandler;
     SearchResultEntry membershipSearchResult = mock(SearchResultEntry.class);
+    DN resultDN = DN.valueOf("uid=tstark,");
     SearchResultEntry groupNameSearchResult = mock(SearchResultEntry.class);
     String groupName = "avengers";
 
@@ -153,6 +227,8 @@ public class RoleClaimsHandlerTest {
     when(membershipReader.isEntry()).thenReturn(false, true);
     when(membershipReader.readEntry()).thenReturn(membershipSearchResult);
 
+    when(membershipSearchResult.getName()).thenReturn(resultDN);
+
     groupNameAttribute.add(groupName);
     when(groupNameSearchResult.getAttribute(anyString())).thenReturn(groupNameAttribute);
 
@@ -164,7 +240,7 @@ public class RoleClaimsHandlerTest {
     when(connection.search(
             anyObject(),
             anyObject(),
-            eq("(&(objectClass=groupOfNames)(member=uid=tstark,))"),
+            eq("(&(objectClass=groupOfNames)(|(member=uid=tstark,)(member=uid=tstark,)))"),
             anyVararg()))
         .thenReturn(groupNameReader);
     when(connection.search(anyString(), anyObject(), anyString(), matches("uid")))

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapConnectionPooledObjectFactory.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapConnectionPooledObjectFactory.java
@@ -17,13 +17,13 @@ import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.forgerock.opendj.ldap.Connection;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.ConnectionFactory;
 
 public class LdapConnectionPooledObjectFactory extends BasePooledObjectFactory<Connection> {
 
-  private final LDAPConnectionFactory ldapConnectionFactory;
+  private final ConnectionFactory ldapConnectionFactory;
 
-  public LdapConnectionPooledObjectFactory(LDAPConnectionFactory ldapConnectionFactory) {
+  public LdapConnectionPooledObjectFactory(ConnectionFactory ldapConnectionFactory) {
     this.ldapConnectionFactory = ldapConnectionFactory;
   }
 

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -83,7 +83,7 @@ public class LdapLoginConfig {
 
   private static final String SUFFICIENT_FLAG = "sufficient";
 
-  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAtttribute";
+  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAttribute";
 
   public static final String MEMBER_USER_ATTRIBUTE = "membershipUserAttribute";
 

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -67,6 +67,8 @@ public class LdapLoginConfig {
 
   public static final String LDAP_LOAD_BALANCING = "ldapLoadBalancing";
 
+  public static final String FAILOVER = "failover";
+
   public static final String BIND_METHOD = "bindMethod";
 
   public static final String USER_BASE_DN = "userBaseDn";
@@ -152,7 +154,7 @@ public class LdapLoginConfig {
 
       String loadBalancingAlgorithm = (String) props.get(LDAP_LOAD_BALANCING);
       Options options = Options.defaultOptions();
-      if (loadBalancingAlgorithm != null && loadBalancingAlgorithm.equalsIgnoreCase("failover")) {
+      if (loadBalancingAlgorithm != null && loadBalancingAlgorithm.equalsIgnoreCase(FAILOVER)) {
         ldapConnectionFactory = Connections.newFailoverLoadBalancer(connectionFactories, options);
       } else {
         ldapConnectionFactory = Connections.newRoundRobinLoadBalancer(connectionFactories, options);

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -154,7 +154,7 @@ public class LdapLoginConfig {
 
       String loadBalancingAlgorithm = (String) props.get(LDAP_LOAD_BALANCING);
       Options options = Options.defaultOptions();
-      if (loadBalancingAlgorithm != null && loadBalancingAlgorithm.equalsIgnoreCase(FAILOVER)) {
+      if (FAILOVER.equalsIgnoreCase(loadBalancingAlgorithm)) {
         ldapConnectionFactory = Connections.newFailoverLoadBalancer(connectionFactories, options);
       } else {
         ldapConnectionFactory = Connections.newRoundRobinLoadBalancer(connectionFactories, options);

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -288,7 +288,10 @@ public class LdapLoginConfig {
     props.put(USER_SEARCH_SUBTREE_OPTIONS_KEY, "true");
     props.put(ROLE_BASE_DN_OPTIONS_KEY, properties.get(GROUP_BASE_DN));
     Object groupMemberAttribute = properties.get(MEMBER_NAME_ATTRIBUTE);
-    groupMemberAttribute = groupMemberAttribute == null ? "member" : groupMemberAttribute;
+    groupMemberAttribute =
+        groupMemberAttribute == null || groupMemberAttribute.toString().trim().isEmpty()
+            ? "member"
+            : groupMemberAttribute;
     props.put(
         ROLE_FILTER_OPTIONS_KEY,
         String.format(

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -27,9 +27,11 @@ import ddf.security.common.audit.SecurityLogger;
 import java.net.InetAddress;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -42,6 +44,8 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.karaf.jaas.config.impl.Module;
 import org.codice.ddf.configuration.DictionaryMap;
 import org.forgerock.opendj.ldap.Connection;
+import org.forgerock.opendj.ldap.ConnectionFactory;
+import org.forgerock.opendj.ldap.Connections;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LDAPUrl;
 import org.forgerock.util.Options;
@@ -61,6 +65,8 @@ public class LdapLoginConfig {
 
   public static final String LDAP_URL = "ldapUrl";
 
+  public static final String LDAP_LOAD_BALANCING = "ldapLoadBalancing";
+
   public static final String BIND_METHOD = "bindMethod";
 
   public static final String USER_BASE_DN = "userBaseDn";
@@ -75,9 +81,11 @@ public class LdapLoginConfig {
 
   private static final String SUFFICIENT_FLAG = "sufficient";
 
-  private static final String LOGIN_USER_ATTRIBUTE = "loginUserAtttribute";
+  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAtttribute";
 
-  private static final String MEMBER_USER_ATTRIBUTE = "membershipUserAttribute";
+  public static final String MEMBER_USER_ATTRIBUTE = "membershipUserAttribute";
+
+  public static final String MEMBER_NAME_ATTRIBUTE = "memberNameAttribute";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(LdapLoginConfig.class);
 
@@ -121,10 +129,34 @@ public class LdapLoginConfig {
         ldapConnectionPool.close();
       }
 
-      LDAPConnectionFactory ldapConnectionFactory =
-          createLdapConnectionFactory(
-              (String) ldapProperties.get(LDAP_URL),
-              Boolean.parseBoolean((String) ldapProperties.get(START_TLS)));
+      ConnectionFactory ldapConnectionFactory = null;
+
+      List<String> urls = new ArrayList<>();
+      Object urlsObj = props.get(LDAP_URL);
+      if (urlsObj instanceof String[]) {
+        urls.addAll(Arrays.asList((String[]) urlsObj));
+      } else {
+        urls.add(urlsObj.toString());
+      }
+
+      List<ConnectionFactory> connectionFactories = new ArrayList<>();
+
+      Boolean startTls =
+          props.get(START_TLS) == null
+              ? false
+              : Boolean.parseBoolean(props.get(START_TLS).toString());
+
+      for (String url : urls) {
+        connectionFactories.add(createLdapConnectionFactory(url, startTls));
+      }
+
+      String loadBalancingAlgorithm = (String) props.get(LDAP_LOAD_BALANCING);
+      Options options = Options.defaultOptions();
+      if (loadBalancingAlgorithm != null && loadBalancingAlgorithm.equalsIgnoreCase("failover")) {
+        ldapConnectionFactory = Connections.newFailoverLoadBalancer(connectionFactories, options);
+      } else {
+        ldapConnectionFactory = Connections.newRoundRobinLoadBalancer(connectionFactories, options);
+      }
 
       ldapConnectionPool =
           new GenericObjectPool<>(
@@ -163,7 +195,7 @@ public class LdapLoginConfig {
     return config;
   }
 
-  protected LDAPConnectionFactory createLdapConnectionFactory(String url, Boolean startTls) {
+  protected ConnectionFactory createLdapConnectionFactory(String url, Boolean startTls) {
     boolean useSsl = url.startsWith("ldaps");
     boolean useTls = !url.startsWith("ldaps") && startTls;
 
@@ -253,10 +285,14 @@ public class LdapLoginConfig {
     props.put(USER_FILTER_OPTIONS_KEY, String.format("(%s=%%u)", loginUserAttribute));
     props.put(USER_SEARCH_SUBTREE_OPTIONS_KEY, "true");
     props.put(ROLE_BASE_DN_OPTIONS_KEY, properties.get(GROUP_BASE_DN));
+    Object groupMemberAttribute = properties.get(MEMBER_NAME_ATTRIBUTE);
+    groupMemberAttribute = groupMemberAttribute == null ? "member" : groupMemberAttribute;
     props.put(
         ROLE_FILTER_OPTIONS_KEY,
-        String.format("(member=%s=%%u,%s)", membershipUserAttribute, userBaseDn));
-    props.put(ROLE_NAME_ATTRIBUTE_OPTIONS_KEY, "cn");
+        String.format(
+            "(|(%1$s=%2$s=%%u,%3$s)(%1$s=%%fqdn)(%1$s=%4$s=%%u,%%dn))",
+            groupMemberAttribute, membershipUserAttribute, userBaseDn, loginUserAttribute));
+    props.put(ROLE_NAME_ATTRIBUTE_OPTIONS_KEY, membershipUserAttribute);
     props.put(ROLE_SEARCH_SUBTREE_OPTIONS_KEY, "true");
     props.put("authentication", "simple");
     props.put("ssl.protocol", "TLS");
@@ -290,9 +326,14 @@ public class LdapLoginConfig {
     ldapProperties.put(LDAP_BIND_USER_PASS, bindUserPass);
   }
 
-  public void setLdapUrl(String ldapUrl) {
+  public void setLdapUrl(String... ldapUrl) {
     LOGGER.trace("setLdapUrl called: {}", ldapUrl);
     ldapProperties.put(LDAP_URL, ldapUrl);
+  }
+
+  public void setLdapLoadBalancing(String ldapLoadBalancing) {
+    LOGGER.trace("setLdapLoadBalancing called: {}", ldapLoadBalancing);
+    ldapProperties.put(LDAP_LOAD_BALANCING, ldapLoadBalancing);
   }
 
   public void setUserBaseDn(String userBaseDn) {
@@ -321,8 +362,13 @@ public class LdapLoginConfig {
   }
 
   public void setMembershipUserAttribute(String membershipUserAttribute) {
-    LOGGER.trace("setMemberUserAttribute called: {}", membershipUserAttribute);
+    LOGGER.trace("setMembershipUserAttribute called: {}", membershipUserAttribute);
     ldapProperties.put(MEMBER_USER_ATTRIBUTE, membershipUserAttribute);
+  }
+
+  public void setMemberNameAttribute(String memberNameAttribute) {
+    LOGGER.trace("setMemberNameAttribute called: {}", memberNameAttribute);
+    ldapProperties.put(MEMBER_NAME_ATTRIBUTE, memberNameAttribute);
   }
 
   public void setBindMethod(String bindMethod) {

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -144,9 +144,7 @@ public class LdapLoginConfig {
       List<ConnectionFactory> connectionFactories = new ArrayList<>();
 
       Boolean startTls =
-          props.get(START_TLS) == null
-              ? false
-              : Boolean.parseBoolean(props.get(START_TLS).toString());
+          props.get(START_TLS) != null && Boolean.parseBoolean(props.get(START_TLS).toString());
 
       for (String url : urls) {
         connectionFactories.add(createLdapConnectionFactory(url, startTls));

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -28,7 +28,11 @@
             <!-- Default properties -->
             <property name="ldapBindUserDn" value="cn=admin"/>
             <property name="ldapBindUserPass" value="secret"/>
-            <property name="ldapUrl" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
+            <property name="ldapUrl">
+                <list>
+                    <value>ldaps://${org.codice.ddf.system.hostname}:1636</value>
+                </list>
+            </property>
             <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
             <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
             <property name="startTls" value="false"/>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -33,6 +33,7 @@
                     <value>ldaps://${org.codice.ddf.system.hostname}:1636</value>
                 </list>
             </property>
+            <property name="ldapLoadBalancing" value="round_robin"/>
             <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
             <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
             <property name="startTls" value="false"/>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -40,6 +40,7 @@
             <property name="ldapService" ref="ldapService"/>
             <property name="loginUserAttribute" value="uid"/>
             <property name="membershipUserAttribute" value="uid"/>
+            <property name="memberNameAttribute" value="member"/>
             <cm:managed-properties persistent-id=""
                                    update-strategy="component-managed" update-method="update"/>
         </cm:managed-component>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -23,6 +23,11 @@
             description="LDAP or LDAPS server and port">
 	    </AD>
 
+		<AD name="LDAP Load Balancing:" id="ldapLoadBalancing" required="false" type="String"
+			default="round_robin"
+			description="Load balancing algorithm to use when multiple LDAP urls are provided (round_robin, failover)">
+		</AD>
+
 		<AD name="LDAP Bind Method" id="bindMethod" required="true" type="String"
 			default="Simple">
 			<Option label="Digest MD5 SASL" value="Digest MD5 SASL" />

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
 	<OCD description="STS Ldap Login Configuration" name="Security STS LDAP Login"
          id="Ldap_Login_Config">
 	    
-	    <AD name="LDAP URL:" id="ldapUrl" required="true" type="String"
+	    <AD name="LDAP URL:" id="ldapUrl" required="true" type="String" cardinality="10"
             default="ldaps://${org.codice.ddf.system.hostname}:1636"
             description="LDAP or LDAPS server and port">
 	    </AD>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -65,6 +65,11 @@
 			default="uid"
 			description="Attribute used as the membership attribute for the user in the group. Usually this is uid, cn, or something similar.">
 		</AD>
+
+		<AD name="LDAP Member Name Attribute:" id="memberNameAttribute" required="true" type="String"
+			default="member"
+			description="Attribute used to identify users in the group. Usually this is member or something similar.">
+		</AD>
 	    
 	    <AD name="LDAP User Login Attribute:" id="loginUserAttribute" required="true" type="String"
             default="uid"

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
@@ -65,7 +65,7 @@ public class LdapLoginConfigTest {
   public void testLdapLoginConfig() {
     LdapService ldapService = new LdapService(context);
 
-    LdapLoginConfig ldapConfigOne = createLdapConfig(ldapService);
+    LdapLoginConfig ldapConfigOne = createLdapConfig(ldapService, "ldaps://ldap:1636");
     ldapConfigOne.configure();
     String configIdOne = ldapConfigOne.getId();
 
@@ -74,7 +74,8 @@ public class LdapLoginConfigTest {
         .registerService(
             eq(JaasRealm.class), any(JaasRealm.class), Matchers.<Dictionary<String, Object>>any());
 
-    LdapLoginConfig ldapConfigTwo = createLdapConfig(ldapService);
+    LdapLoginConfig ldapConfigTwo =
+        createLdapConfig(ldapService, "ldaps://ldap:1636", "ldaps://ldap2:1636");
     ldapConfigTwo.configure();
     String configIdTwo = ldapConfigTwo.getId();
 
@@ -111,17 +112,18 @@ public class LdapLoginConfigTest {
     assertThat(ldapService.delete(configIdTwo), is(equalTo(true)));
   }
 
-  private LdapLoginConfig createLdapConfig(LdapService ldapService) {
+  private LdapLoginConfig createLdapConfig(LdapService ldapService, String... ldapUrl) {
     LdapLoginConfig ldapConfig = new LdapLoginConfig(context);
     ldapConfig.setLdapService(ldapService);
     ldapConfig.setLdapBindUserDn("cn=admin");
     ldapConfig.setLdapBindUserPass("password");
-    ldapConfig.setLdapUrl("ldaps://ldap:1636");
+    ldapConfig.setLdapUrl(ldapUrl);
     ldapConfig.setUserBaseDn("ou=users,dc=example,dc=com");
     ldapConfig.setGroupBaseDn("ou=groups,dc=example,dc=com");
     ldapConfig.setStartTls(false);
     ldapConfig.setLoginUserAttribute("uid");
     ldapConfig.setMembershipUserAttribute("uid");
+    ldapConfig.setMemberNameAttribute("member");
     ldapConfig.setBindMethod("Simple");
     ldapConfig.setRealm("");
     ldapConfig.setKdcAddress("");
@@ -132,6 +134,9 @@ public class LdapLoginConfigTest {
     Map<String, String> ldapProps = new HashMap<>();
     ldapProps.put(LdapLoginConfig.LDAP_BIND_USER_DN, userDn);
     ldapProps.put(LdapLoginConfig.LDAP_BIND_USER_PASS, "secret");
+    ldapProps.put(LdapLoginConfig.LOGIN_USER_ATTRIBUTE, "uid");
+    ldapProps.put(LdapLoginConfig.MEMBER_USER_ATTRIBUTE, "cn");
+    ldapProps.put(LdapLoginConfig.MEMBER_NAME_ATTRIBUTE, "member");
     ldapProps.put(LdapLoginConfig.LDAP_URL, "ldaps://test-ldap:1636");
     ldapProps.put(LdapLoginConfig.USER_BASE_DN, "ou=users,dc=example,dc=com");
     ldapProps.put(LdapLoginConfig.GROUP_BASE_DN, "ou=groups,dc=example,dc=com");
@@ -145,7 +150,7 @@ public class LdapLoginConfigTest {
   @Test
   public void testSetUserNameAttribute() {
     LdapService ldapService = new LdapService(context);
-    LdapLoginConfig config = createLdapConfig(ldapService);
+    LdapLoginConfig config = createLdapConfig(ldapService, "ldaps://ldap:1636");
     config.setLoginUserAttribute("cn");
 
     config.configure();
@@ -154,13 +159,13 @@ public class LdapLoginConfigTest {
     assertThat(properties.getProperty(USER_FILTER_OPTIONS_KEY), is("(cn=%u)"));
     assertThat(
         properties.getProperty(ROLE_FILTER_OPTIONS_KEY),
-        is("(member=uid=%u,ou=users,dc=example,dc=com)"));
+        is("(|(member=uid=%u,ou=users,dc=example,dc=com)(member=%fqdn)(member=cn=%u,%dn))"));
   }
 
   @Test
   public void testSetMembershipAttribute() {
     LdapService ldapService = new LdapService(context);
-    LdapLoginConfig config = createLdapConfig(ldapService);
+    LdapLoginConfig config = createLdapConfig(ldapService, "ldaps://ldap:1636");
     config.setMembershipUserAttribute("cn");
 
     config.configure();
@@ -169,6 +174,22 @@ public class LdapLoginConfigTest {
     assertThat(properties.getProperty(USER_FILTER_OPTIONS_KEY), is("(uid=%u)"));
     assertThat(
         properties.getProperty(ROLE_FILTER_OPTIONS_KEY),
-        is("(member=cn=%u,ou=users,dc=example,dc=com)"));
+        is("(|(member=cn=%u,ou=users,dc=example,dc=com)(member=%fqdn)(member=uid=%u,%dn))"));
+  }
+
+  @Test
+  public void testSetMemberNameAttribute() {
+    LdapService ldapService = new LdapService(context);
+    LdapLoginConfig config = createLdapConfig(ldapService, "ldaps://ldap:1636");
+    config.setMemberNameAttribute("uniqueMember");
+
+    config.configure();
+
+    Properties properties = ldapService.getModules().get(0).getOptions();
+    assertThat(properties.getProperty(USER_FILTER_OPTIONS_KEY), is("(uid=%u)"));
+    assertThat(
+        properties.getProperty(ROLE_FILTER_OPTIONS_KEY),
+        is(
+            "(|(uniqueMember=uid=%u,ou=users,dc=example,dc=com)(uniqueMember=%fqdn)(uniqueMember=uid=%u,%dn))"));
   }
 }

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapLoginConfigTest.java
@@ -47,6 +47,10 @@ public class LdapLoginConfigTest {
 
   private ServiceRegistration<JaasRealm> jaasRealm;
 
+  private static final String LDAP_URL_1 = "ldaps://ldap:1636";
+
+  private static final String LDAP_URL_2 = "ldaps://ldap2:1636";
+
   /** Sets up a new context and JaasRealm before each test. */
   @Before
   public void setUp() {
@@ -65,7 +69,7 @@ public class LdapLoginConfigTest {
   public void testLdapLoginConfig() {
     LdapService ldapService = new LdapService(context);
 
-    LdapLoginConfig ldapConfigOne = createLdapConfig(ldapService, "ldaps://ldap:1636");
+    LdapLoginConfig ldapConfigOne = createLdapConfig(ldapService, LDAP_URL_1);
     ldapConfigOne.configure();
     String configIdOne = ldapConfigOne.getId();
 
@@ -74,8 +78,7 @@ public class LdapLoginConfigTest {
         .registerService(
             eq(JaasRealm.class), any(JaasRealm.class), Matchers.<Dictionary<String, Object>>any());
 
-    LdapLoginConfig ldapConfigTwo =
-        createLdapConfig(ldapService, "ldaps://ldap:1636", "ldaps://ldap2:1636");
+    LdapLoginConfig ldapConfigTwo = createLdapConfig(ldapService, LDAP_URL_1, LDAP_URL_2);
     ldapConfigTwo.configure();
     String configIdTwo = ldapConfigTwo.getId();
 
@@ -150,7 +153,7 @@ public class LdapLoginConfigTest {
   @Test
   public void testSetUserNameAttribute() {
     LdapService ldapService = new LdapService(context);
-    LdapLoginConfig config = createLdapConfig(ldapService, "ldaps://ldap:1636");
+    LdapLoginConfig config = createLdapConfig(ldapService, LDAP_URL_1);
     config.setLoginUserAttribute("cn");
 
     config.configure();
@@ -165,7 +168,7 @@ public class LdapLoginConfigTest {
   @Test
   public void testSetMembershipAttribute() {
     LdapService ldapService = new LdapService(context);
-    LdapLoginConfig config = createLdapConfig(ldapService, "ldaps://ldap:1636");
+    LdapLoginConfig config = createLdapConfig(ldapService, LDAP_URL_1);
     config.setMembershipUserAttribute("cn");
 
     config.configure();
@@ -180,7 +183,7 @@ public class LdapLoginConfigTest {
   @Test
   public void testSetMemberNameAttribute() {
     LdapService ldapService = new LdapService(context);
-    LdapLoginConfig config = createLdapConfig(ldapService, "ldaps://ldap:1636");
+    LdapLoginConfig config = createLdapConfig(ldapService, LDAP_URL_1);
     config.setMemberNameAttribute("uniqueMember");
 
     config.configure();

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapModuleTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapModuleTest.java
@@ -67,7 +67,7 @@ import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.forgerock.opendj.ldap.Connection;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.ConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.junit.After;
 import org.junit.Before;
@@ -101,7 +101,7 @@ public class LdapModuleTest {
 
     server = TestServer.getInstance();
     LdapLoginConfig ldapLoginConfig = new LdapLoginConfig(null);
-    LDAPConnectionFactory ldapConnectionFactory =
+    ConnectionFactory ldapConnectionFactory =
         ldapLoginConfig.createLdapConnectionFactory(TestServer.getUrl("ldap"), false);
     module =
         TestModule.getInstance(


### PR DESCRIPTION
#### What does this PR do?
Remove LDAP structure assumptions, enable LDAP login and attribute claims to work with nested user OUs, allow multiple ldap servers in a single configuration for load balancing / failover
#### Who is reviewing it? 
@ryeats @KalCramer @harrison-tarr 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/security

#### Ask 2 committers to review/merge the PR and tag them here.

@stustison
@tbatie 
@coyotesqrl 

#### How should this be tested?
Create a user in a nested OU under the base user DN 
Set their uid and cn to be different values (e.g. uid=user1, cn=User One)
Add the user to a group and verify that they can log in and that their group information is successfully added.  If added to the admin group the user should be able to log into the admin console

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4090](https://codice.atlassian.net/browse/DDF-4090)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
