### PR TITLE
[2.13.x] DDF-4147 Modified UI installer and migration:import to restart Solr as well as DDF

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddf
+++ b/distribution/ddf-common/src/main/resources/bin/ddf
@@ -28,7 +28,7 @@ refresh_properties() {
 }
 
 
-# Return 0 (success/true) if ddf_on_error.sh created a restart file
+# Return 0 (success/true) if a restart.jvm file was created to request a restart
 is_restarting() {
     local RC=1
     if [ -f "$RESTART_FILE" ]; then

--- a/distribution/ddf-common/src/main/resources/bin/ddf.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddf.bat
@@ -34,7 +34,7 @@ IF "%start.solr%" == "true" (
 REM Actually invoke ddf to gain restart support
 IF "%start.ddf%" == "true" CALL "%DIRNAME%karaf.bat" %ARGS%
 
-REM Check if restart was requested by ddf_on_error.bat
+REM Check if a restart.jvm file was created to request a restart
 IF EXIST "%DIRNAME%restart.jvm" (
     ECHO Restarting JVM...
     CALL :STOP_SOLR

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -58,6 +58,8 @@ grant
 
 grant codeBase "file:/admin-core-appservice" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}-", "read,write";
+    permission java.util.PropertyPermission "karaf.restart.jvm", "write";
+    permission java.io.FilePermission "${ddf.home.perm}bin${/}restart.jvm", "read, write";
 }
 
 grant codeBase "file:/org.apache.felix.fileinstall" {

--- a/platform/admin/core/admin-core-appservice/pom.xml
+++ b/platform/admin/core/admin-core-appservice/pom.xml
@@ -13,7 +13,9 @@
  **/
 
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>admin-core</artifactId>
@@ -61,6 +63,10 @@
             <groupId>org.apache.karaf.bundle</groupId>
             <artifactId>org.apache.karaf.bundle.core</artifactId>
             <version>${karaf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.system</groupId>
+            <artifactId>org.apache.karaf.system.core</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -192,17 +198,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.86</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.78</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.73</minimum>
+                                            <minimum>0.82</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
@@ -541,9 +541,8 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
     try {
       if (!restartServiceWrapperIfControlled()) {
         // create the restart.jvm file such that we would rely on the ddf script to restart
-        // ourselves
-        // and not on karaf. This will have the advantage to restart anything else (e.g. solr) that
-        // is also managed by that script
+        // ourselves and not on karaf. This will have the advantage to restart anything else
+        // (e.g. solr) that is also managed by that script
         LOGGER.debug("generating restart.jvm file");
         AccessController.doPrivileged(
             (PrivilegedExceptionAction<Void>)

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBean.java
@@ -15,6 +15,9 @@ package org.codice.ddf.admin.application.service.impl;
 
 import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_FACTORYPID;
 
+import ddf.security.common.audit.SecurityLogger;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -33,15 +36,19 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
 import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
+import javax.management.ReflectionException;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.karaf.features.BundleInfo;
 import org.apache.karaf.features.Feature;
 import org.apache.karaf.features.FeaturesService;
+import org.apache.karaf.system.SystemService;
 import org.codice.ddf.admin.application.plugin.ApplicationPlugin;
 import org.codice.ddf.admin.application.rest.model.FeatureDetails;
 import org.codice.ddf.admin.application.service.Application;
@@ -93,12 +100,14 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
 
   private final FeaturesService featuresService;
 
-  private ObjectName objectName;
+  private final SystemService systemService;
 
-  private MBeanServer mBeanServer;
+  private final ObjectName objectName;
+
+  private final MBeanServer mBeanServer;
 
   /** the service pid string. */
-  private ApplicationService appService;
+  private final ApplicationService appService;
 
   /** has all the application plugins. */
   private List<ApplicationPlugin> applicationPlugins;
@@ -117,12 +126,14 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
       ApplicationService appService,
       ConfigurationAdmin configAdmin,
       MBeanServer mBeanServer,
-      FeaturesService featuresService)
+      FeaturesService featuresService,
+      SystemService systemService)
       throws ApplicationServiceException {
     this.appService = appService;
     this.configAdmin = configAdmin;
     this.mBeanServer = mBeanServer;
     this.featuresService = featuresService;
+    this.systemService = systemService;
     try {
       objectName =
           new ObjectName(ApplicationService.class.getName() + ":service=application-service");
@@ -525,6 +536,37 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
     }
   }
 
+  @Override
+  public void restart() {
+    try {
+      if (!restartServiceWrapperIfControlled()) {
+        // create the restart.jvm file such that we would rely on the ddf script to restart
+        // ourselves
+        // and not on karaf. This will have the advantage to restart anything else (e.g. solr) that
+        // is also managed by that script
+        LOGGER.debug("generating restart.jvm file");
+        AccessController.doPrivileged(
+            (PrivilegedExceptionAction<Void>)
+                () -> {
+                  FileUtils.touch(
+                      Paths.get(System.getProperty("ddf.home"), "bin", "restart.jvm").toFile());
+                  // make sure Karaf is not going to restart us as we want the ddf script to do it
+                  System.setProperty("karaf.restart.jvm", "false");
+                  systemService.halt();
+                  return null;
+                });
+      }
+      SecurityLogger.audit("Restarting system");
+      LOGGER.info("Restarting the system.");
+    } catch (PrivilegedActionException e) {
+      SecurityLogger.audit("Failed to restart system");
+      LOGGER.debug("failed to request a restart: ", e.getException());
+    } catch (Exception e) {
+      SecurityLogger.audit("Failed to restart system");
+      LOGGER.debug("failed to request a restart: ", e);
+    }
+  }
+
   /**
    * serviceTracker setter method. Needed for use in unit tests.
    *
@@ -532,6 +574,22 @@ public class ApplicationServiceBean implements ApplicationServiceBeanMBean {
    */
   void setServiceTracker(ServiceTracker serviceTracker) {
     this.serviceTracker = (ServiceTracker<Object, Object>) serviceTracker;
+  }
+
+  private boolean restartServiceWrapperIfControlled()
+      throws InstanceNotFoundException, MBeanException, ReflectionException,
+          MalformedObjectNameException {
+    if (System.getProperty("wrapper.key") != null) {
+      LOGGER.debug("asking service wrapper to restart");
+      ManagementFactory.getPlatformMBeanServer()
+          .invoke(
+              new ObjectName("org.tanukisoftware.wrapper:type=WrapperManager"),
+              "restart",
+              null,
+              null);
+      return true;
+    }
+    return false;
   }
 
   private static String computeLocation(Bundle bundle) {

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanMBean.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanMBean.java
@@ -81,4 +81,8 @@ public interface ApplicationServiceBeanMBean {
    */
   @Deprecated
   List<Map<String, Object>> getPluginsForApplication(String appName);
+
+  /** Triggers a restart of the system. */
+  @Deprecated
+  void restart();
 }

--- a/platform/admin/core/admin-core-appservice/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/admin/core/admin-core-appservice/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -16,7 +16,8 @@
 
     <ext:property-placeholder/>
 
-    <bean id="appService" class="org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl">
+    <bean id="appService"
+          class="org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl">
         <cm:managed-properties
             persistent-id="org.codice.ddf.admin.application.service.impl.ApplicationServiceImpl"
             update-strategy="container-managed"/>
@@ -27,6 +28,8 @@
              interface="org.codice.ddf.admin.application.service.ApplicationService"/>
 
     <reference id="featuresService" interface="org.apache.karaf.features.FeaturesService"/>
+
+    <reference id="systemService" interface="org.apache.karaf.system.SystemService"/>
 
     <reference-list id="bundleStateServices"
                     interface="org.apache.karaf.bundle.core.BundleStateService"/>
@@ -43,6 +46,7 @@
         <argument ref="configurationAdmin"/>
         <argument ref="mBeanServer"/>
         <argument ref="featuresService"/>
+        <argument ref="systemService"/>
         <property name="applicationPlugins" ref="applicationPluginList"/>
     </bean>
 

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
@@ -65,6 +65,8 @@ import org.codice.ddf.admin.core.api.ConfigurationAdmin;
 import org.codice.ddf.admin.core.api.Service;
 import org.codice.ddf.admin.core.impl.ServiceImpl;
 import org.codice.ddf.test.mockito.StackCaptor;
+import org.hamcrest.Matchers;
+import org.hamcrest.io.FileMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -168,13 +170,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testInit() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
     serviceBean.init();
 
     verify(mBeanServer).registerMBean(serviceBean, objectName);
@@ -188,13 +184,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testInitTwice() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
     when(mBeanServer.registerMBean(any(Object.class), any(ObjectName.class)))
         .thenThrow(new InstanceAlreadyExistsException())
         .thenReturn(null);
@@ -213,13 +203,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test(expected = ApplicationServiceException.class)
   public void testInitWhenRegisterMBeanThrowsInstanceAlreadyExistsException() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
 
     when(mBeanServer.registerMBean(any(Object.class), any(ObjectName.class)))
         .thenThrow(new NullPointerException());
@@ -234,13 +218,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testDestroy() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
 
     serviceBean.destroy();
 
@@ -255,13 +233,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test(expected = ApplicationServiceException.class)
   public void testDestroyWhenUnregisterMBeanThrowsInstanceNotFoundException() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
 
     doThrow(new InstanceNotFoundException()).when(mBeanServer).unregisterMBean(objectName);
 
@@ -276,13 +248,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test(expected = ApplicationServiceException.class)
   public void testDestroyWhenUnregisterMBeanThrowsMBeanRegistrationException() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
 
     doThrow(new MBeanRegistrationException(new Exception()))
         .when(mBeanServer)
@@ -293,13 +259,7 @@ public class ApplicationServiceBeanTest {
 
   @Test
   public void testInstallProfile() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
     serviceBean.installFeature("profile-name");
 
     ArgumentCaptor<EnumSet<FeaturesService.Option>> captor = ArgumentCaptor.forClass(EnumSet.class);
@@ -312,13 +272,7 @@ public class ApplicationServiceBeanTest {
 
   @Test
   public void testInstallFeatureCallIsPrivileged() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
     serviceBean.installFeature("profile-name");
 
     verify(mockFeaturesService, privileged(times(1)))
@@ -334,13 +288,7 @@ public class ApplicationServiceBeanTest {
         .when(mockFeaturesService)
         .uninstallFeature(anyString(), any(EnumSet.class));
 
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
     serviceBean.uninstallFeature("profile-name");
 
     assertThat(stackCaptor.getStack(), stackContainsDoPrivilegedCall());
@@ -378,13 +326,7 @@ public class ApplicationServiceBeanTest {
     featureList.add(testFeature2);
     when(testAppService.getInstallationProfiles()).thenReturn(featureList);
 
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
 
     List<Map<String, Object>> result = serviceBean.getInstallationProfiles();
 
@@ -402,18 +344,8 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testGetServices() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService) {
-          @Override
-          protected BundleContext getContext() {
-            return bundleContext;
-          }
-        };
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
+
     Bundle testBundle = mock(Bundle.class);
     Bundle[] bundles = {testBundle};
     when(bundleContext.getBundles()).thenReturn(bundles);
@@ -451,18 +383,8 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testGetServicesNotContainsKey() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService) {
-          @Override
-          protected BundleContext getContext() {
-            return bundleContext;
-          }
-        };
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
+
     Bundle testBundle = mock(Bundle.class);
     Bundle[] bundles = {testBundle};
     when(bundleContext.getBundles()).thenReturn(bundles);
@@ -502,18 +424,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testGetServicesMetatypeInfo() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService) {
-          @Override
-          protected BundleContext getContext() {
-            return bundleContext;
-          }
-        };
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
 
     ServiceTracker testServiceTracker = mock(ServiceTracker.class);
     serviceBean.setServiceTracker(testServiceTracker);
@@ -584,18 +495,8 @@ public class ApplicationServiceBeanTest {
     root.addAppender(mockAppender);
     root.setLevel(Level.ALL);
 
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService) {
-          @Override
-          protected BundleContext getContext() {
-            return bundleContext;
-          }
-        };
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
+
     Bundle testBundle = mock(Bundle.class);
     Bundle[] bundles = {testBundle};
     when(bundleContext.getBundles()).thenReturn(bundles);
@@ -619,13 +520,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testGetSetApplicationPlugins() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
     ApplicationPlugin testPlugin1 = mock(ApplicationPlugin.class);
     ApplicationPlugin testPlugin2 = mock(ApplicationPlugin.class);
     List<ApplicationPlugin> pluginList = new ArrayList<>();
@@ -644,13 +539,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testGetAllFeatures() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
     List<FeatureDetails> testFeatureDetailsList = new ArrayList<>();
     FeatureDetails testFeatureDetails1 = mock(FeatureDetails.class);
     testFeatureDetailsList.add(testFeatureDetails1);
@@ -675,13 +564,7 @@ public class ApplicationServiceBeanTest {
    */
   @Test
   public void testGetPluginsForApplication() throws Exception {
-    ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    ApplicationServiceBean serviceBean = newApplicationServiceBean();
     ApplicationPlugin testPlugin1 = mock(ApplicationPlugin.class);
     ApplicationPlugin testPlugin2 = mock(ApplicationPlugin.class);
     List<ApplicationPlugin> pluginList = new ArrayList<>();
@@ -707,32 +590,20 @@ public class ApplicationServiceBeanTest {
 
   @Test
   public void testRestartWithKarafRestart() throws Exception {
-    final ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    final ApplicationServiceBean serviceBean = newApplicationServiceBean();
 
     serviceBean.restart();
 
     assertThat(
         "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
-    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
+    assertThat(ddfBin.resolve("restart.jvm").toFile(), FileMatchers.anExistingFile());
     verify(mockSystemService).halt();
     verify(mockWrapperManager, Mockito.never()).restart();
   }
 
   @Test
   public void testRestartWithWrapperRestart() throws Exception {
-    final ApplicationServiceBean serviceBean =
-        new ApplicationServiceBean(
-            testAppService,
-            testConfigAdminExt,
-            mBeanServer,
-            mockFeaturesService,
-            mockSystemService);
+    final ApplicationServiceBean serviceBean = newApplicationServiceBean();
 
     System.setProperty(WRAPPER_KEY, "abc");
 
@@ -742,9 +613,19 @@ public class ApplicationServiceBeanTest {
         "Restart system property was not cleared",
         System.getProperty(RESTART_JVM),
         equalTo("true"));
-    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(false));
+    assertThat(ddfBin.resolve("restart.jvm").toFile(), Matchers.not(FileMatchers.anExistingFile()));
     verify(mockSystemService, Mockito.never()).halt();
     verify(mockWrapperManager).restart();
+  }
+
+  private ApplicationServiceBean newApplicationServiceBean() throws ApplicationServiceException {
+    return new ApplicationServiceBean(
+        testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService, mockSystemService) {
+      @Override
+      protected BundleContext getContext() {
+        return bundleContext;
+      }
+    };
   }
 
   public static interface WrapperManagerMXBean {

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceBeanTest.java
@@ -17,6 +17,7 @@ import static org.codice.ddf.test.mockito.PrivilegedVerificationMode.privileged;
 import static org.codice.ddf.test.mockito.StackContainsDoPrivilegedCalls.stackContainsDoPrivilegedCall;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -24,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -32,6 +34,9 @@ import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.core.Appender;
+import java.lang.management.ManagementFactory;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -41,6 +46,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
 import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -49,6 +55,7 @@ import org.apache.karaf.features.BundleInfo;
 import org.apache.karaf.features.Dependency;
 import org.apache.karaf.features.Feature;
 import org.apache.karaf.features.FeaturesService;
+import org.apache.karaf.system.SystemService;
 import org.codice.ddf.admin.application.plugin.ApplicationPlugin;
 import org.codice.ddf.admin.application.rest.model.FeatureDetails;
 import org.codice.ddf.admin.application.service.Application;
@@ -58,8 +65,11 @@ import org.codice.ddf.admin.core.api.ConfigurationAdmin;
 import org.codice.ddf.admin.core.api.Service;
 import org.codice.ddf.admin.core.impl.ServiceImpl;
 import org.codice.ddf.test.mockito.StackCaptor;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
@@ -93,6 +103,12 @@ public class ApplicationServiceBeanTest {
   private static final String DO_PRIVILEGED_STACK_ELEMENT =
       "java.security.AccessController.doPrivileged";
 
+  private static final String WRAPPER_KEY = "wrapper.key";
+
+  private static final String RESTART_JVM = "karaf.restart.jvm";
+
+  @Rule public TemporaryFolder testFolder = new TemporaryFolder();
+
   private ApplicationService testAppService;
 
   private ConfigurationAdmin testConfigAdminExt;
@@ -101,11 +117,17 @@ public class ApplicationServiceBeanTest {
 
   private FeaturesService mockFeaturesService;
 
+  private SystemService mockSystemService;
+
   private BundleContext bundleContext;
 
   private MBeanServer mBeanServer;
 
   private ObjectName objectName;
+
+  private WrapperManagerMXBean mockWrapperManager;
+
+  private Path ddfBin;
 
   @Before
   public void setUp() throws Exception {
@@ -113,6 +135,7 @@ public class ApplicationServiceBeanTest {
     testConfigAdminExt = mock(ConfigurationAdmin.class);
     testApp = mock(ApplicationImpl.class);
     mockFeaturesService = mock(FeaturesService.class);
+    mockSystemService = mock(SystemService.class);
 
     when(testApp.getName()).thenReturn(TEST_APP_NAME);
     when(testApp.getDescription()).thenReturn(TEST_APP_DESCRIP);
@@ -120,6 +143,22 @@ public class ApplicationServiceBeanTest {
     mBeanServer = mock(MBeanServer.class);
     objectName =
         new ObjectName(ApplicationService.class.getName() + ":service=application-service");
+    mockWrapperManager = mock(WrapperManagerMXBean.class);
+    ManagementFactory.getPlatformMBeanServer()
+        .registerMBean(
+            mockWrapperManager, new ObjectName("org.tanukisoftware.wrapper:type=WrapperManager"));
+    doNothing().when(mockWrapperManager).restart();
+    System.setProperty(RESTART_JVM, "true");
+    System.setProperty("ddf.home", testFolder.getRoot().toString());
+    ddfBin = testFolder.newFolder("bin").toPath().toRealPath(LinkOption.NOFOLLOW_LINKS);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    System.getProperties().remove(RESTART_JVM);
+    System.getProperties().remove(WRAPPER_KEY);
+    ManagementFactory.getPlatformMBeanServer()
+        .unregisterMBean(new ObjectName("org.tanukisoftware.wrapper:type=WrapperManager"));
   }
 
   /**
@@ -131,7 +170,11 @@ public class ApplicationServiceBeanTest {
   public void testInit() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
     serviceBean.init();
 
     verify(mBeanServer).registerMBean(serviceBean, objectName);
@@ -147,7 +190,11 @@ public class ApplicationServiceBeanTest {
   public void testInitTwice() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
     when(mBeanServer.registerMBean(any(Object.class), any(ObjectName.class)))
         .thenThrow(new InstanceAlreadyExistsException())
         .thenReturn(null);
@@ -168,7 +215,11 @@ public class ApplicationServiceBeanTest {
   public void testInitWhenRegisterMBeanThrowsInstanceAlreadyExistsException() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
 
     when(mBeanServer.registerMBean(any(Object.class), any(ObjectName.class)))
         .thenThrow(new NullPointerException());
@@ -185,7 +236,11 @@ public class ApplicationServiceBeanTest {
   public void testDestroy() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
 
     serviceBean.destroy();
 
@@ -202,7 +257,11 @@ public class ApplicationServiceBeanTest {
   public void testDestroyWhenUnregisterMBeanThrowsInstanceNotFoundException() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
 
     doThrow(new InstanceNotFoundException()).when(mBeanServer).unregisterMBean(objectName);
 
@@ -219,7 +278,11 @@ public class ApplicationServiceBeanTest {
   public void testDestroyWhenUnregisterMBeanThrowsMBeanRegistrationException() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
 
     doThrow(new MBeanRegistrationException(new Exception()))
         .when(mBeanServer)
@@ -232,7 +295,11 @@ public class ApplicationServiceBeanTest {
   public void testInstallProfile() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
     serviceBean.installFeature("profile-name");
 
     ArgumentCaptor<EnumSet<FeaturesService.Option>> captor = ArgumentCaptor.forClass(EnumSet.class);
@@ -247,7 +314,11 @@ public class ApplicationServiceBeanTest {
   public void testInstallFeatureCallIsPrivileged() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
     serviceBean.installFeature("profile-name");
 
     verify(mockFeaturesService, privileged(times(1)))
@@ -265,7 +336,11 @@ public class ApplicationServiceBeanTest {
 
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
     serviceBean.uninstallFeature("profile-name");
 
     assertThat(stackCaptor.getStack(), stackContainsDoPrivilegedCall());
@@ -305,7 +380,11 @@ public class ApplicationServiceBeanTest {
 
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
 
     List<Map<String, Object>> result = serviceBean.getInstallationProfiles();
 
@@ -325,7 +404,11 @@ public class ApplicationServiceBeanTest {
   public void testGetServices() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService) {
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService) {
           @Override
           protected BundleContext getContext() {
             return bundleContext;
@@ -370,7 +453,11 @@ public class ApplicationServiceBeanTest {
   public void testGetServicesNotContainsKey() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService) {
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService) {
           @Override
           protected BundleContext getContext() {
             return bundleContext;
@@ -417,7 +504,11 @@ public class ApplicationServiceBeanTest {
   public void testGetServicesMetatypeInfo() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService) {
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService) {
           @Override
           protected BundleContext getContext() {
             return bundleContext;
@@ -495,7 +586,11 @@ public class ApplicationServiceBeanTest {
 
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService) {
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService) {
           @Override
           protected BundleContext getContext() {
             return bundleContext;
@@ -526,7 +621,11 @@ public class ApplicationServiceBeanTest {
   public void testGetSetApplicationPlugins() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
     ApplicationPlugin testPlugin1 = mock(ApplicationPlugin.class);
     ApplicationPlugin testPlugin2 = mock(ApplicationPlugin.class);
     List<ApplicationPlugin> pluginList = new ArrayList<>();
@@ -547,7 +646,11 @@ public class ApplicationServiceBeanTest {
   public void testGetAllFeatures() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
     List<FeatureDetails> testFeatureDetailsList = new ArrayList<>();
     FeatureDetails testFeatureDetails1 = mock(FeatureDetails.class);
     testFeatureDetailsList.add(testFeatureDetails1);
@@ -574,7 +677,11 @@ public class ApplicationServiceBeanTest {
   public void testGetPluginsForApplication() throws Exception {
     ApplicationServiceBean serviceBean =
         new ApplicationServiceBean(
-            testAppService, testConfigAdminExt, mBeanServer, mockFeaturesService);
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
     ApplicationPlugin testPlugin1 = mock(ApplicationPlugin.class);
     ApplicationPlugin testPlugin2 = mock(ApplicationPlugin.class);
     List<ApplicationPlugin> pluginList = new ArrayList<>();
@@ -596,5 +703,52 @@ public class ApplicationServiceBeanTest {
         "Should return the list of plugins given to it.",
         serviceBean.getPluginsForApplication(TEST_APP_NAME).get(0),
         is(plugin1JSON));
+  }
+
+  @Test
+  public void testRestartWithKarafRestart() throws Exception {
+    final ApplicationServiceBean serviceBean =
+        new ApplicationServiceBean(
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
+
+    serviceBean.restart();
+
+    assertThat(
+        "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
+    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
+    verify(mockSystemService).halt();
+    verify(mockWrapperManager, Mockito.never()).restart();
+  }
+
+  @Test
+  public void testRestartWithWrapperRestart() throws Exception {
+    final ApplicationServiceBean serviceBean =
+        new ApplicationServiceBean(
+            testAppService,
+            testConfigAdminExt,
+            mBeanServer,
+            mockFeaturesService,
+            mockSystemService);
+
+    System.setProperty(WRAPPER_KEY, "abc");
+
+    serviceBean.restart();
+
+    assertThat(
+        "Restart system property was not cleared",
+        System.getProperty(RESTART_JVM),
+        equalTo("true"));
+    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(false));
+    verify(mockSystemService, Mockito.never()).halt();
+    verify(mockWrapperManager).restart();
+  }
+
+  public static interface WrapperManagerMXBean {
+
+    public void restart() throws MBeanException;
   }
 }

--- a/platform/migration/platform-migration/pom.xml
+++ b/platform/migration/platform-migration/pom.xml
@@ -13,7 +13,9 @@
  **/
 
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ddf.platform</groupId>
@@ -179,17 +181,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.83</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.69</minimum>
+                                            <minimum>0.74</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.78</minimum>
+                                            <minimum>0.81</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManager.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManager.java
@@ -410,9 +410,8 @@ public class ConfigurationMigrationManager implements ConfigurationMigrationServ
     try {
       if (!restartServiceWrapperIfControlled()) {
         // create the restart.jvm file such that we would rely on the ddf script to restart
-        // ourselves
-        // and not on karaf. This will have the advantage to restart anything else (e.g. solr) that
-        // is also managed by that script
+        // ourselves and not on karaf. This will have the advantage to restart anything else
+        // (e.g. solr) that is also managed by that script
         LOGGER.debug("generating restart.jvm file");
         FileUtils.touch(
             Paths.get(

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/AbstractMigrationSupport.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/AbstractMigrationSupport.java
@@ -90,6 +90,8 @@ public class AbstractMigrationSupport {
 
   protected Path ddfHome;
 
+  protected Path ddfBin;
+
   /**
    * Retrieves all zip entries representing files from the specified zip file.
    *
@@ -346,7 +348,7 @@ public class AbstractMigrationSupport {
   public void baseSetup() throws Exception {
     root = testFolder.getRoot().toPath().toRealPath(LinkOption.NOFOLLOW_LINKS);
     ddfHome = testFolder.newFolder("ddf").toPath().toRealPath(LinkOption.NOFOLLOW_LINKS);
-
+    ddfBin = testFolder.newFolder("ddf", "bin").toPath().toRealPath(LinkOption.NOFOLLOW_LINKS);
     System.setProperty("ddf.home", ddfHome.toString());
   }
 

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManagerTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManagerTest.java
@@ -61,6 +61,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.StringDescription;
+import org.hamcrest.io.FileMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -313,7 +314,7 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
     assertThat("Import was not successful", report.wasSuccessful(), is(true));
     assertThat(
         "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
-    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
+    assertThat(ddfBin.resolve("restart.jvm").toFile(), FileMatchers.anExistingFile());
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
@@ -344,7 +345,7 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
         "Restart system property was not cleared",
         System.getProperty(RESTART_JVM),
         equalTo("true"));
-    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(false));
+    assertThat(ddfBin.resolve("restart.jvm").toFile(), Matchers.not(FileMatchers.anExistingFile()));
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
@@ -370,7 +371,7 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
     assertThat("Import was not successful", report.wasSuccessful(), is(true));
     assertThat(
         "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
-    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
+    assertThat(ddfBin.resolve("restart.jvm").toFile(), FileMatchers.anExistingFile());
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
@@ -402,7 +403,7 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
     assertThat("Import was not successful", report.wasSuccessful(), is(true));
     assertThat(
         "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
-    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
+    assertThat(ddfBin.resolve("restart.jvm").toFile(), FileMatchers.anExistingFile());
     reportHasInfoMessage(
         report.infos(),
         equalTo(
@@ -464,7 +465,7 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
     assertThat("Import was successful", report.wasSuccessful(), is(true));
     assertThat(
         "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
-    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
+    assertThat(ddfBin.resolve("restart.jvm").toFile(), FileMatchers.anExistingFile());
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
@@ -491,7 +492,7 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
         "Restart system property was not cleared",
         System.getProperty(RESTART_JVM),
         equalTo("true"));
-    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(false));
+    assertThat(ddfBin.resolve("restart.jvm").toFile(), Matchers.not(FileMatchers.anExistingFile()));
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManagerTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/migration/ConfigurationMigrationManagerTest.java
@@ -15,7 +15,6 @@ package org.codice.ddf.configuration.migration;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -117,6 +116,7 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
             Mockito.withSettings()
                 .useConstructor(migratables, mockSystemService)
                 .defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    System.setProperty(RESTART_JVM, "true");
   }
 
   @After
@@ -312,12 +312,13 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
 
     assertThat("Import was not successful", report.wasSuccessful(), is(true));
     assertThat(
-        "Restart system property was not set", System.getProperty(RESTART_JVM), equalTo("true"));
+        "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
+    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
         report.infos(), equalTo("Restarting the system for changes to take effect."));
-    verify(mockSystemService).reboot();
+    verify(mockSystemService).halt();
     verify(mockWrapperManager, Mockito.never()).restart();
     verify(configurationMigrationManager)
         .delegateToImportMigrationManager(
@@ -339,12 +340,16 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
     MigrationReport report = configurationMigrationManager.doImport(path);
 
     assertThat("Import was not successful", report.wasSuccessful(), is(true));
-    assertThat("Restart system property was set", System.getProperty(RESTART_JVM), nullValue());
+    assertThat(
+        "Restart system property was not cleared",
+        System.getProperty(RESTART_JVM),
+        equalTo("true"));
+    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(false));
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
         report.infos(), equalTo("Restarting the system for changes to take effect."));
-    verify(mockSystemService, Mockito.never()).reboot();
+    verify(mockSystemService, Mockito.never()).halt();
     verify(mockWrapperManager).restart();
     verify(configurationMigrationManager)
         .delegateToImportMigrationManager(
@@ -364,12 +369,13 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
 
     assertThat("Import was not successful", report.wasSuccessful(), is(true));
     assertThat(
-        "Restart system property was not set", System.getProperty(RESTART_JVM), equalTo("true"));
+        "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
+    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
         report.infos(), equalTo("Restarting the system for changes to take effect."));
-    verify(mockSystemService).reboot();
+    verify(mockSystemService).halt();
     verify(configurationMigrationManager)
         .delegateToImportMigrationManager(
             any(MigrationReportImpl.class),
@@ -395,7 +401,8 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
 
     assertThat("Import was not successful", report.wasSuccessful(), is(true));
     assertThat(
-        "Restart system property was not set", System.getProperty(RESTART_JVM), equalTo("true"));
+        "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
+    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
     reportHasInfoMessage(
         report.infos(),
         equalTo(
@@ -406,7 +413,7 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
                 + ".dar]."));
     reportHasInfoMessage(
         report.infos(), equalTo("Restarting the system for changes to take effect."));
-    verify(mockSystemService).reboot();
+    verify(mockSystemService).halt();
     verify(configurationMigrationManager)
         .delegateToImportMigrationManager(
             any(MigrationReportImpl.class),
@@ -450,17 +457,19 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
   public void doImportSucceedsWithKarafAndFailsToReboot() throws Exception {
     expectZipWithChecksum(true);
     expectImportDelegationIsSuccessful();
-    doThrow(Exception.class).when(mockSystemService).reboot();
+    doThrow(Exception.class).when(mockSystemService).halt();
 
     MigrationReport report = configurationMigrationManager.doImport(path);
 
     assertThat("Import was successful", report.wasSuccessful(), is(true));
-    assertThat("Restart system property was set", System.getProperty(RESTART_JVM), equalTo("true"));
+    assertThat(
+        "Restart system property was cleared", System.getProperty(RESTART_JVM), equalTo("false"));
+    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(true));
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
         report.infos(), equalTo("Please restart the system for changes to take effect."));
-    verify(mockSystemService).reboot();
+    verify(mockSystemService).halt();
     verify(mockWrapperManager, Mockito.never()).restart();
     verify(configurationMigrationManager)
         .delegateToImportMigrationManager(
@@ -478,12 +487,16 @@ public class ConfigurationMigrationManagerTest extends AbstractMigrationSupport 
     MigrationReport report = configurationMigrationManager.doImport(path);
 
     assertThat("Import was successful", report.wasSuccessful(), is(true));
-    assertThat("Restart system property was set", System.getProperty(RESTART_JVM), nullValue());
+    assertThat(
+        "Restart system property was not cleared",
+        System.getProperty(RESTART_JVM),
+        equalTo("true"));
+    assertThat(ddfBin.resolve("restart.jvm").toFile().exists(), equalTo(false));
     reportHasInfoMessage(
         report.infos(), equalTo("Successfully imported from file [" + encryptedFileName + "]."));
     reportHasInfoMessage(
         report.infos(), equalTo("Please restart the system for changes to take effect."));
-    verify(mockSystemService, Mockito.never()).reboot();
+    verify(mockSystemService, Mockito.never()).halt();
     verify(mockWrapperManager).restart();
     verify(configurationMigrationManager)
         .delegateToImportMigrationManager(

--- a/ui/packages/ui/src/main/webapp/js/models/Installer.js
+++ b/ui/packages/ui/src/main/webapp/js/models/Installer.js
@@ -49,10 +49,7 @@ define([
   Installer.Model = Backbone.Model.extend({
     installUrl: './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/installFeature(java.lang.String)/',
     uninstallUrl: './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/uninstallFeature(java.lang.String)/',
-    shutdownUrl: './jolokia/exec/org.apache.karaf:type=system,name=root/halt()',
-    propertiesUrl: './jolokia/exec/org.apache.karaf:type=system,name=root/setProperty(java.lang.String,java.lang.String,boolean)/karaf.restart.jvm/true/false',
-    restartUrl: './jolokia/exec/org.apache.karaf:type=system,name=root/reboot()',
-    restartWrapperUrl: './jolokia/exec/org.tanukisoftware.wrapper:type=WrapperManager/restart()',
+    restartUrl: './jolokia/exec/org.codice.ddf.admin.application.service.ApplicationService:service=application-service/restart()/',
     defaults: function () {
       return {
         hasNext: true,
@@ -142,44 +139,12 @@ define([
           if (restart) {
             $.ajax({
               type: 'GET',
-              url: that.propertiesUrl,
+              url: that.restartUrl,
               dataType: 'JSON'
             }).done(function () {
-              // try to restart the service wrapper. this will fail with 404 if
-              // the wrapper is not installed
-              $.ajax({
-                type: 'GET',
-                url: that.restartWrapperUrl,
-                dataType: 'JSON'
-              }).fail(function () {
-                // Service wrapper is not installed, must be started via Karaf's script
-                $.ajax({
-                  type: 'GET',
-                  url: that.restartUrl,
-                  dataType: 'JSON'
-                }).done(function () {
-                  window.setTimeout(function () {
-                    window.location.href = that.get("redirectUrl");
-                  }, 60000);
-                });
-              }).done(function (data) {
-                if (data.status === 2000) {
-                  window.setTimeout(function () {
-                    window.location.href = that.get("redirectUrl");
-                  }, 60000);
-                } else if (data.status === 404) {
-                  // Service wrapper is not installed, must be started via Karaf's script
-                  $.ajax({
-                    type: 'GET',
-                    url: that.restartUrl,
-                    dataType: 'JSON'
-                  }).done(function () {
-                    window.setTimeout(function () {
-                      window.location.href = that.get("redirectUrl");
-                    }, 60000);
-                  });
-                }
-              });
+              window.setTimeout(function () {
+                window.location.href = that.get("redirectUrl");
+              }, 60000);
             });
           } else {
             location.reload();


### PR DESCRIPTION
#### What does this PR do?
It modified the installer UI such that when comes time to restart DDF, it actually does it not through karaf reboot behavior but takes advantage of the restart logic defined inside the `ddf` and `ddf.bat` scripts. This has the advantages that the ddf scripts will actually restart Solr as well if it needs to.

It also modified migration:import to do the same thing.

#### Who is reviewing it? 
@ethantmanns 
@jhunzik 
@tyler30clemens 

#### Select relevant component teams: 

#### Ask 2 committers to review/merge the PR and tag them here.
@figliold
@tbatie

#### How should this be tested?
1- Unzip DDF and proceed through the UI installer
2- Click restart
3- Verify that Solr is being shutdown and then restarted in addition to DDF
4- Perform a migration:export
5- Perform a migration:import
6- Same as step 3

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4147](https://codice.atlassian.net/browse/DDF-4147)

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
