### PR TITLE
DDF-4225 Update default search form behavior

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -22,11 +22,18 @@
   .interaction-text {
     display: inline-block;
   }
+
+  .interaction-clear {
+    display: none;
+  }
 }
 
 @{customElementNamespace}search-form-interactions.is-current-template {
   > .interaction-default {
     display: none;
+  }
+  > .interaction-clear {
+    display: block;
   }
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.hbs
@@ -32,6 +32,7 @@
 {{#is type 'custom'}}
     <div>
         <h3 class="search-form-title" data-help="{{name}}">{{name}}</h3>
+        <div class="default-icon"><div class="fa fa-star"></div></div>
         <span class="search-form-contents">
             <span class="search-form-label">Created On: </span>
             {{createdOn}}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.less
@@ -13,6 +13,8 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    display: inline-block;
+    width: 100%;
   }
 
   .search-form-contents {
@@ -35,6 +37,11 @@
     font-size: 3 * @largeFontSize;
     padding-top: @mediumSpacing;
   }
+
+  .default-icon {
+    float: right;
+    display: none;
+  }
 }
 
 @{customElementNamespace}search-form.is-static {
@@ -43,4 +50,13 @@
 
 @{customElementNamespace}search-form-loading {
   padding: 2 * @minimumSpacing;
+}
+
+@{customElementNamespace}search-form.is-default {
+  .default-icon {
+    display: block;
+  }
+  .search-form-title {
+    max-width: ~'calc(100% - @{minimumFontSize})';
+  }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -34,6 +34,12 @@ module.exports = Marionette.LayoutView.extend({
   },
   initialize: function() {
     this.listenTo(this.model, 'change:type', this.changeView)
+    this.handleDefault()
+    this.listenTo(
+      user.getQuerySettings(),
+      'change:template',
+      this.handleDefault
+    )
   },
   onRender: function() {
     if (
@@ -123,6 +129,12 @@ module.exports = Marionette.LayoutView.extend({
 
     user.savePreferences()
     this.triggerCloseDropdown()
+  },
+  handleDefault: function() {
+    this.$el.toggleClass(
+      'is-default',
+      user.getQuerySettings().isTemplate(this.model)
+    )
   },
   triggerCloseDropdown: function() {
     this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
The `Clear Default` option should only be available on the currently selected default (actions should be form specific). Mark the currently selected default form with icon for easy identification of current default.
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@Schachte @Bdthomson @alanchampion 
#### Select relevant component teams: 
@codice/ui
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@bdeining 
#### How should this be tested?
- build/run
- enable search forms by creating ect/forms directory and enabling experimental
- in the UI start a new query and select `Use Another Search Form` and create multiple custom search forms
- verify that forms not selected as default have `Make Default` option available and no `Clear Default` option
<img width="1906" alt="screen shot 2018-10-12 at 4 33 42 pm" src="https://user-images.githubusercontent.com/39923178/46896937-0494fd00-ce3d-11e8-80e3-43eabe0ad3f6.png">

- verify a form selected as default has a star displayed at the top right and has the `Clear Default` option available
<img width="1920" alt="screen shot 2018-10-12 at 4 33 20 pm" src="https://user-images.githubusercontent.com/39923178/46896965-2d1cf700-ce3d-11e8-98a1-f6658e05ae91.png">

- verify no regression in default search form functionality
  - Delete the form currently selected as default, verify enabling default on a different form functions as expected
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4225](https://codice.atlassian.net/browse/DDF-4225)
#### Screenshots
![search_form_default](https://user-images.githubusercontent.com/39923178/46897294-fc3dc180-ce3e-11e8-80c1-9132a30b23a7.gif)



<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
