### PR TITLE
[2.13.x] DDF-3903 The IdP should add its entity ID in the NameQualifier field of all Persistent Identifiers

### DIFF
--- a/features/security/pom.xml
+++ b/features/security/pom.xml
@@ -384,6 +384,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.security.idp</groupId>
+            <artifactId>security-idp-plugin-namequalifier</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.platform.email</groupId>
             <artifactId>platform-email-api</artifactId>
             <version>${project.version}</version>

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -565,6 +565,8 @@
         <feature>security-handler-saml</feature>
         <feature>session-invalidator</feature>
         <bundle>mvn:ddf.security.idp/security-idp-plugin-audiencerestriction/${project.version}</bundle>
+        <bundle>mvn:ddf.security.idp/security-idp-plugin-nameidpolicy/${project.version}</bundle>
+        <bundle>mvn:ddf.security.idp/security-idp-plugin-namequalifier/${project.version}</bundle>
         <feature>platform-paxweb-jettyconfig</feature>
         <bundle>mvn:ddf.security.idp/security-idp-client/${project.version}</bundle>
         <feature>guava</feature>
@@ -577,7 +579,6 @@
         <feature>security-filter-login</feature>
         <bundle>mvn:ddf.security.idp/security-idp-server/${project.version}</bundle>
         <bundle>mvn:io.fastjson/boon/${boon.version}</bundle>
-        <bundle>mvn:ddf.security.idp/security-idp-plugin-nameidpolicy/${project.version}</bundle>
     </feature>
 
     <feature name="security-command-listener" version="${project.version}"

--- a/platform/security/idp/security-idp-plugin/pom.xml
+++ b/platform/security/idp/security-idp-plugin/pom.xml
@@ -30,6 +30,6 @@
         <module>security-idp-plugin-subjectconfirmation</module>
         <module>security-idp-plugin-audiencerestriction</module>
         <module>security-idp-plugin-nameidpolicy</module>
+        <module>security-idp-plugin-namequalifier</module>
     </modules>
-
 </project>

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-namequalifier/pom.xml
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-namequalifier/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.security.idp</groupId>
+        <artifactId>security-idp-plugin</artifactId>
+        <version>2.13.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>security-idp-plugin-namequalifier</artifactId>
+    <name>DDF :: Security :: IdP :: Plugin :: Name Qualifier</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.security.idp</groupId>
+            <artifactId>security-idp-plugin-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--Spock dependencies-->
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            ddf-security-common,
+                            platform-util,
+                            platform-util-unavailableurls
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-namequalifier/src/main/java/org/codice/ddf/security/idp/plugin/namequalifier/NameQualifierPresignPlugin.java
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-namequalifier/src/main/java/org/codice/ddf/security/idp/plugin/namequalifier/NameQualifierPresignPlugin.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.plugin.namequalifier;
+
+import static org.opensaml.saml.saml2.core.NameIDType.PERSISTENT;
+
+import ddf.security.samlp.SamlProtocol;
+import java.util.List;
+import java.util.Set;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.security.idp.plugin.SamlPresignPlugin;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.NameIDType;
+import org.opensaml.saml.saml2.core.Response;
+
+/**
+ * Pre-sign plugin that ensures that "Each bearer assertion must contain an {@code <nameQualifier>}"
+ * as per section 8.3.7 of the SAML Spec.
+ *
+ * @see <a
+ *     href="https://www.oasis-open.org/committees/download.php/56783/sstc-saml-profiles-errata-2.0-wd-07-diff.pdf">
+ *     Profiles for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite</a>
+ */
+public class NameQualifierPresignPlugin implements SamlPresignPlugin {
+  static final String NAME_QUALIFIER = SystemBaseUrl.INTERNAL.constructUrl("idp/login", true);
+
+  @Override
+  public void processPresign(
+      Response response,
+      AuthnRequest authnRequest,
+      List<String> spMetadata,
+      Set<SamlProtocol.Binding> supportedBindings) {
+
+    if (response.getIssuer() != null) {
+      setNameQualifierIfPersistent(response.getIssuer());
+    }
+
+    for (Assertion assertion : response.getAssertions()) {
+      if (assertion.getSubject() != null && assertion.getSubject().getNameID() != null) {
+        setNameQualifierIfPersistent(assertion.getSubject().getNameID());
+      }
+      setNameQualifierIfPersistent(assertion.getIssuer());
+    }
+  }
+
+  private void setNameQualifierIfPersistent(NameIDType nameIDType) {
+    if (nameIDType.getFormat() != null && nameIDType.getFormat().equalsIgnoreCase(PERSISTENT)) {
+      nameIDType.setNameQualifier(NAME_QUALIFIER);
+    }
+  }
+}

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-namequalifier/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-namequalifier/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="nameQualifierPresignPlugin"
+          class="org.codice.ddf.security.idp.plugin.namequalifier.NameQualifierPresignPlugin"/>
+    <service ref="nameQualifierPresignPlugin"
+             interface="org.codice.ddf.security.idp.plugin.SamlPresignPlugin"/>
+</blueprint>

