### PR TITLE
[FORWARDPORT] DDF-4264 Fixes XML unmarshaller object parsing (#3924)

### DIFF
--- a/catalog/transformer/catalog-transformer-xml/pom.xml
+++ b/catalog/transformer/catalog-transformer-xml/pom.xml
@@ -186,17 +186,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.61</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.40</minimum>
+                                            <minimum>0.50</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.35</minimum>
+                                            <minimum>0.42</minimum>
                                         </limit>
 
                                     </limits>

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/adapter/AttributeAdapterTest.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/adapter/AttributeAdapterTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transform.xml.adapter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.AttributeType.AttributeFormat;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.transformer.xml.adapter.AttributeAdapter;
+import ddf.catalog.transformer.xml.binding.AbstractAttributeType;
+import ddf.catalog.transformer.xml.binding.ObjectElement;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class AttributeAdapterTest {
+
+  @Test
+  public void testUnmarshalSeralizedObject() throws Exception {
+    AttributeAdapter attributeAdapter = getObjectAttributeAdapter();
+
+    Map<String, String> originalMap = ImmutableMap.of("key1", "val1", "key2", "val2");
+    Attribute attribute = new AttributeImpl("sampleAttr", (Serializable) originalMap);
+
+    AbstractAttributeType abstractAttributeType = attributeAdapter.marshal(attribute);
+    Attribute result = attributeAdapter.unmarshal(abstractAttributeType);
+
+    Map<String, String> resultMap = (Map) result.getValue();
+    assertThat(
+        "Maps are not equal.", resultMap.entrySet(), everyItem(isIn(originalMap.entrySet())));
+  }
+
+  @Test
+  public void testUnmarshalSeralizedObjectCollectionContainingNull() throws Exception {
+    AttributeAdapter attributeAdapter = getObjectAttributeAdapter();
+
+    List<String> originalList = Collections.unmodifiableList(Arrays.asList("val1", null, "val2"));
+
+    Attribute attribute = new AttributeImpl("sampleAttr", (Serializable) originalList);
+
+    AbstractAttributeType abstractAttributeType = attributeAdapter.marshal(attribute);
+    Attribute result = attributeAdapter.unmarshal(abstractAttributeType);
+
+    List<String> resultList = (List) result.getValues();
+    assertThat("Lists are not equal.", resultList, everyItem(isIn(originalList)));
+  }
+
+  @Test
+  public void testUnmarshalSeralizedObjectEmpty() throws Exception {
+    AttributeAdapter attributeAdapter = getObjectAttributeAdapter();
+
+    Attribute attribute = new AttributeImpl("sampleAttr", Collections.emptyList());
+
+    AbstractAttributeType abstractAttributeType = attributeAdapter.marshal(attribute);
+    Attribute result = attributeAdapter.unmarshal(abstractAttributeType);
+
+    assertThat("Null attribute not returned.", result, is(Matchers.nullValue()));
+  }
+
+  @Test
+  public void testUnmarshalSeralizedObjectInvalidByteArray() throws Exception {
+    AttributeAdapter attributeAdapter = getObjectAttributeAdapter();
+
+    ObjectElement mockObjectElement = mock(ObjectElement.class);
+    doReturn("name").when(mockObjectElement).getName();
+    doReturn(ImmutableList.of(new byte[] {-31, 0, 0, 0})).when(mockObjectElement).getValue();
+    Attribute result = attributeAdapter.unmarshal(mockObjectElement);
+
+    assertThat(
+        "Unmarshalled byte array not returned", result.getValue(), is(instanceOf(byte[].class)));
+  }
+
+  private AttributeAdapter getObjectAttributeAdapter() {
+    MetacardType mockMetacardType = mock(MetacardType.class);
+    AttributeDescriptor mockAttributeDescriptor = mock(AttributeDescriptor.class);
+    AttributeType mockAttributeType = mock(AttributeType.class);
+    doReturn(AttributeFormat.OBJECT).when(mockAttributeType).getAttributeFormat();
+    doReturn(mockAttributeType).when(mockAttributeDescriptor).getType();
+    doReturn("name").when(mockAttributeDescriptor).getName();
+    doReturn(mockAttributeDescriptor).when(mockMetacardType).getAttributeDescriptor(any());
+
+    return new AttributeAdapter(mockMetacardType);
+  }
+}

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/adapter/MetacardTypeAdapterTest.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/adapter/MetacardTypeAdapterTest.java
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package ddf.catalog.transform.xml;
+package ddf.catalog.transform.xml.adapter;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #3924
____

#### What does this PR do?
Resolves issue with metacard XML unmarshalling of object types. Object is now returned as the original Serializable instead of a byte array.

#### Who is reviewing it? 
@paouelle 
@jhunzik 
@tyler30clemens 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@figliold
@lessarderic
@tbatie
#### How should this be tested?
* Create metacard with an attribute that's an object type
* Federate it over CSW (so that it will be transferred over as metacard XML) OR query the metacardXML and re-ingest it
* Look at the resulting metacard and see if the object is preserved as its original type
#### Any background context you want to provide?
* This affect CSW federation
#### What are the relevant tickets?
[DDF-4264](https://codice.atlassian.net/browse/DDF-4264)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
