### PR TITLE
DDF-4073 Document Intrigue metadata upload limitations (#3622)

### DIFF
--- a/distribution/docs/src/main/resources/content/_running/ui-ingest.adoc
+++ b/distribution/docs/src/main/resources/content/_running/ui-ingest.adoc
@@ -9,5 +9,10 @@
 
 Files can also be ingested directly from ${catalog-ui}.
 
+[WARNING]
+====
+The ${catalog-ui} uploader is intended for the upload of products (such as images or documents), not metadata files (such as Metacard XML). A user will not be able to specify which input transformer is used to ingest the document.
+====
+
 See <<{using-prefix}ui_ingest,Ingesting from ${catalog-ui}>> for details.
 

--- a/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
@@ -111,6 +111,11 @@ Workspaces can be shared between users at different levels of access as needed.
 
 Data can be ingested via ${catalog-ui}.
 
+[WARNING]
+====
+The ${catalog-ui} uploader is intended for the upload of products (such as images or documents), not metadata files (such as Metacard XML). A user will not be able to specify which input transformer is used to ingest the document.
+====
+
 . Select the Menu icon (image:navigator-icon.png[]) in the upper left corner.
 . Select *Upload*.
 . Drag and drop file(s) or click to open a navigation window.


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #3622
____

#### What does this PR do?
Updates docs to mention limitations to uploading metadata to Intrigue.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@jhunzik @tyler30clemens @paouelle @figliold 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams/docs
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@ricklarsen - Documentation
@rzwiefel
@tbatie
#### How should this be tested?
Build and verify docs

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews.
