### PR TITLE
DDF-4124 CQL transform handler does not map string values when retrieving serializable values from post body	

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/handlers/CqlTransformHandler.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -95,6 +96,11 @@ public class CqlTransformHandler implements Route {
         return this.args
             .entrySet()
             .stream()
+            .map(
+                entry ->
+                    entry.getValue() instanceof CharSequence
+                        ? new AbstractMap.SimpleEntry<>(entry.getKey(), entry.getValue().toString())
+                        : entry)
             .filter(entry -> entry.getValue() instanceof Serializable)
             .collect(Collectors.toMap(Map.Entry::getKey, e -> (Serializable) e.getValue()));
       }


### PR DESCRIPTION
#### What does this PR do?
Fixed a bug found in the cql transform handler which is used to create a result set and map the request's arguments to transformer arguments. Previously string arguments were not mapped over properly because they come through as a `CharSequence` which does not implement `Serializable`. 

#### Who is reviewing it? 
@Corey-Collins 
@brianfelix 
@GabrielFabian 
@cantstoptheunk 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@coyotesqrl 

#### How should this be tested?
Testing this is a bit tricky since the only transformer that accepts string arguments is the zip compressor and that transformer hasn't been working properly. I can update the testing instructions if there are better ideas for how to test this code.

1. Set a breakpoint in the `CqlTransformHandler` after `Map<String, Serializable> arguments` is instantiated in the `transform` method. 
2. Hit the result set transform endpoint with a request like...
    ```
    POST /search/catalog/internal/cql/transform/html HTTP/1.1
    Host: localhost:8993
    Content-Type: application/json
    X-Requested-With: XMLHttpRequest
    Origin: https://localhost:8993
    {
        "cql":"anyText ILIKE '*'",
        "arguments": {
                "hello": "world"
        }
    }
    ```
3. Verify that the arguments map contains the string you passed into it. 

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-4124](https://codice.atlassian.net/browse/DDF-4124)

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
