### PR TITLE
[2.13.x] DDF-4347 Allow Confluence to query anonymous content

### DIFF
--- a/catalog/confluence/catalog-confluence-source/src/main/java/org/codice/ddf/confluence/source/ConfluenceInputTransformer.java
+++ b/catalog/confluence/catalog-confluence-source/src/main/java/org/codice/ddf/confluence/source/ConfluenceInputTransformer.java
@@ -168,7 +168,12 @@ public class ConfluenceInputTransformer implements InputTransformer {
     metacard.setCreatedDate(created);
     metacard.setAttribute(Core.METACARD_CREATED, created);
 
-    metacard.setAttribute(Contact.CREATOR_NAME, getString(history, "createdBy", "username"));
+    Object creator = getJsonElement(history, "createdBy", "username");
+    if (creator != null && StringUtils.isNotEmpty(creator.toString())) {
+      metacard.setAttribute(Contact.CREATOR_NAME, creator.toString());
+    } else {
+      metacard.setAttribute(Contact.CREATOR_NAME, "Unknown");
+    }
 
     ArrayList<String> contributors = new ArrayList<>();
     getJsonArray(history, "contributors", "publishers", "users")

--- a/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceInputTransformerTest.java
+++ b/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceInputTransformerTest.java
@@ -146,6 +146,17 @@ public class ConfluenceInputTransformerTest {
     assertThat(metacards.size(), is(0));
   }
 
+  @Test
+  public void testTransformingAnonymousContent() throws Exception {
+    String fileContent = getFileContent("anonymous_user_response.json");
+    InputStream stream = new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8));
+    Metacard mcard = transformer.transformConfluenceResponse(stream).get(0);
+    assertThat(
+        "Creator should be Unknown",
+        mcard.getAttribute(Contact.CREATOR_NAME).getValue(),
+        equalTo("Unknown"));
+  }
+
   private String getFileContent(String filePath) {
     try {
       return IOUtils.toString(
@@ -161,10 +172,7 @@ public class ConfluenceInputTransformerTest {
     if (expectedId != null) {
       id = expectedId;
     }
-    String url = "";
-    if (baseUrl != null) {
-      url = baseUrl;
-    }
+
     assertThat(mcard.getId(), equalTo(id));
     assertThat(mcard.getTitle(), equalTo("Formatting Source Code"));
     assertThat(

--- a/catalog/confluence/catalog-confluence-source/src/test/resources/anonymous_user_response.json
+++ b/catalog/confluence/catalog-confluence-source/src/test/resources/anonymous_user_response.json
@@ -1,0 +1,208 @@
+{
+  "results": [
+    {
+      "id": "1179681",
+      "type": "page",
+      "status": "current",
+      "title": "Formatting Source Code",
+      "space": {
+        "id": 1277953,
+        "key": "DDF",
+        "name": "DDF",
+        "type": "global",
+        "_links": {
+          "webui": "/spaces/DDF",
+          "self": "https://codice.atlassian.net/wiki/rest/api/space/DDF"
+        },
+        "_expandable": {
+          "metadata": "",
+          "operations": "",
+          "icon": "",
+          "description": "",
+          "homepage": "/rest/api/content/1179800"
+        }
+      },
+      "history": {
+        "lastUpdated": {
+          "by": {
+            "type": "known",
+            "username": "first.last",
+            "userKey": "ff8080814e7",
+            "profilePicture": {
+              "path": "/wiki/images/icons/profilepics/default.png",
+              "width": 48,
+              "height": 48,
+              "isDefault": true
+            },
+            "displayName": "First Last",
+            "_links": {
+              "self": "https://codice.atlassian.net/wiki/rest/experimental/user?key=ff8080814e7"
+            },
+            "_expandable": {
+              "details": ""
+            }
+          },
+          "when": "2015-06-16T19:21:39.141-07:00",
+          "friendlyWhen": "Jun 16, 2015",
+          "message": "",
+          "number": 19,
+          "minorEdit": false,
+          "_links": {
+            "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681/version/19"
+          },
+          "_expandable": {
+            "content": "/rest/api/content/1179681"
+          }
+        },
+        "latest": true,
+        "createdBy": {
+          "type": "anonymous",
+          "profilePicture": {
+            "path": "/wiki/images/icons/profilepics/default.png",
+            "width": 48,
+            "height": 48,
+            "isDefault": true
+          },
+          "displayName": "Anonymous",
+        },
+        "createdDate": "2013-09-18T14:50:42.616-07:00",
+        "contributors": {
+          "publishers": {
+            "users": [
+              {
+                "type": "known",
+                "username": "first.last",
+                "userKey": "ff8080814e7",
+                "profilePicture": {
+                  "path": "/wiki/images/icons/profilepics/default.png",
+                  "width": 48,
+                  "height": 48,
+                  "isDefault": true
+                },
+                "displayName": "First Last",
+                "_links": {
+                  "self": "https://codice.atlassian.net/wiki/rest/experimental/user?key=ff8080814e7"
+                },
+                "_expandable": {
+                  "details": ""
+                }
+              },
+              {
+                "type": "anonymous",
+                "displayName": "Anonymous",
+                "_expandable": {
+                  "details": ""
+                }
+              }
+            ],
+            "userKeys": [
+              "ff8080814e7",
+              "ff8080814e8"
+            ]
+          }
+        },
+        "_links": {
+          "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681/history"
+        },
+        "_expandable": {
+          "previousVersion": "",
+          "nextVersion": ""
+        }
+      },
+      "extensions": {
+        "position": "none"
+      },
+      "restrictions": {
+        "read": {
+          "operation": "read",
+          "restrictions": {
+            "user": {
+              "results": [
+                {
+                  "type": "known",
+                  "username": "first.last",
+                  "userKey": "ff8080814e7",
+                  "profilePicture": {
+                    "path": "/wiki/images/icons/profilepics/default.png",
+                    "width": 48,
+                    "height": 48,
+                    "isDefault": true
+                  },
+                  "displayName": "First Last",
+                  "_links": {
+                    "self": "https://codice.atlassian.net/wiki/rest/experimental/user?key=ff8080814e7"
+                  },
+                  "_expandable": {
+                    "details": ""
+                  }
+                }
+              ],
+              "start": 0,
+              "limit": 200,
+              "size": 0
+            },
+            "group": {
+              "results": [
+                {
+                  "type": "group",
+                  "name": "ddf-developers",
+                  "_links": {
+                    "self": "https://codice.atlassian.net/wiki/rest/experimental/group/ddf-developers"
+                  }
+                }
+              ],
+              "start": 0,
+              "limit": 200,
+              "size": 0
+            }
+          },
+          "_links": {
+            "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681/restriction/byOperation/read"
+          },
+          "_expandable": {
+            "content": "/rest/api/content/1179681"
+          }
+        },
+        "_links": {
+          "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681/restriction/byOperation"
+        },
+        "_expandable": {
+          "update": ""
+        }
+      },
+      "_links": {
+        "webui": "/display/DDF/Formatting+Source+Code",
+        "tinyui": "/x/IQAS",
+        "self": "https://codice.atlassian.net/wiki/rest/api/content/1179681"
+      },
+      "metadata": {
+        "labels": {
+          "results": [
+            {
+              "name": "testlabel"
+            }
+          ]
+        }
+      },
+      "_expandable": {
+        "childTypes": "",
+        "container": "/rest/api/space/DDF",
+        "metadata": "",
+        "operations": "",
+        "children": "/rest/api/content/1179681/child",
+        "ancestors": "",
+        "body": "",
+        "version": "",
+        "descendants": "/rest/api/content/1179681/descendant"
+      }
+    }
+  ],
+  "start": 0,
+  "limit": 1,
+  "size": 1,
+  "_links": {
+    "self": "https://codice.atlassian.net/wiki/rest/api/content/search?expand=space,history.contributors.publishers.users,history.lastUpdated,restrictions.read.restrictions.group,restrictions.read.restrictions.user&cql=%28+text+~+eclipse+%29+and+space=DDF",
+    "base": "https://codice.atlassian.net/wiki",
+    "context": "/wiki"
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
- Make username no longer required from a Confluence response when transforming results into Metacards. Instead put "Unknown" if username is not present.

#### Who is reviewing it? 
@emmberk @kcover @pvargas @mdang8 

#### Select relevant component teams: 
@codice/io 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@vinamartin

#### How should this be tested?
Query a confluence server for anonymous content. See me for details.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-4347](https://codice.atlassian.net/browse/DDF-4347)

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
