### PR TITLE
[2.13.x] DDF-4171 - Resolved SAML compliance issues when DDF is configured behind a proxy

### DIFF
--- a/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
+++ b/platform/security/idp/security-idp-server/src/main/java/org/codice/ddf/security/idp/server/IdpEndpoint.java
@@ -110,6 +110,7 @@ import org.apache.cxf.rs.security.saml.sso.SSOConstants;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.util.Strings;
 import org.apache.wss4j.common.crypto.CryptoType;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
@@ -1252,8 +1253,17 @@ public class IdpEndpoint implements Idp, SessionHandler {
         validator.setRequestId(requestId);
       }
 
-      validator.buildAndValidate(
-          request.getRequestURL().toString(), SamlProtocol.Binding.HTTP_REDIRECT, logoutRequest);
+      String destination = request.getRequestURL().toString();
+      try {
+        URL url = new URL(destination);
+        if (Strings.isNotBlank(SystemBaseUrl.EXTERNAL.getRootContext())
+            && !url.getPath().startsWith(SystemBaseUrl.EXTERNAL.getRootContext())) {
+          destination = SystemBaseUrl.EXTERNAL.constructUrl(url.getPath());
+        }
+      } catch (MalformedURLException e) {
+        LOGGER.error("Unable to convert request URL to URL object.");
+      }
+      validator.buildAndValidate(destination, SamlProtocol.Binding.HTTP_REDIRECT, logoutRequest);
     }
   }
 
@@ -1312,8 +1322,18 @@ public class IdpEndpoint implements Idp, SessionHandler {
       if (requestId != null) {
         validator.setRequestId(requestId);
       }
-      validator.buildAndValidate(
-          request.getRequestURL().toString(), SamlProtocol.Binding.HTTP_POST, samlObject);
+
+      String destination = request.getRequestURL().toString();
+      try {
+        URL url = new URL(destination);
+        if (Strings.isNotBlank(SystemBaseUrl.EXTERNAL.getRootContext())
+            && !url.getPath().startsWith(SystemBaseUrl.EXTERNAL.getRootContext())) {
+          destination = SystemBaseUrl.EXTERNAL.constructUrl(url.getPath());
+        }
+      } catch (MalformedURLException e) {
+        LOGGER.error("Unable to convert request URL to URL object.");
+      }
+      validator.buildAndValidate(destination, SamlProtocol.Binding.HTTP_POST, samlObject);
     }
   }
 

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/blueprint/cxf-sts.xml
@@ -258,7 +258,7 @@
         <argument ref="STSProperties"/>
         <cm:managed-properties persistent-id="ddf.security.sts"
                                update-strategy="container-managed"/>
-        <property name="issuer" value="https://${org.codice.ddf.system.hostname}:${org.codice.ddf.system.httpsPort}${org.codice.ddf.system.rootContext}/idp/login"/>
+        <property name="issuer" value="${org.codice.ddf.system.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.httpsPort}${org.codice.ddf.external.context}${org.codice.ddf.system.rootContext}/idp/login"/>
         <property name="signatureUsername" value="${org.codice.ddf.system.hostname}"/>
         <property name="encryptionUsername" value="${org.codice.ddf.system.hostname}"/>
     </bean>

--- a/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/sts/security-sts-server/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -21,7 +21,7 @@
         </AD>
 	    
 	    <AD name="Token Issuer:" id="issuer" required="true" type="String"
-            default="${org.codice.ddf.system.protocol}://${org.codice.ddf.system.hostname}:${org.codice.ddf.system.httpsPort}${org.codice.ddf.system.rootContext}/idp/login"
+            default="${org.codice.ddf.system.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.httpsPort}${org.codice.ddf.external.context}${org.codice.ddf.system.rootContext}/idp/login"
             description="The name of the server issuing tokens. Generally this is unique identifier of this IdP.">
 	    </AD>
 	    


### PR DESCRIPTION
#### What does this PR do?
Resolved SAML compliance issues when DDF is configured behind a proxy.

#### Who is reviewing it? 
@brjeter @bakejeyner 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@stustison 

#### How should this be tested?
- Verify that the [SAML-CTK](https://github.com/codice/saml-conformance) tests pass with out-the-box DDF
- Configure DDF behind a proxy both **with** and **without** an external context and verify that the [SAML-CTK](https://github.com/codice/saml-conformance) tests pass. 
See the testing steps on https://github.com/codice/ddf/pull/3692 for steps on how to configure DDF behind a proxy.

#### What are the relevant tickets?
[DDF-4171](https://codice.atlassian.net/browse/DDF-4171)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
