### PR TITLE
DDF-4283 remove search form interaction menu when accessing the search form via the workspace

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-selector/search-form-selector.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-selector/search-form-selector.view.js
@@ -32,6 +32,7 @@ module.exports = Marionette.LayoutView.extend({
       new SearchFormsView({
         queryModel: this.model,
         hideNewForm: true,
+        hideInteractionMenu: true,
       })
     )
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing-tab-container.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing-tab-container.view.js
@@ -40,6 +40,7 @@ module.exports = Marionette.LayoutView.extend({
       new SearchFormCollectionView({
         collection: this.searchFormSharingCollection.getCollection(),
         model: this.model,
+        hideInteractionMenu: this.options.hideInteractionMenu,
       })
     )
     LoadingCompanionView.beginLoading(this, this.$el)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/forms-sharing/search-form-sharing.collection.view.js
@@ -33,6 +33,7 @@ module.exports = Marionette.CollectionView.extend({
     return {
       queryModel: this.options.model,
       sharingLightboxTitle: 'Search Form Sharing',
+      hideInteractionMenu: this.options.hideInteractionMenu,
     }
   },
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form-tab-container.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form-tab-container.view.js
@@ -43,6 +43,7 @@ module.exports = Marionette.LayoutView.extend({
         collectionWrapperModel: this.searchFormCollection,
         queryModel: this.model,
         hideNewForm: this.options.hideNewForm,
+        hideInteractionMenu: this.options.hideInteractionMenu,
       })
     )
     LoadingCompanionView.beginLoading(this, this.$el)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
@@ -30,6 +30,7 @@ module.exports = Marionette.CollectionView.extend({
       queryModel: this.options.queryModel,
       sharingLightboxTitle: 'Search Form Sharing',
       collectionWrapperModel: this.options.collectionWrapperModel,
+      hideInteractionMenu: this.options.hideInteractionMenu,
     }
   },
   filter: function(child) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -54,17 +54,19 @@ module.exports = Marionette.LayoutView.extend({
     ) {
       this.$el.addClass('is-static')
     } else {
-      this.searchFormActions.show(
-        new SearchFormInteractionsDropdownView({
-          model: new DropdownModel(),
-          modelForComponent: this.model,
-          collectionWrapperModel: this.options.collectionWrapperModel,
-          queryModel: this.options.queryModel,
-          dropdownCompanionBehaviors: {
-            navigation: {},
-          },
-        })
-      )
+      if (!this.options.hideInteractionMenu) {
+        this.searchFormActions.show(
+          new SearchFormInteractionsDropdownView({
+            model: new DropdownModel(),
+            modelForComponent: this.model,
+            collectionWrapperModel: this.options.collectionWrapperModel,
+            queryModel: this.options.queryModel,
+            dropdownCompanionBehaviors: {
+              navigation: {},
+            },
+          })
+        )
+      }
     }
   },
   changeView: function() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.view.js
@@ -34,6 +34,7 @@ module.exports = TabsView.extend({
       new activeTab({
         model: this.options.queryModel || new Query.Model(),
         hideNewForm: this.options.hideNewForm,
+        hideInteractionMenu: this.options.hideInteractionMenu,
       })
     )
   },


### PR DESCRIPTION
#### What does this PR do?
Remove search form interaction menu when accessing the search form via the workspace.
#### Who is reviewing it? 
@andrewkfiedler 
@leo-sakh 
@brianfelix 
@jrnorth 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?
First, create a search form as admin. Confirm that the search form menu interaction is not displayed when accessing via the workspace. Confirm that the search form menu interaction is displayed when accessing via the Search Form component. Share the search form with guest. Logout and re-enter as guest. Confirm that the interaction menu is displayed under the collection of shared search forms when accessing via the Search Form component and not display when accessing via the workspace. 
#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-4283](https://codice.atlassian.net/browse/DDF-4283)
#### Screenshots
![screen shot 2018-10-31 at 8 20 58 am](https://user-images.githubusercontent.com/17837152/47799804-3edd1600-dce8-11e8-8e44-5c2d1630b3e4.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
