### PR TITLE
[2.13.x] DDF-4112 Adding privileged calls around System.getProperties in catalog:export

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -292,7 +292,8 @@ public class ExportCommand extends CqlCommands {
     Instant start = Instant.now();
     jarSigner.signJar(
         outputFile,
-        System.getProperty(SystemBaseUrl.EXTERNAL_HOST),
+        AccessController.doPrivileged(
+            (PrivilegedAction<String>) () -> System.getProperty(SystemBaseUrl.EXTERNAL_HOST)),
         AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> System.getProperty("javax.net.ssl.keyStorePassword")),
         AccessController.doPrivileged(

--- a/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
+++ b/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
@@ -260,7 +260,8 @@ public class ZipCompression implements QueryResponseTransformer {
 
     jarSigner.signJar(
         zipFile,
-        System.getProperty(SystemBaseUrl.EXTERNAL_HOST),
+        AccessController.doPrivileged(
+            (PrivilegedAction<String>) () -> System.getProperty(SystemBaseUrl.EXTERNAL_HOST)),
         AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> System.getProperty("javax.net.ssl.keyStorePassword")),
         AccessController.doPrivileged(

--- a/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
+++ b/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
@@ -42,6 +42,8 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -247,19 +249,24 @@ public class ZipCompression implements QueryResponseTransformer {
   private BinaryContent getBinaryContentFromZip(String filePath)
       throws CatalogTransformerException {
     BinaryContent binaryContent;
+    InputStream fileInputStream;
+    File zipFile = new File(filePath);
     try {
-      File zipFile = new File(filePath);
-      InputStream fileInputStream = new ZipInputStream(new FileInputStream(zipFile));
+      fileInputStream = new ZipInputStream(new FileInputStream(zipFile));
       binaryContent = new BinaryContentImpl(fileInputStream);
-      jarSigner.signJar(
-          zipFile,
-          System.getProperty(SystemBaseUrl.EXTERNAL_HOST),
-          System.getProperty("javax.net.ssl.keyStorePassword"),
-          System.getProperty("javax.net.ssl.keyStore"),
-          System.getProperty("javax.net.ssl.keyStorePassword"));
     } catch (FileNotFoundException e) {
       throw new CatalogTransformerException("Unable to get ZIP file from ZipInputStream.", e);
     }
+
+    jarSigner.signJar(
+        zipFile,
+        System.getProperty(SystemBaseUrl.EXTERNAL_HOST),
+        AccessController.doPrivileged(
+            (PrivilegedAction<String>) () -> System.getProperty("javax.net.ssl.keyStorePassword")),
+        AccessController.doPrivileged(
+            (PrivilegedAction<String>) () -> System.getProperty("javax.net.ssl.keyStore")),
+        AccessController.doPrivileged(
+            (PrivilegedAction<String>) () -> System.getProperty("javax.net.ssl.keyStorePassword")));
     return binaryContent;
   }
 


### PR DESCRIPTION
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

Backporting the latest change made in #3749 that @paouelle brought to the spotlight while reviewing the forward port. All System.getProperty("javax.net.ssl.*"); should be inside of doPrivileged blocks. 

@bakejeyner @brjeter
@clockard
@coyotesqrl

Testing steps:
Add the jarsigner to default.policy or turn off the security manager. /shrug
Run catalog:export delete=false
shouldn't see any security manager errors.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
