### PR TITLE
DDF-4060: Fixes restart button for dev=true

### DIFF
--- a/platform/security/filter/security-filter-csrf/src/main/java/org/codice/ddf/security/filter/csrf/CsrfFilter.java
+++ b/platform/security/filter/security-filter-csrf/src/main/java/org/codice/ddf/security/filter/csrf/CsrfFilter.java
@@ -69,14 +69,19 @@ public class CsrfFilter implements SecurityFilter {
   // List of authorities that are treated as same-origin as the system
   private List<String> trustedAuthorities;
 
-  @Override
-  public void init(FilterConfig filterConfig) throws ServletException {
-    LOGGER.debug("Starting CSRF filter.");
-
+  public CsrfFilter() {
+    super();
+    trustedAuthorities = new ArrayList<>();
     protectedContexts = new ArrayList<>();
+
     protectedContexts.add(JOLOKIA_CONTEXT);
     protectedContexts.add(INTRIGUE_CONTEXT);
     protectedContexts.add(WEBSOCKET_CONTEXT);
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    LOGGER.debug("Starting CSRF filter.");
 
     // internal authority system properties
     String internalHostname = SystemBaseUrl.INTERNAL.getHost();
@@ -88,7 +93,6 @@ public class CsrfFilter implements SecurityFilter {
     String externalHttpPort = SystemBaseUrl.EXTERNAL.getHttpPort();
     String externalHttpsPort = SystemBaseUrl.EXTERNAL.getHttpsPort();
 
-    trustedAuthorities = new ArrayList<>();
     // internal http & https authorities
     trustedAuthorities.add(internalHostname + ":" + internalHttpPort);
     trustedAuthorities.add(internalHostname + ":" + internalHttpsPort);


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: [DDF-4060 2.13.x PR](https://github.com/codice/ddf/pull/3673)

#### What does this PR do?
Updates the CSRF filter to allow any hostnames set since last restart. This will allow requests with localhost origin to work until the system is restarted, allowing the installer to finish without errors.

#### Who is reviewing it? 
@blen-desta 
@mcalcote 

#### Select relevant component teams: 
@codice/security

#### Ask 2 committers to review/merge the PR and tag them here.
@stustison
@tbatie

#### How should this be tested?
Install with `?dev=true`, change the hostname during setup, ensure that the restart now button at the end of the installer actually restarts the system instead of the jolokia request returning a 403. After install, check that the hostname was updated to the new hostname.

#### Any background context you want to provide?
Error was caused by the CSRF filter updating to the new hostname and enforcing the same-origin requirement before the installer was finished installing. Since the browser was still using the "localhost" origin, the final restart jolokia request was rejected as being a restricted cross-origin request.

#### What are the relevant tickets?
[DDF-4060](https://codice.atlassian.net/browse/DDF-4060)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
