### PR TITLE
DDF-4238 As a user, I would like to enter MGRS coordinates into the gazetteer search box so I can pan to a certain location quickly

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -346,19 +346,20 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codice.usng4j</groupId>
-            <artifactId>usng4j-api</artifactId>
-            <version>${usng4j.version}</version>
+            <groupId>org.codice.thirdparty</groupId>
+            <artifactId>tika-bundle</artifactId>
+            <version>${tika.thirdparty.bundle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.usng4j</groupId>
+            <artifactId>platform-usng4j-api</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.usng4j</groupId>
             <artifactId>usng4j-impl</artifactId>
             <version>${usng4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codice.thirdparty</groupId>
-            <artifactId>tika-bundle</artifactId>
-            <version>${tika.thirdparty.bundle.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -420,9 +421,7 @@
                             versioning-common,
                             filter-v_2_0,
                             ows-v_1_1_0-schema,
-                            jaxb2-basics-runtime,
-                            usng4j-api,
-                            usng4j-impl
+                            jaxb2-basics-runtime
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
@@ -491,12 +490,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.38</minimum>
+                                            <minimum>0.40</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.34</minimum>
+                                            <minimum>0.36</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -340,16 +340,26 @@
             <artifactId>spatial-csw-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-      <dependency>
-        <groupId>ddf.mime.core</groupId>
-        <artifactId>mime-core-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codice.thirdparty</groupId>
-        <artifactId>tika-bundle</artifactId>
-        <version>${tika.thirdparty.bundle.version}</version>
-      </dependency>
+        <dependency>
+            <groupId>ddf.mime.core</groupId>
+            <artifactId>mime-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.usng4j</groupId>
+            <artifactId>usng4j-api</artifactId>
+            <version>${usng4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.usng4j</groupId>
+            <artifactId>usng4j-impl</artifactId>
+            <version>${usng4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.thirdparty</groupId>
+            <artifactId>tika-bundle</artifactId>
+            <version>${tika.thirdparty.bundle.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -410,7 +420,9 @@
                             versioning-common,
                             filter-v_2_0,
                             ows-v_1_1_0-schema,
-                            jaxb2-basics-runtime
+                            jaxb2-basics-runtime,
+                            usng4j-api,
+                            usng4j-impl
                         </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
@@ -453,7 +465,7 @@
                         <configuration>
                             <rules>
                                 <ArtifactSizeEnforcerRule
-                                    implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
+                                        implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
                                     <maxArtifactSize>5.5_MB</maxArtifactSize>
                                 </ArtifactSizeEnforcerRule>
                             </rules>

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/LatLon.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/LatLon.java
@@ -17,11 +17,7 @@ class LatLon {
   private final Double lat;
   private final Double lon;
 
-  static LatLon from(Double lat, Double lon) {
-    return new LatLon(lat, lon);
-  }
-
-  private LatLon(Double lat, Double lon) {
+  LatLon(Double lat, Double lon) {
     this.lat = lat;
     this.lon = lon;
   }
@@ -58,11 +54,11 @@ class LatLon {
     return "(" + getLat() + ", " + getLon() + ")";
   }
 
-  public static boolean isValidLatitude(double latitude) {
+  static boolean isValidLatitude(double latitude) {
     return latitude >= -90 && latitude <= 90;
   }
 
-  public static boolean isValidLongitude(double longitude) {
+  static boolean isValidLongitude(double longitude) {
     return longitude >= -180 && longitude <= 180;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/LatLonCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/LatLonCoordinateProcessor.java
@@ -14,7 +14,6 @@
 package org.codice.ddf.catalog.ui.query.suggestion;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,12 +37,11 @@ public class LatLonCoordinateProcessor {
    * @param query the query string with potential coordinate literals present.
    */
   public List<Suggestion> enhanceResults(List<Suggestion> results, String query) {
-    LinkedList<Suggestion> enhanced = new LinkedList<>(results);
     LiteralSuggestion literal = getLatLonSuggestions(query);
     if (literal != null && literal.hasGeo()) {
-      enhanced.addFirst(literal);
+      results.add(0, literal);
     }
-    return enhanced;
+    return results;
   }
 
   private LiteralSuggestion getLatLonSuggestions(String query) {
@@ -58,7 +56,7 @@ public class LatLonCoordinateProcessor {
     List<LatLon> latLonList = getLatLonList(numbers);
     String name =
         "Lat/Lon: " + latLonList.stream().map(LatLon::toString).collect(Collectors.joining(", "));
-    return new LiteralSuggestion("LITERAL", name, latLonList);
+    return new LiteralSuggestion("LITERAL1", name, latLonList);
   }
 
   private List<LatLon> getLatLonList(List<Double> numbers) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessor.java
@@ -14,14 +14,13 @@
 package org.codice.ddf.catalog.ui.query.suggestion;
 
 import static java.lang.String.format;
-import static org.codice.ddf.catalog.ui.query.suggestion.LatLon.from;
+import static org.apache.commons.lang3.StringUtils.leftPad;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -30,7 +29,6 @@ import org.codice.ddf.spatial.geocoding.Suggestion;
 import org.codice.usng4j.BoundingBox;
 import org.codice.usng4j.CoordinateSystemTranslator;
 import org.codice.usng4j.UsngCoordinate;
-import org.codice.usng4j.impl.CoordinateSystemTranslatorImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,17 +42,15 @@ import org.slf4j.LoggerFactory;
  *
  * @see #processNumericType(String) for more information on this "backfilling" behavior.
  */
-@SuppressWarnings("squid:S1135" /* Ticket number provided on comment */)
 public class MgrsCoordinateProcessor {
   private static final Logger LOGGER = LoggerFactory.getLogger(MgrsCoordinateProcessor.class);
 
-  private static final Pattern PATTERN_MGRS_ZONE = Pattern.compile("\\d\\d?[CDEFGHJKLMNPQRSTUVWX]");
+  private static final Pattern PATTERN_MGRS_ZONE = Pattern.compile("\\d\\d?[C-HJ-NP-X]");
 
-  private static final Pattern PATTERN_MGRS_100KM =
-      Pattern.compile("[ABCDEFGHJKLMNPQRSTUVWXYZ][ABCDEFGHJKLMNPQRSTUV]");
+  private static final Pattern PATTERN_MGRS_100KM = Pattern.compile("[A-HJ-NP-Z][A-HJ-NP-V]");
 
   private static final Pattern PATTERN_MGRS_NUMERIC =
-      Pattern.compile("((\\d){1,5}(\\h)+(\\d){1,5}(\\h)+)|((\\d){2,10})");
+      Pattern.compile("((\\d){1,5}(\\h)+(\\d){1,5}(\\W)+)|((\\d){2,10})");
 
   private static final Pattern PATTERN_MGRS_ANYPART =
       Pattern.compile(
@@ -62,16 +58,18 @@ public class MgrsCoordinateProcessor {
               "(%s)|(%s)|(%s)",
               PATTERN_MGRS_ZONE.pattern(),
               PATTERN_MGRS_100KM.pattern(),
-              PATTERN_MGRS_NUMERIC.pattern()));
+              PATTERN_MGRS_NUMERIC.pattern()),
+          Pattern.CASE_INSENSITIVE);
 
   // usng4j helper constant for backfilling zeros
-  private static final Integer MAX_EASTING_LENGTH = 5;
-
-  // usng4j helper constant for backfilling zeros
-  private static final Integer MAX_NORTHING_LENGTH = 5;
+  private static final Integer MAX_COORDINATE_LENGTH = 5;
 
   // This key tells the UI that the geo is on the suggestion itself
-  private static final String LITERAL = "LITERAL2";
+  private static final String LITERAL_SUGGESTION_ID = "LITERAL-MGRS";
+
+  private static final String ZERO = "0";
+
+  private static final String WHITESPACE = " ";
 
   /**
    * An {@link MgrsPartType} identifies one of the three different component strings that are glued
@@ -88,7 +86,11 @@ public class MgrsCoordinateProcessor {
     NUMERIC
   }
 
-  private final CoordinateSystemTranslator translator = new CoordinateSystemTranslatorImpl();
+  private final CoordinateSystemTranslator translator;
+
+  public MgrsCoordinateProcessor(CoordinateSystemTranslator translator) {
+    this.translator = translator;
+  }
 
   /**
    * Given a list of {@link Suggestion}s and the query that yielded them, enhance the list with
@@ -96,27 +98,13 @@ public class MgrsCoordinateProcessor {
    *
    * @param results the list of results to enhance.
    * @param query the query string to search for coordinate literals.
-   * @return the enhanced list.
    */
-  public List<Suggestion> enhanceResults(List<Suggestion> results, String query) {
-    LiteralSuggestion literal = getMgrsSuggestion(query);
+  public void enhanceResults(List<Suggestion> results, String query) {
+    final LiteralSuggestion literal = getMgrsSuggestion(query);
     if (literal != null && literal.hasGeo()) {
-      LOGGER.debug("Adding the MGRS suggestion to results");
+      LOGGER.trace("Adding the MGRS suggestion to results [{}]", literal);
       results.add(0, literal);
     }
-    return results;
-  }
-
-  /**
-   * Given an input string, return the list of properly formatted MGRS coordinate strings that are
-   * ready for submission to usng4j for mathematical evaluation.
-   *
-   * @param query the query string to search for coordinate literals.
-   * @return a list of valid MGRS strings ready for evaluation.
-   */
-  @VisibleForTesting
-  List<String> getMgrsCoordinateStrings(String query) {
-    return coordinateStringsFromQuery(query);
   }
 
   /**
@@ -124,36 +112,42 @@ public class MgrsCoordinateProcessor {
    *
    * @param query the query string to search for coordinate literals.
    * @return a suggestion object with geometry attached to it; a {@link BoundingBox} if only one
-   *     coordinate was detected, or a collection of {@link LatLon} center points otherwise.
+   *     coordinate was detected, or a collection of {@link LatLon} center points otherwise. If no
+   *     MGRS was detected in the query, {@code null} is returned.
    */
   @Nullable
   private LiteralSuggestion getMgrsSuggestion(String query) {
-    List<String> matches = coordinateStringsFromQuery(query);
+    final List<String> matches = getMgrsCoordinateStrings(query);
     if (matches.isEmpty()) {
-      LOGGER.debug("No valid MGRS strings were found or could be inferred");
+      LOGGER.debug("No valid MGRS strings were found or could be inferred from query [{}]", query);
       return null;
     }
-    StringBuilder nameBuilder = new StringBuilder("MGRS: ");
-    List<UsngCoordinate> uniqueMatches =
-        matches
-            .stream()
-            .distinct()
-            .map(this::parseMgrsString)
-            .filter(Objects::nonNull)
-            .peek(mgrs -> nameBuilder.append("[ ").append(mgrs.toMgrsString()).append(" ] "))
-            .collect(Collectors.toList());
-    if (uniqueMatches.size() == 1) {
-      UsngCoordinate mgrsCoord = uniqueMatches.get(0);
-      BoundingBox bb = translator.toBoundingBox(mgrsCoord);
-      return new LiteralSuggestion(LITERAL, nameBuilder.toString(), latLonFromBoundingBox(bb));
+
+    final List<UsngCoordinate> mgrsCoordinates = new ArrayList<>();
+    final StringBuilder nameBuilder = new StringBuilder("MGRS:");
+    for (String match : matches) {
+      final UsngCoordinate coordinate = parseMgrsString(match);
+      if (coordinate == null || mgrsCoordinates.contains(coordinate)) {
+        continue;
+      }
+      mgrsCoordinates.add(coordinate);
+      nameBuilder.append(" [ ").append(coordinate.toMgrsString()).append(" ]");
     }
-    List<LatLon> geo =
-        uniqueMatches
+
+    if (mgrsCoordinates.size() == 1) {
+      final UsngCoordinate mgrsCoord = mgrsCoordinates.get(0);
+      final BoundingBox bb = translator.toBoundingBox(mgrsCoord);
+      return new LiteralSuggestion(
+          LITERAL_SUGGESTION_ID, nameBuilder.toString(), latLonFromBoundingBox(bb));
+    }
+    return new LiteralSuggestion(
+        LITERAL_SUGGESTION_ID,
+        nameBuilder.toString(),
+        mgrsCoordinates
             .stream()
             .map(translator::toLatLon)
-            .map(d -> from(d.getLat(), d.getLon()))
-            .collect(Collectors.toList());
-    return new LiteralSuggestion(LITERAL, nameBuilder.toString(), geo);
+            .map(d -> new LatLon(d.getLat(), d.getLon()))
+            .collect(Collectors.toList()));
   }
 
   @Nullable
@@ -161,29 +155,46 @@ public class MgrsCoordinateProcessor {
     try {
       return translator.parseMgrsString(mgrs);
     } catch (ParseException e) {
-      LOGGER.debug(format("Detected string [%s] was not valid MGRS", mgrs), e);
+      LOGGER.debug("Detected string [{}] was not valid MGRS", mgrs, e);
       return null;
     }
   }
 
   private static List<LatLon> latLonFromBoundingBox(BoundingBox bb) {
     return ImmutableList.of(
-        from(bb.getSouth(), bb.getWest()),
-        from(bb.getNorth(), bb.getWest()),
-        from(bb.getNorth(), bb.getEast()),
-        from(bb.getSouth(), bb.getEast()));
+        new LatLon(bb.getSouth(), bb.getWest()),
+        new LatLon(bb.getNorth(), bb.getWest()),
+        new LatLon(bb.getNorth(), bb.getEast()),
+        new LatLon(bb.getSouth(), bb.getEast()));
   }
 
-  private static List<String> coordinateStringsFromQuery(String query) {
-    final Matcher matcher = PATTERN_MGRS_ANYPART.matcher(query.concat(" "));
+  /**
+   * Given the user's query, return a list of valid MGRS strings that could be inferred from the
+   * query. The strings should be ready for submission to usng4j to be parsed and mathematically
+   * evaluated.
+   *
+   * <p>The query is terminated with whitespace so the user does not have to. See the LHS of {@link
+   * #PATTERN_MGRS_NUMERIC} for the cases where this is useful.
+   *
+   * <p>There should be no duplicate entries in the returned list. The order of the entries matters
+   * so a {@link java.util.Set} cannot be used.
+   *
+   * @param query the input string potentially holding MGRS values.
+   * @return a list of valid MGRS values that can be sent to usng4j.
+   * @throws IllegalStateException if the provided query yields an {@link MgrsPartType#NONE}.
+   */
+  @VisibleForTesting
+  List<String> getMgrsCoordinateStrings(String query) {
+    final String terminatedQuery = query.concat(WHITESPACE);
+    final Matcher matcher = PATTERN_MGRS_ANYPART.matcher(terminatedQuery);
     final List<String> mgrsStrings = new ArrayList<>();
+    final StringBuilder mgrsBuilder = new StringBuilder();
 
-    StringBuilder mgrsBuilder = new StringBuilder();
     MgrsPartType previousType = MgrsPartType.NONE;
 
     while (matcher.find()) {
-      String mgrsPart = matcher.group();
-      MgrsPartType type = getPartType(mgrsPart);
+      final String mgrsPart = matcher.group().toUpperCase();
+      final MgrsPartType type = getPartType(mgrsPart);
       switch (type) {
         case ZONE:
           handleZoneWithPreviousType(mgrsPart, previousType, mgrsBuilder, mgrsStrings);
@@ -195,24 +206,23 @@ public class MgrsCoordinateProcessor {
           handleNumericWithPreviousType(mgrsPart, previousType, mgrsBuilder, mgrsStrings);
           break;
         case NONE:
-          throw new IllegalArgumentException(
-              format("The provided mgrs part [ %s ] must have a type", mgrsPart));
+          // This should not be reachable or testable; it indicates the regex contract was broken.
+          throw new IllegalStateException(
+              format("The provided mgrs part [ %s ] must map to a valid type", mgrsPart));
       }
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug(
-            "MGRS strings [{}], builder state [{}], and types [{}|{}]",
-            mgrsStrings,
-            mgrsBuilder,
-            previousType,
-            type);
-      }
+      LOGGER.debug(
+          "MGRS strings [{}], builder state [{}], and types [{}|{}]",
+          mgrsStrings,
+          mgrsBuilder,
+          previousType,
+          type);
       previousType = type;
     }
     LOGGER.trace("Builder's final state [{}]", mgrsBuilder);
     if (previousType != MgrsPartType.NUMERIC && mgrsBuilder.length() > 0) {
       mgrsStrings.add(mgrsBuilder.toString());
     }
-    return mgrsStrings;
+    return mgrsStrings.stream().distinct().collect(Collectors.toList());
   }
 
   private static void handleZoneWithPreviousType(
@@ -224,20 +234,21 @@ public class MgrsCoordinateProcessor {
     switch (previousType) {
       case ZONE:
       case HUNDRED_KM:
-        LOGGER.trace("Storing final result coordinate, clearing the builder, and saving this part");
+        LOGGER.trace(
+            "Storing final result coordinate, clearing the builder, and saving this part [{}]",
+            mgrsPart);
         mgrsStrings.add(mgrsBuilder.toString());
         mgrsBuilder.delete(0, mgrsBuilder.length());
         mgrsBuilder.append(mgrsPart);
         break;
       case NUMERIC:
-        LOGGER.trace("Clearing the builder and saving this part");
+        LOGGER.trace("Clearing the builder and saving this part [{}]", mgrsPart);
         mgrsBuilder.delete(0, mgrsBuilder.length());
         mgrsBuilder.append(mgrsPart);
         break;
       case NONE:
-        LOGGER.trace("Saving this part");
+        LOGGER.trace("Saving this part [{}]", mgrsPart);
         mgrsBuilder.append(mgrsPart);
-        break;
     }
   }
 
@@ -246,14 +257,13 @@ public class MgrsCoordinateProcessor {
     LOGGER.trace("Found a 100KM [{}] which occurs after a {}", mgrsPart, previousType);
     switch (previousType) {
       case ZONE:
-        LOGGER.trace("Saving this part");
+        LOGGER.trace("Saving this part [{}]", mgrsPart);
         mgrsBuilder.append(mgrsPart);
         break;
       case HUNDRED_KM:
       case NUMERIC:
       case NONE:
-        LOGGER.trace("Ignoring this part, since 100KM is only valid after a ZONE");
-        break;
+        LOGGER.trace("Ignoring this part [{}], since 100KM is only valid after a ZONE", mgrsPart);
     }
   }
 
@@ -268,14 +278,14 @@ public class MgrsCoordinateProcessor {
       case HUNDRED_KM:
       case NUMERIC:
         String processed = processNumericType(mgrsPart);
-        LOGGER.trace("NUMERIC [{}] processed = [{}]", mgrsPart, processed);
-        LOGGER.trace("Storing final result coordinate");
+        LOGGER.trace(
+            "NUMERIC [{}] processed = [{}], storing final result coordinate", mgrsPart, processed);
         mgrsStrings.add(mgrsBuilder.toString() + processed);
         break;
       case NONE:
         LOGGER.trace(
-            "Ignoring this part, since NUMERIC is only valid in a ZONE but no ZONE was provided");
-        break;
+            "Ignoring this part [{}], since NUMERIC is only valid in a ZONE but no ZONE was provided",
+            mgrsPart);
     }
   }
 
@@ -298,8 +308,9 @@ public class MgrsCoordinateProcessor {
    * @param mgrsPart an MGRS substring that contains BOTH the easting and northing.
    * @return a modified easting/northing string with zeros backfilled to ensure accurate conversion.
    */
+  @SuppressWarnings("squid:S1135" /* Ticket number provided on to-do comment */)
   private static String processNumericType(String mgrsPart) {
-    String[] numericParts = mgrsPart.split("[ ]+");
+    final String[] numericParts = mgrsPart.split("(\\W)+");
     if (numericParts.length >= 3 || numericParts.length == 0) {
       throw new IllegalArgumentException(
           "The mgrs part provided is not a valid NUMERIC type: " + mgrsPart);
@@ -311,45 +322,21 @@ public class MgrsCoordinateProcessor {
     if (eastingAndNorthing.length() % 2 > 0) {
       eastingAndNorthing = eastingAndNorthing.substring(0, eastingAndNorthing.length() - 1);
     }
-    int halfway = eastingAndNorthing.length() / 2;
-    String easting = eastingAndNorthing.substring(0, halfway);
-    String northing = eastingAndNorthing.substring(halfway, eastingAndNorthing.length());
+    final int halfway = eastingAndNorthing.length() / 2;
+    final String easting = eastingAndNorthing.substring(0, halfway);
+    final String northing = eastingAndNorthing.substring(halfway);
     return assemble(easting, northing);
   }
 
   private static String assemble(String easting, String northing) {
-    StringBuilder numericBuilder = new StringBuilder();
-    Runnable appendZero = () -> numericBuilder.append("0");
-
-    if (easting.length() < MAX_EASTING_LENGTH) {
-      int numberOfZerosNeeded = MAX_EASTING_LENGTH - easting.length();
-      repeat(numberOfZerosNeeded, appendZero);
-    }
-    numericBuilder.append(easting);
-
-    if (northing.length() < MAX_NORTHING_LENGTH) {
-      int numberOfZerosNeeded = MAX_NORTHING_LENGTH - northing.length();
-      repeat(numberOfZerosNeeded, appendZero);
-    }
-    numericBuilder.append(northing);
-
-    return numericBuilder.toString();
+    return leftPad(easting, MAX_COORDINATE_LENGTH, ZERO)
+        + leftPad(northing, MAX_COORDINATE_LENGTH, ZERO);
   }
 
   private static MgrsPartType getPartType(String mgrsPart) {
-    if (PATTERN_MGRS_ZONE.matcher(mgrsPart).matches()) {
-      return MgrsPartType.ZONE;
-    } else if (PATTERN_MGRS_100KM.matcher(mgrsPart).matches()) {
-      return MgrsPartType.HUNDRED_KM;
-    } else if (PATTERN_MGRS_NUMERIC.matcher(mgrsPart).matches()) {
-      return MgrsPartType.NUMERIC;
-    }
+    if (PATTERN_MGRS_ZONE.matcher(mgrsPart).matches()) return MgrsPartType.ZONE;
+    if (PATTERN_MGRS_100KM.matcher(mgrsPart).matches()) return MgrsPartType.HUNDRED_KM;
+    if (PATTERN_MGRS_NUMERIC.matcher(mgrsPart).matches()) return MgrsPartType.NUMERIC;
     return MgrsPartType.NONE;
-  }
-
-  private static void repeat(int numberOfTimes, Runnable action) {
-    for (int i = 0; i < numberOfTimes; i++) {
-      action.run();
-    }
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessor.java
@@ -1,0 +1,355 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.suggestion;
+
+import static java.lang.String.format;
+import static org.codice.ddf.catalog.ui.query.suggestion.LatLon.from;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.codice.ddf.spatial.geocoding.Suggestion;
+import org.codice.usng4j.BoundingBox;
+import org.codice.usng4j.CoordinateSystemTranslator;
+import org.codice.usng4j.UsngCoordinate;
+import org.codice.usng4j.impl.CoordinateSystemTranslatorImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A regex-based processor for identifying potential MGRS coordinate literals in a given input
+ * string despite deviations from the official spec. The general policy is to be as forgiving as
+ * possible without sacrificing determinism.
+ *
+ * <p>Due to the strict expectations of usng4j regarding input strings, some additional processing
+ * is done to "backfill" necessary zeros for occurrences of a {@link MgrsPartType#NUMERIC} string.
+ *
+ * @see #processNumericType(String) for more information on this "backfilling" behavior.
+ */
+@SuppressWarnings("squid:S1135" /* Ticket number provided on comment */)
+public class MgrsCoordinateProcessor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MgrsCoordinateProcessor.class);
+
+  private static final Pattern PATTERN_MGRS_ZONE = Pattern.compile("\\d\\d?[CDEFGHJKLMNPQRSTUVWX]");
+
+  private static final Pattern PATTERN_MGRS_100KM =
+      Pattern.compile("[ABCDEFGHJKLMNPQRSTUVWXYZ][ABCDEFGHJKLMNPQRSTUV]");
+
+  private static final Pattern PATTERN_MGRS_NUMERIC =
+      Pattern.compile("((\\d){1,5}(\\h)+(\\d){1,5}(\\h)+)|((\\d){2,10})");
+
+  private static final Pattern PATTERN_MGRS_ANYPART =
+      Pattern.compile(
+          format(
+              "(%s)|(%s)|(%s)",
+              PATTERN_MGRS_ZONE.pattern(),
+              PATTERN_MGRS_100KM.pattern(),
+              PATTERN_MGRS_NUMERIC.pattern()));
+
+  // usng4j helper constant for backfilling zeros
+  private static final Integer MAX_EASTING_LENGTH = 5;
+
+  // usng4j helper constant for backfilling zeros
+  private static final Integer MAX_NORTHING_LENGTH = 5;
+
+  // This key tells the UI that the geo is on the suggestion itself
+  private static final String LITERAL = "LITERAL2";
+
+  /**
+   * An {@link MgrsPartType} identifies one of the three different component strings that are glued
+   * together to form a valid MGRS coordinate string, including a category {@link #NONE} to be used
+   * when the string is unsuitable for any part of an MGRS coordinate or the type has not been
+   * provided yet.
+   *
+   * <p>Each type corresponds to a regex defined above.
+   */
+  private enum MgrsPartType {
+    NONE,
+    ZONE,
+    HUNDRED_KM,
+    NUMERIC
+  }
+
+  private final CoordinateSystemTranslator translator = new CoordinateSystemTranslatorImpl();
+
+  /**
+   * Given a list of {@link Suggestion}s and the query that yielded them, enhance the list with
+   * additional suggestions based upon the presence of coordinate literals in the query string.
+   *
+   * @param results the list of results to enhance.
+   * @param query the query string to search for coordinate literals.
+   * @return the enhanced list.
+   */
+  public List<Suggestion> enhanceResults(List<Suggestion> results, String query) {
+    LiteralSuggestion literal = getMgrsSuggestion(query);
+    if (literal != null && literal.hasGeo()) {
+      LOGGER.debug("Adding the MGRS suggestion to results");
+      results.add(0, literal);
+    }
+    return results;
+  }
+
+  /**
+   * Given an input string, return the list of properly formatted MGRS coordinate strings that are
+   * ready for submission to usng4j for mathematical evaluation.
+   *
+   * @param query the query string to search for coordinate literals.
+   * @return a list of valid MGRS strings ready for evaluation.
+   */
+  @VisibleForTesting
+  List<String> getMgrsCoordinateStrings(String query) {
+    return coordinateStringsFromQuery(query);
+  }
+
+  /**
+   * Build the MGRS suggestion.
+   *
+   * @param query the query string to search for coordinate literals.
+   * @return a suggestion object with geometry attached to it; a {@link BoundingBox} if only one
+   *     coordinate was detected, or a collection of {@link LatLon} center points otherwise.
+   */
+  @Nullable
+  private LiteralSuggestion getMgrsSuggestion(String query) {
+    List<String> matches = coordinateStringsFromQuery(query);
+    if (matches.isEmpty()) {
+      LOGGER.debug("No valid MGRS strings were found or could be inferred");
+      return null;
+    }
+    StringBuilder nameBuilder = new StringBuilder("MGRS: ");
+    List<UsngCoordinate> uniqueMatches =
+        matches
+            .stream()
+            .distinct()
+            .map(this::parseMgrsString)
+            .filter(Objects::nonNull)
+            .peek(mgrs -> nameBuilder.append("[ ").append(mgrs.toMgrsString()).append(" ] "))
+            .collect(Collectors.toList());
+    if (uniqueMatches.size() == 1) {
+      UsngCoordinate mgrsCoord = uniqueMatches.get(0);
+      BoundingBox bb = translator.toBoundingBox(mgrsCoord);
+      return new LiteralSuggestion(LITERAL, nameBuilder.toString(), latLonFromBoundingBox(bb));
+    }
+    List<LatLon> geo =
+        uniqueMatches
+            .stream()
+            .map(translator::toLatLon)
+            .map(d -> from(d.getLat(), d.getLon()))
+            .collect(Collectors.toList());
+    return new LiteralSuggestion(LITERAL, nameBuilder.toString(), geo);
+  }
+
+  @Nullable
+  private UsngCoordinate parseMgrsString(String mgrs) {
+    try {
+      return translator.parseMgrsString(mgrs);
+    } catch (ParseException e) {
+      LOGGER.debug(format("Detected string [%s] was not valid MGRS", mgrs), e);
+      return null;
+    }
+  }
+
+  private static List<LatLon> latLonFromBoundingBox(BoundingBox bb) {
+    return ImmutableList.of(
+        from(bb.getSouth(), bb.getWest()),
+        from(bb.getNorth(), bb.getWest()),
+        from(bb.getNorth(), bb.getEast()),
+        from(bb.getSouth(), bb.getEast()));
+  }
+
+  private static List<String> coordinateStringsFromQuery(String query) {
+    final Matcher matcher = PATTERN_MGRS_ANYPART.matcher(query.concat(" "));
+    final List<String> mgrsStrings = new ArrayList<>();
+
+    StringBuilder mgrsBuilder = new StringBuilder();
+    MgrsPartType previousType = MgrsPartType.NONE;
+
+    while (matcher.find()) {
+      String mgrsPart = matcher.group();
+      MgrsPartType type = getPartType(mgrsPart);
+      switch (type) {
+        case ZONE:
+          handleZoneWithPreviousType(mgrsPart, previousType, mgrsBuilder, mgrsStrings);
+          break;
+        case HUNDRED_KM:
+          handleHundredKmWithPreviousType(mgrsPart, previousType, mgrsBuilder);
+          break;
+        case NUMERIC:
+          handleNumericWithPreviousType(mgrsPart, previousType, mgrsBuilder, mgrsStrings);
+          break;
+        case NONE:
+          throw new IllegalArgumentException(
+              format("The provided mgrs part [ %s ] must have a type", mgrsPart));
+      }
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "MGRS strings [{}], builder state [{}], and types [{}|{}]",
+            mgrsStrings,
+            mgrsBuilder,
+            previousType,
+            type);
+      }
+      previousType = type;
+    }
+    LOGGER.trace("Builder's final state [{}]", mgrsBuilder);
+    if (previousType != MgrsPartType.NUMERIC && mgrsBuilder.length() > 0) {
+      mgrsStrings.add(mgrsBuilder.toString());
+    }
+    return mgrsStrings;
+  }
+
+  private static void handleZoneWithPreviousType(
+      String mgrsPart,
+      MgrsPartType previousType,
+      StringBuilder mgrsBuilder,
+      List<String> mgrsStrings) {
+    LOGGER.trace("Found a ZONE [{}] which occurs after a {}", mgrsPart, previousType);
+    switch (previousType) {
+      case ZONE:
+      case HUNDRED_KM:
+        LOGGER.trace("Storing final result coordinate, clearing the builder, and saving this part");
+        mgrsStrings.add(mgrsBuilder.toString());
+        mgrsBuilder.delete(0, mgrsBuilder.length());
+        mgrsBuilder.append(mgrsPart);
+        break;
+      case NUMERIC:
+        LOGGER.trace("Clearing the builder and saving this part");
+        mgrsBuilder.delete(0, mgrsBuilder.length());
+        mgrsBuilder.append(mgrsPart);
+        break;
+      case NONE:
+        LOGGER.trace("Saving this part");
+        mgrsBuilder.append(mgrsPart);
+        break;
+    }
+  }
+
+  private static void handleHundredKmWithPreviousType(
+      String mgrsPart, MgrsPartType previousType, StringBuilder mgrsBuilder) {
+    LOGGER.trace("Found a 100KM [{}] which occurs after a {}", mgrsPart, previousType);
+    switch (previousType) {
+      case ZONE:
+        LOGGER.trace("Saving this part");
+        mgrsBuilder.append(mgrsPart);
+        break;
+      case HUNDRED_KM:
+      case NUMERIC:
+      case NONE:
+        LOGGER.trace("Ignoring this part, since 100KM is only valid after a ZONE");
+        break;
+    }
+  }
+
+  private static void handleNumericWithPreviousType(
+      String mgrsPart,
+      MgrsPartType previousType,
+      StringBuilder mgrsBuilder,
+      List<String> mgrsStrings) {
+    LOGGER.trace("Found a NUMERIC [{}] which occurs after a {}", mgrsPart, previousType);
+    switch (previousType) {
+      case ZONE:
+      case HUNDRED_KM:
+      case NUMERIC:
+        String processed = processNumericType(mgrsPart);
+        LOGGER.trace("NUMERIC [{}] processed = [{}]", mgrsPart, processed);
+        LOGGER.trace("Storing final result coordinate");
+        mgrsStrings.add(mgrsBuilder.toString() + processed);
+        break;
+      case NONE:
+        LOGGER.trace(
+            "Ignoring this part, since NUMERIC is only valid in a ZONE but no ZONE was provided");
+        break;
+    }
+  }
+
+  /**
+   * Given an MGRS {@link MgrsPartType#NUMERIC} part format the string to ensure an accurate
+   * conversion, using whitespace as a hint as to the user's intentions.
+   *
+   * <p>The usng4j library demands a minimum of 6 symbols if the easting / northing data is not to
+   * be ignored. That is, the easting component must be fully specified for the conversion to work.
+   * To accomodate this, zeros are prepended onto the easting to whatever appropriate degree.
+   *
+   * <p>For example, an input of <span>4Q KJ 1 2</span> will become <span>4QKJ000012</span> so the
+   * easting / northing is not ignored.
+   *
+   * <p>Refer to the unit tests for more comprehensive examples.
+   *
+   * <p>TODO DDF-4243 - This should be simplified if usng4j is improved
+   *
+   * @see #assemble(String, String)
+   * @param mgrsPart an MGRS substring that contains BOTH the easting and northing.
+   * @return a modified easting/northing string with zeros backfilled to ensure accurate conversion.
+   */
+  private static String processNumericType(String mgrsPart) {
+    String[] numericParts = mgrsPart.split("[ ]+");
+    if (numericParts.length >= 3 || numericParts.length == 0) {
+      throw new IllegalArgumentException(
+          "The mgrs part provided is not a valid NUMERIC type: " + mgrsPart);
+    }
+    if (numericParts.length == 2) {
+      return assemble(numericParts[0], numericParts[1]);
+    }
+    String eastingAndNorthing = numericParts[0];
+    if (eastingAndNorthing.length() % 2 > 0) {
+      eastingAndNorthing = eastingAndNorthing.substring(0, eastingAndNorthing.length() - 1);
+    }
+    int halfway = eastingAndNorthing.length() / 2;
+    String easting = eastingAndNorthing.substring(0, halfway);
+    String northing = eastingAndNorthing.substring(halfway, eastingAndNorthing.length());
+    return assemble(easting, northing);
+  }
+
+  private static String assemble(String easting, String northing) {
+    StringBuilder numericBuilder = new StringBuilder();
+    Runnable appendZero = () -> numericBuilder.append("0");
+
+    if (easting.length() < MAX_EASTING_LENGTH) {
+      int numberOfZerosNeeded = MAX_EASTING_LENGTH - easting.length();
+      repeat(numberOfZerosNeeded, appendZero);
+    }
+    numericBuilder.append(easting);
+
+    if (northing.length() < MAX_NORTHING_LENGTH) {
+      int numberOfZerosNeeded = MAX_NORTHING_LENGTH - northing.length();
+      repeat(numberOfZerosNeeded, appendZero);
+    }
+    numericBuilder.append(northing);
+
+    return numericBuilder.toString();
+  }
+
+  private static MgrsPartType getPartType(String mgrsPart) {
+    if (PATTERN_MGRS_ZONE.matcher(mgrsPart).matches()) {
+      return MgrsPartType.ZONE;
+    } else if (PATTERN_MGRS_100KM.matcher(mgrsPart).matches()) {
+      return MgrsPartType.HUNDRED_KM;
+    } else if (PATTERN_MGRS_NUMERIC.matcher(mgrsPart).matches()) {
+      return MgrsPartType.NUMERIC;
+    }
+    return MgrsPartType.NONE;
+  }
+
+  private static void repeat(int numberOfTimes, Runnable action) {
+    for (int i = 0; i < numberOfTimes; i++) {
+      action.run();
+    }
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -366,10 +366,23 @@
         <argument ref="subjectIdentity"/>
     </bean>
 
+    <reference id="coordinateSystemTranslator" interface="org.codice.usng4j.CoordinateSystemTranslator"
+               filter="(isNad83Datum=true)" />
+
+    <bean id="latLonCoordinateProcessor"
+          class="org.codice.ddf.catalog.ui.query.suggestion.LatLonCoordinateProcessor"/>
+
+    <bean id="mgrsCoordinateProcessor"
+          class="org.codice.ddf.catalog.ui.query.suggestion.MgrsCoordinateProcessor">
+        <argument ref="coordinateSystemTranslator"/>
+    </bean>
+
     <bean id="queryApplication" class="org.codice.ddf.catalog.ui.query.QueryApplication">
         <property name="featureService" ref="featureService"/>
         <property name="endpointUtil" ref="endpointUtil"/>
         <argument ref="cqlTransformHandler"/>
+        <argument ref="latLonCoordinateProcessor"/>
+        <argument ref="mgrsCoordinateProcessor"/>
     </bean>
 
     <reference id="mimeTypeMapper" interface="ddf.mime.MimeTypeMapper"/>

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/LatLonCoordinateProcessorTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/LatLonCoordinateProcessorTest.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.catalog.ui.query.suggestion;
 
-import static org.codice.ddf.catalog.ui.query.suggestion.LatLon.from;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
@@ -32,242 +31,248 @@ public class LatLonCoordinateProcessorTest {
 
   @Test
   public void testProcessorIgnoresSingleValue() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "0");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "0");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorIgnoresSingleValueWithTrailingPeriod() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "0.");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "0.");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorDetectsOrigin() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "0 0");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(0.0, 0.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "0 0");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(0.0, 0.0)));
   }
 
   @Test
   public void testProcessorDetectsOriginWithLeadingDecimals() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), ".0 .0");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(0.0, 0.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), ".0 .0");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(0.0, 0.0)));
   }
 
   @Test
   public void testProcessorDetectsWholeNumbers() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 123");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(50.0, 123.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 123");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(50.0, 123.0)));
   }
 
   @Test
   public void testProcessorIgnoresTooLargeLonWholeNumber() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 1234");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 1234");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorIgnoresTooSmallLonWholeNumber() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 -1234");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 -1234");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorIgnoresTooLargeLonDecimal() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 1234.1234");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 1234.1234");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorIgnoresTooSmallLonDecimal() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 -1234.1234");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 -1234.1234");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorDetectsNegativeLonWholeNumber() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 -123");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(50.0, -123.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 -123");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(50.0, -123.0)));
   }
 
   @Test
   public void testProcessorDetectsLonDecimalWithoutWhole() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 .1234");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(50.0, 0.1234)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 .1234");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(50.0, 0.1234)));
   }
 
   @Test
   public void testProcessorDetectsNegativeLonDecimalWithoutWhole() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 -.1234");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(50.0, -0.1234)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 -.1234");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(50.0, -0.1234)));
   }
 
   @Test
   public void testProcessorDetectsLonDecimal() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "50 123.1234");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(50.0, 123.1234)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "50 123.1234");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(50.0, 123.1234)));
   }
 
   @Test
   public void testProcessorIgnoresTooLargeLatWholeNumber() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "95, 34");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "95, 34");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorIgnoresTooSmallLatWholeNumber() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "-95 34");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "-95 34");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorIgnoresTooLargeLatDecimal() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "1234.1234 34");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "1234.1234 34");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorIgnoresTooSmallLatDecimal() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "-1234.1234 34");
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "-1234.1234 34");
     assertThat(suggestions, empty());
   }
 
   @Test
   public void testProcessorDetectsNegativeLatWholeNumber() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "-56, 34");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(-56.0, 34.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "-56, 34");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(-56.0, 34.0)));
   }
 
   @Test
   public void testProcessorDetectsLatDecimalWithoutWhole() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), ".1234 34");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(0.1234, 34.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), ".1234 34");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(0.1234, 34.0)));
   }
 
   @Test
   public void testProcessorDetectsNegativeLatDecimalWithoutWhole() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "-.1234 34");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(-0.1234, 34.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "-.1234 34");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(-0.1234, 34.0)));
   }
 
   @Test
   public void testProcessorDetectsLatDecimal() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "56.789 34");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(56.789, 34.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "56.789 34");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(56.789, 34.0)));
   }
 
   @Test
   public void testProcessorDetectsAndGracefullyHandlesMassiveDecimals() {
     String massiveDecimal = "50.123456789012345678901234567890123456789012345678901234567890";
     List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), massiveDecimal + " " + massiveDecimal);
