### PR TITLE
DDF-4106 Updates new dropdown to take bottom or top into account

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
@@ -142,7 +142,12 @@ const DropdownWrapper = styled<{ open: boolean }, 'div'>('div')`
   ${props =>
     props.open
       ? `
-  transform: translate3d(0, 0, 0) scale(1);
+  &.is-bottom {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  &.is-top {
+    transform: translate3d(0, -100%, 0) scaleY(1);
+  }
   `
       : `
   transform: translate3d(-50%, -50%, 0) scale(0);


### PR DESCRIPTION
#### What does this PR do?
 - The new dropdown styling wasn't taking the bottom / top styling into account.  So if it was too close to the bottom and flipped, the styling was still such that it stayed on the bottom (whereas the height updated as if it wasn't).  This caused the dropdown to go off the screen.

#### Who is reviewing it? 
@Lambeaux 
@djblue 
@bellcc 
@andrewzimmer 
@bdeining 

#### Select relevant component teams: 
@codice/ui 

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
