### PR TITLE
DDF-3908 Add additional step to docs for the service wrapper

### DIFF
--- a/distribution/docs/src/main/resources/content/_managing/_running/ddf-service.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/ddf-service.adoc
@@ -41,6 +41,14 @@ ${branding-lowercase}${at-symbol}local> wrapper:install -i setenv-wrapper.conf -
 ----
 ${branding-lowercase}${at-symbol}local> wrapper:install -i setenv-windows-wrapper.conf -n${branding-lowercase} -d ${branding-lowercase} -D "${branding} Service"
 ----
+. Edit `${home_directory}/etc/${branding-lowercase}-wrapper.conf` and uncomment both of these lines
+(remove the `#` at the beginning of the lines):
++
+.${home_directory}/etc/${branding-lowercase}-wrapper.conf
+----
+#wrapper.java.additional.9=-Djava.endorsed.dirs=%JAVA_HOME%/jre/lib/endorsed:%JAVA_HOME%/lib/endorsed:%KARAF_HOME%/lib/endorsed
+#wrapper.java.additional.10=-Djava.ext.dirs=%JAVA_HOME%/jre/lib/ext:%JAVA_HOME%/lib/ext:%KARAF_HOME%/lib/ext
+----
 . (Windows users skip this step) (All *NIX) If ${branding} was installed to run as a non-root
 user (as-recommended,) edit `${home_directory}/bin/${branding-lowercase}-service` and change
 the property `#RUN_AS_USER=` to:

--- a/distribution/docs/src/main/resources/content/_managing/_running/ddf-service.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/ddf-service.adoc
@@ -42,7 +42,8 @@ ${branding-lowercase}${at-symbol}local> wrapper:install -i setenv-wrapper.conf -
 ${branding-lowercase}${at-symbol}local> wrapper:install -i setenv-windows-wrapper.conf -n${branding-lowercase} -d ${branding-lowercase} -D "${branding} Service"
 ----
 . Edit `${home_directory}/etc/${branding-lowercase}-wrapper.conf` and uncomment both of these lines
-(remove the `#` at the beginning of the lines):
+(remove the `#` at the beginning of the lines).
+Note: The "9" and "10" indices may need to be changed to follow the sequence of other `wrapper.java.additional.n` properties in this file.
 +
 .${home_directory}/etc/${branding-lowercase}-wrapper.conf
 ----


### PR DESCRIPTION
#### What does this PR do?
Adds documentation for a step in installing the service wrapper that is now needed as of the Karaf 4.2.0 upgrade (https://github.com/codice/ddf/pull/3635). This was found in the hero process of PR 3635, but I forgot to push up the change before merging the original PR.
#### Who is reviewing it? 
@bakejeyner @blen-desta 
#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl 
@ricklarsen - Documentation
#### How should this be tested?
Generate the docs and verify the format of the modified section.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3908](https://codice.atlassian.net/browse/DDF-3908)
#### Screenshots
![image](https://user-images.githubusercontent.com/8130140/46039467-a937e080-c0c2-11e8-81a0-a6b2749e7b2d.png)

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
