### PR TITLE
[2.13.x] DDF-4217 Fix DuplicationValidator catalog query not returning results

### DIFF
--- a/catalog/validator/catalog-validator-metacardduplication/pom.xml
+++ b/catalog/validator/catalog-validator-metacardduplication/pom.xml
@@ -71,17 +71,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.62</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.62</minimum>
+                                            <minimum>0.68</minimum>
                                         </limit>
 
                                     </limits>

--- a/catalog/validator/catalog-validator-metacardduplication/src/main/java/org/codice/ddf/validator/metacard/duplication/DuplicationValidator.java
+++ b/catalog/validator/catalog-validator-metacardduplication/src/main/java/org/codice/ddf/validator/metacard/duplication/DuplicationValidator.java
@@ -202,12 +202,15 @@ public class DuplicationValidator
             collectionToString(uniqueAttributeNames));
       }
 
-      SourceResponse response = query(uniqueAttributes, metacard.getId());
+      SourceResponse response = query(uniqueAttributes);
       if (response != null) {
-        response.getResults().forEach(result -> duplicates.add(result.getMetacard().getId()));
+        response
+            .getResults()
+            .stream()
+            .filter(result -> !result.getMetacard().getId().equals(metacard.getId()))
+            .forEach(result -> duplicates.add(result.getMetacard().getId()));
       }
       if (!duplicates.isEmpty()) {
-
         violation = createViolation(uniqueAttributeNames, duplicates, severity);
         LOGGER.debug(violation.getMessage());
       }
@@ -233,13 +236,9 @@ public class DuplicationValidator
         .toArray(Filter[]::new);
   }
 
-  private SourceResponse query(Set<Attribute> attributes, String originalId) {
+  private SourceResponse query(Set<Attribute> attributes) {
 
-    final Filter filter =
-        filterBuilder.allOf(
-            filterBuilder.anyOf(buildFilters(attributes)),
-            filterBuilder.not(
-                filterBuilder.attribute(Metacard.ID).is().equalTo().text(originalId)));
+    final Filter filter = filterBuilder.allOf(filterBuilder.anyOf(buildFilters(attributes)));
 
     LOGGER.debug("filter {}", filter);
 

--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/catalog.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/catalog.json
@@ -21,6 +21,7 @@
     "mvn:ddf.catalog.transformer/catalog-transformer-pdf/${project.version}",
     "mvn:ddf.catalog.transformer/catalog-transformer-xml/${project.version}",
     "mvn:ddf.catalog.transformer/tika-input-transformer/${project.version}",
-    "mvn:ddf.catalog.plugin/catalog-plugin-metacardingest-network/${project.version}"
+    "mvn:ddf.catalog.plugin/catalog-plugin-metacardingest-network/${project.version}",
+    "mvn:org.codice.ddf.validator/catalog-validator-metacardduplication/${project.version}"
   ]
 }


### PR DESCRIPTION
#### What does this PR do?
- Updated DuplicationValidator query filter to not include a `NOT id = <metacard_id>`, and instead filter out the metacard from the query result set.

This is because when we do a query by ID now, we do a Solr real time query. In the case of a `NOT id`, we attempt to query the real time index with the metacard ID, but this is not what we want in this particular case. This change was chosen for minimal impact.

- Adds Duplication Validator to the Catalog App json definition.

#### Who is reviewing it? 
@kcover @pklinef @bakejeyner 

#### Select relevant component teams: 
@codice/data 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@figliold

#### How should this be tested?
Ingest an item via Intrigue. Ingest the same item again and verify a warning is placed on it.

#### Any background context you want to provide?
This bug started occurring when query by ids were made to respect all of the query's filter.

#### What are the relevant tickets?
[DDF-4217](https://codice.atlassian.net/browse/DDF-4217)

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