+        enhanceAndReturn(new LinkedList<>(), massiveDecimal + " " + massiveDecimal);
     assertThat(suggestions, hasSize(1));
   }
 
   @Test
   public void testProcessorHandlesOddNumberOfInputs() {
-    List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "89, 110, -46, 67, -120");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(89.0, 110.0), from(-46.0, 67.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "89, 110, -46, 67, -120");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(89.0, 110.0), coord(-46.0, 67.0)));
   }
 
   @Test
   public void testProcessorHandlesOddNumberOfInputsInvalidLatitudeInMiddle() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "89 46 99 67 -120");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(89.0, 46.0), from(67.0, -120.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "89 46 99 67 -120");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(89.0, 46.0), coord(67.0, -120.0)));
   }
 
   @Test
   public void testProcessorHandlesOddNumberOfInputsInvalidLatitudeAtBeginning() {
-    List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "99, 89, 46, 67, -120");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(89.0, 46.0), from(67.0, -120.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "99, 89, 46, 67, -120");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(89.0, 46.0), coord(67.0, -120.0)));
   }
 
   @Test
   public void testProcessorHandlesOddNumberOfInvalidLongitudeAtEnd() {
-    List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "-38, 89, 46, 189, -120");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(-38.0, 89.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "-38, 89, 46, 189, -120");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(-38.0, 89.0)));
   }
 
   @Test
   public void testProcessorIgnoresInvalidLongitudeInMiddle() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "38, 189, -46, 89");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(-46.0, 89.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "38, 189, -46, 89");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(-46.0, 89.0)));
   }
 
   @Test
   public void testProcessorIgnoresInvalidLongitudeAtEnd() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "89, 46, 67, -220");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(89.0, 46.0)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "89, 46, 67, -220");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(89.0, 46.0)));
   }
 
   @Test
   public void testRegexDetectsLatLonCommaSpaced() {
-    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "12.153, -39.0352");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(12.153, -39.0352)));
+    List<Suggestion> suggestions = enhanceAndReturn(new LinkedList<>(), "12.153, -39.0352");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(12.153, -39.0352)));
   }
 
   @Test
   public void testRegexDetectsLatLonParentheses() {
     List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "(12.153, -39.0352), (21.098, 19.148)");
