### PR TITLE
DDF-2824 improvement to docs unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,11 +19,8 @@ atlassian-ide-plugin.xml
 *.sonar-ide.properties
 **/webapp/css/styles.css
 platform/solr/**/overlays
-distribution/docs/src/main/resources/content/*/*/.asciidoctor
-distribution/docs/src/main/resources/content/*/*/*.png
-
-
-
+distribution/docs/src/main/resources/content/**/.asciidoctor
+distribution/docs/src/main/resources/content/**/*.png
 # JMeter Related files to ignore
 jmeter.log
 *.jmx.log

--- a/distribution/docs/src/main/resources/content/_architectures/_resources/url-resource-reader.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_resources/url-resource-reader.adoc
@@ -31,7 +31,7 @@ Configure the URL Resource Reader from the ${admin-console}.
 
 See <<{reference-prefix}ddf.catalog.resource.impl.URLResourceReader,URL Resource Reader configurations>> for all possible configurations.
 
-=== Configuring Permissions for the URL Resource Reader
+===== Configuring Permissions for the URL Resource Reader
 
 Configuring the URL Resource Reader to retrieve files requires adding Security Manager read permission entries for the directory containing the resources. To add the correct permission entries, edit the file ${home_directory}/security/configurations.policy. In the URL Resource Reader section of the file, add two new permission for each top-level directory that the Resource Reader needs to access. The Resource Reader needs one permission to read the directory and another to read its contents.
 


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: [#3772](https://github.com/codice/ddf/pull/3772)

#### What does this PR do?

Fixes documentation unit test to be platform-independent.

#### Who is reviewing it? 
@mcalcote @ahoffer @garrettfreibott @austinsteffes 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@lessarderic
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?
builds successfully and test passes

#### What are the relevant tickets?
[DDF-2824](https://codice.atlassian.net/browse/DDF-2824)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
