### PR TITLE
DDF-4163: Improve SynchronizedInstaller bundle error logging

### DIFF
--- a/platform/sync-installer/sync-installer-impl/pom.xml
+++ b/platform/sync-installer/sync-installer-impl/pom.xml
@@ -114,7 +114,7 @@
                                     <limit implementation="org.codice.jacoco.LenientLimit">
                                         <counter>BRANCH</counter>
                                         <value>COVEREDRATIO</value>
-                                        <minimum>.73</minimum>
+                                        <minimum>.70</minimum>
                                     </limit>
                                     <limit implementation="org.codice.jacoco.LenientLimit">
                                         <counter>COMPLEXITY</counter>

--- a/platform/sync-installer/sync-installer-impl/pom.xml
+++ b/platform/sync-installer/sync-installer-impl/pom.xml
@@ -109,17 +109,17 @@
                                     <limit implementation="org.codice.jacoco.LenientLimit">
                                         <counter>INSTRUCTION</counter>
                                         <value>COVEREDRATIO</value>
-                                        <minimum>.82</minimum>
+                                        <minimum>.83</minimum>
                                     </limit>
                                     <limit implementation="org.codice.jacoco.LenientLimit">
                                         <counter>BRANCH</counter>
                                         <value>COVEREDRATIO</value>
-                                        <minimum>.74</minimum>
+                                        <minimum>.73</minimum>
                                     </limit>
                                     <limit implementation="org.codice.jacoco.LenientLimit">
                                         <counter>COMPLEXITY</counter>
                                         <value>COVEREDRATIO</value>
-                                        <minimum>.70</minimum>
+                                        <minimum>.73</minimum>
                                     </limit>
                                 </limits>
                             </rule>

--- a/platform/sync-installer/sync-installer-impl/src/main/java/org/codice/ddf/sync/installer/impl/SynchronizedInstallerImpl.java
+++ b/platform/sync-installer/sync-installer-impl/src/main/java/org/codice/ddf/sync/installer/impl/SynchronizedInstallerImpl.java
@@ -503,9 +503,11 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
     }
 
     if (!states.getUnavailableBundles().isEmpty()) {
-      String unavailableBundles = bundleSymbolicNamesToString(states.getUnavailableBundles());
-      LOGGER.debug(
-          "Waiting on the following bundles to reach a ready state [{}]", unavailableBundles);
+      if (LOGGER.isDebugEnabled()) {
+        String unavailableBundles = bundleSymbolicNamesToString(states.getUnavailableBundles());
+        LOGGER.debug(
+            "Waiting on the following bundles to reach a ready state [{}]", unavailableBundles);
+      }
       return false;
     }
 

--- a/platform/sync-installer/sync-installer-impl/src/main/java/org/codice/ddf/sync/installer/impl/SynchronizedInstallerImpl.java
+++ b/platform/sync-installer/sync-installer-impl/src/main/java/org/codice/ddf/sync/installer/impl/SynchronizedInstallerImpl.java
@@ -20,15 +20,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.EnumSet;
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -57,18 +54,11 @@ import org.slf4j.LoggerFactory;
 
 public class SynchronizedInstallerImpl implements SynchronizedInstaller {
 
-  private static final Map<Integer, String> BUNDLE_STATES;
-
-  static {
-    Map<Integer, String> states = new HashMap<>();
-    states.put(Bundle.UNINSTALLED, "UNINSTALLED");
-    states.put(Bundle.INSTALLED, "INSTALLED");
-    states.put(Bundle.RESOLVED, "RESOLVED");
-    states.put(Bundle.STARTING, "STARTING");
-    states.put(Bundle.STOPPING, "STOPPING");
-    states.put(Bundle.ACTIVE, "ACTIVE");
-    BUNDLE_STATES = Collections.unmodifiableMap(states);
-  }
+  private static final String BUNDLE_DIAG_FORMAT =
+      "%n---------------------------------------------------------------%n"
+          + "Bundle Name: %s%n"
+          + "Status: %s%n"
+          + "Diagnosis:%n%s%n";
 
   private static final String SERVICE_PID_FILTER = "(" + Constants.SERVICE_PID + "=%s)";
 
@@ -287,6 +277,10 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
             .collect(Collectors.toSet());
     String featureNames = String.join(", ", featuresToInstall);
 
+    if (featuresToInstall.isEmpty()) {
+      return;
+    }
+
     LOGGER.info("Installing the following features: [{}]", featureNames);
     long startTime = System.currentTimeMillis();
 
@@ -294,7 +288,7 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
       featuresService.installFeatures(featuresToInstall, options);
     } catch (Exception e) {
       throw new SynchronizedInstallerException(
-          "Failed to install features [" + String.join(",", featuresToInstall) + "]", e);
+          "Failed to install features [" + String.join(", ", featuresToInstall) + "]", e);
     }
 
     waitForBundles(getRemainingTime(startTime, maxWaitTime));
