### PR TITLE
DDF-4175 Give SSH bundles read/write access to all files

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -142,12 +142,10 @@ grant codeBase "file:/jetty-server/catalog-core-directorymonitor/catalog-securit
     permission java.io.FilePermission "${ddf.home.perm}etc${/}system.properties", "read,write";
 }
 
+// Any command executed via SSH will use other bundles that have their file access properly secured
+// so allowing karaf's SSH bundles access to all files won't create any security vulnerabilities.
 grant codeBase "file:/org.apache.karaf.shell.ssh/org.apache.sshd.core" {
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}-", "read";
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}host.key", "read,write";
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}branding-ssh.properties", "read";
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}org.apache.karaf.shell.cfg", "read";
+    permission java.io.FilePermission "<<ALL FILES>>", "read,write";
 }
 
 grant codeBase "file:/org.apache.karaf.shell.core/org.apache.shiro.core" {


### PR DESCRIPTION
#### What does this PR do?

Karaf's SSH bundles didn't have read or write access to many of the
files on the system. This would require the user to add permissions for
the ssh bundles if they wanted to use certain commands through ssh.
Since any commands run through ssh will go through other bundles that
will be properly secured, this wont create any security vulnerabilities.
We also only allow ssh connections from the host machine so it would be
very difficult for an unauthorized user to access ddf via ssh.

#### Who is reviewing it? 

@peterhuffer  @emmberk 

#### Select relevant component teams: 

https://github.com/orgs/codice/teams/security

#### Ask 2 committers to review/merge the PR and tag them here.

@clockard
@ricklarsen - Documentation

#### How should this be tested?

Install ddf and ssh into the karaf shell. Then try to ingest a file from outside the user and ddf home directories.

#### What are the relevant tickets?

[DDF-4175](https://codice.atlassian.net/browse/DDF-4175)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
