### PR TITLE
DDF-4321 Adds backend validation for search forms with missing or empty titles

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import net.opengis.filter.v_2_0.FilterType;
+import org.apache.commons.lang3.StringUtils;
 import org.codice.ddf.catalog.ui.forms.api.FilterNode;
 import org.codice.ddf.catalog.ui.forms.builder.JsonModelBuilder;
 import org.codice.ddf.catalog.ui.forms.builder.XmlModelBuilder;
@@ -78,13 +79,17 @@ public class TemplateTransformer {
   public Metacard toQueryTemplateMetacard(Map<String, Object> formTemplate) {
     try {
       Map<String, Object> filterJson = (Map) formTemplate.get("filterTemplate");
-      String title = (String) formTemplate.get("title");
-      String description = (String) formTemplate.get("description");
-      String id = (String) formTemplate.get("id");
-
       if (filterJson == null) {
         return null;
       }
+
+      String title = (String) formTemplate.get("title");
+      if (StringUtils.isBlank(title)) {
+        throw new IllegalArgumentException("Search form title cannot be blank");
+      }
+
+      String description = (String) formTemplate.get("description");
+      String id = (String) formTemplate.get("id");
 
       TransformVisitor<JAXBElement> visitor = new TransformVisitor<>(new XmlModelBuilder());
       VisitableJsonElementImpl.create(new FilterNodeMapImpl(filterJson)).accept(visitor);

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/TemplateTransformerTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/TemplateTransformerTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.forms;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import org.junit.Test;
+
+public class TemplateTransformerTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTransformerErrorsWithoutTitle() {
+    TemplateTransformer transformer = new TemplateTransformer(null, null, null);
+    transformer.toQueryTemplateMetacard(ImmutableMap.of("filterTemplate", new HashMap<>()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTransformerErrorsWithEmptyTitle() {
+    TemplateTransformer transformer = new TemplateTransformer(null, null, null);
+    transformer.toQueryTemplateMetacard(
+        ImmutableMap.of("filterTemplate", new HashMap<>(), "title", ""));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTransformerErrorsWithBlankTitle() {
+    TemplateTransformer transformer = new TemplateTransformer(null, null, null);
+    transformer.toQueryTemplateMetacard(
+        ImmutableMap.of("filterTemplate", new HashMap<>(), "title", "  "));
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Backend will properly handle missing or empty titles on submitted search forms. 

#### Who is reviewing it? 
@Schachte 
@gjvera 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@millerw8

#### Component team
@codice/io

#### How should this be tested?
Try to save a new search form with an empty or blank title. The exception should be logged at DEBUG on the backend and the UI should correctly prompt the user to fix the mistake. 

#### What are the relevant tickets?
[DDF-4321](https://codice.atlassian.net/browse/DDF-4321)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
