### PR TITLE
DDF-4214 Updated docs for searching with wildcard

### DIFF
--- a/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-catalog-search-ui.adoc
@@ -190,6 +190,9 @@ An existing search can be updated by selecting the search in the *Search* tab of
 *** Search for an exact word, such as `Text = apple` : Returns items containing the word "apple" but not "apples". Matching occurs on word boundaries.
 *** Search for the existence of items containing multiple words, such as `Text = apple orange` : Returns items containing both "apple" and "orange" words. Words can occur anywhere in an item's metadata.
 *** Search using wildcards, such as `Text = foo*` : Returns items containing words like "food", "fool", etc..
+*** Wildcards should only be used for single word searches, not for phrases.
+[WARNING]
+When searching with wildcards, do not include the punctuation at the beginning or the end of a word. For example, search for `Text = ca*` instead of `Text = -ca*` when searching for words like "cat", "-cat", etc..  and search for `Text = *og` instead of `Text = *og.` when searching for words like "dog", "dog.", etc..
 *** Text searches are by default case insensitive, but case sensitive searches are an option.
 +
 ** [[_temporal_search_details]]*Temporal Search Details*: Search based on absolute time of the created, modified, or effective date.


### PR DESCRIPTION

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #3868 

#### What does this PR do?
When searching with a wildcard, beginning and end punctuation are stripped off to make sure the search is done solely on the word. Inner punctuation of the word is still valid. This updates the docs to let the user know that including punctuation at the beginning or the end of a word will not return the result.

#### Who is reviewing it? 
@ethantmanns 
@jhunzik 
@paouelle 

#### Select relevant component teams: 
<!--
@codice/docs 

-->
#### Ask 2 committers to review/merge the PR and tag them here.
@tbatie 
@figliold 
@ricklarsen 

#### How should this be tested?
Install and run DDF
Verify changes are there in the docs

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-4214

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
