### PR TITLE
DDF-4113 Swaps in time-limited RegEx matcher to SearchTerm

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -61,6 +61,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>tlmatcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
@@ -391,6 +396,7 @@
                             platform-email-impl,
                             platform-util,
                             platform-util-unavailableurls,
+                            tlmatcher,
                             proxy-camel-route,
                             proxy-camel-servlet,
                             quartz,
@@ -448,17 +454,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.34</minimum>
+                                            <minimum>0.36</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.29</minimum>
+                                            <minimum>0.31</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.30</minimum>
+                                            <minimum>0.32</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/delegate/SearchTerm.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/delegate/SearchTerm.java
@@ -14,8 +14,12 @@
 package org.codice.ddf.catalog.ui.query.delegate;
 
 import java.util.regex.Pattern;
+import org.codice.util.tlmatcher.TimeLimitedMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SearchTerm {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SearchTerm.class);
 
   private final String term;
 
@@ -47,7 +51,12 @@ public class SearchTerm {
       return true;
     }
     if (pattern != null) {
-      return pattern.matcher(other).matches();
+      try {
+        return TimeLimitedMatcher.create(pattern, other).matches();
+      } catch (TimeLimitedMatcher.TimeoutException e) {
+        LOGGER.warn("Timeout performing RegEx match for {} against string {}", term, other);
+        return false;
+      }
     } else {
       return term.equals(other);
     }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/delegate/SearchTermTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/delegate/SearchTermTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.delegate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Test;
+
+public class SearchTermTest {
+  @Test
+  public void exactMatch() {
+    String inputTerm = "abc";
+    SearchTerm searchTerm = new SearchTerm(inputTerm);
+    assertThat(searchTerm.getTerm(), is(equalTo(inputTerm)));
+    assertThat(searchTerm.getCqlTerm(), is(equalTo(inputTerm)));
+    assertThat(searchTerm.match("abc"), is(true));
+    assertThat(searchTerm.match("XabcX"), is(false));
+  }
+
+  @Test
+  public void lowCaseMatch() {
+    String inputTerm = "ABC";
+    SearchTerm searchTerm = new SearchTerm(inputTerm);
+    assertThat(searchTerm.getTerm(), is(equalTo(inputTerm.toLowerCase())));
+    assertThat(searchTerm.getCqlTerm(), is(equalTo(inputTerm)));
+    assertThat(searchTerm.match("abc"), is(true));
+    assertThat(searchTerm.match("XabcX"), is(false));
+  }
+
+  @Test
+  public void wildcardSwitch() {
+    String inputTerm = "a*B";
+    SearchTerm searchTerm = new SearchTerm(inputTerm);
+    assertThat(searchTerm.getTerm(), is(equalTo(inputTerm.toLowerCase())));
+    assertThat(searchTerm.getCqlTerm(), is(equalTo("a%B")));
+    assertThat(searchTerm.match("aXXXXb"), is(true));
+    assertThat(searchTerm.match("xaXXXB"), is(false));
+  }
+
+  /**
+   * While there is no absolute guarantee that this test will fail on any given machine, during
+   * development and testing, the search against this input value of 1000 'a' with a terminal '!'
+   * ran for well over a minute before being manually stopped. If performance improves to the point
+   * where this test fails, we can bump up the search string by another order of magnitude.
+   *
+   * <p>This test will also fail if a future version of Java were to introduce an improved,
+   * linear-time regex implementation (at which time we could yank this time-limited band-aid);
+   * however, that's not on the table for J11 so we should expect this to be a necessary workaround
+   * for the foreseeable future.
+   */
+  @Test
+  public void questionableMatch() {
+    String inputTerm = "*(a+)+";
+    SearchTerm searchTerm = new SearchTerm(inputTerm);
+    assertThat(searchTerm.match(StringUtils.repeat("a", 1000) + "!"), is(false));
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Replaces standard Java regex search with time-limited regex for the `SearchTerm` class.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@brjeter @blen-desta

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@clockard
@tbatie

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
The only extant public path to the `SearchTerm` regex functionality comes through `CqlResult` which tokenizes and sanitizes the search. There is currently no production path through that could trigger a questionable regex.

The added unit tests will demonstrate and affirm the issue, so a successful CI build is sufficient at this time.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4113](https://codice.atlassian.net/browse/DDF-4113)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
