### PR TITLE
DDF-3955 DDF itest configuration cleanup

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/config/ConfigureTestCommons.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/config/ConfigureTestCommons.java
@@ -22,62 +22,105 @@ import org.osgi.service.cm.Configuration;
 
 public class ConfigureTestCommons {
 
-  public static final String METACARD_VALIDITITY_FILTER_PLUGIN_SERVICE_PID =
+  private static final String METACARD_VALIDITY_FILTER_PLUGIN_SERVICE_PID =
       "ddf.catalog.metacard.validation.MetacardValidityFilterPlugin";
 
-  public static final String METACARD_VALIDITITY_MARKER_PLUGIN_SERVICE_PID =
+  private static final String METACARD_VALIDITY_MARKER_PLUGIN_SERVICE_PID =
       "ddf.catalog.metacard.validation.MetacardValidityMarkerPlugin";
 
-  public static final String METACARD_ATTRIBUTE_SECURITY_POLICY_PLUGIN_PID =
+  private static final String METACARD_ATTRIBUTE_SECURITY_POLICY_PLUGIN_PID =
       "org.codice.ddf.catalog.security.policy.metacard.MetacardAttributeSecurityPolicyPlugin";
 
-  public static final String AUTH_Z_REALM_PID = "ddf.security.pdp.realm.AuthzRealm";
+  private static final String AUTH_Z_REALM_PID = "ddf.security.pdp.realm.AuthzRealm";
+
+  private static final String ADMIN_CONFIG_POLICY_PID =
+      "org.codice.ddf.admin.config.policy.AdminConfigPolicy";
 
   private ConfigureTestCommons() {}
 
-  public static void configureMetacardValidityFilterPlugin(
-      List<String> securityAttributeMappings, AdminConfig configAdmin) throws IOException {
-    Configuration config =
-        configAdmin.getConfiguration(METACARD_VALIDITITY_FILTER_PLUGIN_SERVICE_PID, null);
+  public static Dictionary<String, Object> configureService(
+      String pid, Dictionary<String, Object> newProps, AdminConfig adminConfig) throws IOException {
+    Configuration config = adminConfig.getConfiguration(pid, null);
+    Dictionary<String, Object> oldProps = config.getProperties();
+    config.update(newProps);
+    return oldProps;
+  }
+
+  /**
+   * Configures the MetacardValidityFilterPlugin. See metatype for more detailed descriptions.
+   *
+   * @param securityAttributeMappings - attribute mapping between metacard attribute and user
+   *     attribute
+   * @param filterErrors - sets whether metacards with validation errors are filtered
+   * @param filterWarnings - sets whether metacards with validation warnings are filtered
+   * @return A dictionary containing the old properties that the service had.
+   */
+  public static Dictionary<String, Object> configureMetacardValidityFilterPlugin(
+      List<String> securityAttributeMappings,
+      boolean filterErrors,
+      boolean filterWarnings,
+      AdminConfig configAdmin)
+      throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
     properties.put("attributeMap", securityAttributeMappings);
-    config.update(properties);
-  }
-
-  public static void configureFilterInvalidMetacards(
-      String filterErrors, String filterWarnings, AdminConfig configAdmin) throws IOException {
-    Configuration config =
-        configAdmin.getConfiguration(METACARD_VALIDITITY_FILTER_PLUGIN_SERVICE_PID, null);
-
-    Dictionary<String, Object> properties = new DictionaryMap<>();
     properties.put("filterErrors", filterErrors);
     properties.put("filterWarnings", filterWarnings);
-    config.update(properties);
+    return configureMetacardValidityFilterPlugin(properties, configAdmin);
   }
 
-  public static void configureEnforceValidityErrorsAndWarnings(
-      String enforceErrors, String enforceWarnings, AdminConfig configAdmin) throws IOException {
-    Configuration config =
-        configAdmin.getConfiguration(METACARD_VALIDITITY_MARKER_PLUGIN_SERVICE_PID, null);
-
-    Dictionary<String, Object> properties = new DictionaryMap<>();
-    properties.put("enforceErrors", enforceErrors);
-    properties.put("enforceWarnings", enforceWarnings);
-    config.update(properties);
+  /**
+   * Configures the MetacardValidityFilterPlugin. This method should only be used to reset a service
+   * configuration using a dictionary returned from the overloaded configuration method.
+   *
+   * @param props - dictionary of properties provided from the configuration
+   * @return A dictionary containing the old properties that the service had.
+   */
+  public static Dictionary<String, Object> configureMetacardValidityFilterPlugin(
+      Dictionary<String, Object> props, AdminConfig configAdmin) throws IOException {
+    return configureService(METACARD_VALIDITY_FILTER_PLUGIN_SERVICE_PID, props, configAdmin);
   }
 
-  public static void configureEnforcedMetacardValidators(
-      List<String> enforcedValidators, AdminConfig configAdmin) throws IOException {
-
-    // Update metacardMarkerPlugin config with no enforcedMetacardValidators
-    Configuration config =
-        configAdmin.getConfiguration(METACARD_VALIDITITY_MARKER_PLUGIN_SERVICE_PID, null);
-
+  /**
+   * Configures the MetacardValidityMarkerPlugin. See metatype for more detailed descriptions.
+   *
+   * @param enforcedValidators - names of validators that will be enforced (reject errors/warnings)
+   * @param enforceErrors - sets whether metacards with validation errors are rejected
+   * @param enforceWarnings - sets whether metacards with validation warnings are rejected
+   * @return A dictionary containing the old properties that the service had.
+   */
+  public static Dictionary<String, Object> configureValidationMarkerPlugin(
+      List<String> enforcedValidators,
+      boolean enforceErrors,
+      boolean enforceWarnings,
+      AdminConfig configAdmin)
+      throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
     properties.put("enforcedMetacardValidators", enforcedValidators);
-    config.update(properties);
+    properties.put("enforceErrors", enforceErrors);
+    properties.put("enforceWarnings", enforceWarnings);
+    return configureValidationMarkerPlugin(properties, configAdmin);
   }
 
+  /**
+   * Configures the MetacardValidityMarkerPlugin. This method should only be used to reset a service
+   * configuration using a dictionary returned from the overloaded configuration method.
+   *
+   * @param props - dictionary of properties provided from the configuration
+   * @return A dictionary containing the old properties that the service had.
+   */
+  public static Dictionary<String, Object> configureValidationMarkerPlugin(
+      Dictionary<String, Object> props, AdminConfig configAdmin) throws IOException {
+    return configureService(METACARD_VALIDITY_MARKER_PLUGIN_SERVICE_PID, props, configAdmin);
+  }
+
+  /**
+   * Configures the MetacardAttributeSecurityPolicyPlugin. See metatype for more detailed
+   * descriptions.
+   *
+   * @param intersectAttributes - intersection mapping between source and destination attributes.
+   * @param unionAttributes - union mapping between source and destination attributes.
+   * @return A dictionary containing the old properties that the service had.
+   */
   public static Dictionary<String, Object> configureMetacardAttributeSecurityFiltering(
       List<String> intersectAttributes, List<String> unionAttributes, AdminConfig configAdmin)
       throws IOException {
@@ -87,29 +130,78 @@ public class ConfigureTestCommons {
     return configureMetacardAttributeSecurityFiltering(properties, configAdmin);
   }
 
+  /**
+   * Configures the MetacardAttributeSecurityPolicyPlugin. This method should only be used to reset
+   * a service configuration using a dictionary returned from the overloaded configuration method.
+   *
+   * @param properties - dictionary of properties provided from the configuration
+   * @return A dictionary containing the old properties that the service had.
+   */
   public static Dictionary<String, Object> configureMetacardAttributeSecurityFiltering(
       Dictionary<String, Object> properties, AdminConfig configAdmin) throws IOException {
-    Configuration config =
-        configAdmin.getConfiguration(METACARD_ATTRIBUTE_SECURITY_POLICY_PLUGIN_PID, null);
-
-    Dictionary oldProperties = config.getProperties();
-    config.update(properties);
-    return oldProperties;
+    return configureService(METACARD_ATTRIBUTE_SECURITY_POLICY_PLUGIN_PID, properties, configAdmin);
   }
 
+  /**
+   * Configures the AuthzRealm. See metatype for more detailed descriptions.
+   *
+   * @param matchAllMappings - list of 'Match-All' subject attribute to Metacard attribute mapping
+   * @param matchOneAttributes - list of 'Match-One' subject attribute to Metacard attribute mapping
+   * @param environmentAttributes - List of environment attributes to pass to the XACML engine
+   * @return A dictionary containing the old properties that the service had.
+   */
   public static Dictionary<String, Object> configureAuthZRealm(
-      List<String> attributes, AdminConfig configAdmin) throws IOException {
+      List<String> matchAllMappings,
+      List<String> matchOneAttributes,
+      List<String> environmentAttributes,
+      AdminConfig configAdmin)
+      throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
-    properties.put("matchOneMap", attributes);
+    properties.put("matchAllMappings", matchAllMappings);
+    properties.put("matchOneMappings", matchOneAttributes);
+    properties.put("environmentAttributes", environmentAttributes);
     return configureAuthZRealm(properties, configAdmin);
   }
 
+  /**
+   * Configures the AuthzRealm. This method should only be used to reset a service configuration
+   * using a dictionary returned from the overloaded configuration method.
+   *
+   * @param properties - dictionary of properties provided from the configuration
+   * @return A dictionary containing the old properties that the service had.
+   */
   public static Dictionary<String, Object> configureAuthZRealm(
       Dictionary<String, Object> properties, AdminConfig configAdmin) throws IOException {
-    Configuration config = configAdmin.getConfiguration(AUTH_Z_REALM_PID, null);
+    return configureService(AUTH_Z_REALM_PID, properties, configAdmin);
+  }
 
-    Dictionary oldProperties = config.getProperties();
-    config.update(properties);
-    return oldProperties;
+  /**
+   * Configures the AdminConfigPolicy. See metatype for more detailed descriptions.
+   *
+   * @param featurePolicies - features or apps that will only be modifiable and viewable to users
+   *     with the set attributes
+   * @param servicePolicies - services that will only be modifiable and viewable to users with the
+   *     set attributes
+   * @return A dictionary containing the old properties that the service had.
+   */
+  public static Dictionary<String, Object> configureAdminConfigPolicy(
+      List<String> featurePolicies, List<String> servicePolicies, AdminConfig configAdmin)
+      throws IOException {
+    Dictionary<String, Object> properties = new DictionaryMap<>();
+    properties.put("featurePolicies", featurePolicies);
+    properties.put("servicePolicies", servicePolicies);
+    return configureAdminConfigPolicy(properties, configAdmin);
+  }
+
+  /**
+   * Configures the AdminConfigPolicy. This method should only be used to reset a service
+   * configuration using a dictionary returned from the overloaded configuration method.
+   *
+   * @param properties - dictionary of properties provided from the configuration
+   * @return A dictionary containing the old properties that the service had.
+   */
+  public static Dictionary<String, Object> configureAdminConfigPolicy(
+      Dictionary<String, Object> properties, AdminConfig configAdmin) throws IOException {
+    return configureService(ADMIN_CONFIG_POLICY_PID, properties, configAdmin);
   }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -20,11 +20,10 @@ import static ddf.catalog.data.MetacardType.DEFAULT_METACARD_TYPE_NAME;
 import static java.lang.String.format;
 import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.SECURE_ROOT;
 import static org.codice.ddf.itests.common.WaitCondition.expect;
-import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.deleteMetacard;
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.delete;
 import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingest;
 import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingestGeoJson;
 import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.update;
-import static org.codice.ddf.itests.common.config.ConfigureTestCommons.configureFilterInvalidMetacards;
 import static org.codice.ddf.itests.common.csw.CswTestCommons.getCswFunctionQuery;
 import static org.codice.ddf.itests.common.csw.CswTestCommons.getCswInsertRequest;
 import static org.codice.ddf.itests.common.csw.CswTestCommons.getCswQuery;
@@ -212,7 +211,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             .post(REST_PATH.getUrl())
             .getHeader("id");
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -243,7 +242,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .statusCode(equalTo(200))
         .header(HttpHeaders.CONTENT_TYPE, Matchers.is("image/jpeg"));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -276,7 +275,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .statusCode(equalTo(200))
         .header(HttpHeaders.CONTENT_TYPE, Matchers.is("image/jpeg"));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -287,7 +286,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     LOGGER.info("Getting response to {}", url);
     when().get(url).then().log().all().assertThat().body(hasXPath("/metacard[@id='" + id + "']"));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -322,7 +321,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                     + JSON_RECORD_POC
                     + "']"));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -358,7 +357,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .when()
         .put(new DynamicUrl(REST_PATH, id).getUrl());
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -404,7 +403,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             hasXPath(
                 "/metacard/string[@name='point-of-contact']/value[text()='" + ADMIN_EMAIL + "']"));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -450,10 +449,10 @@ public class TestCatalog extends AbstractIntegrationTest {
         .body(not(hasXPath(format(METACARD_X_PATH, id1))))
         .body(not(hasXPath(format(METACARD_X_PATH, id3))));
 
-    deleteMetacard(id1);
-    deleteMetacard(id2);
-    deleteMetacard(id3);
-    deleteMetacard(id4);
+    delete(id1);
+    delete(id2);
+    delete(id3);
+    delete(id4);
   }
 
   private Response ingestCswRecord() {
@@ -683,7 +682,7 @@ public class TestCatalog extends AbstractIntegrationTest {
           .statusCode(equalTo(200))
           .body(hasXPath("/GetRecordsResponse/SearchResults[@numberOfRecordsReturned]"), not("0"));
     } finally {
-      deleteMetacard(id);
+      delete(id);
     }
   }
 