--- a/platform/security/idp/security-idp-plugin/security-idp-plugin-namequalifier/src/test/groovy/org/codice/ddf/security/idp/plugin/namequalifier/NameQualifierPresignPluginSpec.groovy
+++ b/platform/security/idp/security-idp-plugin/security-idp-plugin-namequalifier/src/test/groovy/org/codice/ddf/security/idp/plugin/namequalifier/NameQualifierPresignPluginSpec.groovy
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.idp.plugin.namequalifier
+
+import static org.opensaml.saml.saml2.core.NameIDType.PERSISTENT
+
+import ddf.security.samlp.SamlProtocol
+import org.apache.wss4j.common.saml.OpenSAMLUtil
+import spock.lang.Specification
+import org.opensaml.saml.saml2.core.AuthnRequest
+import org.opensaml.saml.saml2.core.Issuer
+import org.opensaml.saml.saml2.core.Response
+import org.opensaml.saml.saml2.core.Subject
+import org.opensaml.saml.saml2.core.Assertion
+import org.opensaml.saml.saml2.core.NameIDPolicy
+import org.opensaml.saml.saml2.core.NameID
+
+class NameQualifierPresignPluginSpec extends Specification {
+
+    NameQualifierPresignPlugin plugin = new NameQualifierPresignPlugin()
+
+    Issuer issuer = Mock(Issuer)
+    NameID nameID = Mock(NameID)
+    Subject subject = Mock(Subject)
+    NameID nameIDNeg = Mock(NameID)
+    Response response = Mock(Response)
+    Assertion assertion = Mock(Assertion)
+    AuthnRequest authNReq = Mock(AuthnRequest)
+    NameIDPolicy nameIdPolicy = Mock(NameIDPolicy)
+
+    List<String> spMetadata = new ArrayList<>()
+    List<Assertion> assertions = new ArrayList<>()
+    Set<SamlProtocol.Binding> bindings = new HashSet<>()
+
+    def NEGATIVE_TEST = 'negative test'
+
+    def setupSpec() {
+        OpenSAMLUtil.initSamlEngine()
+    }
+
+    def setup() {
+        authNReq.getIssuer() >> issuer
+        assertion.getIssuer() >> issuer
+        response.assertions >> assertions
+        authNReq.getNameIDPolicy() >> nameIdPolicy
+    }
+
+    def 'test name qualifier when issuer is not null and nameid format is persistent'() {
+        setup:
+        response.getIssuer() >> issuer
+        issuer.getFormat() >> PERSISTENT
+        assertions.add(assertion)
+        assertion.getSubject() >> subject
+        subject.getNameID() >> nameID
+        nameID.getFormat() >> PERSISTENT
+
+        when:
+        plugin.processPresign(response, authNReq, spMetadata, bindings)
+
+        then:
+        1 * nameID.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+        2 * issuer.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+    }
+
+    def 'test name qualifier when issuer is null and nameid format is persistent'() {
+        setup:
+        response.getIssuer() >> null
+        assertions.add(assertion)
+        assertion.getSubject() >> subject
+        subject.getNameID() >> nameID
+        nameID.getFormat() >> PERSISTENT
+
+        when:
+        plugin.processPresign(response, authNReq, spMetadata, bindings)
+
+        then:
+        1 * nameID.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+        0 * issuer.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+    }
+
+    def 'test name qualifier when no assertions'() {
+        setup:
+        response.getIssuer() >> issuer
+        issuer.getFormat() >> PERSISTENT
+        assertion.getSubject() >> subject
+        subject.getNameID() >> nameID
+        nameID.getFormat() >> PERSISTENT
+
+        when:
+        plugin.processPresign(response, authNReq, spMetadata, bindings)
+
+        then:
+        0 * nameID.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+        1 * issuer.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+    }
+
+    def 'test name qualifier when issuer format is null'() {
+        setup:
+        response.getIssuer() >> issuer
+        issuer.getFormat() >> null
+        assertions.add(assertion)
+
+        when:
+        plugin.processPresign(response, authNReq, spMetadata, bindings)
+
+        then:
+        0 * issuer.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+    }
+
+    def 'test name qualifier when issuer format is not persistent'() {
+        setup:
+        response.getIssuer() >> issuer
+        issuer.getFormat() >> NEGATIVE_TEST
+        assertions.add(assertion)
+
+        when:
+        plugin.processPresign(response, authNReq, spMetadata, bindings)
+
+        then:
+        0 * issuer.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+    }
+
+    def 'test name qualifier when assertion subject is null'() {
+        setup:
+        response.getIssuer() >> issuer
+        issuer.getFormat() >> PERSISTENT
+        assertions.add(assertion)
+        assertion.getSubject() >> null
+
+        when:
+        plugin.processPresign(response, authNReq, spMetadata, bindings)
+
+        then:
+        0 * nameID.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+    }
+
+    def 'test name qualifier when assertion subject is not null and name id is not persistent'() {
+        setup:
+        response.getIssuer() >> issuer
+        issuer.getFormat() >> PERSISTENT
+        assertions.add(assertion)
+        assertion.getSubject() >> subject
+        subject.getNameID() >> nameIDNeg
+        nameIDNeg.getFormat() >> NEGATIVE_TEST
+
+        when:
+        plugin.processPresign(response, authNReq, spMetadata, bindings)
+
+        then:
+        0 * nameID.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+        2 * issuer.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+    }
+
+    def 'test name qualifier when assertion subject is not null and name id is null'() {
+        setup:
+        response.getIssuer() >> issuer
+        issuer.getFormat() >> PERSISTENT
+        assertions.add(assertion)
+        assertion.getSubject() >> subject
+        subject.getNameID() >> null
+
+        when:
+        plugin.processPresign(response, authNReq, spMetadata, bindings)
+
+        then:
+        0 * nameID.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+        2 * issuer.setNameQualifier(NameQualifierPresignPlugin.NAME_QUALIFIER)
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Backport of https://github.com/codice/ddf/pull/3354
The IdP should add its entity ID in the NameQualifier field of all Persistent Identifiers

#### Who is reviewing it? 
@bantillo @brjeter @bakejeyner 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@shaundmorris

#### How should this be tested?
Run the [SAML-CTK](https://github.com/codice/saml-conformance) tests against it.

#### What are the relevant tickets?
[DDF-3903](https://codice.atlassian.net/browse/DDF-3903)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
