### PR TITLE
DDF-4153 add null check and logging for 3D map view

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/cesium.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/cesium.view.js
@@ -44,7 +44,7 @@ module.exports = MapView.extend({
     try {
       MapView.prototype.createMap.apply(this, arguments)
     } catch (err) {
-      console.error(err);
+      console.error(err)
       this.$el.addClass('not-supported')
       setTimeout(
         function() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -40,13 +40,13 @@ var pixelOffset = new Cesium.Cartesian2(0.0, 0)
 Cesium.BingMapsApi.defaultKey = properties.bingKey || 0
 var imageryProviderTypes = CesiumLayerCollectionController.imageryProviderTypes
 
-function setupTerrainProvider(viewer, terrainProvider ) {
+function setupTerrainProvider(viewer, terrainProvider) {
   if (terrainProvider == null || terrainProvider === undefined) {
     console.info(`Unknown terrain provider configuration.
               Default Cesium terrain provider will be used.`)
-      return
+    return
   }
-  const {type, ...terrainConfig} = terrainProvider
+  const { type, ...terrainConfig } = terrainProvider
   const TerrainProvider = imageryProviderTypes[type]
   if (TerrainProvider === undefined) {
     console.warn(`


### PR DESCRIPTION

#### What does this PR do?
fix 3D map loading
null check on terrainProvider property
log error

#### Who is reviewing it? 
@andrewkfiedler 
@adimka 
@bdeining 
@troymohl 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8 
@clockard
#### How should this be tested?
Build, ensure 3D map load with terrainProvider property set to blank
admin config > Search UI > catalog ui 

#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-4153

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
