### PR TITLE
DDF-4120 Modify Cql Transform Handler to adapt to existing CSV and CSW Transformers

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -339,7 +339,6 @@
             <groupId>org.codice.ddf.spatial</groupId>
             <artifactId>spatial-csw-common</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -338,7 +338,7 @@
         <dependency>
             <groupId>org.codice.ddf.spatial</groupId>
             <artifactId>spatial-csw-common</artifactId>
-            <version>2.14.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -330,6 +330,17 @@
             <artifactId>platform-configuration-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.ui</groupId>
+            <artifactId>catalog-ui-metacard-sharing-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.spatial</groupId>
+            <artifactId>spatial-csw-common</artifactId>
+            <version>2.14.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -59,6 +59,8 @@ public class CqlTransformHandler implements Route {
   private static final Logger LOGGER = LoggerFactory.getLogger(CqlTransformHandler.class);
   private static final String GZIP = "gzip";
 
+  private static final String CSW_SCHEMA_VALUE = "http://www.opengis.net/cat/csw/2.0.2";
+
   private EndpointUtil util;
   private List<ServiceReference> queryResponseTransformers;
   private BundleContext bundleContext;
@@ -151,7 +153,7 @@ public class CqlTransformHandler implements Route {
 
     if (queryResponseTransformer.getProperty("mime-type").toString().equals("[text/csv]")) {
       arguments = csvTransformArgumentsAdapter(arguments);
-    } else if (schema != null && schema.toString().equals("http://www.opengis.net/cat/csw/2.0.2")) {
+    } else if (schema != null && schema.toString().equals(CSW_SCHEMA_VALUE)) {
       arguments = cswTransformArgumentsAdapter();
     }
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -250,7 +250,7 @@ public class CqlTransformHandler implements Route {
         "\"hiddenFields\":" + (String) mapper.toJson(arguments.get("hiddenFields"));
     String columnAliasMap =
         "\"columnAliasMap\":" + (String) mapper.toJson(arguments.get("columnAliasMap"));
-    String csvBody = "{" + columnOrder + "," + columnAliasMap + "," + hiddenFields + "}";
+    String csvBody = String.format("{%s,%s,%s}", columnOrder, columnAliasMap, hiddenFields);
 
     CsvTransform queryTransform = mapper.readValue(csvBody, CsvTransform.class);
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -22,10 +22,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -271,9 +269,9 @@ public class CqlTransformHandler implements Route {
 
     Map<String, Serializable> args =
         ImmutableMap.<String, Serializable>builder()
-            .put("hiddenFields", new HashSet<>(hiddenFieldsSet))
-            .put("columnOrder", new ArrayList<>(columnOrderList))
-            .put("aliases", new HashMap<>(aliasMap))
+            .put("hiddenFields", (Serializable) hiddenFieldsSet)
+            .put("columnOrder", (Serializable) columnOrderList)
+            .put("aliases", (Serializable) aliasMap)
             .build();
 
     return args;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -151,7 +151,12 @@ public class CqlTransformHandler implements Route {
 
     Object schema = queryResponseTransformer.getProperty("schema");
 
-    if (queryResponseTransformer.getProperty("mime-type").toString().equals("[text/csv]")) {
+    List<String> mimeTypeServiceProperty =
+        queryResponseTransformer.getProperty("mime-type") instanceof List
+            ? (List) queryResponseTransformer.getProperty("mime-type")
+            : Collections.emptyList();
+
+    if (mimeTypeServiceProperty.contains("text/csv")) {
       arguments = csvTransformArgumentsAdapter(arguments);
     } else if (schema != null && schema.toString().equals(CSW_SCHEMA_VALUE)) {
       arguments = cswTransformArgumentsAdapter();

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -43,6 +43,7 @@ import org.codice.ddf.catalog.ui.metacard.transform.CsvTransform;
 import org.codice.ddf.catalog.ui.query.cql.CqlQueryResponse;
 import org.codice.ddf.catalog.ui.query.cql.CqlRequest;
 import org.codice.ddf.catalog.ui.util.EndpointUtil;
+import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.eclipse.jetty.http.HttpStatus;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -146,8 +147,12 @@ public class CqlTransformHandler implements Route {
 
     CqlQueryResponse cqlQueryResponse = util.executeCqlQuery(cqlRequest);
 
+    Object schema = queryResponseTransformer.getProperty("schema");
+
     if (queryResponseTransformer.getProperty("mime-type").toString().equals("[text/csv]")) {
       arguments = csvTransformArgumentsAdapter(arguments);
+    } else if (schema != null && schema.toString().equals("http://www.opengis.net/cat/csw/2.0.2")) {
+      arguments = cswTransformArgumentsAdapter();
     }
 
     attachFileToResponse(request, response, queryResponseTransformer, cqlQueryResponse, arguments);
@@ -225,6 +230,12 @@ public class CqlTransformHandler implements Route {
     LOGGER.trace(
         "Successfully output file using transformer id {}",
         queryResponseTransformer.getProperty("id"));
+  }
+
+  private Map<String, Serializable> cswTransformArgumentsAdapter() {
+    Map<String, Serializable> args = new HashMap<>();
+    args.put(CswConstants.IS_BY_ID_QUERY, true);
+    return args;
   }
 
   private Map<String, Serializable> csvTransformArgumentsAdapter(

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -59,8 +59,6 @@ public class CqlTransformHandler implements Route {
   private static final Logger LOGGER = LoggerFactory.getLogger(CqlTransformHandler.class);
   private static final String GZIP = "gzip";
 
-  private static final String CSW_SCHEMA_VALUE = "http://www.opengis.net/cat/csw/2.0.2";
-
   private EndpointUtil util;
   private List<ServiceReference> queryResponseTransformers;
   private BundleContext bundleContext;
@@ -158,7 +156,7 @@ public class CqlTransformHandler implements Route {
 
     if (mimeTypeServiceProperty.contains("text/csv")) {
       arguments = csvTransformArgumentsAdapter(arguments);
-    } else if (schema != null && schema.toString().equals(CSW_SCHEMA_VALUE)) {
+    } else if (schema != null && schema.toString().equals(CswConstants.CSW_NAMESPACE_URI)) {
       arguments = cswTransformArgumentsAdapter();
     }
 

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandlerTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandlerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import com.google.common.collect.ImmutableList;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.data.types.Core;
@@ -141,6 +142,7 @@ public class CqlTransformHandlerTest {
     queryResponseTransformers = new ArrayList<>();
 
     when(mockServiceReference.getProperty(Core.ID)).thenReturn(RETURN_ID);
+    when(mockServiceReference.getProperty("mime-type")).thenReturn(ImmutableList.of(MIME_TYPE));
 
     MimeType mimeType = new MimeType(MIME_TYPE);
     binaryContent = new BinaryContentImpl(new ByteArrayInputStream(CONTENT.getBytes()), mimeType);


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
The queryResponseTransformer for csv export was utilized in `/transform/csv` and is being replaced by `cql/transform/{transformerId}`.
With the new endpoint, adding arguments and requesting a csv file results in an empty file (a valid file returns when only null arguments are in the json payload).
The argument structure for the csv transformer is different than other queryResponseTransformers, this includes an adapter for the arguments, incorporating some of the logic of the old endpoint to the new one allowing for these arguments to be sent to the csv transformer.

Update: this PR also adds updates in the endpoint to allow the CSW transformer to export properly with a cql request

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@brianfelix 
@bellcc 
@leo-sakh 
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@bdeining
@rzwiefel 
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
use postman to hit the POST endpoint `/search/catalog/internal/cql/transform/csv`
with a request payload like:
```
{
	"arguments": {
		"columnAliasMap":{},
		"hiddenFields":["title", "modified"],
		"columnOrder": ["title", "created","modified","thumbnail","checksum","checksum-algorithm","datatype","effective","id","media.compression","media.height-pixels","media.type","media.width-pixels","metacard-tags","metacard-type","metacard.created","metacard.modified","point-of-contact","resource-download-url","resource-size","resource-uri","source-id"]
		},
    "cql":"anyText ILIKE '*'"
}
```
and ensuring a csv is returned in the response body, with the correct fields attached/hidden.

for testing CSW on endpoint `/search/catalog/internal/cql/transform/csw%3ARecord`:
```
{
    "cql":"anyText ILIKE '*'",
    "arguments": {
        "IS_BY_ID_QUERY": false
    }
}
```

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4120](https://codice.atlassian.net/browse/DDF-4120)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
