### PR TITLE
DDF-4215 ValidationFilterPlugin will show a metacard with an error/wa…

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreFederatedLocalProviderQueryPlugin.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/PreFederatedLocalProviderQueryPlugin.java
@@ -20,10 +20,10 @@ import ddf.catalog.source.SourceCache;
 import java.util.List;
 
 /**
- * A {@link PreFederatedLocalProviderQueryPlugin} is an abstract class implementing the {@link
- * PreFederatedQueryPlugin}. {@link PreFederatedQueryPlugin} that only apply for local source should
- * extend {@link PreFederatedLocalProviderQueryPlugin} This abstract class provide isLocalSource
- * method to check if a given source is a local source.
+ * A {@link PreFederatedLocalProviderQueryPlugin} is an abstract class that implements the {@link
+ * PreFederatedQueryPlugin}. Any {@link PreFederatedQueryPlugin} that is used strictly for local
+ * source only should extend {@link PreFederatedLocalProviderQueryPlugin}. This abstract class
+ * provides isLocalSource method to check if a given source is a local source.
  *
  * @author lamhuy
  */

--- a/catalog/core/catalog-core-validationfilterplugin/src/main/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPlugin.java
+++ b/catalog/core/catalog-core-validationfilterplugin/src/main/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPlugin.java
@@ -110,10 +110,10 @@ public class ValidationFilterPlugin extends PreFederatedLocalProviderQueryPlugin
         boolean subjectCanViewInvalidData = canViewInvalidData(input);
 
         List<Filter> filters = new ArrayList<>();
-        if (!subjectCanViewInvalidData || !showErrors) {
+        if (!subjectCanViewInvalidData && !showErrors) {
           filters.add(filterBuilder.attribute(Validation.VALIDATION_ERRORS).is().empty());
         }
-        if (!subjectCanViewInvalidData || !showWarnings) {
+        if (!subjectCanViewInvalidData && !showWarnings) {
           filters.add(filterBuilder.attribute(Validation.VALIDATION_WARNINGS).is().empty());
         }
 

--- a/catalog/core/catalog-core-validationfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPluginTest.java
+++ b/catalog/core/catalog-core-validationfilterplugin/src/test/java/org/codice/ddf/catalog/plugin/validationfilter/ValidationFilterPluginTest.java
@@ -158,7 +158,7 @@ public class ValidationFilterPluginTest {
     when(catalogProvider.getId()).thenReturn("cat1");
 
     when(subject.isPermitted(any(KeyValueCollectionPermission.class)))
-        .thenReturn(canViewInvalidData);
+        .thenReturn(!canViewInvalidData);
 
     QueryImpl query =
         new QueryImpl(filterBuilder.attribute(Metacard.ANY_TEXT).is().equalTo().text("sample"));
@@ -184,13 +184,13 @@ public class ValidationFilterPluginTest {
         new QueryImpl(filterBuilder.attribute(Metacard.ANY_TEXT).is().equalTo().text("sample"));
 
     when(subject.isPermitted(any(KeyValueCollectionPermission.class)))
-        .thenReturn(canViewInvalidData);
+        .thenReturn(!canViewInvalidData);
 
     QueryRequest queryRequest = new QueryRequestImpl(query, false, null, properties);
 
     plugin.setAttributeMap(Collections.emptyList());
-    plugin.setShowErrors(true);
-    plugin.setShowWarnings(true);
+    plugin.setShowErrors(false);
+    plugin.setShowWarnings(false);
 
     QueryRequest returnQuery = plugin.process(localSource, queryRequest);
 
@@ -217,9 +217,9 @@ public class ValidationFilterPluginTest {
     QueryRequest returnQuery = plugin.process(localSource, queryRequest);
 
     assertThat(
-        filterAdapter.adapt(returnQuery.getQuery(), testValidationErrorQueryDelegate), is(true));
+        filterAdapter.adapt(returnQuery.getQuery(), testValidationErrorQueryDelegate), is(false));
     assertThat(
-        filterAdapter.adapt(returnQuery.getQuery(), testValidationWarningQueryDelegate), is(true));
+        filterAdapter.adapt(returnQuery.getQuery(), testValidationWarningQueryDelegate), is(false));
   }
 
   @Test
@@ -259,9 +259,9 @@ public class ValidationFilterPluginTest {
     QueryRequest returnQuery = plugin.process(localSource, queryRequest);
 
     assertThat(
-        filterAdapter.adapt(returnQuery.getQuery(), testValidationErrorQueryDelegate), is(true));
+        filterAdapter.adapt(returnQuery.getQuery(), testValidationErrorQueryDelegate), is(false));
     assertThat(
-        filterAdapter.adapt(returnQuery.getQuery(), testValidationWarningQueryDelegate), is(true));
+        filterAdapter.adapt(returnQuery.getQuery(), testValidationWarningQueryDelegate), is(false));
   }
 
   @Test