@@ -326,6 +320,11 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
             .filter(featuresService::isInstalled)
             .map(Feature::getName)
             .collect(Collectors.toSet());
+
+    if (featuresToUninstall.isEmpty()) {
+      return;
+    }
+
     String featureNames = String.join(", ", featuresToUninstall);
     LOGGER.info("Uninstalling the following features: [{}]", featureNames);
     long startTime = System.currentTimeMillis();
@@ -333,7 +332,7 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
       featuresService.uninstallFeatures(featuresToUninstall, options);
     } catch (Exception e) {
       throw new SynchronizedInstallerException(
-          "Failed to uninstall features [" + String.join(",", featuresToUninstall) + "]", e);
+          "Failed to uninstall features [" + String.join(", ", featuresToUninstall) + "]", e);
     }
 
     waitForBundles(getRemainingTime(startTime, maxWaitTime));
@@ -398,16 +397,16 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
             ? getAllBundleSymbolicNames()
             : Arrays.stream(symbolicNames).collect(Collectors.toSet());
 
-    Callable<Boolean> areBundlesReady = () -> getUnavailableBundles(toWaitFor).isEmpty();
+    Callable<Boolean> areBundlesReady = () -> areBundlesReady(toWaitFor);
 
     try {
       wait(
           areBundlesReady,
           maxWaitTime,
           DEFAULT_POLLING_INTERVAL,
-          "Failed waiting for bundles to reach a ready state.");
-    } catch (SynchronizedInstallerTimeoutException e) {
-      printBundleInformation(LOGGER::error, getUnavailableBundles(toWaitFor));
+          "Failed waiting for bundles to reach a ready state. Check logs for more details.");
+    } catch (SynchronizedInstallerException e) {
+      printBundleDiags(getUnavailableBundles(toWaitFor).getFailedAndUnavailableBundles());
       throw e;
     }
   }
@@ -439,7 +438,7 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
         }
 
         Thread.sleep(Math.min(remainingTime, pollInterval));
-      } catch (InterruptedException e) {
+      } catch (SynchronizedInstallerException | InterruptedException e) {
         throw e;
       } catch (Exception e) {
         throw new SynchronizedInstallerException(
@@ -448,7 +447,23 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
     }
   }
 
-  private Set<Bundle> getUnavailableBundles(Set<String> toCheck) {
+  private void printBundleDiags(Collection<Bundle> toPrint) {
+    StringBuilder sb = new StringBuilder();
+    toPrint.forEach(bundle -> appendBundleDiag(bundle, sb));
+    LOGGER.error("Printing unsatisfied bundle requirements: {}", sb);
+  }
+
+  private void appendBundleDiag(Bundle bundle, StringBuilder sb) {
+    sb.append(
+        String.format(
+            BUNDLE_DIAG_FORMAT,
+            bundle.getHeaders().get(Constants.BUNDLE_NAME),
+            bundleService.getInfo(bundle).getState().toString(),
+            this.bundleService.getDiag(bundle)));
+  }
+
+  @VisibleForTesting
+  BundleStates getUnavailableBundles(Set<String> toCheck) {
     Set<Bundle> unavailableBundles = new HashSet<>();
     Set<Bundle> failedBundles = new HashSet<>();
 
@@ -457,37 +472,44 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
         continue;
       }
 
-      String bundleName = bundle.getHeaders().get(Constants.BUNDLE_NAME);
       BundleInfo bundleInfo = bundleService.getInfo(bundle);
       BundleState bundleState = bundleInfo.getState();
 
       if (BundleState.Failure.equals(bundleState)) {
         failedBundles.add(bundle);
+        continue;
       }
 
       if (bundleInfo.isFragment()) {
         if (!BundleState.Resolved.equals(bundleState)) {
-          LOGGER.debug("Fragment [{}] not ready with state [{}]", bundleName, bundleState);
           unavailableBundles.add(bundle);
         }
       } else if (!BundleState.Active.equals(bundleState)) {
-        LOGGER.debug("Bundle [{}] not ready with state [{}]", bundleName, bundleState);
         unavailableBundles.add(bundle);
       }
     }
 
