### PR TITLE
DDF-4093  Make getInputStream idempotent

### DIFF
--- a/catalog/async/catalog-async-data-api/src/main/java/org/codice/ddf/catalog/async/data/api/internal/ProcessResource.java
+++ b/catalog/async/catalog-async-data-api/src/main/java/org/codice/ddf/catalog/async/data/api/internal/ProcessResource.java
@@ -61,9 +61,11 @@ public interface ProcessResource {
   String getMimeType();
 
   /**
-   * Return the input stream containing the {@link ProcessResource}'s actual data content.
+   * Returns a new, independent input stream with each call containing the {@link ProcessResource}'s
+   * actual data content. {@link #close()} should be called once new input streams are no longer
+   * needed.
    *
-   * @return the {@link ProcessResource}'s input stream
+   * @return a new, independent input stream containing the {@link ProcessResource}'s data content.
    * @throws IOException if the input stream is not available
    */
   InputStream getInputStream() throws IOException;
@@ -88,9 +90,9 @@ public interface ProcessResource {
   boolean isModified();
 
   /**
-   * This is used to close the input stream.
-   *
-   * <p>Look into having the ProcessResource implement InputStream
+   * close the source of the {@link ProcessResource}'s input stream data. Once this is closed {@link
+   * #getInputStream()} will no longer return valid input streams and any existing input streams
+   * retrieved from this {@link ProcessResource} will no longer be usable.
    */
   void close();
 }

--- a/catalog/async/catalog-async-data/src/test/groovy/org/codice/ddf/catalog/async/data/ProcessResourceImplSpec.groovy
+++ b/catalog/async/catalog-async-data/src/test/groovy/org/codice/ddf/catalog/async/data/ProcessResourceImplSpec.groovy
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.catalog.async.data
 
+import org.apache.commons.io.IOUtils
 import org.codice.ddf.catalog.async.data.api.internal.ProcessResource
 import org.codice.ddf.catalog.async.data.impl.ProcessResourceImpl
 import spock.lang.Specification
@@ -21,7 +22,9 @@ class ProcessResourceImplSpec extends Specification {
 
     static final ID = 'id'
 
-    def inputStream = Mock(InputStream)
+    byte[] inputStreamBytes = "Test Stream".getBytes()
+
+    def inputStream = new ByteArrayInputStream(inputStreamBytes)
 
     static final MIME_TYPE = "mimeType"
 
@@ -42,7 +45,7 @@ class ProcessResourceImplSpec extends Specification {
         processResource.getQualifier() == ''
 
         processResource.isModified()
-        processResource.inputStream == inputStream
+        IOUtils.toByteArray(processResource.getInputStream()) == inputStreamBytes
         processResource.getUri().toString() == RESOURCE_URI
         processResource.getUri().getSchemeSpecificPart() == ID
         processResource.getMimeType() == MIME_TYPE
@@ -59,7 +62,7 @@ class ProcessResourceImplSpec extends Specification {
 
         processResource.getQualifier() == ''
         processResource.isModified()
-        processResource.inputStream == inputStream
+        IOUtils.toByteArray(processResource.getInputStream()) == inputStreamBytes
         processResource.getUri().toString() == RESOURCE_URI
         processResource.getUri().getSchemeSpecificPart() == ID
         processResource.getMimeType() == MIME_TYPE
@@ -73,7 +76,7 @@ class ProcessResourceImplSpec extends Specification {
         processResource.getQualifier() == ''
         !processResource.isModified()
 
-        processResource.inputStream == inputStream
+        IOUtils.toByteArray(processResource.getInputStream()) == inputStreamBytes
         processResource.getUri().toString() == RESOURCE_URI
         processResource.getUri().getSchemeSpecificPart() == ID
         processResource.getMimeType() == MIME_TYPE
@@ -93,23 +96,21 @@ class ProcessResourceImplSpec extends Specification {
 
     def 'test ProcessResourceImpl(String, InputStream, String, String, Int, String, Boolean)'() {
         when:
-        def stream = Mock(InputStream)
-        def processResource = new ProcessResourceImpl(ID, stream, MIME_TYPE, RESOURCE_NAME, SIZE, QUALIFIER)
+        def processResource = new ProcessResourceImpl(ID, inputStream, MIME_TYPE, RESOURCE_NAME, SIZE, QUALIFIER)
 
         then:
         assert processResource.getQualifier() == QUALIFIER
         assert !processResource.isModified()
         assert processResource.getName() == RESOURCE_NAME
         assert processResource.getMimeType() == MIME_TYPE
-        assert processResource.getInputStream() == stream
+        assert IOUtils.toByteArray(processResource.getInputStream()) == inputStreamBytes
         assert processResource.getSize() == SIZE
         assert processResource.getUri().toString() == RESOURCE_URI + "#" + QUALIFIER
     }
 
     def 'test process resource ProcessResourceImpl null qualifier'() {
         when:
-        def stream = Mock(InputStream)
-        def processResource = new ProcessResourceImpl(ID, stream, MIME_TYPE, RESOURCE_NAME, SIZE, null)
+        def processResource = new ProcessResourceImpl(ID, inputStream, MIME_TYPE, RESOURCE_NAME, SIZE, null)
 
         then:
         assert processResource.getUri().toString() == RESOURCE_URI
@@ -118,14 +119,13 @@ class ProcessResourceImplSpec extends Specification {
         assert !processResource.isModified()
         assert processResource.getName() == RESOURCE_NAME
         assert processResource.getMimeType() == MIME_TYPE
-        assert processResource.getInputStream() == stream
+        assert IOUtils.toByteArray(processResource.getInputStream()) == inputStreamBytes
         assert processResource.getSize() == SIZE
     }
 
     def 'test process resource ProcessResourceImpl null mimeType and null fileName'() {
         when:
-        def stream = Mock(InputStream)
-        def processResource = new ProcessResourceImpl(ID, stream, null, null, SIZE, QUALIFIER)
+        def processResource = new ProcessResourceImpl(ID, inputStream, null, null, SIZE, QUALIFIER)
 
         then:
         assert processResource.getName() == ProcessResourceImpl.DEFAULT_NAME
@@ -133,7 +133,7 @@ class ProcessResourceImplSpec extends Specification {
 
         assert processResource.getQualifier() == QUALIFIER
         assert !processResource.isModified()
-        assert processResource.getInputStream() == stream
+        assert IOUtils.toByteArray(processResource.getInputStream()) == inputStreamBytes
         assert processResource.getSize() == SIZE
     }
 
@@ -167,5 +167,60 @@ class ProcessResourceImplSpec extends Specification {
 
         then:
         thrown IllegalArgumentException
+    }
+
+    def 'test getInputStream()'(){
+        def processResource = new ProcessResourceImpl(ID, inputStream, MIME_TYPE, RESOURCE_NAME, SIZE, QUALIFIER)
+
+        expect:
+        IOUtils.toByteArray(processResource.getInputStream()) == inputStreamBytes
+    }
+
+    def 'input stream can be loaded multiple times'(){
+        def processResource = new ProcessResourceImpl(ID, inputStream, MIME_TYPE, RESOURCE_NAME, SIZE, QUALIFIER)
+
+        when:
+        def is1 = processResource.getInputStream()
+        def is2 = processResource.getInputStream()
+        def is3 = processResource.getInputStream()
+
+        then:
+        byte[] is1Bytes = IOUtils.toByteArray(is1)
+        is1Bytes == IOUtils.toByteArray(is2)
+        is1Bytes == IOUtils.toByteArray(is3)
+    }
+
+    def 'IOException is thrown when getInputStream is called after close' () {
+        def processResource = new ProcessResourceImpl(ID, inputStream, MIME_TYPE, RESOURCE_NAME, SIZE, QUALIFIER)
+        processResource.getInputStream()
+        processResource.close()
+
+        when:
+        processResource.getInputStream()
+
+        then:
+        thrown(IOException)
+    }
+
+    def 'input stream is closed when getInputStream is called'(){
+        def spyInputStream = Spy(inputStream)
+        def processResource = new ProcessResourceImpl(ID, spyInputStream, MIME_TYPE, RESOURCE_NAME, SIZE, QUALIFIER)
+
+        when:
+        processResource.getInputStream()
+
+        then:
+        1 * spyInputStream.close()
+    }
+
+    def 'input stream is closed when close is called'(){
+        def spyInputStream = Spy(inputStream)
+        def processResource = new ProcessResourceImpl(ID, spyInputStream, MIME_TYPE, RESOURCE_NAME, SIZE, QUALIFIER)
+
+        when:
+        processResource.close()
+
+        then:
+        1 * spyInputStream.close()
     }
 }


### PR DESCRIPTION
#### What does this PR do?

Before, calling getInputStream on a ProcessResource would always return
    the same input stream, which, once read would no longer be useful. Now
    the first call to getInputStream will create a file backed output stream of the data in the
    input stream so that new input streams can be created each time. Once
    new input streams are no longer needed the file backed output stream
    will need to be closed by calling the close method of the
    ProcessResource.

#### Who is reviewing it? 

@peterhuffer @emmberk 

#### Ask 2 committers to review/merge the PR and tag them here.

@figliold
@vinamartin

#### How should this be tested?

Unit tests
To hero, install alliance and start the async processing framework and the nitf post processing plugin. Then ingest some nitfs and make sure that the nitfs are ingested properly and the logs are quiet.

#### What are the relevant tickets?

[DDF-4093](https://codice.atlassian.net/browse/DDF-4093)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