@@ -303,17 +303,17 @@ public class ValidationFilterPluginTest {
     assertThat(
         filterAdapter.adapt(returnQuery.getQuery(), testValidationErrorQueryDelegate), is(false));
     assertThat(
-        filterAdapter.adapt(returnQuery.getQuery(), testValidationWarningQueryDelegate), is(true));
+        filterAdapter.adapt(returnQuery.getQuery(), testValidationWarningQueryDelegate), is(false));
   }
 
   @Test
-  public void testHideErrorShowWarningWithPermission()
+  public void testHideErrorShowWarningWithNoPermission()
       throws StopProcessingException, UnsupportedQueryException {
     QueryImpl query =
         new QueryImpl(filterBuilder.attribute(Metacard.ANY_TEXT).is().equalTo().text("sample"));
 
     when(subject.isPermitted(any(KeyValueCollectionPermission.class)))
-        .thenReturn(canViewInvalidData);
+        .thenReturn(!canViewInvalidData);
     QueryRequest queryRequest = new QueryRequestImpl(query, false, null, properties);
 
     plugin.setShowErrors(false);

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogValidation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogValidation.java
@@ -729,6 +729,8 @@ public class TestCatalogValidation extends AbstractIntegrationTest {
     Dictionary<String, ?> configProps = new Hashtable<>(pdpProperties);
     config.update(configProps);
 
+    configureShowInvalidMetacards("false", "false", getAdminConfig());
+
     // Configure invalid filtering
     configureMetacardValidityFilterPlugin(
         Arrays.asList("invalid-state=data-manager"), getAdminConfig());
@@ -763,7 +765,7 @@ public class TestCatalogValidation extends AbstractIntegrationTest {
               .body(query)
               .post(CSW_PATH.getUrl())
               .then();
-      // Assert Metacard2 is in results Metacard1
+      // Assert Metacard2 is in results and not Metacard1
       response.body(
           hasXPath(format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]", id1)));
       response.body(
@@ -798,7 +800,7 @@ public class TestCatalogValidation extends AbstractIntegrationTest {
               .body(query)
               .post(CSW_PATH.getUrl())
               .then();
-      // Assert Metacard2 is in results Metacard1
+      // Assert Metacard1 and Metacard2 is in results
       response.body(
           hasXPath(format("/GetRecordsResponse/SearchResults/Record[identifier=\"%s\"]", id1)));
       response.body(


### PR DESCRIPTION
#### What does this PR do?
DDF-4215 ValidationFilterPlugin will show a metacard with an error/warning if showErrors/Warning is true OR the user has the role


#### Who is reviewing it? 
@ethantmanns 
@peterhuffer 
@bdeining 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@millerw8 


#### How should this be tested?

Use DDF image upload to upload an image twice
Reconfigure Duplication Validation configure to mark duplicate as error
Upload the same image again
Configure Validation PreFederation Filter Plugin to ShowError and ShowWarning
Configure Metacard Validity with uncheck filterError and uncheck filterWarning
Use UI to search with *
Three records should be returned. One marked with warning and one with error
Reconfigure Validation Filter Plugin to uncheck ShowWarning
UI Search result in 2 record, 1 as error
Reconfigure Validation Filter plugin to uncheck ShowError
UI Search result in 1 record
Logout and login as localhost
UI search result in 3 records, 1 error and 1 warning 

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-4215

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
