### PR TITLE
DDF-4045 Enhanced PermissionActivator to implement the AC debugger

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/startup.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/startup.properties
@@ -1,16 +1,18 @@
 # Bundles to be started on startup, with startlevel
-mvn\:org.apache.karaf.features/org.apache.karaf.features.extension/4.1.2 = 1
-mvn\:ddf.platform.osgi/platform-osgi-condpermadmin/${project.version} = 2
-mvn\:ddf.platform.osgi/platform-osgi-conditions/${project.version} = 2
-mvn\:org.apache.felix/org.apache.felix.metatype/1.1.2 = 5
-mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/4.1.2 = 5
-mvn\:org.ops4j.pax.url/pax-url-aether/2.5.2 = 5
-mvn\:org.ops4j.pax.logging/pax-logging-api/1.10.1 = 8
-mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.10.1 = 8
+mvn\:org.apache.karaf.features/org.apache.karaf.features.extension/4.1.2=1
+mvn\:ddf.platform.osgi/platform-osgi-condpermadmin/${project.version}=2
+mvn\:ddf.platform.osgi/platform-osgi-conditions/${project.version}=2
+mvn\:org.codice.acdebugger/acdebugger-api/${acdebugger.version}=2
+mvn\:org.codice.acdebugger/acdebugger-backdoor/${acdebugger.version}=2
+mvn\:org.apache.felix/org.apache.felix.metatype/1.1.2=5
+mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/4.1.2=5
+mvn\:org.ops4j.pax.url/pax-url-aether/2.5.2=5
+mvn\:org.ops4j.pax.logging/pax-logging-api/1.10.1=8
+mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.10.1=8
 # Using a boot feature won't be good enough. We need to actually replace Felix with our own impl.
 # The following ddf.platform.osgi line (for the currently used karaf version) used to be:
 # mvn\:org.apache.felix/org.apache.felix.configadmin/1.8.14 = 10
-mvn\:ddf.platform.osgi/platform-osgi-internal-api/${project.version} = 9
-mvn\:ddf.platform.osgi/platform-osgi-configadmin/${project.version} = 10
-mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.0 = 11
-mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.1.2 = 15
+mvn\:ddf.platform.osgi/platform-osgi-internal-api/${project.version}=9
+mvn\:ddf.platform.osgi/platform-osgi-configadmin/${project.version}=10
+mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.0=11
+mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.1.2=15

--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -282,9 +282,9 @@
         <fileSet>
             <directory>${setup.folder}/solr</directory>
             <outputDirectory>/solr</outputDirectory>
-          <excludes>
-            <exclude>**/derby*</exclude>
-          </excludes>
+            <excludes>
+                <exclude>**/derby*</exclude>
+            </excludes>
         </fileSet>
     </fileSets>
 
@@ -320,6 +320,24 @@
             </outputDirectory>
             <includes>
                 <include>ddf.platform.osgi:platform-osgi-conditions:jar:${project.version}</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>
+                system/org/codice/acdebugger/acdebugger-api/${acdebugger.version}
+            </outputDirectory>
+            <includes>
+                <include>org.codice.acdebugger:acdebugger-api:jar:${acdebugger.version}
+                </include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>
+                system/org/codice/acdebugger/acdebugger-backdoor/${acdebugger.version}
+            </outputDirectory>
+            <includes>
+                <include>org.codice.acdebugger:acdebugger-backdoor:jar:${acdebugger.version}
+                </include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -27,6 +27,9 @@ deny {
 
     // Load classes into any protection domain
     permission java.lang.RuntimePermission "createClassLoader";
+
+    permission org.osgi.framework.ServicePermission "org.codice.acdebugger.PermissionService", "get, register";
+    permission org.osgi.framework.ServicePermission "org.osgi.service.condpermadmin.ConditionalPermissionAdmin", "get";
 }
 
 grant
@@ -65,8 +68,11 @@ grant codeBase "file:/org.apache.felix.fileinstall" {
     permission java.io.FilePermission "${ddf.home.perm}wrap:jardir:${ddf.home.perm}etc${/}-", "read";
 }
 
