### PR TITLE
[2.13.x] DDF-4112 removing zip4j dependency in: spatial-geocoding-extract, catalog-transformer-zip, catalog-core-commands, and docs.

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -109,11 +109,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.lingala.zip4j</groupId>
-            <artifactId>zip4j</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>ddf.catalog.transformer</groupId>
             <artifactId>catalog-transformer-zip</artifactId>
             <version>${project.version}</version>
@@ -152,8 +147,7 @@
                             catalog-transformer-zip,
                             ddf-security-common,
                             platform-util-unavailableurls,
-                            platform-util,
-                            zip4j
+                            platform-util
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <Private-Package>

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -37,6 +37,8 @@ import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
 import ddf.security.common.audit.SecurityLogger;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -59,9 +61,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import net.lingala.zip4j.core.ZipFile;
-import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.model.ZipParameters;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
@@ -176,6 +177,47 @@ public class ExportCommand extends CqlCommands {
     revisionFilter = initRevisionFilter();
 
     final File outputFile = initOutputFile(output);
+    checkFile(outputFile);
+
+    if (delete && !force) {
+      final String input =
+          session.readLine(
+              "This action will remove all exported metacards and content from the catalog. Are you sure you wish to continue? (y/N):",
+              null);
+      if (input.length() == 0 || Character.toLowerCase(input.charAt(0)) != 'y') {
+        console.println("ABORTED EXPORT.");
+        return null;
+      }
+    }
+
+    SecurityLogger.audit("Called catalog:export command with path : {}", output);
+
+    try (FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
+        ZipOutputStream zipOutputStream = new ZipOutputStream(fileOutputStream)) {
+
+      return doExport(outputFile, zipOutputStream, filter);
+
+    } catch (FileNotFoundException e) {
+      throw new FileNotFoundException(
+          String.format(
+              "ZipOutputStream could not be created for the path %s", outputFile.getPath()));
+    }
+  }
+
+  private File initOutputFile(String output) {
+    String resolvedOutput;
+    File initialOutputFile = new File(output);
+    if (initialOutputFile.isDirectory()) {
+      // If directory was specified, auto generate file name
+      resolvedOutput = Paths.get(initialOutputFile.getPath(), FILE_NAMER.get()).toString();
+    } else {
+      resolvedOutput = output;
+    }
+
+    return new File(resolvedOutput);
+  }
+
+  private void checkFile(File outputFile) {
     if (outputFile.exists()) {
       printErrorMessage(String.format("File [%s] already exists!", outputFile.getPath()));
       throw new IllegalStateException("File already exists");
@@ -193,28 +235,16 @@ public class ExportCommand extends CqlCommands {
       console.println("Filename must end with '.zip' and not be blank");
       throw new IllegalStateException("Filename must not be blank and must end with '.zip'");
     }
+  }
 
-    if (delete && !force) {
-      final String input =
-          session.readLine(
-              "This action will remove all exported metacards and content from the catalog. Are you sure you wish to continue? (y/N):",
-              null);
-      if (!input.matches("^[yY][eE]?[sS]?$")) {
-        console.println("ABORTED EXPORT.");
-        return null;
-      }
-    }
-
-    SecurityLogger.audit("Called catalog:export command with path : {}", output);
-
-    ZipFile zipFile = new ZipFile(outputFile);
-
+  private Object doExport(File outputFile, ZipOutputStream zipOutputStream, Filter filter)
+      throws IOException {
     console.println("Starting metacard export...");
     Instant start = Instant.now();
-    List<ExportItem> exportedItems = doMetacardExport(zipFile, filter);
+    List<ExportItem> exportedItems = doMetacardExport(zipOutputStream, filter);
     if (exportedItems.isEmpty()) {
       console.println("No metacards found to export, exiting.");
-      FileUtils.deleteQuietly(zipFile.getFile());
+      FileUtils.deleteQuietly(outputFile);
       return null;
     }
 
@@ -232,10 +262,9 @@ public class ExportCommand extends CqlCommands {
 
     console.println("Starting content export...");
     start = Instant.now();
-    List<ExportItem> exportedContentItems = doContentExport(zipFile, exportedItems);
+    List<ExportItem> exportedContentItems = doContentExport(zipOutputStream, exportedItems);
     console.println("Content exported in: " + getFormattedDuration(start));
     console.println("Number of content exported: " + exportedContentItems.size());
-
     console.println();
 
     if (delete) {
@@ -243,11 +272,14 @@ public class ExportCommand extends CqlCommands {
     }
 
     if (!unsafe) {
-      SecurityLogger.audit("Signing exported data. file: [{}]", zipFile.getFile().getName());
+      //  close the stream here to allow the jar writer to certify the full zip.
+      //  Try with resources will close the stream if this is not the case.
+      zipOutputStream.close();
+      SecurityLogger.audit("Signing exported data. file: [{}]", outputFile.getName());
       console.println("Signing zip file...");
       start = Instant.now();
       jarSigner.signJar(
-          zipFile.getFile(),
+          outputFile,
           System.getProperty(SystemBaseUrl.EXTERNAL_HOST),
           System.getProperty("javax.net.ssl.keyStorePassword"),
           System.getProperty("javax.net.ssl.keyStore"),
@@ -256,24 +288,12 @@ public class ExportCommand extends CqlCommands {
     }
 
     console.println("Export complete.");
-    console.println("Exported to: " + zipFile.getFile().getCanonicalPath());
+    console.println("Exported to: " + outputFile.getCanonicalPath());
     return null;
   }
 
-  private File initOutputFile(String output) {
-    String resolvedOutput;
-    File initialOutputFile = new File(output);
-    if (initialOutputFile.isDirectory()) {
-      // If directory was specified, auto generate file name
-      resolvedOutput = Paths.get(initialOutputFile.getPath(), FILE_NAMER.get()).toString();
-    } else {
-      resolvedOutput = output;
-    }
-
-    return new File(resolvedOutput);
-  }
-
-  private List<ExportItem> doMetacardExport(/*Mutable,IO*/ ZipFile zipFile, Filter filter) {
+  private List<ExportItem> doMetacardExport(
+      /*Mutable,IO*/ ZipOutputStream zipOutputStream, Filter filter) {
     Set<String> seenIds = new HashSet<>(1024);
     List<ExportItem> exportedItems = new ArrayList<>();
 
@@ -284,7 +304,7 @@ public class ExportCommand extends CqlCommands {
 
     for (Result result : resultIterable(catalogFramework, queryRequest)) {
       if (!seenIds.contains(result.getMetacard().getId())) {
-        writeToZip(zipFile, result);
+        writeResultToZip(zipOutputStream, result);
         exportedItems.add(
             new ExportItem(
                 result.getMetacard().getId(),
@@ -304,7 +324,7 @@ public class ExportCommand extends CqlCommands {
         if (seenIds.contains(revision.getMetacard().getId())) {
           continue;
         }
-        writeToZip(zipFile, revision);
+        writeResultToZip(zipOutputStream, revision);
         exportedItems.add(
             new ExportItem(
                 revision.getMetacard().getId(),
@@ -334,7 +354,7 @@ public class ExportCommand extends CqlCommands {
 
   @SuppressWarnings("squid:S3776")
   private List<ExportItem> doContentExport(
-      /*Mutable,IO*/ ZipFile zipFile, List<ExportItem> exportedItems) throws ZipException {
+      ZipOutputStream zipOutputStream, List<ExportItem> exportedItems) {
     List<ExportItem> contentItemsToExport =
         exportedItems
             .stream()
@@ -366,7 +386,7 @@ public class ExportCommand extends CqlCommands {
       } catch (ResourceNotFoundException e) {
         continue;
       }
-      writeToZip(zipFile, contentItem, resource);
+      writeResourceToZip(zipOutputStream, contentItem, resource);
       exportedContentItems.add(contentItem);
       if (!contentItem.getMetacardTag().equals(REVISION_METACARD)) {
         for (String derivedUri : contentItem.getDerivedUris()) {
@@ -394,7 +414,7 @@ public class ExportCommand extends CqlCommands {
                 Ansi.ansi().fg(Ansi.Color.RED).toString(), uri, Ansi.ansi().reset().toString());
             continue;
           }
-          writeToZip(zipFile, contentItem, derivedResource);
+          writeResourceToZip(zipOutputStream, contentItem, derivedResource);
         }
       }
     }
@@ -448,16 +468,17 @@ public class ExportCommand extends CqlCommands {
     console.println("Number of content deleted: " + exportedContentItems.size());
   }
 
-  private void writeToZip(
-      /*Mutable,IO*/ ZipFile zipFile, ExportItem exportItem, ResourceResponse resource)
-      throws ZipException {
-    ZipParameters parameters = new ZipParameters();
-    parameters.setSourceExternalStream(true);
+  private void writeResourceToZip(
+      /*Mutable,IO*/ ZipOutputStream zipOutputStream,
+      ExportItem exportItem,
+      ResourceResponse resource) {
     String id = exportItem.getId();
     String path = getContentPath(id, resource);
-    parameters.setFileNameInZip(path);
+    ZipEntry zipEntry = new ZipEntry(path);
+
     try (InputStream resourceStream = resource.getResource().getInputStream()) {
-      zipFile.addStream(resourceStream, parameters);
+      zipOutputStream.putNextEntry(zipEntry);
+      writeDataToZip(zipOutputStream, resourceStream);
     } catch (IOException e) {
       LOGGER.warn(
           "Could not get content. Content will not be included in export [{}]", exportItem.getId());
@@ -482,22 +503,19 @@ public class ExportCommand extends CqlCommands {
     return path;
   }
 
-  private void writeToZip(/*Mutable,IO*/ ZipFile zipFile, Result result) {
-    ZipParameters parameters = new ZipParameters();
-    parameters.setSourceExternalStream(true);
+  private void writeResultToZip(/*Mutable,IO*/ ZipOutputStream zipOutputStream, Result result) {
     String id = result.getMetacard().getId();
-    parameters.setFileNameInZip(
-        Paths.get("metacards", id.substring(0, 3), id, "metacard", id + ".xml").toString());
+    ZipEntry zipEntry =
+        new ZipEntry(
+            Paths.get("metacards", id.substring(0, 3), id, "metacard", id + ".xml").toString());
 
     try {
       BinaryContent binaryMetacard =
           transformer.transform(result.getMetacard(), Collections.emptyMap());
-      try (InputStream metacard = binaryMetacard.getInputStream()) {
-        zipFile.addStream(metacard, parameters);
+      try (InputStream metacardStream = binaryMetacard.getInputStream()) {
+        zipOutputStream.putNextEntry(zipEntry);
+        writeDataToZip(zipOutputStream, metacardStream);
       }
-    } catch (ZipException e) {
-      LOGGER.error("Error processing result and adding to ZIP", e);
-      throw new CatalogCommandRuntimeException(e);
     } catch (CatalogTransformerException | IOException e) {
       LOGGER.warn(
           "Could not transform metacard. Metacard will not be added to zip [{}]",
@@ -508,6 +526,15 @@ public class ExportCommand extends CqlCommands {
           result.getMetacard().getId(),
           result.getMetacard().getTitle(),
           Ansi.ansi().reset().toString());
+    }
+  }
+
+  private void writeDataToZip(ZipOutputStream zipOutputStream, InputStream inputStream)
+      throws IOException {
+    final byte[] bytes = new byte[1024];
+    int length;
+    while ((length = inputStream.read(bytes)) >= 0) {
+      zipOutputStream.write(bytes, 0, length);
     }
   }
 

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -116,6 +117,12 @@ public class ExportCommand extends CqlCommands {
   private Filter revisionFilter;
 
   private JarSigner jarSigner = new JarSigner();
+
+  private static final String SECURITY_AUDIT_DELIMITER = ", ";
+
+  //  Number of bytes that can be sent is 65,507 (due to udp constraints). This gives a
+  //  2002 byte buffer to account for anything the security log prefaces our message with
+  private static final int LOG4J_MAX_BUF_SIZE = 63505;
 
   @Reference protected StorageProvider storageProvider;
 
@@ -252,13 +259,7 @@ public class ExportCommand extends CqlCommands {
     console.println("Number of metacards exported: " + exportedItems.size());
     console.println();
 
-    SecurityLogger.audit(
-        "Ids of exported metacards and content:\n{}",
-        exportedItems
-            .stream()
-            .map(ExportItem::getId)
-            .distinct()
-            .collect(Collectors.joining(", ", "[", "]")));
+    auditRecords(exportedItems);
 
     console.println("Starting content export...");
     start = Instant.now();
@@ -290,6 +291,27 @@ public class ExportCommand extends CqlCommands {
     console.println("Export complete.");
     console.println("Exported to: " + outputFile.getCanonicalPath());
     return null;
+  }
+
+  private void auditRecords(List<ExportItem> exportedItems) {
+    AtomicInteger counter = new AtomicInteger();
+    exportedItems
+        .stream()
+        .map(ExportItem::getId)
+        .distinct()
+        .collect(Collectors.groupingBy(e -> logPartition(e, counter)))
+        .values()
+        .forEach(this::writePartitionToLog);
+  }
+
+  private int logPartition(String e, AtomicInteger counter) {
+    return counter.getAndAdd(e.length() + SECURITY_AUDIT_DELIMITER.length()) / LOG4J_MAX_BUF_SIZE;
+  }
+
+  private void writePartitionToLog(List<String> idList) {
+    SecurityLogger.audit(
+        "Ids of exported metacards and content:\n{}",
+        idList.stream().collect(Collectors.joining(SECURITY_AUDIT_DELIMITER, "[", "]")));
   }
 
   private List<ExportItem> doMetacardExport(

--- a/catalog/spatial/geocoding/spatial-geocoding-extract/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-extract/pom.xml
@@ -38,11 +38,6 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.lingala.zip4j</groupId>
-            <artifactId>zip4j</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -78,7 +73,6 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            zip4j,
                             platform-util
                         </Embed-Dependency>
                         <Export-Package />

--- a/catalog/transformer/catalog-transformer-zip/pom.xml
+++ b/catalog/transformer/catalog-transformer-zip/pom.xml
@@ -46,11 +46,6 @@
             <artifactId>catalog-core-api-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.lingala.zip4j</groupId>
-            <artifactId>zip4j</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
             <version>${project.version}</version>
@@ -78,8 +73,7 @@
                             ant,
                             ant-launcher,
                             catalog-core-api-impl,
-                            platform-util,
-                            zip4j
+                            platform-util
                         </Embed-Dependency>
                         <Export-Package />
                     </instructions>

--- a/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
+++ b/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectOutputStream;
@@ -44,10 +45,9 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-import net.lingala.zip4j.core.ZipFile;
-import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.model.ZipParameters;
+import java.util.zip.ZipOutputStream;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
@@ -56,6 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ZipCompression implements QueryResponseTransformer {
+
   public static final String METACARD_PATH = "metacards" + File.separator;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ZipCompression.class);
@@ -84,6 +85,16 @@ public class ZipCompression implements QueryResponseTransformer {
       SourceResponse upstreamResponse, Map<String, Serializable> arguments)
       throws CatalogTransformerException {
 
+    checkArguments(upstreamResponse, arguments);
+
+    String filePath = (String) arguments.get(ZipDecompression.FILE_PATH);
+    createZip(upstreamResponse, filePath);
+
+    return getBinaryContentFromZip(filePath);
+  }
+
+  private void checkArguments(SourceResponse upstreamResponse, Map<String, Serializable> arguments)
+      throws CatalogTransformerException {
     if (upstreamResponse == null || CollectionUtils.isEmpty(upstreamResponse.getResults())) {
       throw new CatalogTransformerException("No Metacards were found to transform.");
     }
@@ -91,74 +102,57 @@ public class ZipCompression implements QueryResponseTransformer {
     if (MapUtils.isEmpty(arguments) || !arguments.containsKey(ZipDecompression.FILE_PATH)) {
       throw new CatalogTransformerException("No 'filePath' argument found in arguments map.");
     }
+  }
 
-    ZipFile zipFile;
-    String filePath = (String) arguments.get(ZipDecompression.FILE_PATH);
-    try {
-      zipFile = new ZipFile(filePath);
-    } catch (ZipException e) {
-      LOGGER.debug("Unable to create zip file with path : {}", filePath, e);
-      throw new CatalogTransformerException(
-          String.format("Unable to create zip file at %s", filePath), e);
-    }
+  private void createZip(SourceResponse upstreamResponse, String filePath)
+      throws CatalogTransformerException {
+    try (FileOutputStream fileOutputStream = new FileOutputStream(filePath);
+        ZipOutputStream zipOutputStream = new ZipOutputStream(fileOutputStream)) {
 
-    List<Result> resultList = upstreamResponse.getResults();
+      List<Result> resultList = upstreamResponse.getResults();
+      Map<String, Resource> resourceMap = new HashMap<>();
 
-    Map<String, Resource> resourceMap = new HashMap<>();
-
-    resultList
-        .stream()
-        .map(Result::getMetacard)
-        .forEach(
-            metacard -> {
-              ZipParameters zipParameters = new ZipParameters();
-              zipParameters.setSourceExternalStream(true);
-              zipParameters.setFileNameInZip(METACARD_PATH + metacard.getId());
-
-              try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                  ObjectOutputStream objectOutputStream =
-                      new ObjectOutputStream(byteArrayOutputStream)) {
-
-                objectOutputStream.writeObject(new MetacardImpl(metacard));
-                InputStream inputStream =
-                    new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
-                zipFile.addStream(inputStream, zipParameters);
+      // write the metacards to the zip
+      resultList
+          .stream()
+          .map(Result::getMetacard)
+          .forEach(
+              metacard -> {
+                writeMetacardToZip(zipOutputStream, metacard);
 
                 if (hasLocalResources(metacard)) {
                   resourceMap.putAll(getAllMetacardContent(metacard));
                 }
+              });
 
-              } catch (IOException | ZipException e) {
-                LOGGER.debug("Failed to add metacard with id {}.", metacard.getId(), e);
-              }
-            });
+      // write the resources to the zip
+      resourceMap.forEach(
+          (filename, resource) -> writeResourceToZip(zipOutputStream, filename, resource));
 
-    resourceMap.forEach(
-        (filename, resource) -> {
-          try {
-            ZipParameters zipParameters = new ZipParameters();
-            zipParameters.setSourceExternalStream(true);
-            zipParameters.setFileNameInZip(filename);
-            zipFile.addStream(resource.getInputStream(), zipParameters);
-          } catch (ZipException e) {
-            LOGGER.debug("Failed to add resource with id {} to zip.", resource.getName(), e);
-          }
-        });
-
-    BinaryContent binaryContent;
-    try {
-      InputStream fileInputStream = new ZipInputStream(new FileInputStream(zipFile.getFile()));
-      binaryContent = new BinaryContentImpl(fileInputStream);
-      jarSigner.signJar(
-          zipFile.getFile(),
-          System.getProperty(SystemBaseUrl.EXTERNAL_HOST),
-          System.getProperty("javax.net.ssl.keyStorePassword"),
-          System.getProperty("javax.net.ssl.keyStore"),
-          System.getProperty("javax.net.ssl.keyStorePassword"));
-    } catch (FileNotFoundException e) {
-      throw new CatalogTransformerException("Unable to get ZIP file from ZipInputStream.", e);
+    } catch (IOException e) {
+      throw new CatalogTransformerException(
+          String.format(
+              "Error occurred when initializing/closing ZipOutputStream with path %s.", filePath),
+          e);
     }
-    return binaryContent;
+  }
+
+  private void writeMetacardToZip(ZipOutputStream zipOutputStream, Metacard metacard) {
+
+    try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+
+      ZipEntry zipEntry = new ZipEntry(METACARD_PATH + metacard.getId());
+      zipOutputStream.putNextEntry(zipEntry);
+
+      objectOutputStream.writeObject(new MetacardImpl(metacard));
+      InputStream inputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+
+      writeDataToZip(zipOutputStream, inputStream);
+      inputStream.close();
+    } catch (IOException e) {
+      LOGGER.debug("Failed to add metacard with id {}.", metacard.getId(), e);
+    }
   }
 
   private boolean hasLocalResources(Metacard metacard) {
@@ -223,6 +217,50 @@ public class ZipCompression implements QueryResponseTransformer {
       LOGGER.debug("Unable to retrieve content from metacard : {}", metacard.getId(), e);
     }
     return resource;
+  }
+
+  private void writeResourceToZip(
+      ZipOutputStream zipOutputStream, String filename, Resource resource) {
+
+    try {
+      ZipEntry zipEntry = new ZipEntry(filename);
+      zipOutputStream.putNextEntry(zipEntry);
+
+      InputStream inputStream = resource.getInputStream();
+
+      writeDataToZip(zipOutputStream, inputStream);
+      inputStream.close();
+    } catch (IOException e) {
+      LOGGER.debug("Failed to add resource with id {} to zip.", resource.getName(), e);
+    }
+  }
+
+  private void writeDataToZip(ZipOutputStream zipOutputStream, InputStream inputStream)
+      throws IOException {
+    final byte[] bytes = new byte[1024];
+    int length;
+    while ((length = inputStream.read(bytes)) >= 0) {
+      zipOutputStream.write(bytes, 0, length);
+    }
+  }
+
+  private BinaryContent getBinaryContentFromZip(String filePath)
+      throws CatalogTransformerException {
+    BinaryContent binaryContent;
+    try {
+      File zipFile = new File(filePath);
+      InputStream fileInputStream = new ZipInputStream(new FileInputStream(zipFile));
+      binaryContent = new BinaryContentImpl(fileInputStream);
+      jarSigner.signJar(
+          zipFile,
+          System.getProperty(SystemBaseUrl.EXTERNAL_HOST),
+          System.getProperty("javax.net.ssl.keyStorePassword"),
+          System.getProperty("javax.net.ssl.keyStore"),
+          System.getProperty("javax.net.ssl.keyStorePassword"));
+    } catch (FileNotFoundException e) {
+      throw new CatalogTransformerException("Unable to get ZIP file from ZipInputStream.", e);
+    }
+    return binaryContent;
   }
 
   public void setCatalogFramework(CatalogFramework catalogFramework) {

--- a/distribution/docs/src/main/resources/content/_dependencyList/ddf-dependency-list.adoc
+++ b/distribution/docs/src/main/resources/content/_dependencyList/ddf-dependency-list.adoc
@@ -92,7 +92,6 @@
 * net.jodah:failsafe:jar:0.9.3
 * net.jodah:failsafe:jar:0.9.5
 * net.jodah:failsafe:jar:1.0.0
-* net.lingala.zip4j:zip4j:jar:1.3.2
 * net.markenwerk:commons-nulls:jar:1.0.3
 * net.markenwerk:utils-data-fetcher:jar:4.0.1
 * net.minidev:asm:jar:1.0.2


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Removes the zip4j dependency from a few files as it is contains the vulnerability CVE-2018-1002202. 

#### Who is reviewing it? 
@bakejeyner @brjeter 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@clockard 
@coyotesqrl 
#### How should this be tested?
> Start a DDF 
> profile:install standard
> ingest something into ddf
> catalog:export --delete=true --skip-signature-verification
> catalog:import --skip-signature-verification <created_file>
> query ddf see that everything has been added. Download any resource without errors

BugFix
> ingest a lot of data into DDF, 35000+
> run a catalog:export catalog:export --delete=false --skip-signature-verification
> insure no errors appear in the Karaf console.
> cd into the log directory `<ddf_home>/data/log/`
> run `grep "localhost Ids of exported metacards and content" security.log | cut -f2 -d _ | wc -w` 
> that number should be the same as how many records were ingested

Note* you can give jarsigner permissions to execute to run `catalog:export` without `--skip-signature-verification`

<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
The ticket asks to write unit test but catalog:export is already being well tested 

#### What are the relevant tickets?
[DDF-4112](https://codice.atlassian.net/browse/DDF-4112)
#### Screenshots
<!--(if appropriate)-->
<img width="810" alt="screen shot 2018-09-06 at 3 33 25 pm" src="https://user-images.githubusercontent.com/15082890/45188697-5c12ce00-b1ea-11e8-80ed-6a4842dc8377.png">
<img width="778" alt="screen shot 2018-09-06 at 3 39 06 pm" src="https://user-images.githubusercontent.com/15082890/45188893-30441800-b1eb-11e8-97fd-224c3f5825d8.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
