### PR TITLE
[2.13.x] DDF-4057 Remote resources copied to local always evicted which prevents users from pre-caching resources 

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CachedResourceMetacardComparator.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CachedResourceMetacardComparator.java
@@ -103,7 +103,7 @@ class CachedResourceMetacardComparator {
     if (LOGGER.isDebugEnabled() && difference.isPresent()) {
       String attributeName = difference.get();
       LOGGER.debug(
-          "Metacard updated. Attribute changed: (), Cached value: {}. Updated value: {}",
+          "Metacard updated. Attribute changed: {}, Cached value: {}. Updated value: {}",
           attributeName,
           cachedMetacard.getAttribute(attributeName),
           updatedMetacard.getAttribute(attributeName));

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CachedResourceMetacardComparator.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/impl/CachedResourceMetacardComparator.java
@@ -15,6 +15,7 @@ package ddf.catalog.cache.impl;
 
 import com.google.common.collect.ImmutableList;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Core;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -46,16 +47,20 @@ class CachedResourceMetacardComparator {
       LoggerFactory.getLogger(CachedResourceMetacardComparator.class);
 
   private static final List<Function<Metacard, ?>> METACARD_METHODS =
-      ImmutableList.of(Metacard::getModifiedDate, Metacard::getCreatedDate);
+      ImmutableList.of(
+          Metacard::getModifiedDate,
+          Metacard::getCreatedDate,
+          (m) -> m.getAttribute(Core.METACARD_MODIFIED),
+          (m) -> m.getAttribute(Core.METACARD_CREATED));
 
   private CachedResourceMetacardComparator() {}
 
   /**
    * Indicates whether the resource associated with the provided metacard has changed by comparing
    * the state of the metacard when it was cached with the state of the metacard when it was last
-   * retrieved. Since there is no single attribute that clearly indicates whether the resource has
-   * changed or not, this class compares as many attributes as possible and if it find a difference,
-   * it will return {@code false}.
+   * retrieved. The main attributes to be compared to indicate whether a resource has changed or not
+   * are checksum, modified date, and created date. If this finds a difference in these values it
+   * will return {@code false}.
    *
    * @param cachedMetacard version of the metacard when the product was added to the cache
    * @param updatedMetacard current version of the metacard
@@ -77,9 +82,10 @@ class CachedResourceMetacardComparator {
       return false;
     }
 
+    /*The checksum algorithm that can be picked has potential to be poor - we still check modified and created
+    dates if checksums are equal*/
     if (!Objects.equals(
-        cachedMetacard.getAttribute(Metacard.CHECKSUM),
-        updatedMetacard.getAttribute(Metacard.CHECKSUM))) {
+        cachedMetacard.getAttribute(Core.CHECKSUM), updatedMetacard.getAttribute(Core.CHECKSUM))) {
       return false;
     }
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/CachedResourceMetacardComparatorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/CachedResourceMetacardComparatorTest.java
@@ -65,14 +65,6 @@ public class CachedResourceMetacardComparatorTest {
     assertThat(isSame(cachedMetacard, updatedMetacard), is(true));
   }
 
-  @Test
-  public void isSameWhenBothMetacardTypesNull() {
-    cachedMetacard.setType(null);
-    updatedMetacard.setType(null);
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(true));
-  }
-
   /**
    * See the {@link CachedResourceMetacardComparator} class for more information on why {@link
    * CachedResourceMetacardComparator#isSame(Metacard, Metacard)} will return {@code true} even when
@@ -162,6 +154,48 @@ public class CachedResourceMetacardComparatorTest {
     updatedMetacard.setAttribute(Metacard.CHECKSUM, "2");
 
     assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
+  }
+
+  /**
+   * See the {@link CachedResourceMetacardComparator} class for more information on why {@link
+   * CachedResourceMetacardComparator#isSame(Metacard, Metacard)} will return {@code true} even when
+   * these attributes are different
+   */
+  @Test
+  public void isSameWhenCoreAttributesNotModCreatedChecksumChanged() {
+    cachedMetacard.setAttribute(Core.DERIVED_RESOURCE_DOWNLOAD_URL, "testDerivedURLCached");
+    cachedMetacard.setAttribute(Core.DATATYPE, "testDatatypeCached");
+    cachedMetacard.setAttribute(Core.DERIVED_RESOURCE_URI, "testDerivedURICached");
+    cachedMetacard.setAttribute(Core.DESCRIPTION, "testDescriptionCached");
+    cachedMetacard.setAttribute(Core.EXPIRATION, "testExpirationCached");
+    cachedMetacard.setAttribute(Core.LANGUAGE, "testLanguageCached");
+    cachedMetacard.setAttribute(Core.LOCATION, "testLocationCached");
+    cachedMetacard.setAttribute(Core.METACARD_OWNER, "testMetaOwnerCached");
+    cachedMetacard.setAttribute(Core.METACARD_TAGS, "testMetaTagsCached");
+    cachedMetacard.setAttribute(Core.METADATA, "testMetaCached");
+    cachedMetacard.setAttribute(Core.RESOURCE_DOWNLOAD_URL, "testURLCached");
+    cachedMetacard.setAttribute(Core.RESOURCE_SIZE, "1");
+    cachedMetacard.setAttribute(Core.RESOURCE_URI, "testURICached");
+    cachedMetacard.setAttribute(Core.THUMBNAIL, "testThumbnailCached");
+    cachedMetacard.setAttribute(Core.TITLE, "testTitleCached");
+
+    updatedMetacard.setAttribute(Core.DERIVED_RESOURCE_DOWNLOAD_URL, "testDerivedURLUpdated");
+    updatedMetacard.setAttribute(Core.DATATYPE, "testDatatypeUpdated");
+    updatedMetacard.setAttribute(Core.DERIVED_RESOURCE_URI, "testDerivedURIUpdated");
+    updatedMetacard.setAttribute(Core.DESCRIPTION, "testDescriptionUpdated");
+    updatedMetacard.setAttribute(Core.EXPIRATION, "testExpirationUpdated");
+    updatedMetacard.setAttribute(Core.LANGUAGE, "testLanguageUpdated");
+    updatedMetacard.setAttribute(Core.LOCATION, "testLocationUpdated");
+    updatedMetacard.setAttribute(Core.METACARD_OWNER, "testMetaOwnerUpdated");
+    updatedMetacard.setAttribute(Core.METACARD_TAGS, "testMetaTagsUpdated");
+    updatedMetacard.setAttribute(Core.METADATA, "testMetaUpdated");
+    updatedMetacard.setAttribute(Core.RESOURCE_DOWNLOAD_URL, "testURLUpdated");
+    updatedMetacard.setAttribute(Core.RESOURCE_SIZE, "2");
+    updatedMetacard.setAttribute(Core.RESOURCE_URI, "testURIUpdated");
+    updatedMetacard.setAttribute(Core.THUMBNAIL, "testThumbnailUpdated");
+    updatedMetacard.setAttribute(Core.TITLE, "testTitleUpdated");
+
+    assertThat(isSame(cachedMetacard, updatedMetacard), is(true));
   }
 
   private MetacardImpl createMetacard(

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/CachedResourceMetacardComparatorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/impl/CachedResourceMetacardComparatorTest.java
@@ -17,22 +17,14 @@ import static ddf.catalog.cache.impl.CachedResourceMetacardComparator.isSame;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.EmptyMetacardType;
 import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.data.impl.MetacardTypeImpl;
-import java.net.URI;
-import java.net.URL;
+import ddf.catalog.data.types.Core;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,17 +37,27 @@ public class CachedResourceMetacardComparatorTest {
 
   @Before
   public void setup() throws Exception {
-    Instant createdDate = Instant.now();
-    Instant effectiveDate = createdDate.plus(1, ChronoUnit.HOURS);
-    Instant modificationDate = createdDate.plus(2, ChronoUnit.DAYS);
-    Instant expirationDate = createdDate.plus(60, ChronoUnit.DAYS);
+    Instant productCreatedDate = Instant.now();
+    Instant productModificationDate = productCreatedDate.plus(2, ChronoUnit.DAYS);
+    Instant metacardCreateDate = Instant.now();
+    Instant metacardModificationDate = metacardCreateDate.plus(2, ChronoUnit.DAYS);
 
     String metacardId = UUID.randomUUID().toString();
 
     cachedMetacard =
-        createMetacard(metacardId, createdDate, effectiveDate, expirationDate, modificationDate);
+        createMetacard(
+            metacardId,
+            productCreatedDate,
+            productModificationDate,
+            metacardCreateDate,
+            metacardModificationDate);
     updatedMetacard =
-        createMetacard(metacardId, createdDate, effectiveDate, expirationDate, modificationDate);
+        createMetacard(
+            metacardId,
+            productCreatedDate,
+            productModificationDate,
+            metacardCreateDate,
+            metacardModificationDate);
   }
 
   @Test
@@ -120,27 +122,6 @@ public class CachedResourceMetacardComparatorTest {
   }
 
   @Test
-  public void isNotSameWhenCachedMetacardHasNullAttribute() {
-    cachedMetacard.setDescription(null);
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameWhenUpdatedMetacardHasNullAttribute() {
-    updatedMetacard.setDescription(null);
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameWhenMetacardsHaveDifferentTypes() {
-    cachedMetacard.setType(new EmptyMetacardType());
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
   public void isSameWhenMetacardsHaveNullAttributeDescriptorLists() {
     cachedMetacard.setType(new EmptyMetacardType());
     updatedMetacard.setType(new EmptyMetacardType());
@@ -149,133 +130,56 @@ public class CachedResourceMetacardComparatorTest {
   }
 
   @Test
-  public void isNotSameWhenMetacardsHaveAttributeDescriptorListsOfDifferentSizes() {
-    cachedMetacard.setType(
-        new MetacardTypeImpl(MetacardType.DEFAULT_METACARD_TYPE_NAME, new HashSet<>()));
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameEffectiveDate() throws Exception {
-    updatedMetacard.setExpirationDate(Date.from(Instant.now().plusSeconds(2)));
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameExpirationDate() throws Exception {
-    updatedMetacard.setExpirationDate(Date.from(Instant.now().plusSeconds(2)));
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameCreatedDate() throws Exception {
+  public void isNotSameProductCreatedDate() {
     updatedMetacard.setCreatedDate(Date.from(Instant.now().plusSeconds(2)));
 
     assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
   }
 
   @Test
-  public void isNotSameContentType() throws Exception {
-    updatedMetacard.setContentTypeName("testContentType2");
-    cachedMetacard.setContentTypeName("phil");
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameResourceURI() throws Exception {
-    URI nsUri = new URI("http://" + CachedResourceMetacardComparatorTest.class.getName());
-    URI resourceUri = new URI(nsUri.toString() + "/resource2.html");
-    updatedMetacard.setResourceURI(resourceUri);
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameModifiedDate() throws Exception {
+  public void isNotSameProductModifiedDate() {
     updatedMetacard.setModifiedDate(Date.from(Instant.now().plusSeconds(2)));
 
     assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
   }
 
   @Test
-  public void isNotSameChecksum() throws Exception {
+  public void isNotSameMetacardCreatedDate() {
+    updatedMetacard.setAttribute(Core.METACARD_CREATED, Date.from(Instant.now().plusSeconds(2)));
+
+    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
+  }
+
+  @Test
+  public void isNotSameMetacardModifiedDate() {
+    updatedMetacard.setAttribute(Core.METACARD_MODIFIED, Date.from(Instant.now().plusSeconds(2)));
+
+    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
+  }
+
+  @Test
+  public void isNotSameChecksum() {
     updatedMetacard.setAttribute(Metacard.CHECKSUM, "2");
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameTags() throws Exception {
-    updatedMetacard.setAttribute(Metacard.TAGS, ImmutableSet.of("tag99"));
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameLocation() throws Exception {
-    String locWkt = "POLYGON ((29 10, 10 20, 20 40, 40 40, 30 10))";
-    updatedMetacard.setLocation(locWkt);
-
-    assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
-  }
-
-  @Test
-  public void isNotSameThumbnail() throws Exception {
-    updatedMetacard.setThumbnail(new byte[] {5, 4, 3, 2, 1});
 
     assertThat(isSame(cachedMetacard, updatedMetacard), is(false));
   }
 
   private MetacardImpl createMetacard(
       String metacardId,
-      Instant createdDate,
-      Instant effectiveDate,
-      Instant expireDate,
-      Instant modDate)
-      throws Exception {
-    String locWkt = "POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))";
-    URI nsUri = new URI("http://" + CachedResourceMetacardComparatorTest.class.getName());
-    URI resourceUri = new URI(nsUri.toString() + "/resource1.png");
-    URI derivedResourceUri = new URI(nsUri.toString() + "/derived.png");
-    URL deriverResourceUrl = derivedResourceUri.toURL();
-
-    HashMap<String, List<String>> securityMap = new HashMap<>();
-    securityMap.put("key1", ImmutableList.of("value1"));
-    securityMap.put("key2", ImmutableList.of("value1", "value2"));
-
+      Instant productCreatedDate,
+      Instant productModDate,
+      Instant metaCreatedDate,
+      Instant metaModDate) {
     MetacardImpl metacard = new MetacardImpl();
-
-    metacard.setContentTypeName("testContentType");
-    metacard.setContentTypeVersion("testContentTypeVersion");
-    metacard.setCreatedDate(Date.from(createdDate));
-    metacard.setDescription("testDescription");
-    metacard.setEffectiveDate(Date.from(effectiveDate));
-    metacard.setExpirationDate(Date.from(expireDate));
+    metacard.setCreatedDate(Date.from(productCreatedDate));
+    metacard.setAttribute(Core.METACARD_CREATED, metaCreatedDate);
     metacard.setId(metacardId);
-    metacard.setLocation(locWkt);
-    metacard.setMetadata("testMetadata");
-    metacard.setModifiedDate(Date.from(modDate));
-    metacard.setPointOfContact("pointOfContact");
-    metacard.setResourceURI(resourceUri);
+    metacard.setModifiedDate(Date.from(productModDate));
+    metacard.setAttribute(Core.METACARD_MODIFIED, metaModDate);
     metacard.setSourceId("testSourceId");
-    metacard.setTargetNamespace(nsUri);
-    metacard.setThumbnail(new byte[] {1, 2, 3, 4, 5});
-    metacard.setTitle("testTitle");
-    metacard.setResourceSize("1");
-    metacard.setSecurity(securityMap);
-    metacard.setTags(ImmutableSet.of("tag1", "tag2"));
     metacard.setAttribute(Metacard.CHECKSUM, "1");
     metacard.setAttribute(new AttributeImpl(Metacard.CHECKSUM_ALGORITHM, "sha1"));
-    metacard.setAttribute(new AttributeImpl(Metacard.DEFAULT_TAG, "tag1"));
     metacard.setAttribute(new AttributeImpl(Metacard.DERIVED, "derivedMetacard"));
-    metacard.setAttribute(
-        new AttributeImpl(Metacard.DERIVED_RESOURCE_DOWNLOAD_URL, deriverResourceUrl));
-    metacard.setAttribute(new AttributeImpl(Metacard.DERIVED_RESOURCE_URI, derivedResourceUri));
-    metacard.setAttribute(new AttributeImpl(Metacard.RELATED, "otherMetacardId"));
     return metacard;
   }
 }


### PR DESCRIPTION
Backport for this PR: https://github.com/codice/ddf/pull/3611
What does this PR do?
Fixes deletion of cached metacards when cachedMetacard == updatedMetacard under federated environments

Who is reviewing it?
@mcalcote 
@ahoffer
@garrettfreibott

Ask 2 committers to review/merge the PR and tag them here.
@lessarderic
@ricklarsen - Documentation
@clockard 

How should this be tested?
set up a federation
ingest a word document or something with metadata
query and download it
re-search query and make sure product is still in the product/cache -> good
then
download -> edit metadata -> requery -> make sure product is not cached since cached metadata != updated metadata

Any background context you want to provide?
What are the relevant tickets?
DDF-4057

Screenshots
Checklist:
  Documentation Updated
  Update / Add Unit Tests
  Update / Add Integration Tests
Notes on Review Process
Please see Notes on Review Process for further guidance on requirements for merging and abbreviated reviews.

Review Comment Legend:
✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.