-    if (!failedBundles.isEmpty()) {
-      printBundleInformation(LOGGER::error, failedBundles);
+    return new BundleStates(unavailableBundles, failedBundles);
+  }
+
+  private boolean areBundlesReady(Set<String> toCheck) {
+    BundleStates states = getUnavailableBundles(toCheck);
+
+    if (!states.getFailedBundles().isEmpty()) {
       throw new SynchronizedInstallerException(
-          "Bundles failed to start [" + bundleSymbolicNamesToString(failedBundles) + "]");
+          "Bundles failed to start ["
+              + bundleSymbolicNamesToString(states.getFailedBundles())
+              + "]");
     }
 
-    if (!unavailableBundles.isEmpty()) {
-      String bundleNames = bundleSymbolicNamesToString(unavailableBundles);
-      LOGGER.debug("Waiting on the following bundles to reach a ready state [{}]", bundleNames);
+    if (!states.getUnavailableBundles().isEmpty()) {
+      String unavailableBundles = bundleSymbolicNamesToString(states.getUnavailableBundles());
+      LOGGER.debug(
+          "Waiting on the following bundles to reach a ready state [{}]", unavailableBundles);
+      return false;
     }
 
-    return unavailableBundles;
+    return true;
   }
 
   @VisibleForTesting
@@ -501,30 +523,7 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
   }
 
   private String bundleSymbolicNamesToString(Collection<Bundle> bundles) {
-    return bundles.stream().map(Bundle::getSymbolicName).collect(Collectors.joining(","));
-  }
-
-  private void printBundleInformation(
-      BiConsumer<String, Object[]> logConsumer, Collection<Bundle> bundles) {
-    for (Bundle bundle : bundles) {
-      StringBuilder headerString = new StringBuilder("[ ");
-      Enumeration<String> keys = bundle.getHeaders().keys();
-
-      while (keys.hasMoreElements()) {
-        String key = keys.nextElement();
-        headerString.append(key).append("=").append(bundle.getHeaders().get(key)).append(", ");
-      }
-
-      headerString.append(" ]");
-      logConsumer.accept(
-          "\n\tBundle: {}_v{} | {}\n\tHeaders: {}",
-          new Object[] {
-            bundle.getSymbolicName(),
-            bundle.getVersion(),
-            BUNDLE_STATES.getOrDefault(bundle.getState(), "UNKNOWN"),
-            headerString
-          });
-    }
+    return bundles.stream().map(Bundle::getSymbolicName).collect(Collectors.joining(", "));
   }
 
   private Stream<Feature> featuresFromNames(String feature, String... additionalFeatures) {
@@ -593,6 +592,31 @@ public class SynchronizedInstallerImpl implements SynchronizedInstaller {
 
     public boolean isUpdated() {
       return updated;
+    }
+  }
+
+  private static class BundleStates {
+    private Set<Bundle> unavailableBundles;
+
+    private Set<Bundle> failedBundles;
+
+    BundleStates(Set<Bundle> unavailableBundles, Set<Bundle> failedBundles) {
+      this.unavailableBundles =
+          unavailableBundles == null ? Collections.emptySet() : unavailableBundles;
+      this.failedBundles = failedBundles == null ? Collections.emptySet() : failedBundles;
+    }
+
+    Set<Bundle> getUnavailableBundles() {
+      return unavailableBundles;
+    }
+
+    Set<Bundle> getFailedBundles() {
+      return failedBundles;
+    }
+
+    Set<Bundle> getFailedAndUnavailableBundles() {
+      return Stream.concat(getUnavailableBundles().stream(), getFailedBundles().stream())
+          .collect(Collectors.toSet());
     }
   }
 }

--- a/platform/sync-installer/sync-installer-impl/src/main/java/org/codice/ddf/sync/installer/impl/WaitForReadyCommand.java
+++ b/platform/sync-installer/sync-installer-impl/src/main/java/org/codice/ddf/sync/installer/impl/WaitForReadyCommand.java
@@ -16,6 +16,7 @@ package org.codice.ddf.sync.installer.impl;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.TimeUnit;
 import org.apache.karaf.log.core.LogService;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Command;
@@ -41,6 +42,15 @@ public class WaitForReadyCommand implements Action {
   )
   boolean increaseLogLevel = false;
 
+  @Option(
+    name = "-wt",
+    aliases = {"--wait-time"},
+    description = "Amount of time to wait for the system to reach a ready state in seconds.",
+    required = false,
+    multiValued = false
+  )
+  Integer waitTime = null;
+
   @Reference SynchronizedInstaller syncInstaller;
 
   @Reference LogService logService;
