### PR TITLE
DDF-4349 Make documentation table elements scroll at max-width

### DIFF
--- a/distribution/docs/src/main/resources/content/scripts.html
+++ b/distribution/docs/src/main/resources/content/scripts.html
@@ -61,15 +61,28 @@ function addTocListeners() {
 	}
 }
 
+function wrapScrollElements(selector) {
+  document.querySelectorAll( selector ).forEach( elem => {
+    const div = document.createElement( 'div' );
+    div.className = "scroll-wrapper";
+    elem.parentElement.insertBefore(div, elem);
+    div.appendChild(elem);
+  });
+}
+
 document.onreadystatechange = () => {
 	if (document.readyState === 'complete') {
 	  // The page is fully loaded
 		makeTocExpandable();
 		addTocListeners();
+	    wrapScrollElements('table.tableblock');
+	    wrapScrollElements('.CodeRay');
+	    wrapScrollElements('.admonitionblock');
 	}
 };
 </script>
 <style>
 .collapsed {display: none;}
+.scroll-wrapper {overflow-x: auto;}
 </style>
 ++++


### PR DESCRIPTION
#### What does this PR do?
Tables elements in the documentation (tables, codeblocks, notes, warnings, etc) didn't obey max-width and overflowed , so in the Admin UI's iFrame they were being cut off. This PR makes all table elements scrollable when they exceed the max-width.

#### Who is reviewing it? 
@mcalcote 
@garrettfreibott 
@ahoffer 

#### Select relevant component teams: 
@codice/docs 

#### Ask 2 committers to review/merge the PR and tag them here.
@ricklarsen - Documentation
@vinamartin
#### How should this be tested?
Build docs and deploy generated docs in distribution/docs/target/docs/html/.asciidoctor to <your-distro>/documentation/ddf/docs-2.14.0-SNAPSHOT/html/
Verify all tables and codeblocks are visible from the admin UI
#### What are the relevant tickets?
[DDF-4349](https://codice.atlassian.net/browse/DDF-4349)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
