### PR TITLE
DDF-4108 Update UI sharing modal component to account for access-control administrators

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
@@ -23,7 +23,7 @@ import ddf.catalog.filter.FilterBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -218,19 +218,19 @@ public class TemplateTransformer {
    * response
    */
   private static Map<String, List<Serializable>> retrieveSecurityIfPresent(Metacard inputMetacard) {
-    List<Serializable> accessIndividuals = new ArrayList<>();
-    List<Serializable> accessGroups = new ArrayList<>();
-
-    if (inputMetacard.getAttribute(SecurityAttributes.ACCESS_INDIVIDUALS) != null) {
-      accessIndividuals.addAll(
-          inputMetacard.getAttribute(SecurityAttributes.ACCESS_INDIVIDUALS).getValues());
-    }
-
-    if (inputMetacard.getAttribute(SecurityAttributes.ACCESS_GROUPS) != null) {
-      accessGroups.addAll(inputMetacard.getAttribute(SecurityAttributes.ACCESS_GROUPS).getValues());
-    }
-
     return ImmutableMap.of(
-        Security.ACCESS_INDIVIDUALS, accessIndividuals, Security.ACCESS_GROUPS, accessGroups);
+        Security.ACCESS_INDIVIDUALS,
+        getValues(inputMetacard, SecurityAttributes.ACCESS_INDIVIDUALS),
+        Security.ACCESS_GROUPS,
+        getValues(inputMetacard, SecurityAttributes.ACCESS_GROUPS),
+        Security.ACCESS_ADMINISTRATORS,
+        getValues(inputMetacard, SecurityAttributes.ACCESS_ADMINISTRATORS));
+  }
+
+  private static List<Serializable> getValues(Metacard inputMetacard, String fieldName) {
+    if (inputMetacard.getAttribute(fieldName) != null) {
+      return inputMetacard.getAttribute(fieldName).getValues();
+    }
+    return Collections.emptyList();
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/CommonTemplate.java
@@ -51,6 +51,8 @@ public class CommonTemplate {
 
   private List<Serializable> accessIndividuals;
 
+  private List<Serializable> accessAdministrators;
+
   public CommonTemplate(Metacard metacard) {
     this.id = safeGet(metacard, Core.ID, String.class);
     this.title = safeGet(metacard, Core.TITLE, String.class);
@@ -73,6 +75,8 @@ public class CommonTemplate {
     this.accessIndividuals =
         securityAttributes.getOrDefault(Security.ACCESS_INDIVIDUALS, new ArrayList<>());
     this.accessGroups = securityAttributes.getOrDefault(Security.ACCESS_GROUPS, new ArrayList<>());
+    this.accessAdministrators =
+        securityAttributes.getOrDefault(Security.ACCESS_ADMINISTRATORS, new ArrayList<>());
   }
 
   public CommonTemplate(Map<String, Object> input) {
@@ -117,5 +121,9 @@ public class CommonTemplate {
 
   public List<Serializable> getAccessIndividuals() {
     return accessIndividuals;
+  }
+
+  public List<Serializable> getAccessAdministrators() {
+    return accessAdministrators;
   }
 }

--- a/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
@@ -97,6 +97,7 @@ Workspaces can be shared between users at different levels of access as needed.
 . Select *View Sharing*.
 .. To share by user role, set the drop-down menu to *Can Access* for each desired role. All users with that role will be able to view the workspace.
 .. To share with an individual user, add his/her email to the email list.
+.. To allow another user to share this workspace with others, add the user to the Access Administrators list.
 . Click *Apply*.
 
 .Remove Sharing on a Workspace

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -254,6 +254,7 @@ module.exports = Marionette.LayoutView.extend({
       filterTemplate: filterTree,
       accessIndividuals: formModel.get('accessIndividuals'),
       accessGroups: formModel.get('accessGroups'),
+      accessAdministrators: formModel.get('accessAdministrators'),
       creator: formModel.get('createdBy'),
       id: formModel.get('id'),
       title: this.model.get('title'),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-template-sharing/query-template-sharing.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-template-sharing/query-template-sharing.hbs
@@ -22,6 +22,11 @@
 
         <div class="template-sharing-by-email"></div>
     </div>
+    <div class="information-admin">
+        <div class="is-header">Access Administrators:</div>
+
+        <div class="template-sharing-by-admin"></div>
+    </div>
 </div>
 
 <div class="sharing-buttons">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-template-sharing/query-template-sharing.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-template-sharing/query-template-sharing.less
@@ -63,14 +63,30 @@
     }
   }
 
+  .template-sharing-by-admin {
+    input {
+      height: @minimumButtonSize;
+    }
+
+    height: ~'calc(100% - @{minimumButtonSize})';
+    overflow: auto;
+
+    .admin {
+      vertical-align: top;
+      display: inline-block;
+      width: 100%;
+    }
+  }
+
   .template-sharing-by-role {
     height: ~'calc(100% - @{minimumButtonSize})';
     overflow: auto;
   }
 
   .information-role,
+  .information-admin,
   .information-email {
-    width: 50%;
+    width: 33%;
     display: inline-block;
     height: 100%;
     vertical-align: top;
@@ -83,7 +99,8 @@
     white-space: nowrap;
   }
 
-  .information-email {
+  .information-email,
+  .information-admin {
     border-left: 1px solid grey;
     padding: @minimumSpacing;
   }
@@ -95,20 +112,22 @@
 
 .is-small-screen,
 .is-mobile-screen {
-  @{customElementNamespace}template-sharing {
+  @{customElementNamespace}query-template-sharing {
     .sharing-information {
       white-space: normal;
       overflow: auto;
     }
 
-    .information-email {
+    .information-email,
+    .information-admin {
       border-left: none;
     }
 
     .information-role,
+    .information-admin,
     .information-email {
       width: 100%;
-      height: 50%;
+      height: 33%;
     }
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
@@ -80,6 +80,7 @@ module.exports = Backbone.AssociatedModel.extend({
             createdBy: resultForm.creator,
             accessGroups: resultForm.accessGroups,
             accessIndividuals: resultForm.accessIndividuals,
+            accessAdministrators: resultForm.accessAdministrators,
           }
         })
         this.resetResultForm()
@@ -101,6 +102,7 @@ module.exports = Backbone.AssociatedModel.extend({
               type: 'result',
               descriptors: element.descriptors,
               accessIndividuals: element.accessIndividuals,
+              accessAdministrators: element.accessAdministrators,
               accessGroups: element.accessGroups,
               createdBy: element.createdBy,
               description: element.description,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
@@ -180,6 +180,7 @@ module.exports = Marionette.LayoutView.extend({
           description: _this.model.get('description'),
           accessGroups: _this.model.get('accessGroups'),
           accessIndividuals: _this.model.get('accessIndividual'),
+          accessAdministrators: _this.model.get('accessAdministrators'),
         })
         ResultFormCollection.getResultCollection().toggleUpdate()
         _this.cleanup()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -53,3 +53,9 @@
     display: none;
   }
 }
+
+@{customElementNamespace}search-form-interactions.is-not-shareable-template {
+  > .interaction-share {
+    display: none;
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -51,6 +51,7 @@ module.exports = Marionette.ItemView.extend({
     this.checkIfDefaultSearchForm()
     this.checkIfResultForm()
     this.isSystemTemplate()
+    this.isShareableTemplate()
   },
   checkIfSubscribed: function() {
     this.$el.toggleClass('is-subscribed', Boolean(this.model.get('subscribed')))
@@ -189,6 +190,17 @@ module.exports = Marionette.ItemView.extend({
       this.model.get('createdBy') === 'system'
     )
   },
+  isShareableTemplate: function() {
+    const notShareable = function(that) {
+      const loginUser = user.get('user')
+      if (loginUser.get('email') === that.model.get('createdBy')) {
+        return false
+      }
+      const accessAdministrators = that.model.get('accessAdministrators') || []
+      return !accessAdministrators.includes(loginUser.get('email'))
+    }
+    this.$el.toggleClass('is-not-shareable-template', notShareable(this))
+  },
   handleEdit: function() {
     if (this.model.get('type') === 'custom') {
       this.model.set({
@@ -198,6 +210,7 @@ module.exports = Marionette.ItemView.extend({
         id: this.model.get('id'),
         accessGroups: this.model.get('accessGroups'),
         accessIndividuals: this.model.get('accessIndividuals'),
+        accessAdministrators: this.model.get('accessAdministrators'),
       })
     } else if (this.model.get('type') === 'result') {
       this.model.set({
@@ -206,6 +219,7 @@ module.exports = Marionette.ItemView.extend({
         formId: this.model.get('id'),
         accessGroups: this.model.get('accessGroups'),
         accessIndividuals: this.model.get('accessIndividuals'),
+        accessAdministrators: this.model.get('accessAdministrators'),
         descriptors: this.model.get('descriptors'),
         description: this.model.get('description'),
       })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.js
@@ -77,6 +77,7 @@ module.exports = Backbone.AssociatedModel.extend({
                 filterTemplate: JSON.stringify(value.filterTemplate),
                 accessIndividuals: value.accessIndividuals,
                 accessGroups: value.accessGroups,
+                accessAdministrators: value.accessAdministrators,
                 createdBy: value.creator,
                 owner: value.owner,
                 querySettings: value.querySettings,
@@ -89,13 +90,12 @@ module.exports = Backbone.AssociatedModel.extend({
     }
   },
   checkIfShareable: function(template) {
-    if (
-      (this.checkIfInGroup(template) || this.checkIfInIndividiuals(template)) &&
-      !this.checkIfOwner(template)
-    ) {
-      return true
-    }
-    return false
+    return (
+      !this.checkIfOwner(template) &&
+      (this.checkIfInGroup(template) ||
+        this.checkIfInIndividuals(template) ||
+        this.checkIfInAdministrators(template))
+    )
   },
   checkIfOwner: function(template) {
     return user.get('user').get('userid') === template.owner
@@ -108,13 +108,21 @@ module.exports = Backbone.AssociatedModel.extend({
 
     return !_.isEmpty(roleIntersection)
   },
-  checkIfInIndividiuals: function(template) {
+  checkIfInIndividuals: function(template) {
     let myEmail = [user.get('user').get('email')]
     let accessIndividualIntersection = myEmail.filter(function(n) {
       return template.accessIndividuals.indexOf(n) !== -1
     })
 
     return !_.isEmpty(accessIndividualIntersection)
+  },
+  checkIfInAdministrators: function(template) {
+    let myEmail = [user.get('user').get('email')]
+    let accessAdministratorsIntersection = myEmail.filter(function(n) {
+      return template.accessAdministrators.indexOf(n) !== -1
+    })
+
+    return !_.isEmpty(accessAdministratorsIntersection)
   },
   addSearchForm: function(searchForm) {
     this.get('sharedSearchForms').add(searchForm)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
@@ -105,6 +105,7 @@ module.exports = Backbone.AssociatedModel.extend({
                 type: 'custom',
                 filterTemplate: JSON.stringify(value.filterTemplate),
                 accessIndividuals: value.accessIndividuals,
+                accessAdministrators: value.accessAdministrators,
                 accessGroups: value.accessGroups,
                 createdBy: value.creator,
                 owner: value.owner,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
@@ -26,6 +26,7 @@ module.exports = Backbone.Model.extend({
     descriptors: [],
     accessIndividuals: [],
     accessGroups: [],
+    accessAdministrators: [],
     querySettings: {},
   },
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.js
@@ -20,7 +20,7 @@ module.exports = Tabs.extend({
     tabs: properties.hasExperimentalEnabled()
       ? {
           'My Search Forms': MySearchFormCollectionView,
-          'Shared Templates': MySearchSharingFormCollectionView,
+          'Shared Search Forms': MySearchSharingFormCollectionView,
         }
       : {
           'My Search Forms': MySearchFormCollectionView,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.less
@@ -48,3 +48,9 @@
     display: none !important;
   }
 }
+
+@{customElementNamespace}workspace-interactions.is-not-shareable {
+  .interaction-share {
+    display: none !important;
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/workspace-interactions/workspace-interactions.view.js
@@ -66,9 +66,22 @@ define([
     onRender: function() {
       this.checkIfSubscribed()
       this.handleLocal()
+      this.handleShareable()
     },
     handleLocal: function() {
       this.$el.toggleClass('is-local', this.model.isLocal())
+    },
+    handleShareable: function() {
+      const notShareable = function(that) {
+        const userLogin = user.get('user').get('email')
+        if (that.model.get('metacard.owner') === userLogin) {
+          return false
+        }
+        const accessAdministrators =
+          that.model.get('security.access-administrators') || []
+        return !accessAdministrators.includes(userLogin)
+      }
+      this.$el.toggleClass('is-not-shareable', notShareable(this))
     },
     checkIfSubscribed: function() {
       this.$el.toggleClass(

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/workspace-sharing/workspace-sharing.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/workspace-sharing/workspace-sharing.hbs
@@ -22,6 +22,11 @@
 
         <div class="workspace-sharing-by-email"></div>
     </div>
+    <div class="information-admin">
+        <div class="is-header">Access Administrators:</div>
+
+        <div class="workspace-sharing-by-admin"></div>
+    </div>
 </div>
 
 <div class="sharing-buttons">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/workspace-sharing/workspace-sharing.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/workspace-sharing/workspace-sharing.less
@@ -63,14 +63,30 @@
     }
   }
 
+  .workspace-sharing-by-admin {
+    input {
+      height: @minimumButtonSize;
+    }
+
+    height: ~'calc(100% - @{minimumButtonSize})';
+    overflow: auto;
+
+    .admin {
+      vertical-align: top;
+      display: inline-block;
+      width: 100%;
+    }
+  }
+
   .workspace-sharing-by-role {
     height: ~'calc(100% - @{minimumButtonSize})';
     overflow: auto;
   }
 
   .information-role,
+  .information-admin,
   .information-email {
-    width: 50%;
+    width: 33%;
     display: inline-block;
     height: 100%;
     vertical-align: top;
@@ -83,7 +99,8 @@
     white-space: nowrap;
   }
 
-  .information-email {
+  .information-email,
+  .information-admin {
     border-left: 1px solid grey;
     padding: 10px;
   }
@@ -101,14 +118,16 @@
       overflow: auto;
     }
 
-    .information-email {
+    .information-email,
+    .information-admin {
       border-left: none;
     }
 
     .information-role,
+    .information-admin,
     .information-email {
       width: 100%;
-      height: 50%;
+      height: 33%;
     }
   }
 }


### PR DESCRIPTION
Depends on https://github.com/codice/ddf/pull/3655

#### Who is reviewing it? 
@Schachte 
@djblue 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?
Overview:
for workspaces, search forms, and result forms:
* confirm sharing through the access-administrators field works 
* confirm interactions menu (three dot) only displays `Share` if the current user is the owner or on 
the access-administrators list

Steps:
- build
- add empty folder `etc/forms`
- In `users.attributes`:
```
{
    "admin" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"admin@localhost.local"
    },
    "localhost" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"system@localhost.local"
    },
    "dummy" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"dummy@example.com"
    }
}
```
- In `users.properties`:
```
admin=admin,group,admin,manager,viewer,system-admin,systembundles
localhost=localhost,group,admin,manager,viewer,system-admin,system-history,system-user,systembundles
dummy=dummy,group,manager,viewer,system-history,systembundles
```
- run 
- enable `experimental features`
- on `admin` share a new workspace `by email` with `dummy`
- on `admin` share a new workspace `by access administrator` with `dummy`
- on `admin` share a new search form `by email` with `dummy`
- on `admin` share a new search form `by access administrator` with `dummy`
- on `admin` share a new result form `by email` with `dummy`
- on `admin` share a new result form `by access administrator` with `dummy`
- on `dummy` verify shared items are visible, verify `share` interaction only appears if `dummy` was given `access administrator` 

#### What are the relevant tickets?
[DDF-4108](https://codice.atlassian.net/browse/DDF-4108)
#### Screenshots
New access-administrators section in sharing modal:
<img width="978" alt="screen shot 2018-08-31 at 10 56 32 am" src="https://user-images.githubusercontent.com/37838624/44919895-8fe28500-ad0c-11e8-872b-1c03aea080d1.png">

Absence of the `Share` option because the current user (`dummy`) is not on the access-administrators list for this search form:
<img width="378" alt="screen shot 2018-08-31 at 11 41 44 am" src="https://user-images.githubusercontent.com/37838624/44922256-e8b51c00-ad12-11e8-9c95-de583127af06.png">

@djblue 
#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