@@ -708,7 +707,7 @@ public class TestCatalog extends AbstractIntegrationTest {
           .statusCode(equalTo(200))
           .body(hasXPath("/GetRecordsResponse/SearchResults[@numberOfRecordsReturned]"), not("0"));
     } finally {
-      deleteMetacard(id);
+      delete(id);
     }
   }
 
@@ -869,7 +868,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "(//metacard/geometry[@name='location']/value/Polygon/exterior/LinearRing/pos)[5]",
                 is("1.0 2.0")));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -961,8 +960,8 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "//metacard/string[@name='topic.category']/value",
                 is("Hydrography--Dictionaries")));
 
-    deleteMetacard(firstId);
-    deleteMetacard(secondId);
+    delete(firstId);
+    delete(secondId);
   }
 
   @Test
@@ -1072,7 +1071,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     // possible due to DDF-1537, this test will need
     // to be updated to test this once it is fixed.
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -1130,7 +1129,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 "//metacard/string[@name='topic.category']/value",
                 is("Hydrography--Dictionaries")));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -1173,7 +1172,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .statusCode(equalTo(200))
         .body(hasXPath("/GetRecordsResponse/SearchResults[@numberOfRecordsReturned='1']"));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -1199,8 +1198,8 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     verifyGetRecordByIdResponse(response, firstId, secondId);
 