+        enhanceAndReturn(new LinkedList<>(), "(12.153, -39.0352), (21.098, 19.148)");
     assertThat(
-        cast(suggestions).get(0), hasCoordinates(from(12.153, -39.0352), from(21.098, 19.148)));
+        cast(suggestions).get(0), hasCoordinates(coord(12.153, -39.0352), coord(21.098, 19.148)));
   }
 
   @Test
   public void testRegexDetectsLatLonBrackets() {
     List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "[12.153, -39.0352], [21.098, 19.148]");
+        enhanceAndReturn(new LinkedList<>(), "[12.153, -39.0352], [21.098, 19.148]");
     assertThat(
-        cast(suggestions).get(0), hasCoordinates(from(12.153, -39.0352), from(21.098, 19.148)));
+        cast(suggestions).get(0), hasCoordinates(coord(12.153, -39.0352), coord(21.098, 19.148)));
   }
 
   @Test
   public void testRegexDetectsLatLonCurlyBraces() {
     List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "{12.153, -39.0352}, {21.098, 19.148}");
+        enhanceAndReturn(new LinkedList<>(), "{12.153, -39.0352}, {21.098, 19.148}");
     assertThat(
-        cast(suggestions).get(0), hasCoordinates(from(12.153, -39.0352), from(21.098, 19.148)));
+        cast(suggestions).get(0), hasCoordinates(coord(12.153, -39.0352), coord(21.098, 19.148)));
   }
 
   @Test
   public void testRegexDetectsScatteredCoords() {
     List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "blah;;;3g-12j.098     4.1");
