### PR TITLE
[2.13.x] DDF-2985 Fix deploy for modules without primary artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -673,6 +673,11 @@ are essentially embedding a slightly modified version of felix -->
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.5.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
#### What does this PR do?
- Locks down maven-deploy-plugin version. Version 3.0.0-M1 now fails builds, instead of printing a warning, on modules with no primary artifact specified.

#### Who is reviewing it? 
@paouelle @emmberk @oconnormi 

#### Select relevant component teams: 
@codice/build 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@tbatie

#### How should this be tested?
Full build.

#### Any background context you want to provide?
In maven-deploy-plugin version 3.0.0-M1 now fails builds for modules without primary artifacts, whereas before it would look for attachments. Our feature modules have attachments, not primary artifacts. Version 2.8.2 only prints a warning.

#### What are the relevant tickets?
[DDF-2985](https://codice.atlassian.net/browse/DDF-2985)

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
