### PR TITLE
[2.13.x] DDF-4099 Search should autocomplete on label, not real value

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/select/select.collection.view.js
@@ -161,7 +161,10 @@ define([
                     }).length > 1))) {
                 return false;
             }
-            if (this.getAppropriateString(child.get('value')).indexOf(filterValue) === -1) {
+            if (child.get('label') !== undefined && this.getAppropriateString(child.get('label')).indexOf(filterValue) === -1) {
+                return false;
+            }
+            if (child.get('label') === undefined && this.getAppropriateString(child.get('value')).indexOf(filterValue) === -1) {
                 return false;
             }
             return true;


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to master PR: #3660

#### What does this PR do?
[BACKPORT] Using an advanced search in Intrigue and searching the field with the dropdown (defaulted to anyText) returns results based on the real value, not the label. This made it confusing for users because what was searched for was not always displayed. Now the results in the dropdown correspond with what is being searched. 

#### Who is reviewing it? 
@paouelle 
@jhunzik

#### Select relevant component teams: 
@codice/ui

#### Ask 2 committers to review/merge the PR and tag them here.
@tbatie
@figliold
@andrewkfiedler

#### How should this be tested?
Create a new advanced query in Intrigue and add a new field. Open the field drop down (defaults to anyText) and type "created" to get results and "ext.created" to not get results. Search other attributes and verify that they autocomplete based on what is displayed to the user. 

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-4099)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
