### PR TITLE
[2.13.x] DDF-4191 Fix mvn install issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -660,6 +660,11 @@ are essentially embedding a slightly modified version of felix -->
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
#### What does this PR do?
- Locks down the maven-install-plugins version to 2.5.2. With 3.0.0-M1, any modules that have attachments but do not have primary artifacts will now fail with an exception instead of printing a warning, like 2.5.2 and before would. This primarily effects the feature modules which have only attachments - so they now fail to build on 3.0.0+.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@paouelle @emmberk @kcover @tbatie 

#### Select relevant component teams: 
@codice/build 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@coyotesqrl

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Full build

#### Any background context you want to provide?
https://issues.apache.org/jira/browse/MINSTALL-151

#### What are the relevant tickets?
[DDF-4191](https://codice.atlassian.net/browse/DDF-4191)

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
