### PR TITLE
DDF-4135 Don't overwite internal ports with external ports

### DIFF
--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
@@ -142,27 +142,6 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
     try {
       Properties systemDotProperties = new Properties(systemPropertiesFile);
 
-      // Duplicate properties into the internal properties for legacy functionality
-      if (updatedSystemProperties.containsKey(SystemBaseUrl.EXTERNAL_HOST)) {
-        updatedSystemProperties.put(
-            SystemBaseUrl.INTERNAL_HOST, updatedSystemProperties.get(SystemBaseUrl.EXTERNAL_HOST));
-      }
-      if (updatedSystemProperties.containsKey(SystemBaseUrl.EXTERNAL_PROTOCOL)) {
-        updatedSystemProperties.put(
-            SystemBaseUrl.INTERNAL_PROTOCOL,
-            updatedSystemProperties.get(SystemBaseUrl.EXTERNAL_PROTOCOL));
-      }
-      if (updatedSystemProperties.containsKey(SystemBaseUrl.EXTERNAL_HTTP_PORT)) {
-        updatedSystemProperties.put(
-            SystemBaseUrl.INTERNAL_HTTP_PORT,
-            updatedSystemProperties.get(SystemBaseUrl.EXTERNAL_HTTP_PORT));
-      }
-      if (updatedSystemProperties.containsKey(SystemBaseUrl.EXTERNAL_HTTPS_PORT)) {
-        updatedSystemProperties.put(
-            SystemBaseUrl.INTERNAL_HTTPS_PORT,
-            updatedSystemProperties.get(SystemBaseUrl.EXTERNAL_HTTPS_PORT));
-      }
-
       updateProperty(SystemBaseUrl.EXTERNAL_HOST, updatedSystemProperties, systemDotProperties);
       updateProperty(SystemBaseUrl.EXTERNAL_PROTOCOL, updatedSystemProperties, systemDotProperties);
       updateProperty(

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
@@ -158,7 +158,7 @@ public class SystemPropertiesAdminTest {
     Properties sysProps = new Properties();
     try (FileReader sysPropsReader = new FileReader(systemPropsFile)) {
       sysProps.load(sysPropsReader);
-      assertThat(sysProps.size(), is(3));
+      assertThat(sysProps.size(), is(2));
       assertThat(sysProps.getProperty(SystemBaseUrl.EXTERNAL_HOST), equalTo("newhost"));
     }
 


### PR DESCRIPTION
#### What does this PR do?

This commit changes the SystemPropertiesAdmin to no longer overwrite the
system ports whenever the external ports are changed. Now if the user
changes their external ports before install, the installer won't
overwrite the system ports. Changing the ports in the installer will
also only change the external ports, as it says it will.

#### Who is reviewing it? 

@peterhuffer @emmberk 

#### Ask 2 committers to review/merge the PR and tag them here.

@clockard 
@vinamartin

#### How should this be tested?

Unzip ddf and in the system.properties file find the external host, protocol, http port, and https port and change them. Go through the installer and when you get to the page that displays the ports/hostname make sure they have values you gave them. After installing, go back into the system.properties file and make sure the system host, protocol, and ports haven't been overwritten with the values you gave the external ones.

#### What are the relevant tickets?

[DDF-4135](https://codice.atlassian.net/browse/DDF-4135)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