-    deleteMetacard(firstId);
-    deleteMetacard(secondId);
+    delete(firstId);
+    delete(secondId);
   }
 
   @Test
@@ -1225,8 +1224,8 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     verifyGetRecordByIdResponse(response, firstId, secondId);
 
-    deleteMetacard(firstId);
-    deleteMetacard(secondId);
+    delete(firstId);
+    delete(secondId);
   }
 
   @Test
@@ -1243,7 +1242,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     given().get(url).then().log().all().assertThat().statusCode(equalTo(200)).body(is(SAMPLE_DATA));
 
-    deleteMetacard(metacardId);
+    delete(metacardId);
   }
 
   @Test
@@ -1296,7 +1295,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .assertThat()
         .header(HttpHeaders.CONTENT_LENGTH, notNullValue());
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -1323,7 +1322,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .statusCode(equalTo(200))
         .body(is(SAMPLE_DATA));
 
-    deleteMetacard(metacardId);
+    delete(metacardId);
   }
 
   @Test
@@ -1363,7 +1362,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .body(is(partialSampleData));
     // @formatter:on
 
-    deleteMetacard(metacardId);
+    delete(metacardId);
   }
 
   @Test
@@ -1394,7 +1393,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .statusCode(equalTo(400));
     // @formatter:on
 