-    assertThat(cast(suggestions).get(0), hasCoordinates(from(3.0, -12.0), from(0.098, 4.1)));
+        enhanceAndReturn(new LinkedList<>(), "blah;;;3g-12j.098     4.1");
+    assertThat(cast(suggestions).get(0), hasCoordinates(coord(3.0, -12.0), coord(0.098, 4.1)));
   }
 
   @Test
   // TODO DDF-4242: Future improvement ... allow whitespace between relevant symbols: "- 14" & ".12"
   public void testRegexIgnoresStandaloneSymbols() {
     List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "blah10.19205123gagne . - -.12 . 12 - 14");
+        enhanceAndReturn(new LinkedList<>(), "blah10.19205123gagne . - -.12 . 12 - 14");
     // The below assertion's latter coord would change from 12.0 & 14.0 --> 0.12 & -14.0
     assertThat(
-        cast(suggestions).get(0), hasCoordinates(from(10.19205123, -0.12), from(12.0, 14.0)));
+        cast(suggestions).get(0), hasCoordinates(coord(10.19205123, -0.12), coord(12.0, 14.0)));
   }
 
   @Test
   public void testRegexIgnoresStandaloneSymbolsChainedTwice() {
     List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "blah10.19205123gagne .. -- -.12 . 12 - 14");
