### PR TITLE
DDF-4259: Component tests configurations should be easily retrievable at test runtime

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -668,5 +668,12 @@
             <artifactId>catalog-transformer-rtf</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.features</groupId>
+            <artifactId>utilities</artifactId>
+            <version>${project.version}</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -28,9 +28,12 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
+    <repository>mvn:ddf.features/utilities/${project.version}/xml/features</repository>
+
     <feature name="catalog-core-api" version="${project.version}"
              description="Catalog API interfaces and simple implementations.">
         <feature>security-core</feature>
+        <feature>action-core-impl</feature>
         <bundle>mvn:ddf.platform.api/platform-api/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-api/${project.version}</bundle>
         <bundle>mvn:ddf.mime.core/mime-core-api/${project.version}</bundle>
@@ -44,7 +47,6 @@
              description="Catalog Core feature containing the API, third party bundles necessary to run ddf-core.">
         <feature>catalog-core-api</feature>
         <feature version="${cxf.version}">cxf-jaxrs</feature>
-
         <bundle>mvn:ddf.catalog.core/catalog-core-commons/${project.version}</bundle>
         <bundle>mvn:ddf.measure/measure-api/${project.version}</bundle>
         <bundle>mvn:org.codice.thirdparty/picocontainer/1.3_1</bundle>
@@ -54,6 +56,7 @@
         <bundle>
             mvn:commons-collections/commons-collections/${commons-collections.version}
         </bundle>
+        <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-federationstrategy/${project.version}</bundle>
         <bundle>mvn:org.codice.thirdparty/lucene-core/3.0.2_1</bundle>
         <feature>jodah-failsafe</feature>

--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/security-services.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/security-services.json
@@ -18,6 +18,8 @@
     "mvn:ddf.security.sts/security-sts-certificateclaimshandler/${project.version}",
     "mvn:ddf.security.sts/security-sts-guestclaimshandler/${project.version}",
     "mvn:ddf.security.sts/security-sts-guestvalidator/${project.version}",
+    "mvn:ddf.security.sts/security-sts-ldaplogin/${project.version}",
+    "mvn:ddf.security.sts/security-sts-ldapclaimshandler/${project.version}",
     "mvn:ddf.security.sts/security-sts-pkivalidator/${project.version}",
     "mvn:ddf.security.sts/security-sts-propertyclaimshandler/${project.version}",
     "mvn:ddf.security.sts/security-sts-realm/${project.version}",

--- a/features/test-utilities/src/main/feature/feature.xml
+++ b/features/test-utilities/src/main/feature/feature.xml
@@ -16,6 +16,7 @@
           xmlns="http://karaf.apache.org/xmlns/features/v1.3.0"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
+    <repository>mvn:ddf.thirdparty/rest-assured/${project.version}/xml/feature</repository>
     <repository>mvn:ddf.features/kernel/${project.version}/xml/features</repository>
 
     <feature name="test-common" version="${project.version}"

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/features/AppsFeatures.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/features/AppsFeatures.java
@@ -30,7 +30,13 @@ public class AppsFeatures {
               .classifier("features")
               .version(DependencyVersionResolver.resolver()));
 
+  public static final String SECURITY_SERVICES_APP = "security-services-app";
+
   public static FeatureRepo featureRepo() {
     return FEATURE_COORDINATES;
+  }
+
+  public static Feature securityServicesApp() {
+    return new FeatureImpl(FEATURE_COORDINATES.getFeatureFileUrl(), SECURITY_SERVICES_APP);
   }
 }

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/features/InstallProfilesFeatures.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/features/InstallProfilesFeatures.java
@@ -30,7 +30,13 @@ public class InstallProfilesFeatures {
               .classifier("features")
               .version(DependencyVersionResolver.resolver()));
 
