### PR TITLE
DDF-4236 Hide the "New Form" button from the search dropdown menu

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-selector/search-form-selector.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-selector/search-form-selector.view.js
@@ -31,6 +31,7 @@ module.exports = Marionette.LayoutView.extend({
     this.tabsContent.show(
       new SearchFormsView({
         queryModel: this.model,
+        hideNewForm: true,
       })
     )
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form-tab-container.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form-tab-container.view.js
@@ -42,6 +42,7 @@ module.exports = Marionette.LayoutView.extend({
         collection: this.searchFormCollection.getCollection(),
         collectionWrapperModel: this.searchFormCollection,
         queryModel: this.model,
+        hideNewForm: this.options.hideNewForm,
       })
     )
     LoadingCompanionView.beginLoading(this, this.$el)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
@@ -32,4 +32,11 @@ module.exports = Marionette.CollectionView.extend({
       collectionWrapperModel: this.options.collectionWrapperModel,
     }
   },
+  filter: function(child) {
+    if (this.options.hideNewForm) {
+      return child.get('type') !== 'new-form'
+    } else {
+      return true
+    }
+  },
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.view.js
@@ -33,6 +33,7 @@ module.exports = TabsView.extend({
     this.tabsContent.show(
       new activeTab({
         model: this.options.queryModel || new Query.Model(),
+        hideNewForm: this.options.hideNewForm,
       })
     )
   },


### PR DESCRIPTION
#### What does this PR do?
Disables the "New Form" button under "Use Another Search Form" in the search dropdown, but not under "Search Forms" on the sidebar menu
#### Who is reviewing it? 
@Bdthomson @andrewzimmer 
#### Select relevant component teams:  
#### Ask 2 committers to review/merge the PR and tag them here.
@djblue @bdeining
#### How should this be tested?
- Open a search, click on the dropdown menu and select "Use Another Search Form"
- Verify that what pops up matches the second screenshot below
- Go to the sidebar menu and select "Search Forms"
- Verify that the page still looks like the third screenshot below
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4236](https://codice.atlassian.net/browse/DDF-4236)
#### Screenshots
"Use Another Search Form" in the search dropdown before:
![image](https://user-images.githubusercontent.com/39737329/47109738-455d8f00-d20c-11e8-890d-904d72152a6c.png)
and after: 
![image](https://user-images.githubusercontent.com/39737329/47109747-4abad980-d20c-11e8-90c9-c8634b56db3a.png)
"Search Forms" in the sidebar menu before and after:
![image](https://user-images.githubusercontent.com/39737329/47110367-ded97080-d20d-11e8-976e-8bf96f924ed6.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
