### PR TITLE
Backport usng version fix

### DIFF
--- a/ui/packages/catalog-ui-search/package.json
+++ b/ui/packages/catalog-ui-search/package.json
@@ -82,7 +82,7 @@
     "terraformer": "1.0.5",
     "terraformer-wkt-parser": "1.1.0",
     "urijs": "1.19.1",
-    "usng.js": "https://github.com/codice/usng.js#b756a1dddd6292d7af44db363131d848a87a2be2",
+    "usng.js": "0.2.3",
     "uuid": "2.0.2",
     "vis": "4.15.0",
     "wellknown": "https://github.com/connexta/wellknown.git#4d9ae612e7e308509ec76400b258c9db1581ea82",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15759,9 +15759,9 @@ username@3.0.0:
     execa "^0.7.0"
     mem "^1.1.0"
 
-"usng.js@https://github.com/codice/usng.js#b756a1dddd6292d7af44db363131d848a87a2be2":
-  version "0.1.1"
-  resolved "https://github.com/codice/usng.js#b756a1dddd6292d7af44db363131d848a87a2be2"
+usng.js@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/usng.js/-/usng.js-0.2.3.tgz#944093f38984834ba9877f1879453962376c05f3"
 
 utf-8-validate@1.2.x:
   version "1.2.2"


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
