### PR TITLE
DDF-4297 Fix camel S3 connection with changes in Camel 2.22

### DIFF
--- a/catalog/plugin/catalog-plugin-metacardbackup-s3storage/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-s3storage/pom.xml
@@ -154,7 +154,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
@@ -164,7 +164,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.91</minimum>
+                                            <minimum>0.94</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/plugin/catalog-plugin-metacardbackup-s3storage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-s3storage/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -35,6 +35,7 @@
             <property name="s3AccessKey" value="" />
             <property name="s3SecretKey" value="" />
             <property name="s3Endpoint" value="" />
+            <property name="s3Region" value="" />
             <property name="s3Bucket" value=""/>
             <property name="s3CannedAclName" value="BucketOwnerFullControl"/>
             <property name="backupMetacardTags">

--- a/catalog/plugin/catalog-plugin-metacardbackup-s3storage/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-s3storage/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -54,6 +54,10 @@
             name="S3 Endpoint" id="s3Endpoint" required="true" type="String"
             default=""/>
 
+        <AD description="The Region to use for the AWS Signing Region."
+            name="S3 Region" id="s3Region" required="true" type="String"
+            default=""/>
+
         <AD description="One of the pre-defined Amazon S3 ACL names."
             name="S3 Canned ACL" id="s3CannedAclName" required="true" type="String"
             default="BucketOwnerFullControl"/>

--- a/catalog/plugin/catalog-plugin-metacardbackup-s3storage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/s3storage/MetacardBackupS3StorageTest.java
+++ b/catalog/plugin/catalog-plugin-metacardbackup-s3storage/src/test/java/org/codice/ddf/catalog/plugin/metacard/backup/storage/s3storage/MetacardBackupS3StorageTest.java
@@ -33,6 +33,8 @@ public class MetacardBackupS3StorageTest {
 
   private static final String ENDPOINT = "test.amazonaws.com";
 
+  private static final String REGION = "test-region-1";
+
   private static final String ACCESS_KEY = "access_key";
 
   private static final String SECRET_KEY = "secret_key";
@@ -48,6 +50,7 @@ public class MetacardBackupS3StorageTest {
     s3StorageProvider.setObjectTemplate(OBJECT_TEMPLATE);
     s3StorageProvider.setS3Bucket(BUCKET);
     s3StorageProvider.setS3Endpoint(ENDPOINT);
+    s3StorageProvider.setS3Region(REGION);
     s3StorageProvider.setS3AccessKey(ACCESS_KEY);
     s3StorageProvider.setS3SecretKey(SECRET_KEY);
     s3StorageProvider.setS3CannedAclName(CANNED_ACL);
@@ -68,6 +71,7 @@ public class MetacardBackupS3StorageTest {
     String secretKey = "newSecretKey";
     String bucket = "new-bucket";
     String endpoint = "endpoint.amazonaws.com";
+    String region = "region-test-1";
     String cannedAcl = "PublicRead";
 
     Map<String, Object> properties = new HashMap<>();
@@ -79,6 +83,7 @@ public class MetacardBackupS3StorageTest {
     properties.put("s3SecretKey", secretKey);
     properties.put("s3Bucket", bucket);
     properties.put("s3Endpoint", endpoint);
+    properties.put("s3Region", region);
     properties.put("s3CannedAclName", cannedAcl);
 
     s3StorageProvider.refresh(properties);
@@ -90,6 +95,7 @@ public class MetacardBackupS3StorageTest {
     assertThat(s3StorageProvider.getS3SecretKey(), is(secretKey));
     assertThat(s3StorageProvider.getS3Bucket(), is(bucket));
     assertThat(s3StorageProvider.getS3Endpoint(), is(endpoint));
+    assertThat(s3StorageProvider.getS3Region(), is(region));
     assertThat(s3StorageProvider.getS3CannedAclName(), is(cannedAcl));
   }
 
@@ -102,6 +108,7 @@ public class MetacardBackupS3StorageTest {
     properties.put("s3Bucket", 5);
     properties.put("s3Endpoint", 4);
     properties.put("s3CannedAclName", 7);
+    properties.put("s3Region", 4);
 
     s3StorageProvider.refresh(properties);
     assertThat(s3StorageProvider.getObjectTemplate(), is(OBJECT_TEMPLATE));
@@ -109,6 +116,7 @@ public class MetacardBackupS3StorageTest {
     assertThat(s3StorageProvider.getS3SecretKey(), is(SECRET_KEY));
     assertThat(s3StorageProvider.getS3Bucket(), is(BUCKET));
     assertThat(s3StorageProvider.getS3Endpoint(), is(ENDPOINT));
+    assertThat(s3StorageProvider.getS3Region(), is(REGION));
     assertThat(s3StorageProvider.getS3CannedAclName(), is(CANNED_ACL));
   }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes how the S3 endpoint is set with the changes in Camel 2.22. Need to construct the AmazonS3 client using the clientbuilder. 

#### Who is reviewing it? 
@ryeats 
@Bdthomson 

#### Select relevant component teams: 
@codice/io 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@clockard

#### How should this be tested?
Full build with tests.
In order to fully test, you need to have an S3 environment present. Configure the Metacard S3 Route to connect to S3 and verify that ingesting catalog data writes a file to S3.

#### Any background context you want to provide?
The correct way to connect to a specific S3 endpoint changed with Camel 2.22. Since everything is property driven (vs compiled API), this change was not noticed during the Camel 2.22 upgrade.

#### What are the relevant tickets?
[DDF-4297](https://codice.atlassian.net/browse/DDF-4297)

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
