### PR TITLE
[2.13.x] DDF-4122 Do not start DDF if JAVA_HOME not set

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddf
+++ b/distribution/ddf-common/src/main/resources/bin/ddf
@@ -51,6 +51,14 @@ managing_solr() {
     return $RC
 }
 
+shutdown_no_java_home() {
+    # Shutdown if JAVA_HOME is not set
+    if [ -z $JAVA_HOME ]; then
+        echo "JAVA_HOME not set. Set JAVA_HOME to proceed - exiting."
+        exit 1
+    fi
+}
+
 attempt_startup() {
     if managing_solr; then
         $SOLR_EXEC restart
@@ -78,6 +86,7 @@ attempt_shutdown() {
 while true; do
     clear_restart_flag
     refresh_properties
+    shutdown_no_java_home
     attempt_startup
     attempt_shutdown
 done

--- a/distribution/ddf-common/src/main/resources/bin/ddf.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddf.bat
@@ -10,6 +10,12 @@ POPD
 SET GET_PROPERTY=%DIRNAME%get_property.bat
 SET SOLR_EXEC=%DDF_HOME%\bin\ddfsolr.bat
 
+REM Exit if JAVA_HOME not set
+IF "%JAVA_HOME%" == "" (
+    ECHO JAVA_HOME not set. Set JAVA_HOME to proceed - exiting.
+    EXIT /B
+)
+
 :RESTART
 REM Remove the restart file indicator so we can detect later if restart was requested
 IF EXIST "%DIRNAME%restart.jvm" DEL "%DIRNAME%restart.jvm"


### PR DESCRIPTION
Backport of https://github.com/codice/ddf/pull/3739

What does this PR do?
Sets the start scripts on window and *nix to not start/exit if JAVA_HOME is not set

Who is reviewing it?
@garrettfreibott @ahoffer @mcalcote

Select relevant component teams:
https://github.com/orgs/codice/teams

Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann
@clockard
@shaundmorris 
@ricklarsen - Documentation

How should this be tested?
Unset JAVA_HOME
Start up DDF
DDF should not start and should output message saying to set JAVA_HOME to start

Any background context you want to provide?
What are the relevant tickets?
DDF-4122

Screenshots
Checklist:
  Documentation Updated
  Update / Add Unit Tests
  Update / Add Integration Tests
Notes on Review Process
Please see Notes on Review Process for further guidance on requirements for merging and abbreviated reviews.

Review Comment Legend:
✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.