### PR TITLE
DDF-4198 Fixed a typo in the property for 'Internal Default Port'

### DIFF
--- a/distribution/docs/src/main/resources/content/_managing/_configuring/global-settings.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/global-settings.adoc
@@ -121,7 +121,7 @@ NOTE: This *DOES* change the port the system runs on.
 |Yes
 
 |Internal Default Port
-|org.codice.ddf.external.port
+|org.codice.ddf.system.port
 |String
 |The default port that the system uses. This should match either the above http or https port.
 


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?

Fixed a typo in the Global Settings documentation with the "Internal Default Port" property.

#### Who is reviewing it? 

@oconnormi @pvargas @peterhuffer @emmberk @kcover 

#### Select relevant component teams: 

@codice/docs 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->

@clockard
@coyotesqrl

#### What are the relevant tickets?
[DDF-4198](https://codice.atlassian.net/browse/DDF-4198)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
