### PR TITLE
DDF-3945 Align sync-installer permissions with karaf.features.core

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -83,7 +83,7 @@ grant codeBase "file:/org.apache.felix.configadmin" {
     permission org.osgi.framework.BundlePermission "*", "provide, require, host, fragment";
 }
 
-grant codeBase "file:/org.apache.karaf.features.core" {
+grant codeBase "file:/org.apache.karaf.features.core/sync-installer-impl" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}-", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}examples", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}examples${/}-", "read,write";


### PR DESCRIPTION
#### What does this PR do?

Sync-installer attaches itself to the thread that's running
org.apache.karaf.features.core when installing a feature. This means
the sync-installer needs to have the same permissions as
karaf.features.core to avoid unwanted Access Control Exceptions.

#### Who is reviewing it? 

@peterhuffer @emmberk @oconnormi @pvargas @mdang8 

#### Select relevant component teams: 

@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.

@clockard
@tbatie

#### How should this be tested

Contact me for testing steps.

#### What are the relevant tickets?

[DDF-3945](https://codice.atlassian.net/browse/DDF-3945)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
