### PR TITLE
DDF-4035 Constraining java.ext.dirs to java home in external Solr

### DIFF
--- a/distribution/solr-distro/src/main/resources/bin/solr
+++ b/distribution/solr-distro/src/main/resources/bin/solr
@@ -48,6 +48,7 @@
 # ******************************************************
 # *****          DDF SECURITY MANAGER              *****
 SEC_MAN_ARGS="-Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.policy==../security/solr-default.policy -Dsolr.ssl.keystore=${SOLR_SSL_KEY_STORE} -Dsolr.ssl.truststore=${SOLR_SSL_TRUST_STORE} -classpath ../security/pro-grade-1.1.3.jar:start.jar org.eclipse.jetty.start.Main"
+JAVA_EXT_DIRS="-Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext"
 # ******************************************************
 
 SOLR_SCRIPT="$0"
@@ -2121,12 +2122,12 @@ function launch_solr() {
   esac
 
   if [ "$run_in_foreground" == "true" ]; then
-    exec "$JAVA" "${SOLR_START_OPTS[@]}" $SOLR_ADDL_ARGS $SEC_MAN_ARGS "${SOLR_JETTY_CONFIG[@]}" $SOLR_JETTY_ADDL_CONFIG
+    exec "$JAVA" "${SOLR_START_OPTS[@]}" $SOLR_ADDL_ARGS $JAVA_EXT_DIRS $SEC_MAN_ARGS "${SOLR_JETTY_CONFIG[@]}" $SOLR_JETTY_ADDL_CONFIG
   else
     # run Solr in the background
     nohup "$JAVA" "${SOLR_START_OPTS[@]}" $SOLR_ADDL_ARGS -Dsolr.log.muteconsole \
 	"-XX:OnOutOfMemoryError=$SOLR_TIP/bin/oom_solr.sh $SOLR_PORT $SOLR_LOGS_DIR" \
-        $SEC_MAN_ARGS "${SOLR_JETTY_CONFIG[@]}" $SOLR_JETTY_ADDL_CONFIG \
+        $JAVA_EXT_DIRS $SEC_MAN_ARGS "${SOLR_JETTY_CONFIG[@]}" $SOLR_JETTY_ADDL_CONFIG \
 	1>"$SOLR_LOGS_DIR/solr-$SOLR_PORT-console.log" 2>&1 & echo $! > "$SOLR_PID_DIR/solr-$SOLR_PORT.pid"
 
     # check if /proc/sys/kernel/random/entropy_avail exists then check output of cat /proc/sys/kernel/random/entropy_avail to see if less than 300

--- a/distribution/solr-distro/src/main/resources/bin/solr.cmd
+++ b/distribution/solr-distro/src/main/resources/bin/solr.cmd
@@ -30,6 +30,7 @@
 @REM ******************************************************
 @REM *****          DDF SECURITY MANAGER              *****
 set "SEC_MAN_ARGS=-Djava.security.manager=net.sourceforge.prograde.sm.ProGradeJSM -Dpolicy.provider=net.sourceforge.prograde.policy.ProGradePolicy -Djava.security.policy==../security/solr-default.policy -Dsolr.ssl.keystore=%SOLR_SSL_KEY_STORE% -Dsolr.ssl.truststore=%SOLR_SSL_TRUST_STORE% -classpath ../security/pro-grade-1.1.3.jar;start.jar org.eclipse.jetty.start.Main"
+set "JAVA_EXT_DIRS=-Djava.ext.dirs=%JAVA_HOME%\jre\lib\ext;%JAVA_HOME%\lib\ext"
 @REM ******************************************************
 
 IF "%OS%"=="Windows_NT" setlocal enabledelayedexpansion enableextensions
@@ -1313,7 +1314,7 @@ IF "%FG%"=="1" (
     -Dlog4j.configurationFile="%LOG4J_CONFIG%" -DSTOP.PORT=!STOP_PORT! -DSTOP.KEY=%STOP_KEY% ^
     -Dsolr.solr.home="%SOLR_HOME%" -Dsolr.install.dir="%SOLR_TIP%" -Dsolr.default.confdir="%DEFAULT_CONFDIR%" ^
     -Djetty.host=%SOLR_JETTY_HOST% -Djetty.port=%SOLR_PORT% -Djetty.home="%SOLR_SERVER_DIR%" ^
-    -Djava.io.tmpdir="%SOLR_SERVER_DIR%\tmp" %SEC_MAN_ARGS% ^
+    -Djava.io.tmpdir="%SOLR_SERVER_DIR%\tmp" %JAVA_EXT_DIRS% %SEC_MAN_ARGS% ^
     %SOLR_JETTY_CONFIG% "%SOLR_JETTY_ADDL_CONFIG%"
 ) ELSE (
   START /B "Solr-%SOLR_PORT%" /D "%SOLR_SERVER_DIR%" ^
@@ -1322,7 +1323,7 @@ IF "%FG%"=="1" (
     -Dsolr.log.muteconsole ^
     -Dsolr.solr.home="%SOLR_HOME%" -Dsolr.install.dir="%SOLR_TIP%" -Dsolr.default.confdir="%DEFAULT_CONFDIR%" ^
     -Djetty.host=%SOLR_JETTY_HOST% -Djetty.port=%SOLR_PORT% -Djetty.home="%SOLR_SERVER_DIR%" ^
-    -Djava.io.tmpdir="%SOLR_SERVER_DIR%\tmp" %SEC_MAN_ARGS% ^
+    -Djava.io.tmpdir="%SOLR_SERVER_DIR%\tmp" %JAVA_EXT_DIRS% %SEC_MAN_ARGS% ^
    %SOLR_JETTY_CONFIG% "%SOLR_JETTY_ADDL_CONFIG%" > "!SOLR_LOGS_DIR!\solr-%SOLR_PORT%-console.log"
   echo %SOLR_PORT%>"%SOLR_TIP%"\bin\solr-%SOLR_PORT%.port
 


### PR DESCRIPTION
#### What does this PR do?
For the Solr JVM, sets the property `java.ext.dirs` to the extension directory under java home only (excluding other default directories on the JVM's system).

This was causing the `SunEC` security provider fail to load due to an AccessControlException, *and* on jdk versions older than 8u112 Solr would fail to come up at all.

#### Who is reviewing it? 
@garrettfreibott @adimka @gordocanchola 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@coyotesqrl
@pklinef 
@stustison
#### How should this be tested?
Should be tested across multiple OS's:
- Make sure a jar is in one of the default extension directories outside of java home (see https://docs.oracle.com/javase/6/docs/technotes/guides/extensions/spec.html for details)
- Add debug options to the solr script, so that the JVM can be debugged remotely (reach out to me if you need help)
- Attach acdebugger to the debug port configured from the previous step
- Run DDF
- Verify the acdebugger prints nothing while Solr is coming up
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4035](https://codice.atlassian.net/browse/DDF-4035)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
