### PR TITLE
DDF-4260 Fix surefire argline to include jacoco

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -551,4 +551,15 @@
         <module>confluence</module>
         <module>async</module>
     </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -510,7 +510,6 @@
                 </executions>
             </plugin>
         </plugins>
-
     </build>
 
 </project>

--- a/platform/admin/pom.xml
+++ b/platform/admin/pom.xml
@@ -34,6 +34,9 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -307,9 +307,9 @@
         <xpp3.bundle.version>1.1.4c_6</xpp3.bundle.version>
         <xstream.version>1.4.9</xstream.version>
         <!-- Command line argument properties for the maven-surefire-plugin -->
-        <jacoco.argline/> <!-- Automagically set by Jacoco -->
         <surefire.argline.append/>
-        <surefire.argline>${surefire.argline.append} ${jacoco.argline} -Xmx1024m -Djava.awt.headless=true -noverify</surefire.argline>
+        <surefire.argline>${jacoco.argline} ${surefire.argline.append} -Xmx1024m -Djava.awt.headless=true -noverify</surefire.argline>
+        <failsafe.argline>${jacoco.argline}</failsafe.argline>
     </properties>
     <!--
     NOTE: The properties ddf.scm.connection.url, snapshots.repository.url and releases.repository.url should be defined
@@ -489,6 +489,9 @@
                                 <goal>integration-test</goal>
                                 <goal>verify</goal>
                             </goals>
+                            <configuration>
+                                <argLine>${failsafe.argline}</argLine>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug in [#3918](https://github.com/codice/ddf/pull/3918) where jacoco coverage reports were not being generated. The fix is to remove the empty default `<jacoco.argline/>` property from the root pom and let jacoco set `jacoco.argline` instead.

#### Who is reviewing it? 
@blen-desta 
@Kjames5269 
@willwill96 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@clockard
@coyotesqrl 

#### How should this be tested?
On both Mac and Windows, run `mvn clean verify` under `<ddf_home>/catalog/ui/catalog-ui-search`. Verify that jacoco coverage checks are being ran:
```
[INFO] --- jacoco-maven-plugin:0.8.1:check (default-check) @ catalog-ui-search ---
[INFO] Loading execution data file C:\Projects\Source\ddf\catalog\ui\catalog-ui-search\target\jacoco.exec
[INFO] Analyzed bundle 'catalog-ui-search' with 151 classes
[INFO] All coverage checks have been met.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

#### What are the relevant tickets?
[DDF-4260](https://codice.atlassian.net/browse/DDF-4260)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
