### PR TITLE
DDF-4346 Changed result/search form from human readable to moment date

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.js
@@ -93,7 +93,7 @@ module.exports = Backbone.AssociatedModel.extend({
             d.setUTCSeconds(utcSeconds)
             this.addSearchForm(
               new SearchForm({
-                createdOn: Common.getHumanReadableDateTime(d),
+                createdOn: Common.getMomentDate(d),
                 id: value.id,
                 name: value.title,
                 description: value.description,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.less
@@ -2,7 +2,7 @@
   display: inline-block;
   padding: @minimumSpacing;
   margin: @minimumSpacing;
-  width: 7 * @minimumButtonSize;
+  width: 9 * @minimumButtonSize;
   height: 4 * @minimumButtonSize;
   text-align: left;
   vertical-align: top;


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Changes the Search/Result form date from human readable to moment to shorten the text to prevent text overflowing.
Also slightly adjusts the width of each box that the result and search form encloses.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@bdeining 
@adimka 
@andrewkfiedler 
@Schachte 

#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Create new result and search forms and ensure that the text does not over flow.
Verify that the date uses moment instead of human readable.

#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
