### PR TITLE
DDF-3908 Remove jsp exclude causing startup failures with empty m2

### DIFF
--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -40,7 +40,6 @@
                 <exclude>etc/shell.init.script</exclude>
                 <exclude>etc/org.apache.karaf.kar.cfg</exclude>
                 <exclude>system/**/org.ops4j.pax.tipi.tomcat*</exclude>
-                <exclude>system/**/pax-web-jsp*</exclude>
                 <exclude>system/**/*elasticsearch*</exclude>
                 <exclude>system/**/*kibana*</exclude>
                 <exclude>system/**/pax-web-tomcat*</exclude>


### PR DESCRIPTION
#### What does this PR do?
The distribution was trying to exclude the pax-web JSP jar, which was causing failures when starting up with an empty m2 repo:

> Error resolving artifact org.ops4j.pax.web:pax-web-jsp:jar:7.2.3: [Could not find artifact org.ops4j.pax.web:pax-web-jsp:jar:7.2.3]
#### Who is reviewing it? 
@emmberk @peterhuffer 
#### Ask 2 committers to review/merge the PR and tag them here.

@clockard
@coyotesqrl 
#### How should this be tested?
Clean your m2 repo and start up DDF. Verify the above error is not in the logs.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-3908](https://codice.atlassian.net/browse/DDF-3908)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
