### PR TITLE
DDF-4090 - Remove LDAP structure assumptions

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -393,8 +393,8 @@ grant codeBase "file:/admin-core-migration-commands/catalog-core-solrcommands/se
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}*", "read";
 }
 
-grant codeBase "file:/security-sts-attributequeryclaimshandler/security-sts-ldapclaimshandler" {
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}attributeMap.properties", "read";
+grant codeBase "file:/security-core-api/security-sts-attributequeryclaimshandler/security-sts-ldapclaimshandler" {
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}-", "read";
 }
 
 //

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -24,8 +24,10 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -34,7 +36,10 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.sts.claims.ClaimsHandler;
 import org.codice.ddf.configuration.PropertyResolver;
+import org.forgerock.opendj.ldap.ConnectionFactory;
+import org.forgerock.opendj.ldap.Connections;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.LDAPUrl;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.util.Options;
 import org.osgi.framework.Bundle;
@@ -48,6 +53,10 @@ import org.slf4j.LoggerFactory;
 public class ClaimsHandlerManager {
 
   public static final String URL = "url";
+
+  public static final String LOAD_BALANCING = "ldapLoadBalancing";
+
+  public static final String FAILOVER = "failover";
 
   public static final String START_TLS = "startTls";
 
@@ -109,7 +118,14 @@ public class ClaimsHandlerManager {
       return;
     }
     LOGGER.debug("Received an updated set of configurations for the LDAP/Role Claims Handlers.");
-    String url = new PropertyResolver((String) props.get(ClaimsHandlerManager.URL)).toString();
+    List<String> urls = new ArrayList<>();
+    Object urlObj = props.get(ClaimsHandlerManager.URL);
+    if (urlObj instanceof String[]) {
+      urls.addAll(Arrays.asList((String[]) urlObj));
+    } else {
+      urls.add(urlObj.toString());
+    }
+    String loadBalancingAlgorithm = (String) props.get(ClaimsHandlerManager.LOAD_BALANCING);
     Boolean startTls;
     if (props.get(ClaimsHandlerManager.START_TLS) instanceof String) {
       startTls = Boolean.valueOf((String) props.get(ClaimsHandlerManager.START_TLS));
@@ -155,8 +171,10 @@ public class ClaimsHandlerManager {
       if (encryptService != null) {
         password = encryptService.decryptValue(password);
       }
-      LDAPConnectionFactory connection1 = createLdapConnectionFactory(url, startTls);
-      LDAPConnectionFactory connection2 = createLdapConnectionFactory(url, startTls);
+      ConnectionFactory connection1 =
+          createConnectionFactory(urls, startTls, loadBalancingAlgorithm);
+      ConnectionFactory connection2 =
+          createConnectionFactory(urls, startTls, loadBalancingAlgorithm);
       registerRoleClaimsHandler(
           connection1,
           propertyFileLocation,
@@ -193,6 +211,23 @@ public class ClaimsHandlerManager {
 
   public void destroy() {}
 
+  protected ConnectionFactory createConnectionFactory(
+      List<String> urls, Boolean startTls, String loadBalancingAlgorithm) throws LdapException {
+    List<ConnectionFactory> connectionFactories = new ArrayList<>();
+
+    for (String singleUrl : urls) {
+      connectionFactories.add(
+          createLdapConnectionFactory(new PropertyResolver(singleUrl).toString(), startTls));
+    }
+
+    Options options = Options.defaultOptions();
+    if (FAILOVER.equalsIgnoreCase(loadBalancingAlgorithm)) {
+      return Connections.newFailoverLoadBalancer(connectionFactories, options);
+    } else {
+      return Connections.newRoundRobinLoadBalancer(connectionFactories, options);
+    }
+  }
+
   protected LDAPConnectionFactory createLdapConnectionFactory(String url, Boolean startTls)
       throws LdapException {
     boolean useSsl = url.startsWith("ldaps");
@@ -218,12 +253,9 @@ public class ClaimsHandlerManager {
         LDAPConnectionFactory.TRANSPORT_PROVIDER_CLASS_LOADER,
         ClaimsHandlerManager.class.getClassLoader());
 
-    String host = url.substring(url.indexOf("://") + 3, url.lastIndexOf(':'));
-    Integer port = useSsl ? 636 : 389;
-    try {
-      port = Integer.valueOf(url.substring(url.lastIndexOf(':') + 1));
-    } catch (NumberFormatException ignore) {
-    }
+    LDAPUrl parsedUrl = LDAPUrl.valueOf(url);
+    String host = parsedUrl.getHost();
+    Integer port = parsedUrl.getPort();
 
     auditRemoteConnection(host);
 
@@ -254,7 +286,7 @@ public class ClaimsHandlerManager {
    * @param groupBaseDn Base DN of the group.
    */
   private void registerRoleClaimsHandler(
-      LDAPConnectionFactory connection,
+      ConnectionFactory connection,
       String propertyFileLoc,
       String userBaseDn,
       String loginUserAttribute,
@@ -296,7 +328,7 @@ public class ClaimsHandlerManager {
    * @param userNameAttr Identifier that defines the user.
    */
   private void registerLdapClaimsHandler(
-      LDAPConnectionFactory connection,
+      ConnectionFactory connection,
       String propertyFileLoc,
       String userBaseDn,
       String userNameAttr,
@@ -355,9 +387,14 @@ public class ClaimsHandlerManager {
     return null;
   }
 
-  public void setUrl(String url) {
+  public void setUrl(String... url) {
     LOGGER.trace("Setting url: {}", url);
     ldapProperties.put(URL, url);
+  }
+
+  public void setLoadBalancing(String loadBalancing) {
+    LOGGER.trace("Setting loadBalancing: {}", loadBalancing);
+    ldapProperties.put(LOAD_BALANCING, loadBalancing);
   }
 
   public void setStartTls(boolean startTls) {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -118,13 +118,7 @@ public class ClaimsHandlerManager {
       return;
     }
     LOGGER.debug("Received an updated set of configurations for the LDAP/Role Claims Handlers.");
-    List<String> urls = new ArrayList<>();
-    Object urlObj = props.get(ClaimsHandlerManager.URL);
-    if (urlObj instanceof String[]) {
-      urls.addAll(Arrays.asList((String[]) urlObj));
-    } else {
-      urls.add(urlObj.toString());
-    }
+    List<String> urls = getUrls(props, ClaimsHandlerManager.URL);
     String loadBalancingAlgorithm = (String) props.get(ClaimsHandlerManager.LOAD_BALANCING);
     Boolean startTls;
     if (props.get(ClaimsHandlerManager.START_TLS) instanceof String) {
@@ -207,6 +201,18 @@ public class ClaimsHandlerManager {
           "Experienced error while configuring claims handlers. Handlers are NOT configured and claim retrieval will not work. Check LDAP configuration.",
           e);
     }
+  }
+
+  private List<String> getUrls(Map<String, Object> props, String key) {
+    List<String> urls = new ArrayList<>();
+    Object urlProperty = props.get(key);
+    if (urlProperty instanceof String[]) {
+      urls.addAll(Arrays.asList((String[]) urlProperty));
+    } else {
+      urls.add(urlProperty.toString());
+    }
+
+    return urls;
   }
 
   public void destroy() {}

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
@@ -26,7 +26,7 @@ import org.apache.cxf.sts.claims.ProcessedClaimCollection;
 import org.forgerock.opendj.ldap.Attribute;
 import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.opendj.ldap.Connection;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.ConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.SearchResultReferenceIOException;
 import org.forgerock.opendj.ldap.SearchScope;
@@ -44,7 +44,7 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
 
   private String propertyFileLocation;
 
-  private LDAPConnectionFactory connectionFactory;
+  private ConnectionFactory connectionFactory;
 
   private String bindUserCredentials;
 
@@ -62,11 +62,11 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
     super();
   }
 
-  public LDAPConnectionFactory getLdapConnectionFactory() {
+  public ConnectionFactory getLdapConnectionFactory() {
     return connectionFactory;
   }
 
-  public void setLdapConnectionFactory(LDAPConnectionFactory connection) {
+  public void setLdapConnectionFactory(ConnectionFactory connection) {
     this.connectionFactory = connection;
   }
 
@@ -169,6 +169,7 @@ public class LdapClaimsHandler extends org.apache.cxf.sts.claims.LdapClaimsHandl
             } else {
               // Got a continuation reference
               LOGGER.debug("Referral ignored while searching for user {}", user);
+              entryReader.readReference();
             }
           }
         } else {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
@@ -254,7 +254,7 @@ public class RoleClaimsHandler implements ClaimsHandler {
             SearchResultEntry entry = entryReader.readEntry();
 
             userDN = entry.getName().toString();
-            specificUserBaseDN = userDN.substring(userDN.indexOf(",") + 1);
+            specificUserBaseDN = userDN.substring(userDN.indexOf(',') + 1);
             if (!membershipUserAttribute.equals(loginUserAttribute)) {
               Attribute attr = entry.getAttribute(membershipUserAttribute);
               if (attr != null) {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
@@ -27,7 +27,7 @@ import org.apache.cxf.sts.claims.ProcessedClaimCollection;
 import org.forgerock.opendj.ldap.Attribute;
 import org.forgerock.opendj.ldap.ByteString;
 import org.forgerock.opendj.ldap.Connection;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.ConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.SearchResultReferenceIOException;
 import org.forgerock.opendj.ldap.SearchScope;
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ldap.filter.AndFilter;
 import org.springframework.ldap.filter.EqualsFilter;
+import org.springframework.ldap.filter.OrFilter;
 
 public class RoleClaimsHandler implements ClaimsHandler {
 
@@ -48,7 +49,7 @@ public class RoleClaimsHandler implements ClaimsHandler {
 
   private Map<String, String> claimsLdapAttributeMapping;
 
-  private LDAPConnectionFactory connectionFactory;
+  private ConnectionFactory connectionFactory;
 
   private String delimiter = ";";
 
@@ -137,11 +138,11 @@ public class RoleClaimsHandler implements ClaimsHandler {
     this.groupBaseDn = groupBaseDn;
   }
 
-  public LDAPConnectionFactory getLdapConnectionFactory() {
+  public ConnectionFactory getLdapConnectionFactory() {
     return connectionFactory;
   }
 
-  public void setLdapConnectionFactory(LDAPConnectionFactory connection) {
+  public void setLdapConnectionFactory(ConnectionFactory connection) {
     this.connectionFactory = connection;
   }
 
@@ -240,41 +241,49 @@ public class RoleClaimsHandler implements ClaimsHandler {
 
         String membershipValue = user;
 
-        AndFilter filter;
-        ConnectionEntryReader entryReader;
-        if (!membershipUserAttribute.equals(loginUserAttribute)) {
-          String baseDN = AttributeMapLoader.getBaseDN(principal, userBaseDn, overrideCertDn);
-          filter = new AndFilter();
-          filter.and(new EqualsFilter(this.getLoginUserAttribute(), user));
-          entryReader =
-              connection.search(
-                  baseDN, SearchScope.WHOLE_SUBTREE, filter.toString(), membershipUserAttribute);
-          while (entryReader.hasNext()) {
-            if (entryReader.isEntry()) {
-              SearchResultEntry entry = entryReader.readEntry();
+        String baseDN = AttributeMapLoader.getBaseDN(principal, userBaseDn, overrideCertDn);
+        AndFilter filter = new AndFilter();
+        filter.and(new EqualsFilter(this.getLoginUserAttribute(), user));
+        ConnectionEntryReader entryReader =
+            connection.search(
+                baseDN, SearchScope.WHOLE_SUBTREE, filter.toString(), membershipUserAttribute);
+        String userDN = String.format("%s=%s,%s", loginUserAttribute, user, baseDN);
+        String specificUserBaseDN = baseDN;
+        while (entryReader.hasNext()) {
+          if (entryReader.isEntry()) {
+            SearchResultEntry entry = entryReader.readEntry();
 
+            userDN = entry.getName().toString();
+            specificUserBaseDN = userDN.substring(userDN.indexOf(",") + 1);
+            if (!membershipUserAttribute.equals(loginUserAttribute)) {
               Attribute attr = entry.getAttribute(membershipUserAttribute);
               if (attr != null) {
                 for (ByteString value : attr) {
                   membershipValue = value.toString();
                 }
               }
-            } else {
-              // Got a continuation reference
-              LOGGER.debug("Referral ignored while searching for user {}", user);
             }
+          } else {
+            // Got a continuation reference
+            LOGGER.debug("Referral ignored while searching for user {}", user);
+            entryReader.readReference();
           }
         }
 
         filter = new AndFilter();
-        String userBaseDN =
-            AttributeMapLoader.getBaseDN(principal, getUserBaseDn(), overrideCertDn);
         filter
             .and(new EqualsFilter("objectClass", getObjectClass()))
             .and(
-                new EqualsFilter(
-                    getMemberNameAttribute(),
-                    getMembershipUserAttribute() + "=" + membershipValue + "," + userBaseDN));
+                new OrFilter()
+                    .or(
+                        new EqualsFilter(
+                            getMemberNameAttribute(),
+                            getMembershipUserAttribute()
+                                + "="
+                                + membershipValue
+                                + ","
+                                + specificUserBaseDN))
+                    .or(new EqualsFilter(getMemberNameAttribute(), userDN)));
 
         if (bindResult.isSuccess()) {
           LOGGER.trace(
@@ -306,6 +315,7 @@ public class RoleClaimsHandler implements ClaimsHandler {
             } else {
               // Got a continuation reference
               LOGGER.debug("Referral ignored while searching for user {}", user);
+              entryReader.readReference();
             }
           }
         } else {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -48,7 +48,12 @@
                               init-method="configure" destroy-method="destroy">
             <argument ref="encryptionService"/>
             <!-- Default properties -->
-            <property name="url" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
+            <property name="url">
+                <list>
+                    <value>ldaps://${org.codice.ddf.system.hostname}:1636</value>
+                </list>
+            </property>
+            <property name="loadBalancing" value="round_robin"/>
             <property name="startTls" value="false"/>
             <property name="ldapBindUserDn" value="cn=admin"/>
             <property name="password" value="secret"/>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,10 +18,15 @@
 	<OCD description="STS Ldap and Roles Claims Handler Configuration. WARNING: The server must be restarted for these updates to take affect."
          name="Security STS LDAP and Roles Claims Handler" id="Claims_Handler_Manager">
 
-	    <AD name="LDAP URL:" id="url" required="true" type="String"
+	    <AD name="LDAP URL:" id="url" required="true" type="String" cardinality="10"
             default="ldaps://${org.codice.ddf.system.hostname}:1636"
             description="LDAP or LDAPS server and port">
 	    </AD>
+
+		<AD name="LDAP Load Balancing:" id="loadBalancing" required="false" type="String"
+			default="round_robin"
+			description="Load balancing algorithm to use when multiple LDAP urls are provided (round_robin, failover)">
+		</AD>
 
 		<AD name="LDAP Bind Method" id="bindMethod" required="true" type="String"
 			default="Simple">

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
@@ -34,6 +34,7 @@ import org.apache.cxf.sts.claims.ProcessedClaim;
 import org.apache.cxf.sts.claims.ProcessedClaimCollection;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.forgerock.opendj.ldap.Connection;
+import org.forgerock.opendj.ldap.DN;
 import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.LinkedAttribute;
@@ -76,6 +77,7 @@ public class RoleClaimsHandlerTest {
     ProcessedClaimCollection processedClaims;
     RoleClaimsHandler claimsHandler;
     SearchResultEntry membershipSearchResult = mock(SearchResultEntry.class);
+    DN resultDN = DN.valueOf("uid=tstark,");
     SearchResultEntry groupNameSearchResult = mock(SearchResultEntry.class);
     String groupName = "avengers";
 
@@ -89,6 +91,8 @@ public class RoleClaimsHandlerTest {
     when(membershipReader.isEntry()).thenReturn(true);
     when(membershipReader.readEntry()).thenReturn(membershipSearchResult);
 
+    when(membershipSearchResult.getName()).thenReturn(resultDN);
+
     groupNameAttribute.add(groupName);
     when(groupNameSearchResult.getAttribute(anyString())).thenReturn(groupNameAttribute);
 
@@ -100,7 +104,7 @@ public class RoleClaimsHandlerTest {
     when(connection.search(
             anyObject(),
             anyObject(),
-            eq("(&(objectClass=groupOfNames)(member=uid=tstark,))"),
+            eq("(&(objectClass=groupOfNames)(|(member=uid=tstark,)(member=uid=tstark,)))"),
             anyVararg()))
         .thenReturn(groupNameReader);
     when(connection.search(anyString(), anyObject(), anyString(), matches("uid")))
@@ -113,6 +117,75 @@ public class RoleClaimsHandlerTest {
     claimsHandler.setBindMethod("Simple");
     claimsHandler.setBindUserCredentials("foo");
     claimsHandler.setBindUserDN("bar");
+
+    claimsParameters = new ClaimsParameters();
+    claimsParameters.setPrincipal(new UserPrincipal(USER_CN));
+    ClaimCollection claimCollection = new ClaimCollection();
+    processedClaims = claimsHandler.retrieveClaimValues(claimCollection, claimsParameters);
+    assertThat(processedClaims, hasSize(1));
+    ProcessedClaim claim = processedClaims.get(0);
+    assertThat(claim.getPrincipal(), equalTo(new UserPrincipal(USER_CN)));
+    assertThat(claim.getValues(), hasSize(1));
+    assertThat(claim.getValues().get(0), equalTo(groupName));
+  }
+
+  @Test
+  public void testRetrieveClaimsValuesNestedUserOU()
+      throws LdapException, SearchResultReferenceIOException {
+    BindResult bindResult = mock(BindResult.class);
+    ClaimsParameters claimsParameters;
+    Connection connection = mock(Connection.class);
+    ConnectionEntryReader membershipReader = mock(ConnectionEntryReader.class);
+    ConnectionEntryReader groupNameReader = mock(ConnectionEntryReader.class);
+    LDAPConnectionFactory connectionFactory = PowerMockito.mock(LDAPConnectionFactory.class);
+    LinkedAttribute membershipAttribute = new LinkedAttribute("cn");
+    LinkedAttribute groupNameAttribute = new LinkedAttribute("cn");
+    ProcessedClaimCollection processedClaims;
+    RoleClaimsHandler claimsHandler;
+    SearchResultEntry membershipSearchResult = mock(SearchResultEntry.class);
+    DN resultDN = DN.valueOf("uid=tstark,OU=nested,");
+    SearchResultEntry groupNameSearchResult = mock(SearchResultEntry.class);
+    String groupName = "avengers";
+
+    when(bindResult.isSuccess()).thenReturn(true);
+
+    membershipAttribute.add("tstark");
+    when(membershipSearchResult.getAttribute(anyString())).thenReturn(membershipAttribute);
+
+    // hasNext() returns 'true' the first time, then 'false' every time after.
+    when(membershipReader.hasNext()).thenReturn(true, false);
+    when(membershipReader.isEntry()).thenReturn(true);
+    when(membershipReader.readEntry()).thenReturn(membershipSearchResult);
+
+    when(membershipSearchResult.getName()).thenReturn(resultDN);
+
+    groupNameAttribute.add(groupName);
+    when(groupNameSearchResult.getAttribute(anyString())).thenReturn(groupNameAttribute);
+
+    when(groupNameReader.hasNext()).thenReturn(true, false);
+    when(groupNameReader.isEntry()).thenReturn(true);
+    when(groupNameReader.readEntry()).thenReturn(groupNameSearchResult);
+
+    when(connection.bind(anyObject())).thenReturn(bindResult);
+    when(connection.search(
+            anyObject(),
+            anyObject(),
+            eq(
+                "(&(objectClass=groupOfNames)(|(member=cn=tstark,OU=nested,)(member=uid=tstark,OU=nested,)))"),
+            anyVararg()))
+        .thenReturn(groupNameReader);
+    when(connection.search(anyString(), anyObject(), anyString(), matches("cn")))
+        .thenReturn(membershipReader);
+
+    when(connectionFactory.getConnection()).thenReturn(connection);
+
+    claimsHandler = new RoleClaimsHandler();
+    claimsHandler.setLdapConnectionFactory(connectionFactory);
+    claimsHandler.setBindMethod("Simple");
+    claimsHandler.setBindUserCredentials("foo");
+    claimsHandler.setBindUserDN("bar");
+    claimsHandler.setMembershipUserAttribute("cn");
+    claimsHandler.setLoginUserAttribute("uid");
 
     claimsParameters = new ClaimsParameters();
     claimsParameters.setPrincipal(new UserPrincipal(USER_CN));
@@ -139,6 +212,7 @@ public class RoleClaimsHandlerTest {
     ProcessedClaimCollection processedClaims;
     RoleClaimsHandler claimsHandler;
     SearchResultEntry membershipSearchResult = mock(SearchResultEntry.class);
+    DN resultDN = DN.valueOf("uid=tstark,");
     SearchResultEntry groupNameSearchResult = mock(SearchResultEntry.class);
     String groupName = "avengers";
 
@@ -153,6 +227,8 @@ public class RoleClaimsHandlerTest {
     when(membershipReader.isEntry()).thenReturn(false, true);
     when(membershipReader.readEntry()).thenReturn(membershipSearchResult);
 
+    when(membershipSearchResult.getName()).thenReturn(resultDN);
+
     groupNameAttribute.add(groupName);
     when(groupNameSearchResult.getAttribute(anyString())).thenReturn(groupNameAttribute);
 
@@ -164,7 +240,7 @@ public class RoleClaimsHandlerTest {
     when(connection.search(
             anyObject(),
             anyObject(),
-            eq("(&(objectClass=groupOfNames)(member=uid=tstark,))"),
+            eq("(&(objectClass=groupOfNames)(|(member=uid=tstark,)(member=uid=tstark,)))"),
             anyVararg()))
         .thenReturn(groupNameReader);
     when(connection.search(anyString(), anyObject(), anyString(), matches("uid")))

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapConnectionPooledObjectFactory.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapConnectionPooledObjectFactory.java
@@ -17,13 +17,13 @@ import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.forgerock.opendj.ldap.Connection;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.ConnectionFactory;
 
 public class LdapConnectionPooledObjectFactory extends BasePooledObjectFactory<Connection> {
 
-  private final LDAPConnectionFactory ldapConnectionFactory;
+  private final ConnectionFactory ldapConnectionFactory;
 
-  public LdapConnectionPooledObjectFactory(LDAPConnectionFactory ldapConnectionFactory) {
+  public LdapConnectionPooledObjectFactory(ConnectionFactory ldapConnectionFactory) {
     this.ldapConnectionFactory = ldapConnectionFactory;
   }
 

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -83,7 +83,7 @@ public class LdapLoginConfig {
 
   private static final String SUFFICIENT_FLAG = "sufficient";
 
-  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAtttribute";
+  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAttribute";
 
   public static final String MEMBER_USER_ATTRIBUTE = "membershipUserAttribute";
 
@@ -288,7 +288,10 @@ public class LdapLoginConfig {
     props.put(USER_SEARCH_SUBTREE_OPTIONS_KEY, "true");
     props.put(ROLE_BASE_DN_OPTIONS_KEY, properties.get(GROUP_BASE_DN));
     Object groupMemberAttribute = properties.get(MEMBER_NAME_ATTRIBUTE);
-    groupMemberAttribute = groupMemberAttribute == null ? "member" : groupMemberAttribute;
+    groupMemberAttribute =
+        groupMemberAttribute == null || groupMemberAttribute.toString().trim().isEmpty()
+            ? "member"
+            : groupMemberAttribute;
     props.put(
         ROLE_FILTER_OPTIONS_KEY,
         String.format(

--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/LdapLoginConfig.java
@@ -144,9 +144,7 @@ public class LdapLoginConfig {
       List<ConnectionFactory> connectionFactories = new ArrayList<>();
 
       Boolean startTls =
-          props.get(START_TLS) == null
-              ? false
-              : Boolean.parseBoolean(props.get(START_TLS).toString());
+          props.get(START_TLS) != null && Boolean.parseBoolean(props.get(START_TLS).toString());
 
       for (String url : urls) {
         connectionFactories.add(createLdapConnectionFactory(url, startTls));

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -40,6 +40,7 @@
             <property name="ldapService" ref="ldapService"/>
             <property name="loginUserAttribute" value="uid"/>
             <property name="membershipUserAttribute" value="uid"/>
+            <property name="memberNameAttribute" value="member"/>
             <cm:managed-properties persistent-id=""
                                    update-strategy="component-managed" update-method="update"/>
         </cm:managed-component>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -28,7 +28,12 @@
             <!-- Default properties -->
             <property name="ldapBindUserDn" value="cn=admin"/>
             <property name="ldapBindUserPass" value="secret"/>
-            <property name="ldapUrl" value="ldaps://${org.codice.ddf.system.hostname}:1636"/>
+            <property name="ldapUrl">
+                <list>
+                    <value>ldaps://${org.codice.ddf.system.hostname}:1636</value>
+                </list>
+            </property>
+            <property name="ldapLoadBalancing" value="round_robin"/>
             <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
             <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
             <property name="startTls" value="false"/>

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,10 +18,15 @@
 	<OCD description="STS Ldap Login Configuration" name="Security STS LDAP Login"
          id="Ldap_Login_Config">
 	    
-	    <AD name="LDAP URL:" id="ldapUrl" required="true" type="String"
+	    <AD name="LDAP URL:" id="ldapUrl" required="true" type="String" cardinality="10"
             default="ldaps://${org.codice.ddf.system.hostname}:1636"
             description="LDAP or LDAPS server and port">
 	    </AD>
+
+		<AD name="LDAP Load Balancing:" id="ldapLoadBalancing" required="false" type="String"
+			default="round_robin"
+			description="Load balancing algorithm to use when multiple LDAP urls are provided (round_robin, failover)">
+		</AD>
 
 		<AD name="LDAP Bind Method" id="bindMethod" required="true" type="String"
 			default="Simple">

--- a/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -65,6 +65,11 @@
 			default="uid"
 			description="Attribute used as the membership attribute for the user in the group. Usually this is uid, cn, or something similar.">
 		</AD>
+
+		<AD name="LDAP Member Name Attribute:" id="memberNameAttribute" required="true" type="String"
+			default="member"
+			description="Attribute used to identify users in the group. Usually this is member or something similar.">
+		</AD>
 	    
 	    <AD name="LDAP User Login Attribute:" id="loginUserAttribute" required="true" type="String"
             default="uid"

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapModuleTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/LdapModuleTest.java
@@ -67,7 +67,7 @@ import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.forgerock.opendj.ldap.Connection;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
+import org.forgerock.opendj.ldap.ConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.junit.After;
 import org.junit.Before;
@@ -101,7 +101,7 @@ public class LdapModuleTest {
 
     server = TestServer.getInstance();
     LdapLoginConfig ldapLoginConfig = new LdapLoginConfig(null);
-    LDAPConnectionFactory ldapConnectionFactory =
+    ConnectionFactory ldapConnectionFactory =
         ldapLoginConfig.createLdapConnectionFactory(TestServer.getUrl("ldap"), false);
     module =
         TestModule.getInstance(


### PR DESCRIPTION

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: [#3665](https://github.com/codice/ddf/pull/3665)
____


#### What does this PR do?
Remove LDAP structure assumptions, enable LDAP login and attribute claims to work with nested user OUs, allow multiple ldap servers in a single configuration for load balancing / failover

#### Who is reviewing it? 
@ryeats 
@KalCramer 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams/security
#### Ask 2 committers to review/merge the PR and tag them here.

@coyotesqrl
@stustison
@tbatie

#### How should this be tested?
Create a user in a nested OU under the base user DN
Set their uid and cn to be different values (e.g. uid=user1, cn=User One)
Add the user to a group and verify that they can log in and that their group information is successfully added. If added to the admin group the user should be able to log into the admin console

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4090](https://codice.atlassian.net/browse/DDF-4090)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
