### PR TITLE
DDF-4106 Adds react wrappers over marionette inputs for ease of use

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/color/input-color.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/color/input-color.less
@@ -4,6 +4,11 @@
     width: 100%;
   }
 
+  .sp-replacer button {
+    width: @minimumButtonSize;
+    height: @minimumButtonSize;
+  }
+
   label {
     padding-left: ~'calc(2px + .5*@{minimumFontSize})';
     line-height: @minimumButtonSize;

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/autocomplete/autocomplete.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/autocomplete/autocomplete.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Autocomplete from '../../../react-component/container/input-wrappers/autocomplete'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Autocomplete 
+                  label="Autocomplete 1"
+                  placeholder="Enter something"
+                  minimumInputLength={3}
+                  url="./notvalid"
+              />
+
+              <Autocomplete 
+                  label="Autocomplete 2"
+                  onChange={(checked) => alert(checked)}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider
+                code={this.getCode()}
+                scope={{ Autocomplete, alert }}
+              >
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/autocomplete/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/autocomplete/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './autocomplete'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/checkbox/checkbox.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/checkbox/checkbox.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Checkbox from '../../../react-component/container/input-wrappers/checkbox'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Checkbox 
+                  checked={true}
+                  label="Checkbox 1"
+              />
+
+              <Checkbox 
+                  checked={false}
+                  label="Checkbox 2"
+                  onChange={(checked) => alert(checked.toString())}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Checkbox, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/checkbox/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/checkbox/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './checkbox'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/color/color.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/color/color.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Color from '../../../react-component/container/input-wrappers/color'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Color 
+                  value="#ef1ca1"
+                  label="Color 1"
+              />
+
+              <Color 
+                  value="#es3cf1"
+                  label="Color 2"
+                  onChange={(value) => alert(value)}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Color, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/color/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/color/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './color'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/date/date.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/date/date.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import alert from '../utils/alert'
+import { hot } from 'react-hot-loader'
+
+import DateComponent from '../../../react-component/container/input-wrappers/date'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class DateGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <DateComponent 
+                  value={new Date().toISOString()}
+                  label="Date 1"
+              />
+
+              <DateComponent 
+                value={new Date().toISOString()}
+                  label="Date 2"
+                  onChange={(value) => alert(value)}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider
+                code={this.getCode()}
+                scope={{ DateComponent, alert }}
+              >
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(DateGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/date/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/date/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './date'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/enum/enum.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/enum/enum.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Enum from '../../../react-component/container/input-wrappers/enum'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Enum 
+                  options={[{label: 'Test', value: 'test'}, {label: 'Test2', value: 'test2'}]}
+                  value="test"
+                  label="Enum 1"
+              />
+
+              <Enum 
+                  options={[{label: 'Test1', value: 'test'}, {label: 'Test2', value: 'test2'}]}
+                  value="test"
+                  label="Enum 2"
+                  onChange={(checked) => alert(checked)}
+              />
+
+              <Enum 
+                  options={[{label: 'Test', value: 'test'}, {label: 'Test2', value: 'test2'}]}
+                  value="test"
+                  filtering={true}
+                  label="Enum with filtering"
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Enum, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/enum/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/enum/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './enum'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/geometry/geometry.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/geometry/geometry.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Geometry from '../../../react-component/container/input-wrappers/geometry'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class GeometryGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Geometry 
+                  value="POINT (0 0)"
+                  label="Geometry 1"
+              />
+
+              <Geometry 
+                value="POINT (0 0)"
+                  label="Geometry 2"
+                  onChange={(value) => alert(value)}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Geometry, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(GeometryGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/geometry/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/geometry/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './geometry'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/guide/guide.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/guide/guide.view.js
@@ -11,6 +11,20 @@ const InputGuideView = require('dev/component/input-guide/input-guide.view')
 const JSXGuideView = require('dev/component/jsx-guide/jsx-guide.view')
 const RegionGuideView = require('dev/component/region-guide/region-guide.view')
 import Button from '../button'
+import Checkbox from '../checkbox'
+import Text from '../text'
+import Range from '../range'
+import DateComponent from '../date'
+import Location from '../location'
+import Thumbnail from '../thumbnail'
+import Geometry from '../geometry'
+import NumberComponent from '../number'
+import Color from '../color'
+import Autocomplete from '../autocomplete'
+import Enum from '../enum'
+import InputWithParam from '../input-with-param'
+import Textarea from '../textarea'
+import MultiEnum from '../multi-enum'
 import MarionetteRegionContainer from '../../../react-component/container/marionette-region-container'
 import React from 'react'
 
@@ -26,11 +40,11 @@ module.exports = Marionette.LayoutView.extend({
       isEditing: true,
       enum: [
         {
-          label: 'Card',
+          label: 'Card (Marionette)',
           value: 'Card',
         },
         {
-          label: 'Button',
+          label: 'Button (Marionette)',
           value: 'Button',
         },
         {
@@ -38,15 +52,71 @@ module.exports = Marionette.LayoutView.extend({
           value: 'ButtonReact',
         },
         {
+          label: 'Checkbox',
+          value: 'checkbox',
+        },
+        {
+          label: 'Text',
+          value: 'text',
+        },
+        {
+          label: 'Range',
+          value: 'range',
+        },
+        {
+          label: 'Date',
+          value: 'date',
+        },
+        {
+          label: 'Location',
+          value: 'location',
+        },
+        {
+          label: 'Thumbnail',
+          value: 'thumbnail',
+        },
+        {
+          label: 'Geometry',
+          value: 'geometry',
+        },
+        {
+          label: 'Number',
+          value: 'number',
+        },
+        {
+          label: 'Autocomplete',
+          value: 'autocomplete',
+        },
+        {
+          label: 'Enum',
+          value: 'enum',
+        },
+        {
+          label: 'MultiEnum',
+          value: 'multienum',
+        },
+        {
+          label: 'Text Area',
+          value: 'textarea',
+        },
+        {
+          label: 'Input with Param',
+          value: 'inputwithparam',
+        },
+        {
+          label: 'Color',
+          value: 'color',
+        },
+        {
           label: 'Static Dropdowns (deprecated)',
           value: 'Static Dropdowns',
         },
         {
-          label: 'Dropdowns',
+          label: 'Dropdowns (Marionette)',
           value: 'Dropdowns',
         },
         {
-          label: 'Inputs',
+          label: 'Inputs (Marionette)',
           value: 'Inputs',
         },
         {
@@ -57,7 +127,7 @@ module.exports = Marionette.LayoutView.extend({
           label: 'Regions (Layout Views)',
           value: 'Regions',
         },
-      ],
+      ].sort((a, b) => a.label.localeCompare(b.label)),
       id: 'component',
     })
     this.listenTo(this.componentGuideModel, 'change:value', this.render)
@@ -103,6 +173,48 @@ module.exports = Marionette.LayoutView.extend({
         break
       case 'ButtonReact':
         componentToShow = Button
+        break
+      case 'checkbox':
+        componentToShow = Checkbox
+        break
+      case 'text':
+        componentToShow = Text
+        break
+      case 'range':
+        componentToShow = Range
+        break
+      case 'date':
+        componentToShow = DateComponent
+        break
+      case 'location':
+        componentToShow = Location
+        break
+      case 'thumbnail':
+        componentToShow = Thumbnail
+        break
+      case 'geometry':
+        componentToShow = Geometry
+        break
+      case 'number':
+        componentToShow = NumberComponent
+        break
+      case 'color':
+        componentToShow = Color
+        break
+      case 'autocomplete':
+        componentToShow = Autocomplete
+        break
+      case 'inputwithparam':
+        componentToShow = InputWithParam
+        break
+      case 'enum':
+        componentToShow = Enum
+        break
+      case 'multienum':
+        componentToShow = MultiEnum
+        break
+      case 'textarea':
+        componentToShow = Textarea
         break
       case 'Dropdowns':
         componentToShow = DropdownGuideView

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/input-with-param/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/input-with-param/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './input-with-param'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/input-with-param/input-with-param.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/input-with-param/input-with-param.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+
+import InputWithParam from '../../../react-component/container/input-wrappers/input-with-param'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <InputWithParam 
+                  value={{value: 'dog', distance: 5}}
+                  param="without"
+                  label="Input with Param 1"
+              />
+
+              <InputWithParam 
+                  value={{value: 'dog', distance: 2}}
+                  label="Input with Param 2"
+                  param="within"
+                  onChange={(value) => alert(JSON.stringify(value))}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ InputWithParam }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/location/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/location/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './location'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/location/location.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/location/location.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Location from '../../../react-component/container/input-wrappers/location'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Location 
+                value=""
+                label="Location 1"
+              />
+
+              <Location 
+                value=""
+                label="Location 2"
+                onChange={(value) => alert(JSON.stringify(value))}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Location, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/multi-enum/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/multi-enum/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './multi-enum'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/multi-enum/multi-enum.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/multi-enum/multi-enum.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import MultiEnum from '../../../react-component/container/input-wrappers/multi-enum'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <MultiEnum 
+                  options={[{label: 'Test', value: 'test'}, {label: 'Test2', value: 'test2'}]}
+                  value={['test', 'test2']}
+                  label="Enum 1"
+              />
+
+              <MultiEnum 
+                  options={[{label: 'Test', value: 'test'}, {label: 'Test2', value: 'test2'}]}
+                  value={['test', 'test2']}
+                  label="Enum 2"
+                  onChange={(checked) => alert(checked.toString())}
+              />
+
+              <MultiEnum 
+                  options={[{label: 'Test', value: 'test'}, {label: 'Test2', value: 'test2'}]}
+                  value={['test', 'test2']}
+                  filtering={true}
+                  label="Enum with filtering"
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ MultiEnum, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/number/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/number/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './number'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/number/number.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/number/number.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Number from '../../../react-component/container/input-wrappers/number'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class NumberGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Number 
+                  value={4}
+                  label="Number 1"
+              />
+
+              <Number 
+                value={5}
+                  label="Number 2"
+                  onChange={(value) => alert(value)}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Number, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(NumberGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/range/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/range/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './range'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/range/range.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/range/range.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Range from '../../../react-component/container/input-wrappers/range'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Range 
+                value={150}
+                label="Range 1"
+                min={60}
+                max={200}
+                units="%"
+              />
+
+              <Range 
+                value={80}
+                label="Range 2"
+                min={60}
+                max={200}
+                units="%"
+                onChange={(value) => alert(value)}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Range, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/text/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/text/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './text'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/text/text.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/text/text.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Text from '../../../react-component/container/input-wrappers/text'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Text 
+                value="value"
+                label="TextInput 1"
+              />
+
+              <Text 
+                value="value"
+                label="TextInput 1"
+                  onChange={(value) => alert(value)}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Text, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/textarea/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/textarea/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './textarea'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/textarea/textarea.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/textarea/textarea.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Textarea from '../../../react-component/container/input-wrappers/textarea'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+        <div>
+          <Textarea 
+            value="value"
+            label="TextInput 1"
+          />
+
+          <Textarea 
+            value="value"
+            label="TextInput 1"
+              onChange={(value) => alert(value)}
+          />
+        </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Textarea, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/thumbnail/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/thumbnail/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './thumbnail'

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/thumbnail/thumbnail.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/thumbnail/thumbnail.tsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import styled from '../../../react-component/styles/styled-components'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
+import { hot } from 'react-hot-loader'
+import alert from '../utils/alert'
+
+import Thumbnail from '../../../react-component/container/input-wrappers/thumbnail'
+
+const Root = styled.div`
+  height: 100%;
+`
+
+class ButtonGuide extends React.Component<{}, {}> {
+  constructor(props: any) {
+    super(props)
+  }
+  getCode() {
+    return `
+            <div>
+              <Thumbnail 
+                value=""
+                label="Thumbnail 1"
+              />
+
+              <Thumbnail 
+                value=""
+                label="Thumbnail 2"
+                onChange={(value) => alert(value)}
+              />
+            </div>
+        `
+  }
+  render() {
+    return (
+      <Root {...this.props}>
+        <div className="section">
+          <div className="is-header">Examples</div>
+          <div className="examples is-list has-list-highlighting">
+            <div className="example">
+              <div className="title">Example</div>
+              <LiveProvider code={this.getCode()} scope={{ Thumbnail, alert }}>
+                <LiveEditor contentEditable={true} />
+                <LiveError />
+                <LivePreview style={{ padding: '20px' }} />
+              </LiveProvider>
+            </div>
+          </div>
+        </div>
+      </Root>
+    )
+  }
+}
+
+export default hot(module)(ButtonGuide)

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/utils/alert/alert.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/utils/alert/alert.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+const announcement = require('component/announcement')
+
+const alert = (message: string) => {
+  announcement.announce({
+    title: message,
+  })
+}
+
+export default alert

--- a/ui/packages/catalog-ui-search/src/main/webapp/dev/component/utils/alert/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/dev/component/utils/alert/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './alert'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/README.me
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/README.me
@@ -1,0 +1,3 @@
+## Collection of wrappers over the old marionette property view
+
+As we move towards react we'll make new inputs, but these should help hold us over until then.

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/autocomplete/autocomplete.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/autocomplete/autocomplete.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = BaseProps & {
+  value: string
+  placeholder: string
+  url: string
+  minimumInputLength: number
+  onChange?: (value: string) => void
+}
+
+export default hot(module)((props: Props) => {
+  const {
+    value,
+    label,
+    placeholder = 'Enter a region, country, or city',
+    url = './internal/geofeature/suggestions',
+    minimumInputLength = 2,
+    onChange,
+    ...otherProps
+  } = props
+  return (
+    <Base
+      value={[value]}
+      label={label}
+      placeholder={placeholder}
+      url={url}
+      minimumInputLength={minimumInputLength}
+      type={Type.autocomplete}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/autocomplete/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/autocomplete/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './autocomplete'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/base/base.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/base/base.tsx
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
+type Subtract<T, K> = Omit<T, keyof K> // so the user of the wrapped component doesn't have to pass in listenTo!
+
+import * as React from 'react'
+import MarionetteRegionContainer from '../../marionette-region-container'
+import withListenTo, { WithBackboneProps } from '../../backbone-container'
+import { hot } from 'react-hot-loader'
+const PropertyView = require('component/property/property.view')
+const PropertyModel = require('component/property/property')
+
+export enum Type {
+  autocomplete = 'AUTOCOMPLETE',
+  range = 'RANGE',
+  date = 'DATE',
+  location = 'LOCATION',
+  thumbnail = 'BINARY',
+  checkbox = 'BOOLEAN',
+  number = 'INTEGER',
+  geometry = 'GEOMETRY',
+  color = 'COLOR',
+  inputWithParam = 'NEAR',
+  text = 'STRING',
+  textarea = 'TEXTAREA',
+}
+
+/**
+ * Meant to be available on all downstream implementations using Base.
+ * However, we need to subtract these from the HTMLProps first so we don't confuse types.
+ */
+type DownstreamProps = {
+  label?: string
+  showLabel?: boolean
+  showValidationIssues?: boolean
+  initializeToDefault?: boolean
+  required?: boolean
+  showRequiredWarning?: boolean
+  transformValue?: boolean
+}
+
+/**
+ * For use by downstream users of Base directly, not necessarily exposed to developers.
+ * Basically, the implementation should be passing these in, not the person using the
+ * implementation.  For instance, I use an enum, but all I see is multi as an option,
+ * not enumMulti since we're wrapping it.
+ */
+type MyProps = {
+  onChange?: (value: any) => void
+  placeholder?: string
+  value?: any[]
+  values?: object
+  enumeration?: any[]
+  description?: string
+  readOnly?: boolean
+  id?: string
+  isEditing?: boolean
+  bulk?: boolean
+  multivalued?: boolean
+  type?: Type
+  param?: string
+  url?: string
+  minimumInputLength?: number
+  min?: number
+  max?: number
+  units?: string
+  enumFiltering?: boolean
+  enumCustom?: boolean
+  enumMulti?: boolean
+  valueTransformer?: (value: any[]) => any
+}
+
+/**
+ * Meant to avoid issues with value being an html prop for instance.  We want to expose
+ * things like onKeyUp without taking along the rest of the kitchen sink.
+ */
+type SubsetHTML = Subtract<
+  React.HTMLProps<HTMLDivElement>,
+  DownstreamProps & MyProps
+>
+
+export type BaseProps = DownstreamProps & SubsetHTML
+
+export const destructureBaseProps = (
+  props: object & BaseProps
+): BaseProps & { htmlProps: SubsetHTML } => {
+  const {
+    label,
+    showLabel,
+    showValidationIssues,
+    initializeToDefault,
+    required,
+    showRequiredWarning,
+    transformValue,
+    ...htmlProps
+  } = props
+  return {
+    label,
+    showLabel,
+    showValidationIssues,
+    initializeToDefault,
+    required,
+    showRequiredWarning,
+    transformValue,
+    htmlProps,
+  }
+}
+
+type Props = {
+  htmlProps?: SubsetHTML
+} & MyProps &
+  WithBackboneProps &
+  BaseProps
+
+type State = {
+  value?: any[]
+}
+
+class BasePropertyWrapper extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    const {
+      value = [],
+      values = {},
+      enumeration,
+      label,
+      description = '',
+      readOnly = false,
+      id = '',
+      isEditing = true,
+      bulk = false,
+      multivalued = false,
+      type = Type.text,
+      showValidationIssues = true,
+      showLabel = true,
+      initializeToDefault = false,
+      required = false,
+      showRequiredWarning = false,
+      transformValue = true,
+      param,
+      placeholder = 'Enter a region, country, or city',
+      url = './internal/geofeature/suggestions',
+      minimumInputLength = 2,
+      min = 1,
+      max = 100,
+      units = '%',
+      enumFiltering,
+      enumCustom,
+      enumMulti,
+    } = props
+    this.state = {
+      value,
+    }
+    this.propertyModel = new PropertyModel({
+      value: this.state.value,
+      values,
+      enum: enumeration,
+      label,
+      description,
+      readOnly,
+      id,
+      isEditing,
+      bulk,
+      multivalued,
+      type,
+      showValidationIssues,
+      showLabel,
+      initializeToDefault,
+      required,
+      showRequiredWarning,
+      transformValue,
+      param,
+      placeholder,
+      url,
+      minimumInputLength,
+      min,
+      max,
+      units,
+      enumFiltering,
+      enumCustom,
+      enumMulti,
+    })
+  }
+  propertyModel: any
+  componentDidMount() {
+    if (this.props.onChange !== undefined) {
+      this.props.listenTo(
+        this.propertyModel,
+        'change:value',
+        this.modelOnChange.bind(this)
+      )
+    }
+  }
+  defaultValueTransformer(value: any[]) {
+    return value[0]
+  }
+  modelOnChange() {
+    if (this.props.onChange !== undefined) {
+      const transformValue =
+        this.props.valueTransformer || this.defaultValueTransformer
+      this.props.onChange(transformValue(this.propertyModel.getValue()))
+    }
+  }
+  render() {
+    return (
+      <MarionetteRegionContainer
+        view={PropertyView}
+        viewOptions={() => ({
+          model: this.propertyModel,
+        })}
+        {...this.props.htmlProps as any}
+      />
+    )
+  }
+}
+
+export default hot(module)(withListenTo(BasePropertyWrapper))

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/base/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/base/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default, Type, BaseProps, destructureBaseProps } from './base'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/checkbox/checkbox.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/checkbox/checkbox.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = BaseProps & {
+  checked: boolean
+  onChange?: (value: boolean) => void
+}
+
+export default hot(module)((props: Props) => {
+  const { checked, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[checked]}
+      type={Type.checkbox}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/checkbox/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/checkbox/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './checkbox'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/color/color.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/color/color.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = BaseProps & {
+  value: string
+  onChange?: (value: string) => void
+}
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      type={Type.color}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/color/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/color/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './color'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/date/date.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/date/date.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = BaseProps & {
+  value: string
+  onChange?: (value: string) => void
+}
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      type={Type.date}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/date/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/date/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './date'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/enum/enum.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/enum/enum.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Option = {
+  label: string
+  value: any
+}
+export type Props = BaseProps & {
+  options: Option[]
+  value: any
+  filtering?: boolean
+  custom?: boolean
+  onChange?: (value: any) => void
+}
+
+export default hot(module)((props: Props) => {
+  const { options, value, filtering, custom, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      enumeration={options}
+      enumFiltering={filtering}
+      enumCustom={custom}
+      type={Type.color}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/enum/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/enum/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './enum'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/geometry/geometry.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/geometry/geometry.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = BaseProps & {
+  value: string
+  onChange?: (value: string) => void
+}
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      type={Type.geometry}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/geometry/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/geometry/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './geometry'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/input-with-param/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/input-with-param/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './input-with-param'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/input-with-param/input-with-param.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/input-with-param/input-with-param.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Value = {
+  value: string
+  distance: number
+}
+type Props = BaseProps & {
+  value: Value
+  param: string
+  onChange?: (value: string) => void
+}
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, param, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      param={param}
+      type={Type.inputWithParam}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/location/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/location/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './location'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/location/location.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/location/location.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = {
+  value: string
+  onChange?: (value: any) => void
+} & BaseProps
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      type={Type.location}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/multi-enum/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/multi-enum/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './multi-enum'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/multi-enum/multi-enum.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/multi-enum/multi-enum.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Option = {
+  label: string
+  value: any
+}
+export type Props = {
+  options: Option[]
+  value: any
+  filtering?: boolean
+  custom?: boolean
+  onChange?: (value: any) => void
+} & BaseProps
+
+export default hot(module)((props: Props) => {
+  const { options, value, filtering, custom, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      enumeration={options}
+      enumFiltering={filtering}
+      enumCustom={custom}
+      enumMulti={true}
+      type={Type.color}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/number/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/number/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './number'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/number/number.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/number/number.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = {
+  value: string
+  onChange?: (value: boolean) => void
+} & BaseProps
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      type={Type.number}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/range/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/range/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './range'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/range/range.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/range/range.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = {
+  value: number
+  min: number
+  max: number
+  units: string
+  onChange?: (value: boolean) => void
+} & BaseProps
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, min, max, units, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      min={min}
+      max={max}
+      units={units}
+      type={Type.range}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/text/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/text/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './text'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/text/text.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/text/text.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = BaseProps & {
+  placeholder: string
+  value: string
+  onChange?: (value: string) => void
+}
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, placeholder, ...otherProps } = props
+  return (
+    <Base
+      placeholder={placeholder}
+      value={[value]}
+      type={Type.text}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/textarea/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/textarea/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './textarea'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/textarea/textarea.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/textarea/textarea.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = {
+  value: string
+  onChange?: (value: boolean) => void
+} & BaseProps
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      type={Type.textarea}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/thumbnail/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/thumbnail/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './thumbnail'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/thumbnail/thumbnail.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/thumbnail/thumbnail.tsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+import Base, { Type, BaseProps, destructureBaseProps } from '../base'
+
+type Props = {
+  value: string
+  onChange?: (value: boolean) => void
+} & BaseProps
+
+export default hot(module)((props: Props) => {
+  const { value, onChange, ...otherProps } = props
+  return (
+    <Base
+      value={[value]}
+      type={Type.thumbnail}
+      onChange={onChange}
+      {...destructureBaseProps(otherProps) as any}
+    />
+  )
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/marionette-region-container/marionette-region-container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/marionette-region-container/marionette-region-container.tsx
@@ -21,8 +21,7 @@ type Props = {
   viewOptions?: object
   replaceElement?: boolean
   className?: string
-} & React.HTMLProps<HTMLButtonElement> &
-  JSX.IntrinsicAttributes
+} & React.HTMLProps<HTMLDivElement>
 
 const RegionContainer = styled.div`
   ${CustomElement};

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/workspaces-templates-container/workspaces-templates-container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/workspaces-templates-container/workspaces-templates-container.tsx
@@ -11,11 +11,11 @@
  **/
 import * as React from 'react'
 import WorkspacesTemplates from '../../presentation/workspaces-templates'
+import { hot } from 'react-hot-loader'
 
 const store = require('js/store')
 const LoadingView = require('component/loading/loading.view')
 const wreqr = require('wreqr')
-const Property = require('component/property/property')
 const properties = require('properties')
 
 interface Props {
@@ -26,29 +26,26 @@ interface Props {
 }
 
 interface State {
-  adhocModel: any
+  value: string
+  placeholder: string
 }
 
 class WorkspacesTemplatesContainer extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
-      adhocModel: new Property({
-        value: [''],
-        label: '',
-        type: 'STRING',
-        showValidationIssues: false,
-        showLabel: false,
-        placeholder: 'Search ' + properties.branding + ' ' + properties.product,
-        isEditing: true,
-      }),
+      placeholder: 'Search ' + properties.branding + ' ' + properties.product,
+      value: '',
     }
   }
   startAdhocSearch() {
     this.prepForCreateNewWorkspace()
-    store
-      .get('workspaces')
-      .createAdhocWorkspace(this.state.adhocModel.getValue()[0])
+    store.get('workspaces').createAdhocWorkspace(this.state.value)
+  }
+  onChange(value: string) {
+    this.setState({
+      value,
+    })
   }
   prepForCreateNewWorkspace() {
     var loadingview = new LoadingView()
@@ -94,10 +91,12 @@ class WorkspacesTemplatesContainer extends React.Component<Props, State> {
         hasTemplatesExpanded={this.props.hasTemplatesExpanded}
         toggleExpansion={this.props.toggleExpansion}
         startAdhocSearch={this.startAdhocSearch.bind(this)}
-        adhocModel={this.state.adhocModel}
+        onChange={this.onChange.bind(this)}
+        value={this.state.value}
+        placeholder={this.state.placeholder}
       />
     )
   }
 }
 
-export default WorkspacesTemplatesContainer
+export default hot(module)(WorkspacesTemplatesContainer)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/workspaces-templates/workspaces-templates.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/workspaces-templates/workspaces-templates.tsx
@@ -14,9 +14,8 @@ import styled from '../../styles/styled-components'
 import { CustomElement } from '../../styles/mixins'
 import { ChangeBackground } from '../../styles/mixins'
 import { transparentize, readableColor } from 'polished'
-import MarionetteRegionContainer from '../../container/marionette-region-container'
+import Text from '../../container/input-wrappers/text'
 import WorkspaceTemplate from '../workspace-template'
-const PropertyView = require('component/property/property.view')
 
 type RootProps = {
   hasTemplatesExpanded: boolean
@@ -25,7 +24,9 @@ type RootProps = {
 type Props = {
   startAdhocSearch: () => void
   toggleExpansion: () => void
-  adhocModel: Backbone.Model
+  onChange: () => void
+  value: string
+  placeholder: string
   createWorkspace: () => void
   createLocalWorkspace: () => void
   createAllWorkspace: () => void
@@ -222,13 +223,13 @@ const WorkspacesTemplates = (props: Props & RootProps) => {
         </div>
         <div className="home-templates-adhoc">
           <div className="adhoc-search">
-            <MarionetteRegionContainer
-              view={PropertyView}
-              viewOptions={() => {
-                return {
-                  model: props.adhocModel,
-                }
-              }}
+            <Text
+              value={props.value}
+              label=""
+              showLabel={false}
+              showValidationIssues={false}
+              placeholder={props.placeholder}
+              onChange={props.onChange}
               onKeyUp={event => {
                 switch (event.keyCode) {
                   case 13:


### PR DESCRIPTION
#### What does this PR do?
 - Adds a number of react wrappers for inputs to allow easier usage from React.

#### Who is reviewing it? 
@djblue 
@brianfelix 
@adimka 
@gjvera 

#### How should this be tested?
Check out the dev guide, that's where most of these are available to test.  I tried out replacing one instance where we were using marionette region container with a property view in workspaces-templates component with the text wrapper and it worked well.

#### Any background context you want to provide?
The marionette region container is a nice way to embed any sort of marionette view, but this makes a number of wrappers that hide the fact that you're interacting with a marionette view (almost) entirely.  It also exposes a typed api to make interacting with common components much simpler.

#### What are the relevant tickets?
[DDF-4106](https://codice.atlassian.net/browse/DDF-4106)
