### PR TITLE
DDF-4106 Fixes dropdown interop

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.utility.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/behaviors/dropdown.behavior.utility.js
@@ -70,12 +70,22 @@ module.exports = {
       $dropdownEl
         .prevAll(`${CustomElements.getNamespace()}dropdown-companion`)
         .find(clickedElement)
+        .addBack(clickedElement).length > 0 ||
+      $dropdownEl
+        .closest('react-portal')
+        .prevAll(`${CustomElements.getNamespace()}dropdown-companion`)
+        .find(clickedElement)
         .addBack(clickedElement).length > 0
     )
   },
   withinParentDropdownBehavior($dropdownEl, clickedElement) {
     return (
       $dropdownEl
+        .prevAll('[data-behavior-dropdown]')
+        .find(clickedElement)
+        .addBack(clickedElement).length > 0 ||
+      $dropdownEl
+        .closest('react-portal')
         .prevAll('[data-behavior-dropdown]')
         .find(clickedElement)
         .addBack(clickedElement).length > 0
@@ -85,6 +95,10 @@ module.exports = {
     return (
       $dropdownEl
         .closest('react-portal')
+        .prevAll('react-portal')
+        .find(clickedElement)
+        .addBack(clickedElement).length > 0 ||
+      $dropdownEl
         .prevAll('react-portal')
         .find(clickedElement)
         .addBack(clickedElement).length > 0


### PR DESCRIPTION
#### What does this PR do?
 - Legacy dropdowns weren't seeing clicks inside the new dropdowns.
 - Updates the dropdown code to properly check clicks.

#### Who is reviewing it? 
@djblue 
@Bdthomson 
@andrewzimmer 
@Schachte 
@rzwiefel 

#### How should this be tested?
Verify that the dropdown in the screenshot (
![image](https://user-images.githubusercontent.com/11984853/48229943-b35a2980-e366-11e8-8d7b-b114ac1680a6.png)) works as expected.  Dropdowns within it should close when the parent dropdown is clicked.
