### PR TITLE
DDF-4273 properly handle hidden attributes in Table visual

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -89,7 +89,7 @@ module.exports = Marionette.LayoutView.extend({
         .get('metacard')
         .get('properties')
         .get('thumbnail') &&
-      !_.includes(hiddenColumns, 'thumbnail')
+      !this.isHidden('thumbnail')
     ) {
       this.resultThumbnail.show(
         new HoverPreviewDropdown({
@@ -143,7 +143,7 @@ module.exports = Marionette.LayoutView.extend({
         .filter(function(property) {
           return availableAttributes.indexOf(property) !== -1
         })
-        .map(function(property) {
+        .map(property => {
           var value = result.metacard.properties[property]
           if (value === undefined) {
             value = ''
@@ -172,12 +172,21 @@ module.exports = Marionette.LayoutView.extend({
             property: property,
             value: value,
             class: className,
-            hidden:
-              hiddenColumns.indexOf(property) >= 0 ||
-              properties.isHidden(property) ||
-              metacardDefinitions.isHiddenTypeExceptThumbnail(property),
+            hidden: this.isHidden(property),
           }
         }),
     }
+  },
+  isHidden: function(property) {
+    const hiddenColumns = user
+      .get('user')
+      .get('preferences')
+      .get('columnHide')
+
+    return (
+      hiddenColumns.indexOf(property) >= 0 ||
+      properties.isHidden(property) ||
+      metacardDefinitions.isHiddenTypeExceptThumbnail(property)
+    )
   },
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -131,10 +131,6 @@ module.exports = Marionette.LayoutView.extend({
       .get('user')
       .get('preferences')
       .get('columnOrder')
-    var hiddenColumns = user
-      .get('user')
-      .get('preferences')
-      .get('columnHide')
     var availableAttributes = this.options.selectionInterface.getActiveSearchResultsAttributes()
     var result = this.model.toJSON()
     return {


### PR DESCRIPTION
#### What does this PR do?
Align the logic that determines if an attribute is hidden when rendering thumbnail hovers.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@brianfelix 
@jrnorth 
@andrewkfiedler 
@leo-sakh 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?
To reproduce the error on master, add `^thumbnail$` to the list of hidden attributes in `Catalog UI Search Hidden Attributes`.  Upload a document that produces a thumbnail, such a PNG. Add the `Table` visual. The search results should indicate that there is one result, but no results will be shown. Also, in the javascript console, you should see a message like `Error: An "el" undefined must exist in DOM`. Repeat this steps with this PR and confirm that the search results are displayed and the console message is no longer present.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4273](https://codice.atlassian.net/browse/DDF-4273)
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
