### PR TITLE
DDF-1366 Use framework to get source status in AdminPollerServiceBean

### DIFF
--- a/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBean.java
+++ b/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBean.java
@@ -150,7 +150,6 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
     }
   }
 
-  // returns 1 = available, 0 = unavailable, -1 = status pending
   @Override
   public int sourceStatus(String servicePID) {
     try {
@@ -174,7 +173,7 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
       LOGGER.info("Could not get service reference list");
     }
 
-    return 0;
+    return UNAVAILABLE;
   }
 
   private int sourceIsAvailable(String sourceId) {
@@ -184,18 +183,22 @@ public class AdminPollerServiceBean implements AdminPollerServiceBeanMBean {
       final SourceInfoResponse sourceInfoResponse =
           catalogFramework.getSourceInfo(sourceInfoRequest);
       final Set<SourceDescriptor> sourceDescriptors = sourceInfoResponse.getSourceInfo();
+
+      if (sourceDescriptors.isEmpty()) {
+        return STATUS_PENDING;
+      }
       final SourceDescriptor sourceDescriptor = Iterables.getOnlyElement(sourceDescriptors);
 
       if (sourceDescriptor.getLastAvailabilityDate() == null) {
-        return -1;
+        return STATUS_PENDING;
       }
       if (sourceDescriptor.isAvailable()) {
-        return 1;
+        return AVAILABLE;
       }
     } catch (Exception e) {
       LOGGER.info("Couldn't get availability on source {}", sourceId, e);
     }
-    return 0;
+    return UNAVAILABLE;
   }
 
   @Override

--- a/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanMBean.java
+++ b/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanMBean.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.codice.ddf.admin.core.api.Service;
 
 public interface AdminPollerServiceBeanMBean {
-  boolean sourceStatus(String servicePID);
+  int sourceStatus(String servicePID);
 
   List<Service> allSourceInfo();
 }

--- a/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanMBean.java
+++ b/catalog/admin/admin-poller-service/src/main/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanMBean.java
@@ -16,8 +16,31 @@ package org.codice.ddf.catalog.admin.poller;
 import java.util.List;
 import org.codice.ddf.admin.core.api.Service;
 
+/**
+ * {@link AdminPollerServiceBeanMBean} defines an interface for accessing information about
+ * configured sources
+ */
 public interface AdminPollerServiceBeanMBean {
+
+  static final int AVAILABLE = 1;
+
+  static final int UNAVAILABLE = 0;
+
+  static final int STATUS_PENDING = -1;
+
+  /**
+   * Get the current status of the source.
+   *
+   * @param servicePID the PID of the source to get the status of.
+   * @return Int indicating the status of the source. 1 if the source is available, 0 if
+   *     unavailable, and -1 if the source has not yet been polled for availability.
+   */
   int sourceStatus(String servicePID);
 
+  /**
+   * Get information on all configured sources.
+   *
+   * @return A list of sources represented by Service objects.
+   */
   List<Service> allSourceInfo();
 }

--- a/catalog/admin/admin-poller-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/admin/admin-poller-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,6 +21,8 @@
 
     <reference id="configurationAdmin" interface="org.codice.ddf.admin.core.api.ConfigurationAdmin"/>
 
+    <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
+
     <reference-list id="reportActionProviders" interface="ddf.action.MultiActionProvider"
                     filter="(id=catalog.source.report.*)" availability="optional"/>
 
@@ -33,6 +35,7 @@
           destroy-method="destroy">
         <argument ref="configurationAdmin"/>
         <argument ref="felixConfigurationAdmin"/>
+        <argument ref="catalogFramework"/>
         <cm:managed-properties persistent-id="org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean"
                                update-strategy="container-managed"/>
         <property name="reportActionProviders" ref="reportActionProviders"/>

--- a/catalog/admin/admin-poller-service/src/test/groovy/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanSpec.groovy
+++ b/catalog/admin/admin-poller-service/src/test/groovy/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanSpec.groovy
@@ -13,13 +13,15 @@
  */
 package org.codice.ddf.catalog.admin.poller
 
+import ddf.catalog.CatalogFramework
 import spock.lang.Specification
 
 class AdminPollerServiceBeanSpec extends Specification {
 
     def "test LDAP filter generation"() {
         setup:
-        def apsb = new AdminPollerServiceBean(null, null)
+        def catalogFramework = Mock(CatalogFramework)
+        def apsb = new AdminPollerServiceBean(null, null, catalogFramework)
         apsb.setIncludeAsSource(includes)
         apsb.setExcludeAsSource(excludes)
 

--- a/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanTest.java
+++ b/catalog/admin/admin-poller-service/src/test/java/org/codice/ddf/catalog/admin/poller/AdminPollerServiceBeanTest.java
@@ -218,6 +218,18 @@ public class AdminPollerServiceBeanTest {
   }
 
   @Test
+  public void testSourceStatusReceivesNoSourceDescriptors() throws Exception {
+    Set<SourceDescriptor> descriptors = new HashSet<SourceDescriptor>();
+    SourceInfoRequest request =
+        new SourceInfoRequestSources(false, Collections.singleton("sourceId"));
+    SourceInfoResponse response =
+        new SourceInfoResponseImpl(request, Collections.EMPTY_MAP, descriptors);
+    when(catalogFramework.getSourceInfo(any(SourceInfoRequest.class))).thenReturn(response);
+
+    assertThat(poller.sourceStatus(CONFIG_PID), is(-1));
+  }
+
+  @Test
   public void testSourceStatusHandlesSourceUnavailableException() throws Exception {
     when(catalogFramework.getSourceInfo(any(SourceInfoRequest.class)))
         .thenThrow(SourceUnavailableException.class);

--- a/ui/packages/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
+++ b/ui/packages/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
@@ -75,10 +75,10 @@ define([
                     data.disabledConfigurations = this.model.get('disabledConfigurations').toJSON();
                 }
 
-                if(typeof this.model.get('available') === 'undefined') {
+                if(typeof this.model.get('available') === 'undefined' || this.model.get('available') === -1) {
                     data.loading = true;
                 } else {
-                    data.available = this.model.get('available');
+                    data.available = this.model.get('available') === 1;
                 }
 
                 data.name = this.model.get('name');


### PR DESCRIPTION
####DO NOT MERGE BEFORE THE NEW SOURCEPOLLER IMPLEMENTATION

#### What does this PR do?
Modifies the AdminPollerServiceBean to use the CatalogFramework to
check the availability of the sources and adds tests for the new
functionality.

#### Who is reviewing it? 

@emmberk @peterhuffer 

#### Select relevant component teams: 

@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.

@clockard 
@vinamartin

#### How should this be tested?

build and install ddf. Setup some sources and make sure the sources tab in the catalog app is updated when the status of a source changes. Make sure that the source isn't queried each time the refresh button in the tab is clicked.

#### What are the relevant tickets?

[DDF-1366](https://codice.atlassian.net/browse/DDF-1366)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
