### PR TITLE
[2.13.x] DDF-4130 Fixed searching an OpenSearchSource by a keyword that contains a space

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchParserImpl.java
@@ -23,8 +23,6 @@ import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
@@ -117,13 +115,8 @@ public class OpenSearchParserImpl implements OpenSearchParser {
     if (searchPhraseMap != null) {
       String queryStr = searchPhraseMap.get(OpenSearchConstants.SEARCH_TERMS);
       if (queryStr != null) {
-        try {
-          queryStr = URLEncoder.encode(queryStr, "UTF-8");
-        } catch (UnsupportedEncodingException uee) {
-          LOGGER.debug("Could not encode contextual string", uee);
-        }
+        checkAndReplace(client, queryStr, OpenSearchConstants.SEARCH_TERMS, parameters);
       }
-      checkAndReplace(client, queryStr, OpenSearchConstants.SEARCH_TERMS, parameters);
     }
   }
 

--- a/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/OpenSearchParserImplSpec.groovy
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/OpenSearchParserImplSpec.groovy
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.opensearch.source
+
+import org.apache.cxf.jaxrs.client.WebClient
+import spock.lang.Specification
+
+class OpenSearchParserImplSpec extends Specification {
+
+    private OpenSearchParser openSearchParser = new OpenSearchParserImpl()
+
+    private WebClient webClient = Mock(WebClient)
+
+    // {@link OpenSearchParser#populateContextual(WebClient, Map, List)} tests
+
+    def 'test populate contextual'() {
+        when:
+        openSearchParser.populateContextual(
+                webClient,
+                [q: searchPhrase],
+                ['q', 'src', 'mr', 'start', 'count', 'mt', 'dn', 'lat', 'lon', 'radius', 'bbox', 'polygon', 'dtstart', 'dtend', 'dateName', 'filter', 'sort']
+        )
+
+        then:
+        1 * webClient.replaceQueryParam('q', searchPhrase)
+
+        where:
+        searchPhrase << ['TestQuery123', 'Test Query 123']
+    }
+
+    def 'test contextual not populated'() {
+        when:
+        openSearchParser.populateContextual(
+                webClient,
+                searchPhraseMap,
+                ['q', 'src', 'mr', 'start', 'count', 'mt', 'dn', 'lat', 'lon', 'radius', 'bbox', 'polygon', 'dtstart', 'dtend', 'dateName', 'filter', 'sort']
+        )
+
+        then:
+        0 * webClient._
+
+        where:
+        searchPhraseMap << [[unrecognizedParameter: 'TestQuery123'], [:], null]
+    }
+}

--- a/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/OpenSearchSourceSpec.groovy
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/groovy/org/codice/ddf/opensearch/source/OpenSearchSourceSpec.groovy
@@ -151,6 +151,7 @@ class OpenSearchSourceSpec extends Specification {
         where:
         filter << [
                 PROPERTY_IS_LIKE_FILTER,
+                (PropertyIsLike) filterBuilder.attribute("this attribute name is ignored").is().like().text("some search phrase"), // the search phrase contains spaces
                 DURING_FILTER,
                 INTERSECTS_FILTER, // polygon filter
                 D_WITHIN_FILTER, // point-radius filter
@@ -170,6 +171,7 @@ class OpenSearchSourceSpec extends Specification {
         ]
         expectedQueryParameters << [
                 [start: ["1"], count: ["20"], mt: ["0"], q: ["someSearchPhrase"], src: [""]],
+                [start: ["1"], count: ["20"], mt: ["0"], q: ["some search phrase"], src: [""]],
                 [start: ["1"], count: ["20"], mt: ["0"], dtstart: ["1970-01-01T00:00:10.000Z"], dtend: ["1970-01-01T00:00:10.005Z"], src: [""]],
                 [start: ["1"], count: ["20"], mt: ["0"], geometry:["POLYGON ((10.2 10.2, 10.2 20.2, 20.2 20.2, 20.2 10.2, 10.2 10.2))"] , src: [""]],
                 [start: ["1"], count: ["20"], mt: ["0"], lat: ["2.0"], lon: ["1.0"], radius: ["5.0"], src: [""]],

--- a/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchParserImplTest.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/test/java/org/codice/ddf/opensearch/source/OpenSearchParserImplTest.java
@@ -41,8 +41,6 @@ import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.codice.ddf.opensearch.OpenSearchConstants;
@@ -75,64 +73,6 @@ public class OpenSearchParserImplTest {
   public void setUp() {
     openSearchParser = new OpenSearchParserImpl();
     webClient = mock(WebClient.class);
-  }
-
-  // {@link OpenSearchParser#populateContextual(WebClient, Map, List)} tests
-
-  @Test
-  public void populateContextual() {
-    Map<String, String> searchPhraseMap = new HashMap<>();
-    searchPhraseMap.put("q", "TestQuery123");
-
-    openSearchParser.populateContextual(
-        webClient,
-        searchPhraseMap,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-
-    assertQueryParameterPopulated(OpenSearchConstants.SEARCH_TERMS, searchPhraseMap.get("q"));
-  }
-
-  @Test
-  public void populateContextualUnrecognizedParameter() {
-    Map<String, String> searchPhraseMap = new HashMap<>();
-    searchPhraseMap.put("z", "TestQuery123");
-
-    openSearchParser.populateContextual(
-        webClient,
-        searchPhraseMap,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-
-    assertNoQueryParametersPopulated();
-  }
-
-  @Test
-  public void populateEmptyContextual() {
-    Map<String, String> searchPhraseMap = new HashMap<>();
-
-    openSearchParser.populateContextual(
-        webClient,
-        searchPhraseMap,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-
-    assertNoQueryParametersPopulated();
-  }
-
-  @Test
-  public void populateNullContextual() {
-    openSearchParser.populateContextual(
-        webClient,
-        null,
-        Arrays.asList(
-            "q,src,mr,start,count,mt,dn,lat,lon,radius,bbox,polygon,dtstart,dtend,dateName,filter,sort"
-                .split(",")));
-
-    assertNoQueryParametersPopulated();
   }
 
   // {@link OpenSearchParser#populateTemporal(WebClient, TemporalFilter, List)} tests


### PR DESCRIPTION
#### What does this PR do?
This PR fixes querying an OpenSearchSource by a keyword that contains a space.
#### Who is reviewing it? 
@peterhuffer @kcover @lamhuy 
#### Select relevant component teams: 
@codice/io 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@clockard
#### How should this be tested?

1. Ingest a product that contains a phrase with spaces. (I modified [this test file](https://github.com/codice/ddf/blob/dfbce3ca3636bb80c98e5c2271e917686e5dd8d9/distribution/test/itests/test-itests-common/src/main/resources/metacard1.xml#L22) to have a title of `Metacard 1`.)
2. Create a loopback OpenSearch source.
3. Confirm that the product is returned when you search for it by the phrase. 

#### Any background context you want to provide?
The search phrase was being encoded twice: first with the URLEncoder (the part that is removed in the PR) and second in the `WebClient` after `replaceQueryParam`.
#### What are the relevant tickets?
[DDF-4130](https://codice.atlassian.net/browse/DDF-4130)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.