### PR TITLE
[2.13.x] DDF-4174 Fixed blueprint.xml parameter order for EndpointUtil

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -175,11 +175,11 @@
     </bean>
 
     <bean id="endpointUtil" class="org.codice.ddf.catalog.ui.util.EndpointUtil">
-        <argument ref="catalogFramework"/>
-        <argument ref="filterBuilder"/>
         <argument>
             <reference-list interface="ddf.catalog.data.MetacardType"/>
         </argument>
+        <argument ref="catalogFramework"/>
+        <argument ref="filterBuilder"/>
         <argument ref="injectableAttributes"/>
         <argument>
             <reference interface="ddf.catalog.data.AttributeRegistry" availability="optional"/>


### PR DESCRIPTION


##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #3796 
____
-->

#### What does this PR do?
BACKPORT - Fixes problem in master with Intrigue unable to get metacardtypes due to blueprint.xml parameter ordering on EndpointUtil.

#### Who is reviewing it? 
@ethantmanns 
@jhunzik 
@paouelle 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@tbatie 
@figliold 
@clockard 

#### How should this be tested?
Full build with tests.
Build DDF and launch UI. Verify no errors in Inspector.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-4174

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
