### PR TITLE
DDF-4183 Single quoted property name support in cql.js

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -23,6 +23,7 @@ define(['moment'], function(moment) {
     temporalClass = 'Temporal',
     timePatter = /([0-9]{4})(-([0-9]{2})(-([0-9]{2})(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?/i,
     patterns = {
+      //Allows for non-standard single-quoted property names
       PROPERTY: /^([_a-zA-Z]\w*|"[^"]+"|'[^']+')/,
       COMPARISON: /^(=|<>|<=|<|>=|>|LIKE|ILIKE)/i,
       IS_NULL: /^IS NULL/i,

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -23,7 +23,7 @@ define(['moment'], function(moment) {
     temporalClass = 'Temporal',
     timePatter = /([0-9]{4})(-([0-9]{2})(-([0-9]{2})(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?/i,
     patterns = {
-      PROPERTY: /^([_a-zA-Z]\w*|"[^"]+")/,
+      PROPERTY: /^([_a-zA-Z]\w*|"[^"]+"|'[^']+')/,
       COMPARISON: /^(=|<>|<=|<|>=|>|LIKE|ILIKE)/i,
       IS_NULL: /^IS NULL/i,
       COMMA: /^,/,
@@ -252,6 +252,8 @@ define(['moment'], function(moment) {
       var tok = tokens.shift()
       switch (tok.type) {
         case 'PROPERTY':
+          //Remove single quotes if they exist in property name
+          tok.text = tok.text.replace(/^'|'$/g, '')
         case 'GEOMETRY':
         case 'VALUE':
         case 'TIME':

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.spec.js
@@ -132,5 +132,10 @@ describe('tokenize', () => {
       const result = cql.write(filter)
       expect(result).equals("anyText ILIKE '%%\\%\\%\\_\\___\\*\\*\\?\\?'")
     })
+
+    it('parses single quote property name', () => {
+      const result = cql.read("'ext.test-attribute' = 'this is a test'")
+      expect(result.property).equals('ext.test-attribute')
+    })
   })
 })


### PR DESCRIPTION
#### What does this PR do?
Adds support for single ' property names in cql.js

#### Who is reviewing it? 
@Bdthomson 
@Schachte 

#### Select relevant component teams: 
https://github.com/orgs/codice/teams
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@djblue

#### How should this be tested?
Full build.
Modify the ddf.home/etc/org.codice.ddf.catalog.ui.config and set listTemplates to something like:
listTemplates=[ \
  "{\"id\":\ \"Targets\",\ \"list.icon\":\ \"target\",\ \"list.cql\":\ \"(('title'\ \=\ 'User\ Defined'\))"\ }", \
  ]
Create a list of type target
Query for data, and Click the Add/Remove from list drop down and verify your list created previously is in the list. Unless the title is User Defined you won't be able to add to that list though. It showing in the dropdown is enough to verify this PR.

#### Any background context you want to provide?
Currently properties can be escaped with " but not ', single quotes gives the ability to nest within already quoted configuration settings like the listTemplates example above. 

#### What are the relevant tickets?
[DDF-4183](https://codice.atlassian.net/browse/DDF-4183)

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
