### PR TITLE
[2.13.x] DDF-4145 Fix mismatch in Solr property name

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -61,7 +61,7 @@ set_security_properties() {
 }
 
 start_solr() {
-    export SOLR_JAVA_MEM=-Xmx$($GET solr.max.heap.size)
+    export SOLR_JAVA_MEM=-Xmx$($GET solr.mem)
     if [ "$SOLR_UNSECURE" != "true" ]; then
         set_security_properties
     fi


### PR DESCRIPTION
#### What does this PR do?
Fixes a mismatch between what the ddfsolr script expects and what is in the system.properties file.
This is not a problem on master.

#### Who is reviewing it? 
@mcalcote @ricklarsen @austinsteffes @garrettfreibott 

If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@clockard
@vinamartin

#### How should this be tested?
- I have tested it. To test it yourself, build DDF and unzip the distro. 
- Change Solr to http instead of https:
  - Edit system.properties. Set **solr.http.protocol=http**
- Start Solr 
  - **bin/ddfsolr start**
- Open the Solr admin view at http://localhost:8994
  - Verify the Solr heap is allocated 2 gigabytes

#### Any background context you want to provide?
No. None.

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
