### PR TITLE
DDF-4256 Filtered search forms page to only show New Form and Custom Forms

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/component.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/component.less
@@ -201,6 +201,7 @@
 @import 'dropdown/hover-preview/dropdown.hover-preview.less';
 @import 'search-settings/search-settings';
 @import 'search-form/search-form.less';
+@import 'search-form/search-form.collection.less';
 @import 'search-form-selector/search-form-selector.less';
 @import 'dropdown/search-form-selector/dropdown.search-form-selector.less';
 @import 'workspace-lists/workspace-lists';

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.less
@@ -1,0 +1,6 @@
+@{customElementNamespace}search-form-collection {
+  > .collection {
+    margin: auto;
+    max-width: 1020px;
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
@@ -35,8 +35,7 @@ module.exports = Marionette.CollectionView.extend({
   filter: function(child) {
     if (this.options.hideNewForm) {
       return child.get('type') !== 'new-form'
-    } else {
-      return true
     }
+    return child.get('type') !== 'basic' && child.get('type') !== 'text'
   },
 })


### PR DESCRIPTION
#### What does this PR do?
- Filters the search form page to only contain New Form button + all custom forms
- Centers the search forms page content so that it looks similar to the Workspaces page 
#### Who is reviewing it? 
@andrewzimmer @Bdthomson 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining 
#### How should this be tested?
- Ensure that the Basic and Text searches are still available under "Use Another Search Form" in the search dropdown menu 
- Verify that the Search Forms page looks like the "after" screenshot below (note that I had the custom search forms enabled in the screenshot, which do not show up by default) 
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4256](https://codice.atlassian.net/browse/DDF-4256)
#### Screenshots
Before
![image](https://user-images.githubusercontent.com/39737329/47371371-e92fba80-d6a4-11e8-9654-eab82bbdeaee.png)
After
![image](https://user-images.githubusercontent.com/39737329/47323666-fc497880-d619-11e8-92bf-6a73d9399318.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
