### PR TITLE
DDF-4059 Adding a null check in AssertionConsumerService:getSamlResponse()

### DIFF
--- a/platform/security/idp/security-idp-client/pom.xml
+++ b/platform/security/idp/security-idp-client/pom.xml
@@ -226,17 +226,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.62</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.61</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.59</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/AssertionConsumerServiceTest.java
+++ b/platform/security/idp/security-idp-client/src/test/java/org/codice/ddf/security/idp/client/AssertionConsumerServiceTest.java
@@ -185,6 +185,16 @@ public class AssertionConsumerServiceTest {
   }
 
   @Test
+  public void testGetSamlResponseNullSamlResponse() throws Exception {
+    Response response =
+        assertionConsumerService.getSamlResponse(null, RELAY_STATE_VAL, SIG_ALG_VAL, SIGNATURE_VAL);
+    assertThat(
+        "The http response was not 500 SERVER ERROR",
+        response.getStatus(),
+        is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
+  }
+
+  @Test
   public void testGetSamlResponseInvalidSignature() throws Exception {
     Response response =
         assertionConsumerService.getSamlResponse(


### PR DESCRIPTION
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #3667
____

#### Who is reviewing it? 
@ahoffer @blen-desta @brjeter 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@tbatie 
@rzwiefel 

https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