@@ -54,7 +64,11 @@ public class WaitForReadyCommand implements Action {
                 if (increaseLogLevel) {
                   logService.setLevel("org.codice.ddf.sync.installer.impl", "TRACE");
                 }
-                syncInstaller.waitForBootFinish();
+                if (waitTime == null) {
+                  syncInstaller.waitForBootFinish();
+                } else {
+                  syncInstaller.waitForBootFinish(Math.max(0, TimeUnit.SECONDS.toMillis(waitTime)));
+                }
                 return null;
               });
     } catch (PrivilegedActionException e) {


### PR DESCRIPTION
#### What does this PR do?
 - Changing logging to print a diagnosis of the bundle instead of the headers & imports
 - Added an option to the wait-for-ready command to specify time to wait

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@troymohl 
@paouelle 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@coyotesqrl 
@figliold  

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Run the wait for ready command on bundles in the failed/graceperiod state and ensure the logs look as expected.
 
#### Any background context you want to provide?

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)

#### Screenshots
```
admin@root()> wait-for-ready -wt 100
15:30:20,873 | INFO  | or-ready -wt 100 | installer.impl.SynchronizedInstallerImpl  444 | sync-installer-impl  | Printing unsatisfied bundle requirements:
---------------------------------------------------------------
Bundle Name: DDF :: Admin Console :: Query :: Security :: LDAP
Status: Failure
Diagnosis:
Blueprint
10/4/18 1:54 PM
Exception:
null
java.util.concurrent.TimeoutException
	at org.apache.aries.blueprint.container.BlueprintContainerImpl$1.run(BlueprintContainerImpl.java:373)
	at org.apache.aries.blueprint.utils.threading.impl.DiscardableRunnable.run(DiscardableRunnable.java:45)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)

Missing dependencies:
(objectClass=org.codice.ddf.internal.admin.configurator.actions.ConfiguratorSuite)
Declarative Services


---------------------------------------------------------------
Bundle Name: DDF :: Admin :: Configurator :: Transactional Implementation
Status: Resolved
Diagnosis:
Declarative Services


15:30:20,874 | ERROR | nsole user admin | org.apache.karaf.shell.support.ShellUtil  149 | che.karaf.shell.core | Exception caught while executing command
org.codice.ddf.sync.installer.api.SynchronizedInstallerException: Bundles failed to start [admin-query-ldap, admin-configurator-impl]
	at org.codice.ddf.sync.installer.impl.SynchronizedInstallerImpl.areBundlesReady(SynchronizedInstallerImpl.java:491) ~[?:?]
	at org.codice.ddf.sync.installer.impl.SynchronizedInstallerImpl.lambda$waitForBundles$4(SynchronizedInstallerImpl.java:391) ~[?:?]
	at org.codice.ddf.sync.installer.impl.SynchronizedInstallerImpl.wait(SynchronizedInstallerImpl.java:421) ~[?:?]
	at org.codice.ddf.sync.installer.impl.SynchronizedInstallerImpl.waitForBundles(SynchronizedInstallerImpl.java:394) ~[?:?]
	at org.codice.ddf.sync.installer.impl.SynchronizedInstallerImpl.waitForBootFinish(SynchronizedInstallerImpl.java:114) ~[?:?]
	at org.codice.ddf.sync.installer.impl.WaitForReadyCommand.lambda$execute$0(WaitForReadyCommand.java:69) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at org.codice.ddf.sync.installer.impl.WaitForReadyCommand.execute(WaitForReadyCommand.java:60) ~[?:?]
	at org.apache.karaf.shell.impl.action.command.ActionCommand.execute(ActionCommand.java:84) ~[?:?]
	at org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand.execute(SecuredCommand.java:68) ~[?:?]
	at org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand.execute(SecuredCommand.java:86) ~[?:?]
	at org.apache.felix.gogo.runtime.Closure.executeCmd(Closure.java:571) ~[?:?]
	at org.apache.felix.gogo.runtime.Closure.executeStatement(Closure.java:497) ~[?:?]
	at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:386) ~[?:?]
	at org.apache.felix.gogo.runtime.Pipe.doCall(Pipe.java:417) ~[?:?]
	at org.apache.felix.gogo.runtime.Pipe.call(Pipe.java:229) ~[?:?]
	at org.apache.felix.gogo.runtime.Pipe.call(Pipe.java:59) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:?]
	at java.lang.Thread.run(Thread.java:748) [?:?]
Error executing command: Bundles failed to start [admin-query-ldap, admin-configurator-impl]
```
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
