### PR TITLE
[2.13.x] DDF-4203 Fixes "%" wildcard discrepancies in Intrigue

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-adhoc/query-adhoc.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-adhoc/query-adhoc.view.js
@@ -25,9 +25,10 @@ define([
     'component/property/property',
     'component/singletons/user-instance',
     'js/Common',
-    'properties'
+    'properties',
+    'js/CQLUtils'
 ], function (Marionette, Backbone, _, $, template, CustomElements, store,
-           PropertyView, Property, user, Common, properties) {
+           PropertyView, Property, user, Common, properties, CQLUtils) {
 
     return Marionette.LayoutView.extend({
         template: template,
@@ -96,11 +97,11 @@ define([
             var text = this.textField.currentView.model.getValue()[0];
             var cql;
             if (text.length === 0) {
-                cql = "anyText ILIKE '*'";
+                cql = CQLUtils.generateFilter('ILIKE', 'anyText', "*");
             } else {
-                cql = "anyText ILIKE '"+text+"'";
+                cql = CQLUtils.generateFilter('ILIKE', 'anyText', text);
             }
-            this.model.set('cql', cql);
+            this.model.set('cql', CQLUtils.transformFilterToCQL(cql));
         },
         save: function(){
             this.$el.find('form')[0].submit();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -293,7 +293,7 @@ define([
                 model: new Property({
                     value: [this.filter.anyText ? this.filter.anyText[0].value : ''],
                     id: 'Text',
-                    placeholder: 'Text to search for.  Use "%" or "*" for wildcard.'
+                    placeholder: 'Text to search for.  Use "*" for wildcard.'
                 })
             }));
         },


### PR DESCRIPTION
#### What does this PR do?
- The Basic Search Form says "%" can be used as a wildcard but that is not the behavior. This is removed.
- The Text Search Form does behave like "%" is a wildcard. This functionality is changed to be consistent with other search forms.

#### Who is reviewing it? 
@garrettfreibott @blen-desta 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler 
@rzwiefel  
#### How should this be tested?
- Pull up the Basic Search Form in Intrigue and verify the help text does not mention "%"
- Verify the Text Search Form in Intrigue does not count % as a wildcard.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4203](https://codice.atlassian.net/browse/DDF-4203)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