-grant codeBase "file:/platform-osgi-condpermadmin" {
+grant codeBase "file:/platform-osgi-condpermadmin/acdebugger-backdoor" {
     permission java.io.FilePermission "${ddf.home.perm}security${/}-", "read";
+    permission org.osgi.framework.ServicePermission "org.codice.acdebugger.PermissionService", "get, register";
+    permission org.osgi.framework.ServicePermission "org.osgi.service.condpermadmin.ConditionalPermissionAdmin", "get";
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 }
 
 grant codeBase "file:/org.apache.felix.configadmin" {

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -183,6 +183,28 @@
                                         platform-osgi-condpermadmin-${project.version}.jar
                                     </destFileName>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codice.acdebugger</groupId>
+                                    <artifactId>acdebugger-api</artifactId>
+                                    <version>${acdebugger.version}</version>
+                                    <outputDirectory>
+                                        ${setup.folder}/system/org/codice/acdebugger/acdebugger-api/${acdebugger.version}
+                                    </outputDirectory>
+                                    <destFileName>
+                                        acdebugger-api-${acdebugger.version}.jar
+                                    </destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codice.acdebugger</groupId>
+                                    <artifactId>acdebugger-backdoor</artifactId>
+                                    <version>${acdebugger.version}</version>
+                                    <outputDirectory>
+                                        ${setup.folder}/system/org/codice/acdebugger/acdebugger-backdoor/${acdebugger.version}
+                                    </outputDirectory>
+                                    <destFileName>
+                                        acdebugger-backdoor-${acdebugger.version}.jar
+                                    </destFileName>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -313,6 +335,16 @@
             <groupId>ddf.platform.osgi</groupId>
             <artifactId>platform-osgi-condpermadmin</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.acdebugger</groupId>
+            <artifactId>acdebugger-api</artifactId>
+            <version>${acdebugger.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.acdebugger</groupId>
+            <artifactId>acdebugger-backdoor</artifactId>
+            <version>${acdebugger.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.features</groupId>

--- a/platform/osgi/platform-osgi-condpermadmin/pom.xml
+++ b/platform/osgi/platform-osgi-condpermadmin/pom.xml
@@ -44,6 +44,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.codice.acdebugger</groupId>
+            <artifactId>acdebugger-api</artifactId>
+            <version>${acdebugger.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.codice.pro-grade</groupId>
             <artifactId>pro-grade</artifactId>
             <version>1.1.3</version>
@@ -74,7 +79,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
                 <configuration>
                     <instructions>
                         <Bundle-Category>osgi</Bundle-Category>
@@ -93,6 +97,9 @@
                             pro-grade,
                             commons-lang3
                         </Embed-Dependency>
+                        <Provide-Capability>
+                            osgi.service;objectClass="org.codice.acdebugger.PermissionService"
+                        </Provide-Capability>
                         <Require-Capability>
                             osgi.service;filter:="(objectClass=org.osgi.service.condpermadmin.ConditionalPermissionAdmin)";effective:=active;resolution:=mandatory
                         </Require-Capability>
@@ -117,12 +124,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.93</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.87</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,8 @@
         <project.scm.id>github</project.scm.id>
         <!-- Must MANUALLY update this if the ddf/support project's version changes -->
         <ddf.support.version>2.3.14</ddf.support.version>
+        <!-- Must MANUALLY update this if the AC Debugger project's version changes -->
+        <acdebugger.version>1.4</acdebugger.version>
         <!-- Do NOT set karaf.data or karaf.base -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -250,10 +252,10 @@
         <ddf-spatial>Spatial</ddf-spatial>
         <ddf-ui>Search UI</ddf-ui>
         <deprecated>
-[IMPORTANT]
-====
-This Feature has been *DEPRECATED* and will be removed in a future version.
-====
+            [IMPORTANT]
+            ====
+            This Feature has been *DEPRECATED* and will be removed in a future version.
+            ====
         </deprecated>
 
         <asciidoctor.maven.plugin.version>1.5.6</asciidoctor.maven.plugin.version>
@@ -854,17 +856,20 @@ are essentially embedding a slightly modified version of felix -->
                                                 will be set to 0 not 0.75
                                                 -->
                                                 <limits>
-                                                    <limit implementation="org.codice.jacoco.LenientLimit">
+                                                    <limit
+                                                        implementation="org.codice.jacoco.LenientLimit">
                                                         <counter>INSTRUCTION</counter>
                                                         <value>COVEREDRATIO</value>
                                                         <minimum>0.75</minimum>
                                                     </limit>
-                                                    <limit implementation="org.codice.jacoco.LenientLimit">
+                                                    <limit
+                                                        implementation="org.codice.jacoco.LenientLimit">
                                                         <counter>BRANCH</counter>
                                                         <value>COVEREDRATIO</value>
                                                         <minimum>0.75</minimum>
                                                     </limit>
-                                                    <limit implementation="org.codice.jacoco.LenientLimit">
+                                                    <limit
+                                                        implementation="org.codice.jacoco.LenientLimit">
                                                         <counter>COMPLEXITY</counter>
                                                         <value>COVEREDRATIO</value>
                                                         <minimum>0.75</minimum>


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to master PR: #3627
____

#### What does this PR do?
This PR updates the kernel to include 2 AC debugger-specific bundles which by design do nothing except start. The backdoor bundle is meant to be discovered by the debugger using reflection to optimize the communication between the VM being debugged and the debugger. The PermissionActivator is also enhanced to implement an AC debugger service which would allow it to temporarily grant permissions. The service is protected against anybody but the AC debugger backdoor to get their hands on it.

#### Who is reviewing it? 
@tyler30clemens 
@figliold 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@stustison 

#### What are the relevant tickets?
[DDF-4045](https://codice.atlassian.net/browse/DDF-4045)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
