### PR TITLE
DDF-4275 Fixed authz config in itests

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/config/ConfigureTestCommons.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/config/ConfigureTestCommons.java
@@ -100,7 +100,7 @@ public class ConfigureTestCommons {
   public static Dictionary<String, Object> configureAuthZRealm(
       List<String> attributes, AdminConfig configAdmin) throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
-    properties.put("matchOneMap", attributes);
+    properties.put("matchOneMappings", attributes);
     return configureAuthZRealm(properties, configAdmin);
   }
 


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Fixed authz config in itests
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@Bdthomson @Schachte 
#### Select relevant component teams: 
@codice/build 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@clockard
@figliold
#### How should this be tested?
Full Build
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
