### PR TITLE
DDF-4220 allows system-user to query for all workspaces

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -88,7 +88,6 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -187,7 +186,7 @@ public class MetacardApplication implements SparkApplication {
 
   private final NoteUtil noteUtil;
 
-  private final List<String> systemUserList = new ArrayList<>();
+  private final AccessControlSecurityConfiguration accessControlSecurityConfiguration;
 
   public MetacardApplication(
       CatalogFramework catalogFramework,
@@ -219,8 +218,7 @@ public class MetacardApplication implements SparkApplication {
     this.configuration = configuration;
     this.noteUtil = noteUtil;
     this.subjectIdentity = subjectIdentity;
-    this.systemUserList.addAll(
-        Arrays.asList(accessControlSecurityConfiguration.getSystemUserAttributeValue().split(",")));
+    this.accessControlSecurityConfiguration = accessControlSecurityConfiguration;
   }
 
   private String getSubjectEmail() {
@@ -233,6 +231,11 @@ public class MetacardApplication implements SparkApplication {
 
   // TODO: DDF-4249 to refactor this logic for PreQueryPlugin Access Control
   private boolean isElevatedUser(List<String> subjectRoles) {
+    List<String> systemUserList =
+        StringUtils.isNotEmpty(accessControlSecurityConfiguration.getSystemUserAttributeValue())
+            ? Collections.singletonList(
+                accessControlSecurityConfiguration.getSystemUserAttributeValue())
+            : Collections.EMPTY_LIST;
     return !Collections.disjoint(subjectRoles, systemUserList);
   }
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -479,7 +479,7 @@ public class MetacardApplication implements SparkApplication {
 
           // TODO: DDF-4249 to refactor this logic for PreQueryPlugin Access Control
           Map<String, Set<String>> permissions = new HashMap<>();
-          if (!StringUtils.isNotEmpty(
+          if (StringUtils.isNotEmpty(
               accessControlSecurityConfiguration.getSystemUserAttributeValue())) {
             Set<String> systemUserSet =
                 new HashSet<>(

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -235,7 +235,7 @@ public class MetacardApplication implements SparkApplication {
         StringUtils.isNotEmpty(accessControlSecurityConfiguration.getSystemUserAttributeValue())
             ? Collections.singletonList(
                 accessControlSecurityConfiguration.getSystemUserAttributeValue())
-            : Collections.EMPTY_LIST;
+            : Collections.emptyList();
     return !Collections.disjoint(subjectRoles, systemUserList);
   }
 

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -364,6 +364,7 @@
         <argument ref="configurationApplication"/>
         <argument ref="noteUtil"/>
         <argument ref="subjectIdentity"/>
+        <argument ref="accessControlSecurityConfiguration"/>
     </bean>
 
     <bean id="queryApplication" class="org.codice.ddf.catalog.ui.query.QueryApplication">


### PR DESCRIPTION
What does this PR do?

This PR is an amendment to https://github.com/codice/ddf/pull/3893 to allows privilege `system-user` to view all workspaces

Who is reviewing it?
@millerw8
@bdeining
@rzwiefel

Select relevant component teams:
@codice/security 

Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8

How should this be tested?
Quickbuild and install DDF standard profile
login as admin
create a new workspace
logout and login as localhost
navigate to the workspace page
verify workspace created earlier by admin is available

Any background context you want to provide?
What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-4220

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
