### PR TITLE
DDF-4325 Allow the user to set their home location for 2D and 3D maps

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -399,9 +399,9 @@ module.exports = function CesiumMap(
     },
     getBoundingBox: function() {
       const viewRectangle = map.scene.camera.computeViewRectangle()
-      return _.mapObject(viewRectangle, function(val, key) {
-        return Cesium.Math.toDegrees(val)
-      })
+      return _.mapObject(viewRectangle, (val, key) =>
+        Cesium.Math.toDegrees(val)
+      )
     },
     overlayImage: function(model) {
       var metacardId = model.get('properties').get('id')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -397,6 +397,12 @@ module.exports = function CesiumMap(
         destination: Cesium.Rectangle.fromDegrees(west, south, east, north),
       })
     },
+    getBoundingBox: function() {
+      const viewRectangle = map.scene.camera.computeViewRectangle()
+      return _.mapObject(viewRectangle, function(val, key) {
+        return Cesium.Math.toDegrees(val)
+      })
+    },
     overlayImage: function(model) {
       var metacardId = model.get('properties').get('id')
       this.removeOverlay(metacardId)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -147,6 +147,7 @@ module.exports = Marionette.LayoutView.extend({
   events: {
     'click .cluster-button': 'toggleClustering',
     'click .zoomToHome': 'zoomToHome',
+    'click .saveAsHome': 'saveAsHome',
   },
   clusterCollection: undefined,
   clusterCollectionView: undefined,
@@ -248,9 +249,17 @@ module.exports = Marionette.LayoutView.extend({
     this.setupMapInfo()
   },
   zoomToHome: function() {
-    this.map.zoomToBoundingBox(
-      homeBoundingBox !== undefined ? homeBoundingBox : defaultHomeBoundingBox
-    )
+    const home = [
+      user.get('user').get('mapHome'),
+      homeBoundingBox,
+      defaultHomeBoundingBox,
+    ].find(element => element !== undefined)
+
+    this.map.zoomToBoundingBox(home)
+  },
+  saveAsHome: function() {
+    const boundingBox = this.map.getBoundingBox()
+    user.get('user').set('mapHome', boundingBox)
   },
   addPanZoom: function() {
     const self = this
@@ -268,12 +277,14 @@ module.exports = Marionette.LayoutView.extend({
     this.toolbarPanZoom.show(new PanZoomView())
   },
   addHome: function() {
+    // TODO replace Save button once this is refactored to React
     this.$el
       .find('.cesium-viewer-toolbar')
       .append(
         '<div class="is-button zoomToHome">' +
           '<span>Home </span>' +
-          '<span class="cf cf-map-marker"></span></div>'
+          '<span class="cf cf-map-marker"></span></div>' +
+          '<div class="is-button saveAsHome"><span>Save </span></div>'
       )
   },
   addClustering: function() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -250,7 +250,10 @@ module.exports = Marionette.LayoutView.extend({
   },
   zoomToHome: function() {
     const home = [
-      user.get('user').get('mapHome'),
+      user
+        .get('user')
+        .get('preferences')
+        .get('mapHome'),
       homeBoundingBox,
       defaultHomeBoundingBox,
     ].find(element => element !== undefined)
@@ -259,7 +262,10 @@ module.exports = Marionette.LayoutView.extend({
   },
   saveAsHome: function() {
     const boundingBox = this.map.getBoundingBox()
-    user.get('user').set('mapHome', boundingBox)
+    user
+      .get('user')
+      .get('preferences')
+      .set('mapHome', boundingBox)
   },
   addPanZoom: function() {
     const self = this
@@ -277,7 +283,7 @@ module.exports = Marionette.LayoutView.extend({
     this.toolbarPanZoom.show(new PanZoomView())
   },
   addHome: function() {
-    // TODO replace Save button once this is refactored to React
+    // TODO combine home and save buttons once this is refactored to React: https://codice.atlassian.net/browse/DDF-4327
     this.$el
       .find('.cesium-viewer-toolbar')
       .append(
@@ -388,6 +394,7 @@ module.exports = Marionette.LayoutView.extend({
     this.addLayers()
     this.addSettings()
     this.endLoading()
+    this.zoomToHome()
   },
   addLayers: function() {
     this.$el

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -163,6 +163,7 @@ module.exports = Marionette.LayoutView.extend({
     this.listenTo(store.get('content'), 'change:drawing', this.handleDrawing)
     this.handleDrawing()
     this.setupMouseLeave()
+    this.listenTo(store.get('workspaces'), 'add', this.zoomToHome)
   },
   setupMouseLeave: function() {
     this.$el.on('mouseleave', () => {
@@ -283,14 +284,17 @@ module.exports = Marionette.LayoutView.extend({
     this.toolbarPanZoom.show(new PanZoomView())
   },
   addHome: function() {
-    // TODO combine home and save buttons once this is refactored to React: https://codice.atlassian.net/browse/DDF-4327
+    // TODO combine home and save buttons into a "split button dropdown" once this is refactored to React: DDF-4327
     this.$el
       .find('.cesium-viewer-toolbar')
       .append(
         '<div class="is-button zoomToHome">' +
           '<span>Home </span>' +
           '<span class="cf cf-map-marker"></span></div>' +
-          '<div class="is-button saveAsHome"><span>Save </span></div>'
+          '<div class="is-button saveAsHome">' +
+          '<span title="Save Current View as Home Location">Save </span>' +
+          '<span class="fa fa-floppy-o"/>' +
+          '</div>'
       )
   },
   addClustering: function() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -290,10 +290,10 @@ module.exports = Marionette.LayoutView.extend({
       .append(
         '<div class="is-button zoomToHome">' +
           '<span>Home </span>' +
-          '<span class="cf cf-map-marker"></span></div>' +
+          '<span class="fa fa-home"></span></div>' +
           '<div class="is-button saveAsHome">' +
-          '<span title="Save Current View as Home Location">Save </span>' +
-          '<span class="fa fa-floppy-o"/>' +
+          '<span title="Save Current View as Home Location">Set Home </span>' +
+          '<span class="cf cf-map-marker"/>' +
           '</div>'
       )
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -259,6 +259,19 @@ module.exports = function OpenlayersMap(
     zoomToBoundingBox: function({ north, east, south, west }) {
       this.zoomToExtent([[west, south], [east, north]])
     },
+    limit: function(value, min, max) {
+      return Math.min(Math.max(value, min), max)
+    },
+    getBoundingBox: function() {
+      const extent = map.getView().calculateExtent(map.getSize())
+
+      return {
+        north: this.limit(extent[3], -90, 90),
+        east: this.limit(extent[2], -180, 180),
+        south: this.limit(extent[1], -90, 90),
+        west: this.limit(extent[0], -180, 180),
+      }
+    },
     overlayImage: function(model) {
       var metacardId = model.get('properties').get('id')
       this.removeOverlay(metacardId)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -143,6 +143,7 @@ User.Preferences = Backbone.AssociatedModel.extend({
       animation: true,
       hoverPreview: true,
       querySettings: new QuerySettings(),
+      mapHome: undefined,
     }
   },
   relations: [
@@ -192,6 +193,7 @@ User.Preferences = Backbone.AssociatedModel.extend({
     this.listenTo(this, 'change:goldenLayoutUpload', this.savePreferences)
     this.listenTo(this, 'change:goldenLayoutMetacard', this.savePreferences)
     this.listenTo(this, 'change:goldenLayoutAlert', this.savePreferences)
+    this.listenTo(this, 'change:mapHome', this.savePreferences)
   },
   handleRemove: function() {
     this.savePreferences()


### PR DESCRIPTION
#### What does this PR do?
Allow the user to save the current map location and zoom, and then return to that location by clicking the Home button. Also, zoom to home when a new workspace is created.

NOTE: The "Save" button is temporary. @andrewkfiedler and @Lambeaux have plans to convert the map code to React, which will make it easy to implement a "split button dropdown" that will combine the Home and Save buttons.

#### Who is reviewing it? 
@brianfelix 
@jrnorth 
@Corey-Collins 
@leo-sakh 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?
Navigate to a variety of map locations and zoom levels. Click the Save button (next to the Home button). Navigate to a different location and map. Click the Home button. Confirm that the map
returns to the desired location. Test with extreme locations, like being zoomed all the way out.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4325](https://codice.atlassian.net/browse/DDF-4325)
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