+        enhanceAndReturn(new LinkedList<>(), "blah10.19205123gagne .. -- -.12 . 12 - 14");
     assertThat(
-        cast(suggestions).get(0), hasCoordinates(from(10.19205123, -0.12), from(12.0, 14.0)));
+        cast(suggestions).get(0), hasCoordinates(coord(10.19205123, -0.12), coord(12.0, 14.0)));
   }
 
   @Test
   public void testRegexIgnoresStandaloneSymbolsChainedThrice() {
     List<Suggestion> suggestions =
-        processor.enhanceResults(new LinkedList<>(), "blah10.19205123gagne ... --- -.12 . 12 - 14");
+        enhanceAndReturn(new LinkedList<>(), "blah10.19205123gagne ... --- -.12 . 12 - 14");
     assertThat(
-        cast(suggestions).get(0), hasCoordinates(from(10.19205123, -0.12), from(12.0, 14.0)));
+        cast(suggestions).get(0), hasCoordinates(coord(10.19205123, -0.12), coord(12.0, 14.0)));
+  }
+
+  private List<Suggestion> enhanceAndReturn(List<Suggestion> input, String query) {
+    processor.enhanceResults(input, query);
+    return input;
   }
 
   private static List<LiteralSuggestion> cast(List<Suggestion> suggestions) {
     return suggestions.stream().map(LiteralSuggestion.class::cast).collect(Collectors.toList());
+  }
+
+  private static LatLon coord(Double lat, Double lon) {
+    return new LatLon(lat, lon);
   }
 
   private static org.hamcrest.Matcher<LiteralSuggestion> hasCoordinates(LatLon... coords) {

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessorTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessorTest.java
@@ -1,0 +1,360 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.suggestion;
+
+import static org.codice.ddf.catalog.ui.query.suggestion.LatLon.from;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.codice.ddf.spatial.geocoding.Suggestion;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+public class MgrsCoordinateProcessorTest {
+  private final MgrsCoordinateProcessor processor = new MgrsCoordinateProcessor();
+
+  @Test
+  public void testProcessorDetectsZone() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4Q")));
+  }
+
+  @Test
+  public void testProcessorDetectsTwoZones() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q 10P");
+    assertThat(detectedMgrsStrings, both(hasSize(2)).and(contains("4Q", "10P")));
+  }
+
+  @Test
+  public void testProcessorDetectsTwoZonesNoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q10P");
+    assertThat(detectedMgrsStrings, both(hasSize(2)).and(contains("4Q", "10P")));
+  }
+
+  @Test
+  public void testProcessorDetectsHundredKm() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ")));
+  }
+
+  @Test
+  public void testProcessorDetectsHundredKmNoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJ");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ")));
+  }
+
+  @Test
+  public void testProcessorDetectsTwoHundredKm() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 10P EG");
+    assertThat(detectedMgrsStrings, both(hasSize(2)).and(contains("4QFJ", "10PEG")));
+  }
+
+  @Test
+  public void testProcessorDetectsTwoHundredKmNoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJ10PEG");
+    assertThat(detectedMgrsStrings, both(hasSize(2)).and(contains("4QFJ", "10PEG")));
+  }
+
+  @Test
+  public void testProcessorIgnoresExtraneousHundredKm() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ EG");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ")));
+  }
+
+  @Test
+  public void testProcessorIgnoresExtraneousHundredKmNoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJEG");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ")));
+  }
+
+  @Test
+  public void testProcessorIgnoresExtraneousHundredKmFollowedByZone() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ EG 10P");
+    assertThat(detectedMgrsStrings, both(hasSize(2)).and(contains("4QFJ", "10P")));
+  }
+
+  @Test
+  public void testProcessorIgnoresExtraneousHundredKmFollowedByZoneNoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJEG10P");
+    assertThat(detectedMgrsStrings, both(hasSize(2)).and(contains("4QFJ", "10P")));
+  }
+
+  @Test
+  public void testProcessorDoesNotUseNextZoneDigitsAsPartOfPreviousNumeric() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("14T11 7Q22");
+    assertThat(
+        detectedMgrsStrings, both(hasSize(2)).and(contains("14T0000100001", "7Q0000200002")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision1() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 1 6");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0000100006")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision1NoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 16");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0000100006")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision1NoSpaceAtAll() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJ16");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0000100006")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision2() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 12 67");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0001200067")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision2OffsetLeft() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 126 7");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0012600007")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision2OffsetRight() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 1 267");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0000100267")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision2NoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 1267");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0001200067")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision2NoSpaceAtAll() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJ1267");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0001200067")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision3() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 123 678");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0012300678")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision3OffsetLeft() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 1236 78");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0123600078")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision3OffsetRight() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 12 3678");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0001203678")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision3NoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 123678");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0012300678")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision3NoSpaceAtAll() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJ123678");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0012300678")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision4() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 1234 6789");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0123406789")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision4OffsetLeft() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 12346 789");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ1234600789")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision4OffsetRight() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 123 46789");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0012346789")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision4NoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 12346789");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0123406789")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision4NoSpaceAtAll() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJ12346789");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0123406789")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision5() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 12345 67891");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ1234567891")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision5OffsetLeft() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 123456 7891");
+    assertThat(
+        detectedMgrsStrings, both(hasSize(2)).and(contains("4QFJ0012300456", "4QFJ0007800091")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision5OffsetRight() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 1234 567891");
+    assertThat(
+        detectedMgrsStrings, both(hasSize(2)).and(contains("4QFJ0001200034", "4QFJ0056700891")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision5NoSpace() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 1234567891");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ1234567891")));
+  }
+
+  @Test
+  public void testProcessorDetectsPrecision5NoSpaceAtAll() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QFJ1234567891");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ1234567891")));
+  }
+
+  @Test
+  public void testProcessorHandlesAttemptedPrecision6() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 123456 789123");
+    assertThat(
+        detectedMgrsStrings, both(hasSize(2)).and(contains("4QFJ0012300456", "4QFJ0078900123")));
+  }
+
+  @Test
+  public void testProcessorHandlesAttemptedPrecision7() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ 1234567 8912345");
+    assertThat(
+        detectedMgrsStrings, both(hasSize(2)).and(contains("4QFJ0012300456", "4QFJ0089100234")));
+  }
+
+  @Test
+  public void testProcessorIgnoresDuplicateZone() {
+    String query = "1D 1D"; // Should yield 2 points
+    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), query);
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings(query);
+    assertThat(detectedMgrsStrings, both(hasSize(2)).and(contains("1D", "1D")));
+    assertThat(
+        cast(suggestions).get(0).getGeo(),
+        hasSize(4)); // Yields 4 since 1 MGRS match returns a bbox, proving deduplication
+  }
+
+  @Test
+  public void testProcessorDetectsDuplicateZoneIfMoreSpecificsFollow() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("1D 1D FJ");
+    assertThat(detectedMgrsStrings, both(hasSize(2)).and(contains("1D", "1DFJ")));
+  }
+
+  @Test
+  public void testProcessorDetectsZone100kReuse() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("1D FJ 1 2 3 4 5 6");
+    assertThat(
+        detectedMgrsStrings,
+        both(hasSize(3)).and(contains("1DFJ0000100002", "1DFJ0000300004", "1DFJ0000500006")));
+  }
+
+  @Test
+  public void testProcessorDetectsOnlyZoneReuse() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("1D 1 2 3 4 5 6");
+    assertThat(
+        detectedMgrsStrings,
+        both(hasSize(3)).and(contains("1D0000100002", "1D0000300004", "1D0000500006")));
+  }
+
+  @Test
+  public void testProcessorDetectsDuplicateCoordsWithZoneReuse() {
+    String query = "1D FJ 1 2 1 2 1 2"; // Should yield 3 points
+    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), query);
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings(query);
+    assertThat(
+        detectedMgrsStrings,
+        both(hasSize(3)).and(contains("1DFJ0000100002", "1DFJ0000100002", "1DFJ0000100002")));
+    assertThat(
+        cast(suggestions).get(0).getGeo(),
+        hasSize(4)); // Yields 4 since 1 MGRS match returns a bbox, proving deduplication
+  }
+
+  @Test
+  public void testProcessorCanInferPrecision() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4Q FJ B12345");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4QFJ0001200034")));
+  }
+
+  @Test
+  public void testProcessorFallsBackToZoneWhen100KmGridIsWrong() {
+    List<String> detectedMgrsStrings = processor.getMgrsCoordinateStrings("4QJ1");
+    assertThat(detectedMgrsStrings, both(hasSize(1)).and(contains("4Q")));
+  }
+
+  @Test
+  public void testProcessorDetectsMultipleMgrsCoordinatesWithDelimiter() {
+    List<Suggestion> suggestions = processor.enhanceResults(new LinkedList<>(), "4Q, 1D");
+    validateHasCoordinates(
+        suggestions,
+        from(19.828721744493368, -163.77046585527026),
+        from(-67.19807978145084, -188.61742944126627));
+  }
+
+  private static void validateHasCoordinates(List<Suggestion> suggestions, LatLon... lls) {
+    assertThat(suggestions, hasSize(1));
+    List<LiteralSuggestion> literalSuggestions = cast(suggestions);
+    assertThat(literalSuggestions.get(0).getGeo(), hasSize(lls.length));
+    assertThat(literalSuggestions.get(0), hasCoordinates(lls));
+  }
+
+  private static List<LiteralSuggestion> cast(List<Suggestion> suggestions) {
+    return suggestions.stream().map(LiteralSuggestion.class::cast).collect(Collectors.toList());
+  }
+
+  private static org.hamcrest.Matcher<LiteralSuggestion> hasCoordinates(LatLon... coords) {
+    return new TypeSafeMatcher<LiteralSuggestion>() {
+      @Override
+      public void describeTo(final Description description) {
+        description
+            .appendText("coordinates should be on the object ")
+            .appendValue(Arrays.asList(coords));
+      }
+
+      @Override
+      protected void describeMismatchSafely(
+          final LiteralSuggestion item, final Description mismatchDescription) {
+        mismatchDescription.appendText(" was ").appendValue(item.getGeo());
+      }
+
+      @Override
+      protected boolean matchesSafely(final LiteralSuggestion item) {
+        return item.hasGeo() && item.getGeo().containsAll(Arrays.asList(coords));
+      }
+    };
+  }
+}

