### PR TITLE
[2.13.x] DDF-4216: Allow upload of .pfx keystores during installation

### DIFF
--- a/platform/security/certificate/security-certificate-keystoreeditor/src/main/java/org/codice/ddf/security/certificate/keystore/editor/KeystoreEditor.java
+++ b/platform/security/certificate/security-certificate-keystoreeditor/src/main/java/org/codice/ddf/security/certificate/keystore/editor/KeystoreEditor.java
@@ -444,7 +444,8 @@ public class KeystoreEditor implements KeystoreEditorMBean {
         throw new IllegalArgumentException("Alias cannot be null.");
       }
       KeyStore ks = null;
-      if (StringUtils.endsWithIgnoreCase(keystoreFileName, ".p12")) {
+      if (StringUtils.endsWithIgnoreCase(keystoreFileName, ".p12")
+          || StringUtils.endsWithIgnoreCase(keystoreFileName, ".pfx")) {
         ks = KeyStore.getInstance("PKCS12");
       } else if (StringUtils.endsWithIgnoreCase(keystoreFileName, ".jks")) {
         ks = KeyStore.getInstance("jks");


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
PKCS12 files typically have .p12 OR .pfx extenstions. Currently, DDF only accepts .p12 during installation. This PR allows for .pfx files to be uploaded as well.

#### Who is reviewing it? 
@ahoffer 
@mcalcote 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@stustison
@tbatie 

#### How should this be tested?
Ensure that uploading a valid PKCS12 certificate with .pfx extension no longer returns an error in the installer. Ensure that an alias in the keystore matches the hostname being set.

#### What are the relevant tickets?
[DDF-4216](https://codice.atlassian.net/browse/DDF-4216)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
