### PR TITLE
DDF-4301 anyGeo BBox - upper-left northing field not cleared when switching shape tabs

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -198,7 +198,7 @@ module.exports = Backbone.AssociatedModel.extend({
     )
     this.listenTo(
       this,
-      'change:utmUpsUpperLeftEasting change:utmUpsUpperLeftNorthing change:utmUpsUpperLeftZone change:utmUpsUpperLeftEasting change:utmUpsUpperLeftHemisphere change:utmUpsLowerRightEasting change:utmUpsLowerRightNorthing change:utmUpsLowerRightZone change:utmUpsLowerRightEasting change:utmUpsLowerRightHemisphere',
+      'change:utmUpsUpperLeftEasting change:utmUpsUpperLeftNorthing change:utmUpsUpperLeftZone change:utmUpsUpperLeftHemisphere change:utmUpsLowerRightEasting change:utmUpsLowerRightNorthing change:utmUpsLowerRightZone change:utmUpsLowerRightHemisphere',
       this.setBboxUtmUps
     )
     this.listenTo(this, 'EndExtent', this.notDrawing)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -203,7 +203,7 @@ module.exports = Marionette.LayoutView.extend({
       utmUpsZone: 1,
       utmUpsHemisphere: 'Northern',
       utmUpsUpperLeftEasting: undefined,
-      utmUpsUpsUpperLeftNorthing: undefined,
+      utmUpsUpperLeftNorthing: undefined,
       utmUpsUpperLeftZone: 1,
       utmUpsUpperLeftHemisphere: 'Northern',
       utmUpsLowerRightEasting: undefined,


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Fixes incorrect model attribute name which prevents clearing of field when switching tabs in the anyGeo component
#### Who is reviewing it? 
@Variadicism 
@Lambeaux 
@dimitry-sherman
@BernardIgiri 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/ui 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/website 
-->
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@bdeining
@millerw8 
#### How should this be tested?
Verify that upper Left Northing field is cleared when switching tabs to/from Bounding Box in the anyGeo component.
![image](https://user-images.githubusercontent.com/4467636/48026757-33348980-e104-11e8-9c81-9dd1f7e3538a.png)

<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
Tested switching to/from all different shapes
#### What are the relevant tickets?
[DDF-4301](https://codice.atlassian.net/browse/DDF-4301)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