-    deleteMetacard(metacardId);
+    delete(metacardId);
   }
 
   private void verifyGetRecordByIdResponse(
@@ -1468,7 +1467,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     config.update(configProps);
     getServiceManager().waitForAllBundles();
 
-    deleteMetacard(id1);
+    delete(id1);
   }
 
   @Test
@@ -1951,7 +1950,6 @@ public class TestCatalog extends AbstractIntegrationTest {
               .replaceFirst("ddf\\.metacard", newMetacardTypeName)
               .replaceFirst("resource-uri", "new-attribute-required-2");
       id = ingest(modifiedMetacardXml, "text/xml");
-      configureFilterInvalidMetacards("false", "false", getAdminConfig());
 
       String newMetacardXpath = format("/metacards/metacard[@id=\"%s\"]", id);
 
@@ -1973,7 +1971,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                   newMetacardXpath + "/string[@name=\"new-attribute-required-2\"]/value",
                   is("\" + uri + \"")));
     } finally {
-      deleteMetacard(id);
+      delete(id);
       uninstallDefinitionJson(
           file,
           () -> {
@@ -1985,7 +1983,6 @@ public class TestCatalog extends AbstractIntegrationTest {
             return null;
           });
       getServiceManager().startFeature(true, "catalog-security-filter");
-      configureFilterInvalidMetacards("true", "true", getAdminConfig());
     }
   }
 
