### PR TITLE
[2.13.x]DDF-4284 Adding POST support for the ErrorServlet

### DIFF
--- a/platform/error/platform-error-impl/src/main/resources/codeMessages.properties
+++ b/platform/error/platform-error-impl/src/main/resources/codeMessages.properties
@@ -7,12 +7,12 @@
 # See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
 # <http://www.gnu.org/licenses/lgpl.html>.
 
-400=Bad request. Please <a href="../login/index.html?prevurl={{uri}}">Sign In</a> to \
-  continue.
-401=You are not authenticated. Please <a href="../login/index.html?prevurl={{uri}}">Sign In</a> to \
-  continue.
-403=You are not authorized to see the resource you are attempting to view. Please \
+400=Bad request. If you are not already signed in, please \
+  <a href="../login/index.html?prevurl={{uri}}">Sign In</a> and try again.
+401=You are not authenticated. If you are not already signed in, please \
   <a href="../login/index.html?prevurl={{uri}}">Sign In</a> to continue.
+403=You are not authorized to see the resource you are attempting to view. If you are not already \
+  signed in, please <a href="../login/index.html?prevurl={{uri}}">Sign In</a> and try again.
 404=The page you are requesting could not be found on this server. Ensure that the URL was typed \
   in correctly and try again.
 405=The method specified in the Request-Line is not allowed for the resource identified by the \

--- a/platform/error/platform-error-servlet/src/main/java/org/codice/ddf/platform/error/servlet/ErrorServlet.java
+++ b/platform/error/platform-error-servlet/src/main/java/org/codice/ddf/platform/error/servlet/ErrorServlet.java
@@ -14,7 +14,6 @@
 package org.codice.ddf.platform.error.servlet;
 
 import java.io.IOException;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -67,8 +66,16 @@ public class ErrorServlet extends HttpServlet {
   }
 
   @Override
-  protected void doGet(HttpServletRequest request, HttpServletResponse response)
-      throws ServletException, IOException {
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+    handleError(request, response);
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+    handleError(request, response);
+  }
+
+  private void handleError(HttpServletRequest request, HttpServletResponse response) {
     Object codeObj = request.getAttribute(ERROR_STATUS_CODE);
     Object messageObj = request.getAttribute(ERROR_MESSAGE);
     Object typeObj = request.getAttribute(ERROR_EXCEPTION_TYPE);


### PR DESCRIPTION
#### What does this PR do?
Errors from the backend that happen during a POST request were not being handled by the ErrorServlet, so the default Jetty error page was being shown instead. (see screenshot below)
#### Who is reviewing it? 
@Kjames5269 @bakejeyner 
#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@coyotesqrl 
#### How should this be tested?
- Spin up DDF
- Go to https://localhost:8993/services/csw
- Login to the IdP
- Our custom error page should display with a 403 instead of the 405 like the below screenshot.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4284](https://codice.atlassian.net/browse/DDF-4284)
#### Screenshots
![image](https://user-images.githubusercontent.com/8130140/47805025-85843d80-dcf3-11e8-98c2-1cffb77213fd.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
