### PR TITLE
DDF-4193 make the installer set system.hostname to the given hostname when dev=true

### DIFF
--- a/ui/packages/ui/src/main/webapp/js/models/installer/Configuration.js
+++ b/ui/packages/ui/src/main/webapp/js/models/installer/Configuration.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define*/
+/*global define, location*/
 /** Main view page for add. */
 define(['backbone', 'jquery', 'backboneassociations'], function(Backbone, $) {
   var Configuration = {}
@@ -73,6 +73,12 @@ define(['backbone', 'jquery', 'backboneassociations'], function(Backbone, $) {
       this.models.forEach(function(model) {
         propertiesMap[model.get('key')] = model.get('value')
       })
+
+      var devMode = location.search.indexOf('dev=true') > -1 ? true : false
+      if (devMode) {
+        var hostname = propertiesMap['org.codice.ddf.external.hostname']
+        propertiesMap['org.codice.ddf.system.hostname'] = hostname
+      }
 
       data.arguments = [propertiesMap]
       data = JSON.stringify(data)


### PR DESCRIPTION
#### What does this PR do?
Makes the installer set system.hostname to the given hostname when the query parameter dev=true

#### Who is reviewing it? 
@oconnormi @emmberk @kcover @peterhuffer @mdang8 

#### Select relevant component teams: 

@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.

@clockard
@vinamartin

#### How should this be tested?
set dev=true in the query string and check that hostname is set for both external.hostname and system.hostname.

#### What are the relevant tickets?
#3747
[DDF-4193](https://codice.atlassian.net/browse/DDF-4193)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
