### PR TITLE
[2.13.X backport] DDF-4208 Increase default `Maximum xml metadata length` to 5MB.

### DIFF
--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/PdfInputTransformer.java
@@ -63,7 +63,7 @@ public class PdfInputTransformer implements InputTransformer {
 
   private int previewMaxLength = 30000;
 
-  private int metadataMaxLength = 30000;
+  private int metadataMaxLength = 5000000;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PdfInputTransformer.class);
 

--- a/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -29,7 +29,7 @@
         <AD description="The maximum length of xml metadata to be extracted."
             name="Maximum xml metadata length (bytes)" id="metadataMaxLength" required="true"
             type="Integer"
-            default="30000"/>
+            default="5000000"/>
 
     </OCD>
 

--- a/distribution/docs/src/main/resources/content/_tables/ddf.catalog.transformer.input.pdf.PdfInputTransformer.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/ddf.catalog.transformer.input.pdf.PdfInputTransformer.adoc
@@ -35,7 +35,7 @@
 |metadataMaxLength
 |Integer
 |The maximum length of xml metadata to be extracted.
-|30000
+|5000000
 |true
 
 |===


### PR DESCRIPTION
Backports #3849 
#### What does this PR do?
It increases the `Maximum xml metadata length` to 5MB, since the previous default work for larger files
#### Who is reviewing it? 
@oconnormi @mdang8 @kcover @emmberk @peterhuffer 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@coyotesqrl 

#### How should this be tested?
Ingest a large PDF through the Content Directory Monitor

#### What are the relevant tickets?
[DDF-4208](https://codice.atlassian.net/browse/DDF-4208)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