@@ -2064,8 +2061,8 @@ public class TestCatalog extends AbstractIntegrationTest {
               hasXPath(
                   metacard4XPath + "/dateTime[@name='expiration']/value", is(defaultExpiration)));
     } finally {
-      deleteMetacard(id3);
-      deleteMetacard(id4);
+      delete(id3);
+      delete(id4);
       uninstallDefinitionJson(
           file,
           () -> {
@@ -2153,8 +2150,8 @@ public class TestCatalog extends AbstractIntegrationTest {
               hasXPath(
                   metacard2XPath + "/dateTime[@name='expiration']/value", is(defaultExpiration)));
     } finally {
-      deleteMetacard(id1);
-      deleteMetacard(id2);
+      delete(id1);
+      delete(id2);
       uninstallDefinitionJson(
           file,
           () -> {
@@ -2202,8 +2199,8 @@ public class TestCatalog extends AbstractIntegrationTest {
           .body(hasXPath(otherMetacardXpath + "/int[@name='page-count']/value", is("55")))
           .body(hasXPath(otherMetacardXpath + "/double[@name='temperature']/value", is("-12.541")));
     } finally {
-      deleteMetacard(id);
-      deleteMetacard(id2);
+      delete(id);
+      delete(id2);
     }
   }
 
@@ -2243,8 +2240,8 @@ public class TestCatalog extends AbstractIntegrationTest {
           .body(not(hasXPath(basicMetacardXpath + "/string[@name='point-of-contact']")));
 
     } finally {
-      deleteMetacard(id);
-      deleteMetacard(id2);
+      delete(id);
+      delete(id2);
     }
   }
 
@@ -2331,7 +2328,6 @@ public class TestCatalog extends AbstractIntegrationTest {
 
       invalidCardId = ingestXmlFromResource("/metacard-datatype-validation.xml");
 
-      configureFilterInvalidMetacards("false", "false", getAdminConfig());
       String newMetacardXpath = format("/metacards/metacard[@id=\"%s\"]", invalidCardId);
 
       getOpenSearch("xml", null, null, "q=*")
@@ -2361,15 +2357,14 @@ public class TestCatalog extends AbstractIntegrationTest {
     } finally {
 
       if (invalidCardId != null) {
-        deleteMetacard(invalidCardId);
+        delete(invalidCardId);
       }
 
       if (validCardId != null) {
-        deleteMetacard(validCardId);
+        delete(validCardId);
       }
 
       getServiceManager().startFeature(true, "catalog-security-filter");
-      configureShowInvalidMetacardsReset();
     }
   }
 
@@ -2413,7 +2408,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             hasXPath(
                 metacardPath + "/string[@name=\"" + Core.TITLE + "\"]/value", is(overrideTitle)));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -2448,7 +2443,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .when()
         .put(REST_PATH.getUrl() + id);
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -2516,7 +2511,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             hasXPath(format(METACARD_X_PATH, id) + "/string[@name='title']/value", is("file.bin")));
 
     // clean up
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -2549,7 +2544,7 @@ public class TestCatalog extends AbstractIntegrationTest {
                 format(METACARD_X_PATH, id) + "/string[@name='title']/value", is("bad_file.bin")));
 
     // clean up
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test
@@ -2620,14 +2615,6 @@ public class TestCatalog extends AbstractIntegrationTest {
     }
     FileUtils.writeByteArrayToFile(file, IOUtils.toByteArray(data));
     return file;
