### PR TITLE
DDF-3340 Deconflict itest Solr port

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -719,8 +719,8 @@ public abstract class AbstractIntegrationTest {
     return options(
         editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "solr.client", "HttpSolrClient"),
         editConfigurationFilePut(
-            SYSTEM_PROPERTIES_REL_PATH, "solr.http.url", "http://localhost:9994/solr"),
-        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "solr.http.port", "9994"),
+            SYSTEM_PROPERTIES_REL_PATH, "solr.http.url", "http://localhost:9784/solr"),
+        editConfigurationFilePut(SYSTEM_PROPERTIES_REL_PATH, "solr.http.port", "9784"),
         editConfigurationFilePut(
             SYSTEM_PROPERTIES_REL_PATH,
             "solr.data.dir",

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -28,7 +28,7 @@
         <solr.script.dir>
             ${project.build.directory}/solr/bin/
         </solr.script.dir>
-        <solr.port>9994</solr.port>
+        <solr.port>9784</solr.port>
     </properties>
     <dependencies>
         <!-- Pax Exam Karaf container dependencies -->


### PR DESCRIPTION
#### What does this PR do?
Changes the port the itests use for Solr server.
Solr makes some assumptions about ports. It assumes the main port and kill port are exactly 1000 apart. Therefore, attempting to run two instances of Solr, one at 8994 and another at 9994 causes problems. This PR fixes the problem so the itests do not conflict with a running instance of DDF.

#### Who is reviewing it? 
@mcalcote @ethantmanns @austinsteffes @kcover 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@figliold
@lessarderic

#### How should this be tested?
Run itests. Confirm that Solr server is running on port 9784 and that the itests are able to communicate with Solr.

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