+  public static final String PROFILE_STANDARD = "profile-standard";
+
   public static FeatureRepo featureRepo() {
     return FEATURE_REPO_URL;
+  }
+
+  public static Feature profileStandard() {
+    return new FeatureImpl(FEATURE_REPO_URL.getFeatureFileUrl(), PROFILE_STANDARD);
   }
 }

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/features/TestUtilitiesFeatures.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/features/TestUtilitiesFeatures.java
@@ -29,6 +29,8 @@ public class TestUtilitiesFeatures {
 
   public static final String TINY_BUNDLES = "tinybundles";
 
+  public static final String REST_ASSURED = "rest-assured";
+
   private static final FeatureRepo FEATURE_COORDINATES =
       new FeatureRepoImpl(
           maven()
@@ -56,5 +58,9 @@ public class TestUtilitiesFeatures {
 
   public static Feature tinyBundles() {
     return new FeatureImpl(FEATURE_COORDINATES.getFeatureFileUrl(), TINY_BUNDLES);
+  }
+
+  public static Feature restAssured() {
+    return new FeatureImpl(FEATURE_COORDINATES.getFeatureFileUrl(), REST_ASSURED);
   }
 }

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/options/DebugOptions.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/options/DebugOptions.java
@@ -43,7 +43,7 @@ public class DebugOptions extends BasicOptions {
    */
   public static Option keepRuntimeFolder() {
     String keepRuntimeFolder = System.getProperty(KEEP_RUNTIME_FOLDER_FLAG, "true");
-    recordConfiguration("keepRuntimeFolder=%s", keepRuntimeFolder);
+    recordConfiguration(KEEP_RUNTIME_FOLDER_FLAG, keepRuntimeFolder);
     return when(Boolean.valueOf(keepRuntimeFolder))
         .useOptions(org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder());
   }
@@ -56,7 +56,7 @@ public class DebugOptions extends BasicOptions {
    */
   public static Option enableRemoteDebugging() {
     String port = getPortFinder().getPortAsString(DEBUG_PORT_KEY);
-    recordConfiguration("%s=%s", DEBUG_PORT_KEY, port);
+    recordConfiguration(DEBUG_PORT_KEY, port);
     final String DEBUG_OPTS =
         format(
             "-Xrunjdwp:transport=dt_socket,server=y,suspend=%s,address=%s",
@@ -84,7 +84,7 @@ public class DebugOptions extends BasicOptions {
       return null;
     }
 
-    recordConfiguration("custom logging: %s", customLogging);
+    appendConfiguration("custom_logging", customLogging);
     Map<String, String> parsedCustomLogging = parseCustomLogging(customLogging);
 
     List<Option> options =

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/options/LoggingOptions.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/options/LoggingOptions.java
@@ -35,12 +35,12 @@ public class LoggingOptions extends BasicOptions {
   }
 
   public static Option ddfLoggingLevel(String logLevel) {
-    recordConfiguration("ddf packages log level: %s=%s", DEFAULT_DDF_PKG, logLevel);
+    recordConfiguration("ddf_log_level", DEFAULT_DDF_PKG + "=" + logLevel);
     return logLevelOption(DEFAULT_DDF_PKG, logLevel);
   }
 
   public static Option codiceLoggingLevel(String logLevel) {
-    recordConfiguration("alliance packages log level: %s=%s", DEFAULT_CODICE_PKG, logLevel);
+    recordConfiguration("alliance_log_level", DEFAULT_CODICE_PKG + "=" + logLevel);
     return logLevelOption(DEFAULT_CODICE_PKG, logLevel);
   }
 

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/options/PortOptions.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/options/PortOptions.java
@@ -60,49 +60,53 @@ public class PortOptions extends BasicOptions {
 
   public static Option httpsPort() {
     String port = getPortFinder().getPortAsString(HTTPS_PORT_KEY);
-    recordConfiguration("%s=%s", HTTPS_PORT_KEY, port);
+    recordConfiguration(HTTPS_PORT_KEY, port);
     return KarafDistributionOption.editConfigurationFilePut(
         SystemProperties.SYSTEM_PROPERTIES_FILE_PATH, SystemProperties.HTTPS_PORT_PROPERTY, port);
   }
 
   public static Option httpPort() {
     String port = getPortFinder().getPortAsString(HTTP_PORT_KEY);
-    recordConfiguration("%s=%s", HTTP_PORT_KEY, port);
+    recordConfiguration(HTTP_PORT_KEY, port);
     return KarafDistributionOption.editConfigurationFilePut(
         SystemProperties.SYSTEM_PROPERTIES_FILE_PATH, SystemProperties.HTTP_PORT_PROPERTY, port);
   }
 
   public static Option ftpPort() {
     String port = getPortFinder().getPortAsString(FTP_PORT_KEY);
-    recordConfiguration("%s=%s", FTP_PORT_KEY, port);
+    recordConfiguration(FTP_PORT_KEY, port);
     return KarafDistributionOption.editConfigurationFilePut(
         SystemProperties.SYSTEM_PROPERTIES_FILE_PATH, SystemProperties.FTP_PORT_PROPERTY, port);
   }
 
   public static Option rmiRegistryPort() {
     String port = getPortFinder().getPortAsString(RMI_REG_PORT_KEY);
-    recordConfiguration("%s=%s", RMI_REG_PORT_KEY, port);
+    recordConfiguration(RMI_REG_PORT_KEY, port);
     return KarafDistributionOption.editConfigurationFilePut(
         KARAF_MGMT_CFG_FILE_PATH, RMI_REGISTRY_PORT_PROPERTY, port);
   }
 
   public static Option rmiServerPort() {
     String port = getPortFinder().getPortAsString(RMI_SERVER_PORT_KEY);
-    recordConfiguration("%s=%s", RMI_SERVER_PORT_KEY, port);
+    recordConfiguration(RMI_SERVER_PORT_KEY, port);
     return KarafDistributionOption.editConfigurationFilePut(
         KARAF_MGMT_CFG_FILE_PATH, RMI_SERVER_PORT_PROPERTY, port);
   }
 
   public static Option sshPort() {
     String port = getPortFinder().getPortAsString(SSH_PORT_KEY);
-    recordConfiguration("%s=%s", SSH_PORT_KEY, port);
+    recordConfiguration(SSH_PORT_KEY, port);
     return KarafDistributionOption.editConfigurationFilePut(
         KARAF_SHELL_CFG_FILE_PATH, SSH_PORT_PROPERTY, port);
   }
 
   public static Option solrPort() {
     String port = getPortFinder().getPortAsString(SSH_PORT_KEY);
-    recordConfiguration("%s=%s", SOLR_PORT_KEY, port);
+    recordConfiguration(SOLR_PORT_KEY, port);
     return editConfigurationFilePut(SYSTEM_PROPERTIES_FILE_PATH, "solr.http.port", port);
+  }
+
+  public static String getHttpsPort() {
+    return getConfiguration(HTTPS_PORT_KEY);
   }
 }


### PR DESCRIPTION
#### What does this PR do?
- Changed configurations options for component tests to be recorded and
retrievable from a config file at runtime
- Cleaned up several features
- Added ldap services to security app json

#### Who is reviewing it? 
@blen-desta 
@peterhuffer 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl 
@figliold 

#### How should this be tested?
CI passes

#### Any background context you want to provide?

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
