### PR TITLE
DDF-4138 ValidationFilterPlugin to execute only for local provider

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreFederatedLocalProviderQueryPlugin.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreFederatedLocalProviderQueryPlugin.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package ddf.catalog.plugin;
 
 import ddf.catalog.operation.QueryRequest;
@@ -6,6 +19,14 @@ import ddf.catalog.source.Source;
 import ddf.catalog.source.SourceCache;
 import java.util.List;
 
+/**
+ * A {@link PreFederatedLocalProviderQueryPlugin} is an abstract class implementing the {@link
+ * PreFederatedQueryPlugin}. {@link PreFederatedQueryPlugin} that only apply for local source should
+ * extend {@link PreFederatedLocalProviderQueryPlugin} This abstract class provide isLocalSource
+ * method to check if a given source is a local source.
+ *
+ * @author lamhuy
+ */
 public abstract class PreFederatedLocalProviderQueryPlugin implements PreFederatedQueryPlugin {
 
   protected final List<CatalogProvider> catalogProviders;
@@ -14,11 +35,11 @@ public abstract class PreFederatedLocalProviderQueryPlugin implements PreFederat
     this.catalogProviders = catalogProviders;
   }
 
-  protected boolean isCacheSource(Source source) {
+  private boolean isCacheSource(Source source) {
     return source instanceof SourceCache;
   }
 
-  protected boolean isCatalogProvider(Source source) {
+  private boolean isCatalogProvider(Source source) {
     return source instanceof CatalogProvider
         && catalogProviders.stream().map(CatalogProvider::getId).anyMatch(source.getId()::equals);
   }

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreFederatedLocalProviderQueryPlugin.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreFederatedLocalProviderQueryPlugin.java
@@ -1,0 +1,5 @@
+package ddf.catalog.plugin;
+
+public class PreFederatedLocalProviderQueryPlugin {
+
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreFederatedLocalProviderQueryPlugin.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreFederatedLocalProviderQueryPlugin.java
@@ -1,5 +1,33 @@
 package ddf.catalog.plugin;
 
-public class PreFederatedLocalProviderQueryPlugin {
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.source.CatalogProvider;
+import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceCache;
+import java.util.List;
 
+public abstract class PreFederatedLocalProviderQueryPlugin implements PreFederatedQueryPlugin {
+
+  protected final List<CatalogProvider> catalogProviders;
+
+  public PreFederatedLocalProviderQueryPlugin(List<CatalogProvider> catalogProviders) {
+    this.catalogProviders = catalogProviders;
+  }
+
+  protected boolean isCacheSource(Source source) {
+    return source instanceof SourceCache;
+  }
+
+  protected boolean isCatalogProvider(Source source) {
+    return source instanceof CatalogProvider
+        && catalogProviders.stream().map(CatalogProvider::getId).anyMatch(source.getId()::equals);
+  }
+
+  /** Given a source, determine if it is a registered catalog provider or a cache. */
+  protected boolean isLocalSource(Source source) {
+    return isCacheSource(source) || isCatalogProvider(source);
+  }
+
+  public abstract QueryRequest process(Source source, QueryRequest input)
+      throws StopProcessingException;
 }

--- a/catalog/core/catalog-core-tagsfilterplugin/src/main/java/org/codice/ddf/catalog/plugin/tagsfilter/TagsFilterQueryPlugin.java
+++ b/catalog/core/catalog-core-tagsfilterplugin/src/main/java/org/codice/ddf/catalog/plugin/tagsfilter/TagsFilterQueryPlugin.java
@@ -21,12 +21,9 @@ import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.plugin.PluginExecutionException;
-import ddf.catalog.plugin.PreFederatedQueryPlugin;
-import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.plugin.PreFederatedLocalProviderQueryPlugin;
 import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.Source;
-import ddf.catalog.source.SourceCache;
 import ddf.catalog.source.UnsupportedQueryException;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,10 +36,8 @@ import org.slf4j.LoggerFactory;
  * filter will also be added to include metacards without any tags attribute to support backwards
  * compatibility.
  */
-public class TagsFilterQueryPlugin implements PreFederatedQueryPlugin {
+public class TagsFilterQueryPlugin extends PreFederatedLocalProviderQueryPlugin {
   private static final Logger LOGGER = LoggerFactory.getLogger(TagsFilterQueryPlugin.class);
-
-  private final List<CatalogProvider> catalogProviders;
 
   private final FilterAdapter filterAdapter;
 
@@ -52,28 +47,13 @@ public class TagsFilterQueryPlugin implements PreFederatedQueryPlugin {
       List<CatalogProvider> catalogProviders,
       FilterAdapter filterAdapter,
       FilterBuilder filterBuilder) {
-    this.catalogProviders = catalogProviders;
+    super(catalogProviders);
     this.filterAdapter = filterAdapter;
     this.filterBuilder = filterBuilder;
   }
 
-  private boolean isCacheSource(Source source) {
-    return source instanceof SourceCache;
-  }
-
-  private boolean isCatalogProvider(Source source) {
-    return source instanceof CatalogProvider
-        && catalogProviders.stream().map(CatalogProvider::getId).anyMatch(source.getId()::equals);
-  }
-
-  /** Given a source, determine if it is a registered catalog provider or a cache. */
-  private boolean isLocalSource(Source source) {
-    return isCacheSource(source) || isCatalogProvider(source);
-  }
-
   @Override
-  public QueryRequest process(Source source, QueryRequest input)
-      throws PluginExecutionException, StopProcessingException {
+  public QueryRequest process(Source source, QueryRequest input) {
     if (!isLocalSource(source)) {
       return input;
     }

--- a/catalog/core/catalog-core-validationfilterplugin/src/main/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPlugin.java
+++ b/catalog/core/catalog-core-validationfilterplugin/src/main/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPlugin.java
@@ -23,11 +23,10 @@ import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.Request;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.plugin.PreFederatedQueryPlugin;
+import ddf.catalog.plugin.PreFederatedLocalProviderQueryPlugin;
 import ddf.catalog.plugin.StopProcessingException;
 import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.Source;
-import ddf.catalog.source.SourceCache;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
 import ddf.security.permission.CollectionPermission;
@@ -46,16 +45,12 @@ import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ValidationFilterPlugin implements PreFederatedQueryPlugin {
+public class ValidationFilterPlugin extends PreFederatedLocalProviderQueryPlugin {
   private static final Logger LOGGER = LoggerFactory.getLogger(ValidationFilterPlugin.class);
 
   private static final String ENTERING = "ENTERING {}";
 
   private static final String EXITING = "EXITING {}";
-
-  private FilterBuilder filterBuilder;
-
-  private final List<CatalogProvider> catalogProviders;
 
   private Map<String, List<String>> attributeMap = new HashMap<>();
 
@@ -63,25 +58,13 @@ public class ValidationFilterPlugin implements PreFederatedQueryPlugin {
 
   private boolean showWarnings = true;
 
+  private final FilterBuilder filterBuilder;
+
   public ValidationFilterPlugin(
       FilterBuilder filterBuilder, List<CatalogProvider> catalogProviders) {
-    LOGGER.trace("INSIDE: ValidationFilterPlugin constructor");
+    super(catalogProviders);
     this.filterBuilder = filterBuilder;
-    this.catalogProviders = catalogProviders;
-  }
-
-  private boolean isCacheSource(Source source) {
-    return source instanceof SourceCache;
-  }
-
-  private boolean isCatalogProvider(Source source) {
-    return source instanceof CatalogProvider
-        && catalogProviders.stream().map(CatalogProvider::getId).anyMatch(source.getId()::equals);
-  }
-
-  /** Given a source, determine if it is a registered catalog provider or a cache. */
-  private boolean isLocalSource(Source source) {
-    return isCacheSource(source) || isCatalogProvider(source);
+    LOGGER.trace("INSIDE: ValidationFilterPlugin constructor");
   }
 
   public Map<String, List<String>> getAttributeMap() {

--- a/catalog/core/catalog-core-validationfilterplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-validationfilterplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,6 +14,15 @@
 -->
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
   xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="catalogProviderSortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
+
+    <reference-list id="catalogProviders" interface="ddf.catalog.source.CatalogProvider"
+      availability="optional">
+        <reference-listener
+          ref="catalogProviderSortedList"
+          bind-method="bindPlugin"
+          unbind-method="unbindPlugin"/>
+    </reference-list>
 
     <reference id="filterBuilder"
                interface="ddf.catalog.filter.FilterBuilder"/>
@@ -21,6 +30,7 @@
     <bean id="validationPlugin"
       class="org.codice.ddf.catalog.plugin.validationfilter.ValidationFilterPlugin">
         <argument ref="filterBuilder"/>
+        <argument ref="catalogProviderSortedList"/>
         <cm:managed-properties
           persistent-id="org.codice.ddf.catalog.plugin.validationfilter.ValidationFilterPlugin"
           update-strategy="container-managed"/>

--- a/catalog/core/catalog-core-validationfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPluginTest.java
+++ b/catalog/core/catalog-core-validationfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPluginTest.java
@@ -14,7 +14,6 @@
 package org.codice.ddf.catalog.plugin.validationfilter;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -141,7 +140,7 @@ public class ValidationFilterPluginTest {
     QueryRequest queryRequest = new QueryRequestImpl(query, false, null, properties);
     QueryRequest returnQuery = plugin.process(federatedSource, queryRequest);
 
-    assertEquals(returnQuery, queryRequest);
+    assertThat(returnQuery.equals(queryRequest), is(true));
   }
 
   @Test
@@ -155,7 +154,7 @@ public class ValidationFilterPluginTest {
     QueryRequest queryRequest = new QueryRequestImpl(query, false, null, properties);
     QueryRequest returnQuery = plugin.process(catalogProvider, queryRequest);
 
-    assertEquals(returnQuery, queryRequest);
+    assertThat(returnQuery.equals(queryRequest), is(true));
   }
 
   @Test

--- a/catalog/core/catalog-core-validationfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPluginTest.java
+++ b/catalog/core/catalog-core-validationfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPluginTest.java
@@ -32,6 +32,7 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.plugin.StopProcessingException;
 import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceCache;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
@@ -66,7 +67,7 @@ public class ValidationFilterPluginTest {
   @Before
   public void setup() {
 
-    source = mock(CatalogProvider.class);
+    source = mock(SourceCache.class);
     when(source.getId()).thenReturn("source1");
 
     CatalogProvider catProvider1 = mock(CatalogProvider.class);

--- a/catalog/core/catalog-core-validationfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPluginTest.java
+++ b/catalog/core/catalog-core-validationfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPluginTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.types.Validation;
 import ddf.catalog.filter.FilterAdapter;
@@ -66,7 +67,17 @@ public class ValidationFilterPluginTest {
   public void setup() {
 
     source = mock(CatalogProvider.class);
-    when(source.getId()).thenReturn("cat1");
+    when(source.getId()).thenReturn("source1");
+
+    CatalogProvider catProvider1 = mock(CatalogProvider.class);
+    CatalogProvider catProvider2 = mock(CatalogProvider.class);
+    CatalogProvider catProvider3 = mock(CatalogProvider.class);
+    when(catProvider1.getId()).thenReturn("cat1");
+    when(catProvider2.getId()).thenReturn("cat2");
+    when(catProvider3.getId()).thenReturn("cat3");
+
+    ImmutableList<CatalogProvider> catalogProviders =
+        ImmutableList.of(catProvider1, catProvider2, catProvider3);
 
     subject = mock(Subject.class);
     properties.put(SecurityConstants.SECURITY_SUBJECT, subject);
@@ -78,7 +89,7 @@ public class ValidationFilterPluginTest {
         new ValidationQueryDelegate(Validation.VALIDATION_WARNINGS);
     testValidationErrorQueryDelegate = new ValidationQueryDelegate(Validation.VALIDATION_ERRORS);
 
-    plugin = new ValidationFilterPlugin(filterBuilder);
+    plugin = new ValidationFilterPlugin(filterBuilder, catalogProviders);
 
     List<String> attributeMapping = new ArrayList<>();
     attributeMapping.add("invalid-state=data-manager,system-admin");


### PR DESCRIPTION
#### What does this PR do?
ValidationFilterPlugin to execute only for local provider. 

as a PreFederateQueryPlugin, this plugin get execute for all 'sources'
but we only want this logic to be applied for 'catalogProvider' only i.e. solr provider and not during federated sources

#### Who is reviewing it? 
@Bdthomson 
@coyotesqrl 
@bdeining
@clockard
@millerw8

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.

@pklinef 
@bdeining
@clockard
@millerw8

#### How should this be tested?
Create a loop back CSW federation
Login UI as admin
Turn log:set DEBUG org.apache.cxf
Perform a wild card federated search for the loop back source
Verify the outbound message in the log does not contain any VALIDATION constraint filter
Verify no error in the log

#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-4138
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