--- a/catalog/ui/search-ui-app/src/main/resources/features.xml
+++ b/catalog/ui/search-ui-app/src/main/resources/features.xml
@@ -26,6 +26,8 @@
         <feature>spatial-app</feature>
         <feature>camel-http</feature>
         <feature>catalog-ui-search-api</feature>
+        <feature>platform-usng4j</feature>
+
         <configfile finalname="${ddf.etc}/org.codice.ddf.catalog.ui.config" override="false">
             mvn:ddf.ui/search-ui-app/${project.version}/properties/catalog-ui-config
         </configfile>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.less
@@ -91,6 +91,11 @@
     overflow: hidden;
   }
 
+  .toolbar-panzoom {
+    min-width: 450px;
+    margin-left: 0 !important;
+  }
+
   .is-clustering {
     display: none;
     padding-right: 5px;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/auto-complete/auto-complete.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/auto-complete/auto-complete.js
@@ -30,6 +30,7 @@ class AutoComplete extends React.Component {
         const suggestions = await suggester(input)
         this.setState({ loading: false, suggestions })
       } catch (e) {
+        console.log(e)
         this.setState({ loading: false, error: 'Endpoint unavailable' }, () => {
           if (typeof this.props.onError === 'function') {
             this.props.onError(e)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/auto-complete/auto-complete.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/auto-complete/auto-complete.js
@@ -30,7 +30,6 @@ class AutoComplete extends React.Component {
         const suggestions = await suggester(input)
         this.setState({ loading: false, suggestions })
       } catch (e) {
-        console.log(e)
         this.setState({ loading: false, error: 'Endpoint unavailable' }, () => {
           if (typeof this.props.onError === 'function') {
             this.props.onError(e)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.js
@@ -51,7 +51,9 @@ class Gazetteer extends React.Component {
     }
   }
   async suggesterWithLiteralSupport(input) {
-    const res = await this.fetch(`./internal/geofeature/suggestions?q=${input}`)
+    const res = await this.fetch(
+      `./internal/geofeature/suggestions?q=${encodeURIComponent(input)}`
+    )
     return await res.json()
   }
   async geofeatureWithLiteralSupport(suggestion) {
@@ -76,7 +78,9 @@ class Gazetteer extends React.Component {
   }
   async suggester(input) {
     const res = await window.fetch(
-      `https://nominatim.openstreetmap.org/search?format=json&q=${input}`
+      `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
+        input
+      )}`
     )
     const suggestions = await res.json()
     return suggestions.map(place => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.js
@@ -55,7 +55,7 @@ class Gazetteer extends React.Component {
     return await res.json()
   }
   async geofeatureWithLiteralSupport(suggestion) {
-    if (suggestion.id === 'LITERAL') {
+    if (suggestion.id.startsWith('LITERAL')) {
       return this.extractGeo(suggestion)
     }
     const { id } = suggestion

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
@@ -16,21 +16,10 @@ class Keyword extends React.Component {
     }
     this.fetch = this.props.fetch || fetch
   }
-  extractGeo(suggestion) {
-    return {
-      type: 'Feature',
-      geometry: {
-        type: 'Polygon',
-        coordinates: [suggestion.geo.map(coord => [coord.lon, coord.lat])],
-      },
-      properties: {},
-      id: suggestion.id,
-    }
-  }
   async suggester(input) {
     const res = await this.fetch(`./internal/geofeature/suggestions?q=${input}`)
     const json = await res.json()
-    return await json.filter(suggestion => suggestion.id !== 'LITERAL')
+    return await json.filter(suggestion => !suggestion.id.startsWith('LITERAL'))
   }
   async geofeature(suggestion) {
     const { id } = suggestion


### PR DESCRIPTION
#### What does this PR do?
The gazetteer search box will now identify MGRS coordinates entered into the box and users can pan to the extent of those coordinates. 

#### Who is reviewing it? 
@BernardIgiri 
@Variadicism 
@samuelechu 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@millerw8

#### How should this be tested?
##### Configure a tile server

- Use wizard under the *catalog* category of configuration
- Select a provider (https://wiki.openstreetmap.org/wiki/Tile_servers)
- Uncheck _Proxy Imagery Provider URL

##### Test the feature

Ensure the offline gazetteer is being used. Literal suggestions are not currently supported with the online one. Try typing some MGRS coordinates into the search box and panning around **both** maps using this technique. 

Some examples:

1. `12S` should yield itself as a suggestion and pan to the main grid with AZ in view
1. `12S VB` should yield itself as a suggestion and pan to the 100 km grid encompassing the south valley
1. `12S VB 13 98` should pan to a grid in tempe ... ensure incrementing the easting from `13` -> `14` pans east, and incrementing the northing from `98` -> `99` pans north. 
1. `12S 4Q` should yield two coords, `12S` and `4Q`, and pan to the extent of their center points
1. `12S VB 13 98 4Q` should yield `12SVB1398` and `4Q` and pan to the extent of their center points
1. `12S VB 1212121212` should yield itself as a suggestion
1. `12S 121212121212` should yield `12SVB1212121212` and `12SVB0000100002` as suggestions
1. `39UVR 283 391, 39UVR 283 391` should yield one coordinate `39UVR283391` because of the dupe
1. `39UVR 283 391, 39UVR 283 392` should yield two coordinates `39UVR283391` and `39UVR283392` respectively
1. `39UVR 283, 391, 39UVR 283 392` should yield three coordinates `39UVR28`, `39UVR39`, and `39UVR283392` respectively

#### What are the relevant tickets?
[DDF-4238](https://codice.atlassian.net/browse/DDF-4238)

#### Screenshots


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
