### PR TITLE
DDF-4160 Update Basic Search Form to use configurable attribute for type

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -217,6 +217,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   private List<String> basicSearchTemporalSelectionDefault;
 
+  private String basicSearchMatchType;
+
   private Set<String> editorAttributes = Collections.emptySet();
   private Set<String> requiredAttributes = Collections.emptySet();
   private Map<String, Set<String>> attributeEnumMap = Collections.emptyMap();
@@ -500,6 +502,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("requiredAttributes", getRequiredAttributes());
     config.put("enums", getAttributeEnumMap());
     config.put("basicSearchTemporalSelectionDefault", basicSearchTemporalSelectionDefault);
+    config.put("basicSearchMatchType", basicSearchMatchType);
     return config;
   }
 
@@ -1157,5 +1160,13 @@ public class ConfigurationApplication implements SparkApplication {
 
   public List<String> getBasicSearchTemporalSelectionDefault() {
     return basicSearchTemporalSelectionDefault;
+  }
+
+  public String getBasicSearchMatchType() {
+    return basicSearchMatchType;
+  }
+
+  public void setBasicSearchMatchType(String basicSearchMatchType) {
+    this.basicSearchMatchType = basicSearchMatchType;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -195,6 +195,12 @@
             cardinality="10000"
             default="created,effective,modified,metacard.created,metacard.modified"/>
 
+        <AD id="basicSearchMatchType"
+            name="Basic Search Match Type Metacard Attribute"
+            description="Metacard attribute used for Basic Search Type Match."
+            type="String"
+            default="datatype"/>
+
         <AD id="typeNameMapping"
             name="Type Name Mapping"
             description="Mapping of display names to content types in the form name=type."

--- a/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
+++ b/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
@@ -58,6 +58,7 @@ basicSearchTemporalSelectionDefault=[ \
   "metacard.created", \
   "metacard.modified", \
   ]
+basicSearchMatchType="datatype"
 resultPageSize=I"25"
 queryFeedbackEnabled=B"false"
 webSocketsEnabled=B"true"

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -444,7 +444,7 @@
                             <rules>
                                 <ArtifactSizeEnforcerRule
                                     implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
-                                    <maxArtifactSize>1.8_MB</maxArtifactSize>
+                                    <maxArtifactSize>2.16_MB</maxArtifactSize>
                                 </ArtifactSizeEnforcerRule>
                             </rules>
                         </configuration>

--- a/distribution/docs/src/main/resources/content/_reference/_tables/catalog.ui.config.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/catalog.ui.config.adoc
@@ -224,6 +224,13 @@ metacard.version.versioned-on, +
 modified
 |false
 
+|Basic Search Match Type Metacard Attribute
+|basicSearchMatchType
+|String
+|Metacard attribute used for Basic Search Type Match.
+|datatype
+|true
+
 |Type Name Mapping
 |typeNameMapping
 |String

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -25,6 +25,7 @@ define([
   'component/dropdown/query-src/dropdown.query-src.view',
   'component/property/property.view',
   'component/property/property',
+  'properties',
   'js/cql',
   'component/singletons/metacard-definitions',
   'component/singletons/sources-instance',
@@ -44,6 +45,7 @@ define([
   QuerySrcView,
   PropertyView,
   Property,
+  properties,
   cql,
   metacardDefinitions,
   sources,
@@ -60,6 +62,12 @@ define([
     return nested
   }
 
+  function getMatchTypeAttribute() {
+    return metacardDefinitions.metacardTypes[properties.basicSearchMatchType]
+      ? properties.basicSearchMatchType
+      : 'datatype'
+  }
+
   function isTypeLimiter(filter) {
     var typesFound = {}
     filter.filters.forEach(function(subfilter) {
@@ -69,7 +77,7 @@ define([
     return (
       typesFound.length === 2 &&
       typesFound.indexOf('metadata-content-type') >= 0 &&
-      typesFound.indexOf('datatype') >= 0
+      typesFound.indexOf(getMatchTypeAttribute()) >= 0
     )
   }
 
@@ -494,7 +502,7 @@ define([
               typesSpecific.map(function(specificType) {
                 return CQLUtils.generateFilter(
                   'ILIKE',
-                  'datatype',
+                  getMatchTypeAttribute(),
                   specificType
                 )
               })


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Update Basic Search Form to use configurable attribute for type; right now it is hardcoded to use the datatype attribute.
#### Who is reviewing it? 
@bdeining @Bdthomson @alanchampion 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@djblue
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- build/run
- Run a Basic Search with a specific Match Type selected 
- verify type selected was searched with "datatype" and "metadata-content-type" 
<img width="972" alt="screen shot 2018-09-24 at 12 17 30 pm" src="https://user-images.githubusercontent.com/39923178/45970481-d79aba80-bff3-11e8-8c42-bc469a3551f8.png">

- in Admin search ui config set Basic Search Match Type Metacard Attribute to a valid metacard attribute
<img width="1025" alt="screen shot 2018-09-24 at 12 09 42 pm" src="https://user-images.githubusercontent.com/39923178/45970278-57745500-bff3-11e8-965a-8cf62b0f8cfc.png">

- run another search and verify type selected was searched with "metadata-content-type" and the attribute set in admin config
- in Admin search ui config set Basic Search Match Type Metacard Attribute to an invalid metacard attribute
- run another search and verify type selected was searched with "metadata-content-type" and "datatype"
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4160](https://codice.atlassian.net/browse/DDF-4160)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