-  }
-
-  public void configureShowInvalidMetacardsReset() throws IOException {
-    configureFilterInvalidMetacards("true", "false", getAdminConfig());
-  }
-
-  public void configureFilterInvalidMetacardsReset() throws IOException {
-    configureFilterInvalidMetacards("true", "false", getAdminConfig());
   }
 
   private void verifyMetadataBackup() {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
@@ -162,7 +162,7 @@ public class TestFanout extends AbstractIntegrationTest {
     String id =
         CatalogTestCommons.ingest(
             "Some data to ingest", MediaType.TEXT_PLAIN, HttpStatus.SC_CREATED);
-    CatalogTestCommons.deleteMetacard(id, HttpStatus.SC_OK);
+    CatalogTestCommons.delete(id);
   }
 
   @Test
@@ -180,7 +180,7 @@ public class TestFanout extends AbstractIntegrationTest {
         CatalogTestCommons.ingest(
             "Some data to ingest", MediaType.TEXT_PLAIN, HttpStatus.SC_CREATED);
     CatalogTestCommons.update(id, "Some data to update", MediaType.TEXT_PLAIN, HttpStatus.SC_OK);
-    CatalogTestCommons.deleteMetacard(id, HttpStatus.SC_OK);
+    CatalogTestCommons.delete(id);
   }
 
   @Test
@@ -199,7 +199,7 @@ public class TestFanout extends AbstractIntegrationTest {
     getServiceManager().waitForAllBundles();
     // Set blacklist to empty list so the delete will succeed
     getCatalogBundle().setFanoutTagBlacklist(new ArrayList<>());
-    CatalogTestCommons.deleteMetacard(id, HttpStatus.SC_OK);
+    CatalogTestCommons.delete(id);
   }
 
   @Test
@@ -214,10 +214,10 @@ public class TestFanout extends AbstractIntegrationTest {
 
     // Set blacklist so update will fail
     getCatalogBundle().setFanoutTagBlacklist(TAG_BLACKLIST);
-    CatalogTestCommons.deleteMetacard(id, HttpStatus.SC_BAD_REQUEST);
+    CatalogTestCommons.delete(id, HttpStatus.SC_BAD_REQUEST);
 
     // Set blacklist to empty list so the delete will succeed
     getCatalogBundle().setFanoutTagBlacklist(new ArrayList<>());
-    CatalogTestCommons.deleteMetacard(id, HttpStatus.SC_OK);
+    CatalogTestCommons.delete(id);
   }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSecurityAuditPlugin.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSecurityAuditPlugin.java
@@ -13,7 +13,7 @@
  */
 package ddf.test.itests.catalog;
 
-import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.deleteMetacard;
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.delete;
 import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingestXmlFromResourceAndWait;
 import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.update;
 
@@ -99,7 +99,7 @@ public class TestSecurityAuditPlugin extends AbstractIntegrationTest {
         .checkEvery(2, TimeUnit.SECONDS)
         .until(() -> getFileContent(securityLog).contains(expectedLogMessage));
 
-    deleteMetacard(id);
+    delete(id);
   }
 
   @Test

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSpatial.java
@@ -21,10 +21,9 @@ import static com.xebialabs.restito.semantics.Condition.parameter;
 import static com.xebialabs.restito.semantics.Condition.post;
 import static com.xebialabs.restito.semantics.Condition.withPostBodyContaining;
 import static ddf.catalog.Constants.DEFAULT_PAGE_SIZE;
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingest;
 import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingestCswRecord;
-import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingestMetacards;
-import static org.codice.ddf.itests.common.config.ConfigureTestCommons.configureFilterInvalidMetacards;
-import static org.codice.ddf.itests.common.config.ConfigureTestCommons.configureMetacardValidityFilterPlugin;
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingestGeoJson;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -261,6 +260,30 @@ public class TestSpatial extends AbstractIntegrationTest {
     return file.contains(".") ? file.substring(0, file.lastIndexOf(".")) : file;
   }
 
+  public static Map<String, String> ingestMetacards(Map<String, String> metacardsIds) {
+    // ingest csw
+    String cswRecordId =
+        ingestCswRecord(getFileContent(CSW_RESOURCE_ROOT + "csw/record/CswRecord.xml"));
+    metacardsIds.put(CSW_METACARD, cswRecordId);
+
+    // ingest xml
+    String plainXmlNearId =
+        ingest(getFileContent(CSW_RESOURCE_ROOT + "xml/PlainXmlNear.xml"), MediaType.TEXT_XML);
+    String plainXmlFarId =
+        ingest(getFileContent(CSW_RESOURCE_ROOT + "xml/PlainXmlFar.xml"), MediaType.TEXT_XML);
+    metacardsIds.put(PLAINXML_NEAR_METACARD, plainXmlNearId);
+    metacardsIds.put(PLAINXML_FAR_METACARD, plainXmlFarId);
+
+    // ingest json
+    String geoJsonNearId =
+        ingestGeoJson(getFileContent(CSW_RESOURCE_ROOT + "json/GeoJsonNear.json"));
+    String geoJsonFarId = ingestGeoJson(getFileContent(CSW_RESOURCE_ROOT + "json/GeoJsonFar.json"));
+    metacardsIds.put(GEOJSON_NEAR_METACARD, geoJsonNearId);
+    metacardsIds.put(GEOJSON_FAR_METACARD, geoJsonFarId);
+
+    return metacardsIds;
+  }
+
   @BeforeExam
   public void beforeExam() throws Exception {
     try {
@@ -282,8 +305,6 @@ public class TestSpatial extends AbstractIntegrationTest {
 
   @Before
   public void setup() throws Exception {
-    configureFilterInvalidMetacards("false", "false", getAdminConfig());
-    configureMetacardValidityFilterPlugin(Arrays.asList("invalid-state=guest"), getAdminConfig());
     clearCatalogAndWait();
   }
 


### PR DESCRIPTION
#### What does this PR do?
The primary purpose is to clean up the usages of the test configuration helper methods defined in ConfigureTestCommons, but also achieves the following:

* Makes configuration helper methods return old props so tests can better reset themselves
* Makes configuration helper methods wait and check to make sure the configuration change was registered before proceeding
* Fixes AuthzRealm configuration method in ConfigureTestCommons
* Added more useful rest helper methods to CatalogTestCommons
* Cleans up lots of static analysis findings
* Simplifies TestCatalogValidation (reduces much unnecessary configuration)
* Removes un-needed configuration in TestCatalog
* Fixes tests in TestSecurity that were not working as intended (did not cover what they were intended to cover)
* Localizes TestSpatial ingest logic (removes it from CatalogTestCommons)

#### Who is reviewing it? 
@jhunzik 
@paouelle 
@tyler30clemens 

#### Select relevant component teams: 
@codice/test 

#### Ask 2 committers to review/merge the PR and tag them here.
@figliold
@tbatie

#### How should this be tested?
Run itest suite.

#### What are the relevant tickets?
[DDF-3955](https://codice.atlassian.net/browse/DDF-3955)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
