### PR TITLE
DDF-4350 Add internal/system hostname and port to the installer

### DIFF
--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
@@ -53,16 +53,25 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
   private static final String SYSTEM_PROPERTIES_FILE = "custom.system.properties";
   private static final String USERS_PROPERTIES_FILE = "users.properties";
   private static final String USERS_ATTRIBUTES_FILE = "users.attributes";
-  private static final String HOST_TITLE = "Host";
-  private static final String HOST_DESCRIPTION =
+  private static final String EXTERNAL_HOST_TITLE = "External Host";
+  private static final String INTERNAL_HOST_TITLE = "Internal Host";
+  private static final String INTERNAL_HOST_DESCRIPTION =
+      "The hostname or IP address this system runs on. NOTE: This setting will take effect after a system restart.";
+  private static final String EXTERNAL_HOST_DESCRIPTION =
       "The host name or IP address used to advertise the system. Possibilities include the address of a single node of that of a load balancer in a multi-node deployment. NOTE: This setting will take effect after a system restart.";
   private static final ArrayList<String> PROTOCOL_OPTIONS = new ArrayList<>();
-  private static final String HTTP_PORT_TITLE = "HTTP Port";
-  private static final String HTTP_PORT_DESCRIPTION =
+  private static final String EXTERNAL_HTTP_PORT_TITLE = "External HTTP Port";
+  private static final String INTERNAL_HTTP_PORT_TITLE = "Internal HTTP Port";
+  private static final String EXTERNAL_HTTP_PORT_DESCRIPTION =
       "The port used to advertise the system. Possibilities include the port of a single node of that of a load balancer in a multi-node deployment. NOTE: This setting will take effect after a system restart.";
-  private static final String HTTPS_PORT_TITLE = "HTTPS Port";
-  private static final String HTTPS_PORT_DESCRIPTION =
+  private static final String INTERNAL_HTTP_PORT_DESCRIPTION =
+      "The http port that the system uses. NOTE: This *DOES* change the port the system runs on.";
+  private static final String EXTERNAL_HTTPS_PORT_TITLE = "External HTTPS Port";
+  private static final String INTERNAL_HTTPS_PORT_TITLE = "Internal HTTPS Port";
+  private static final String EXTERNAL_HTTPS_PORT_DESCRIPTION =
       "The secure port used to advertise the system. Possibilities include the port of a single node of that of a load balancer in a multi-node deployment. NOTE: This setting will take effect after a system restart.";
+  private static final String INTERNAL_HTTPS_PORT_DESCRIPTION =
+      "The https port that the system uses. NOTE: This *DOES* change the port the system runs on.";
   private static final String ORGANIZATION_TITLE = "Organization";
   private static final String ORGANIZATION_DESCRIPTION =
       "The name of the organization that runs this instance.";
@@ -99,13 +108,35 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
 
     ArrayList<SystemPropertyDetails> properties = new ArrayList<>();
     properties.add(
-        getSystemPropertyDetails(SystemBaseUrl.EXTERNAL_HOST, HOST_TITLE, HOST_DESCRIPTION, null));
+        getSystemPropertyDetails(
+            SystemBaseUrl.EXTERNAL_HOST, EXTERNAL_HOST_TITLE, EXTERNAL_HOST_DESCRIPTION, null));
     properties.add(
         getSystemPropertyDetails(
-            SystemBaseUrl.EXTERNAL_HTTP_PORT, HTTP_PORT_TITLE, HTTP_PORT_DESCRIPTION, null));
+            SystemBaseUrl.EXTERNAL_HTTP_PORT,
+            EXTERNAL_HTTP_PORT_TITLE,
+            EXTERNAL_HTTP_PORT_DESCRIPTION,
+            null));
     properties.add(
         getSystemPropertyDetails(
-            SystemBaseUrl.EXTERNAL_HTTPS_PORT, HTTPS_PORT_TITLE, HTTPS_PORT_DESCRIPTION, null));
+            SystemBaseUrl.EXTERNAL_HTTPS_PORT,
+            EXTERNAL_HTTPS_PORT_TITLE,
+            EXTERNAL_HTTPS_PORT_DESCRIPTION,
+            null));
+    properties.add(
+        getSystemPropertyDetails(
+            SystemBaseUrl.INTERNAL_HOST, INTERNAL_HOST_TITLE, INTERNAL_HOST_DESCRIPTION, null));
+    properties.add(
+        getSystemPropertyDetails(
+            SystemBaseUrl.INTERNAL_HTTP_PORT,
+            INTERNAL_HTTP_PORT_TITLE,
+            INTERNAL_HTTP_PORT_DESCRIPTION,
+            null));
+    properties.add(
+        getSystemPropertyDetails(
+            SystemBaseUrl.INTERNAL_HTTPS_PORT,
+            INTERNAL_HTTPS_PORT_TITLE,
+            INTERNAL_HTTPS_PORT_DESCRIPTION,
+            null));
     properties.add(
         getSystemPropertyDetails(
             SystemInfo.ORGANIZATION, ORGANIZATION_TITLE, ORGANIZATION_DESCRIPTION, null));

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
@@ -159,7 +159,7 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
     }
     // Get custom.system.properties file
     // save off the current/old hostname before we make any changes
-    oldHostName = SystemBaseUrl.EXTERNAL.getHost();
+    oldHostName = SystemBaseUrl.INTERNAL.getHost();
 
     String etcDir = System.getProperty(KARAF_ETC);
     String systemPropertyFilename = etcDir + File.separator + SYSTEM_PROPERTIES_FILE;

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
@@ -92,7 +92,7 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
 
   private MBeanServer mbeanServer;
   private ObjectName objectName;
-  private String oldHostName = SystemBaseUrl.EXTERNAL.getHost();
+  private String oldHostName = SystemBaseUrl.INTERNAL.getHost();
   private GuestClaimsHandlerExt guestClaimsHandlerExt;
 
   public SystemPropertiesAdmin(GuestClaimsHandlerExt guestClaimsHandlerExt)
@@ -215,7 +215,7 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
         if (oldHostValue != null) {
           usersDotProperties.remove(oldHostName);
           usersDotProperties.setProperty(
-              System.getProperty(SystemBaseUrl.EXTERNAL_HOST), oldHostValue);
+              System.getProperty(SystemBaseUrl.INTERNAL_HOST), oldHostValue);
 
           usersDotProperties.save();
         }
@@ -240,7 +240,7 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
     addGuestClaimsProfileAttributes(json);
 
     if (json.containsKey(oldHostName)) {
-      json.put(System.getProperty(SystemBaseUrl.EXTERNAL_HOST), json.remove(oldHostName));
+      json.put(System.getProperty(SystemBaseUrl.INTERNAL_HOST), json.remove(oldHostName));
     }
 
     for (Map.Entry<String, Object> entry : json.entrySet()) {
@@ -291,7 +291,7 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
       if (val.contains(DEFAULT_LOCALHOST_DN)) {
         map.put(
             entry.getKey(),
-            val.replace(DEFAULT_LOCALHOST_DN, System.getProperty(SystemBaseUrl.EXTERNAL_HOST)));
+            val.replace(DEFAULT_LOCALHOST_DN, System.getProperty(SystemBaseUrl.INTERNAL_HOST)));
       }
     }
     return map;

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
@@ -64,6 +64,12 @@ public class SystemPropertiesAdminTest {
     expectedSystemPropertiesCount++;
     System.setProperty(SystemBaseUrl.EXTERNAL_HTTPS_PORT, "8901");
     expectedSystemPropertiesCount++;
+    System.setProperty(SystemBaseUrl.INTERNAL_HOST, "internal_host");
+    expectedSystemPropertiesCount++;
+    System.setProperty(SystemBaseUrl.INTERNAL_HTTP_PORT, "5567");
+    expectedSystemPropertiesCount++;
+    System.setProperty(SystemBaseUrl.INTERNAL_HTTPS_PORT, "9901");
+    expectedSystemPropertiesCount++;
     System.setProperty(SystemInfo.ORGANIZATION, "org");
     expectedSystemPropertiesCount++;
     System.setProperty(SystemInfo.SITE_CONTACT, "contact");
@@ -90,6 +96,9 @@ public class SystemPropertiesAdminTest {
     assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HOST), equalTo("host"));
     assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HTTP_PORT), equalTo("4567"));
     assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HTTPS_PORT), equalTo("8901"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HOST), equalTo("internal_host"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HTTP_PORT), equalTo("5567"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HTTPS_PORT), equalTo("9901"));
     assertThat(getDetailsValue(details, SystemInfo.ORGANIZATION), equalTo("org"));
     assertThat(getDetailsValue(details, SystemInfo.SITE_CONTACT), equalTo("contact"));
     assertThat(getDetailsValue(details, SystemInfo.SITE_NAME), equalTo("site"));
@@ -106,6 +115,9 @@ public class SystemPropertiesAdminTest {
     assertThat(SystemBaseUrl.EXTERNAL.getPort(), equalTo("1234"));
     assertThat(SystemBaseUrl.EXTERNAL.getHttpPort(), equalTo("4567"));
     assertThat(SystemBaseUrl.EXTERNAL.getHttpsPort(), equalTo("8901"));
+    assertThat(SystemBaseUrl.INTERNAL.getHost(), equalTo("internal_host"));
+    assertThat(SystemBaseUrl.INTERNAL.getHttpPort(), equalTo("5567"));
+    assertThat(SystemBaseUrl.INTERNAL.getHttpsPort(), equalTo("9901"));
     assertThat(SystemBaseUrl.EXTERNAL.getProtocol(), equalTo("https://"));
     assertThat(SystemInfo.getOrganization(), equalTo("org"));
     assertThat(SystemInfo.getSiteContatct(), equalTo("contact"));
@@ -146,6 +158,9 @@ public class SystemPropertiesAdminTest {
     assertThat(SystemBaseUrl.EXTERNAL.getPort(), equalTo("8901"));
     assertThat(SystemBaseUrl.EXTERNAL.getHttpPort(), equalTo("4567"));
     assertThat(SystemBaseUrl.EXTERNAL.getHttpsPort(), equalTo("8901"));
+    assertThat(SystemBaseUrl.INTERNAL.getHost(), equalTo("internal_host"));
+    assertThat(SystemBaseUrl.INTERNAL.getHttpPort(), equalTo("5567"));
+    assertThat(SystemBaseUrl.INTERNAL.getHttpsPort(), equalTo("9901"));
     assertThat(SystemBaseUrl.EXTERNAL.getProtocol(), equalTo("https://"));
     assertThat(SystemInfo.getOrganization(), equalTo("org"));
     assertThat(SystemInfo.getSiteContatct(), equalTo("contact"));

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
@@ -131,7 +131,7 @@ public class SystemPropertiesAdminTest {
 
     Properties userProps = new Properties();
     userProps.put("admin", "admin,group,somethingelse");
-    userProps.put("host", "host,group,somethingelse");
+    userProps.put("internal_host", "host,group,somethingelse");
     try (FileOutputStream outProps = new FileOutputStream(userPropsFile)) {
       userProps.store(outProps, null);
     }
@@ -142,7 +142,7 @@ public class SystemPropertiesAdminTest {
               + "    \"admin\" : {\n"
               + "\n"
               + "    },\n"
-              + "    \"host\" : {\n"
+              + "    \"internal_host\" : {\n"
               + "\n"
               + "    }\n"
               + "}";
@@ -151,14 +151,14 @@ public class SystemPropertiesAdminTest {
 
     SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
     Map<String, String> map = new HashMap<>();
-    map.put(SystemBaseUrl.EXTERNAL_HOST, "newhost");
+    map.put(SystemBaseUrl.INTERNAL_HOST, "newhost");
     spa.writeSystemProperties(map);
     List<SystemPropertyDetails> details = spa.readSystemProperties();
-    assertThat(SystemBaseUrl.EXTERNAL.getHost(), equalTo("newhost"));
+    assertThat(SystemBaseUrl.EXTERNAL.getHost(), equalTo("host"));
     assertThat(SystemBaseUrl.EXTERNAL.getPort(), equalTo("8901"));
     assertThat(SystemBaseUrl.EXTERNAL.getHttpPort(), equalTo("4567"));
     assertThat(SystemBaseUrl.EXTERNAL.getHttpsPort(), equalTo("8901"));
-    assertThat(SystemBaseUrl.INTERNAL.getHost(), equalTo("internal_host"));
+    assertThat(SystemBaseUrl.INTERNAL.getHost(), equalTo("newhost"));
     assertThat(SystemBaseUrl.INTERNAL.getHttpPort(), equalTo("5567"));
     assertThat(SystemBaseUrl.INTERNAL.getHttpsPort(), equalTo("9901"));
     assertThat(SystemBaseUrl.EXTERNAL.getProtocol(), equalTo("https://"));
@@ -174,7 +174,7 @@ public class SystemPropertiesAdminTest {
     try (FileReader sysPropsReader = new FileReader(systemPropsFile)) {
       sysProps.load(sysPropsReader);
       assertThat(sysProps.size(), is(2));
-      assertThat(sysProps.getProperty(SystemBaseUrl.EXTERNAL_HOST), equalTo("newhost"));
+      assertThat(sysProps.getProperty(SystemBaseUrl.INTERNAL_HOST), equalTo("newhost"));
     }
 
     userProps = new Properties();
@@ -184,7 +184,7 @@ public class SystemPropertiesAdminTest {
       assertThat(userProps.getProperty("newhost"), equalTo("host,group,somethingelse"));
     }
 
-    map.put(SystemBaseUrl.EXTERNAL_HOST, "anotherhost");
+    map.put(SystemBaseUrl.INTERNAL_HOST, "anotherhost");
     spa.writeSystemProperties(map);
     userProps = new Properties();
     try (FileReader userPropsReader = new FileReader(userPropsFile)) {

--- a/ui/packages/ui/src/main/webapp/js/models/installer/Configuration.js
+++ b/ui/packages/ui/src/main/webapp/js/models/installer/Configuration.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-/*global define, location*/
+/*global define*/
 /** Main view page for add. */
 define([
     'backbone',
@@ -78,12 +78,6 @@ define([
             this.models.forEach(function(model){
                 propertiesMap[model.get('key')] = model.get('value');
             });
-
-            var devMode = location.search.indexOf('dev=true') > -1 ? true : false;
-            if (devMode) {
-                var hostname = propertiesMap['org.codice.ddf.external.hostname'];
-                propertiesMap['org.codice.ddf.system.hostname'] = hostname;
-            }
 
             data.arguments = [propertiesMap];
             data = JSON.stringify(data);

--- a/ui/packages/ui/src/main/webapp/js/views/installer/Configuration.view.js
+++ b/ui/packages/ui/src/main/webapp/js/views/installer/Configuration.view.js
@@ -111,13 +111,13 @@ define([
             this.model.each(function (model) {
                 hasErrors = hasErrors || model.validationError;
 
-                if (model.get('title') === 'Host') {
+                if (model.get('title') === 'Internal Host') {
                     hostName = model.get('value');
                     layout.certificateModel.set('hostName', hostName);
                     if (model.get('value') === model.get('defaultValue')) {
                         hostChange = false;
                     }
-                } else if (model.get('title') === 'HTTPS Port') {
+                } else if (model.get('title') === 'Internal HTTPS Port') {
                     port = model.get('value');
                 }
             });

--- a/ui/packages/ui/src/main/webapp/less/installer/style.less
+++ b/ui/packages/ui/src/main/webapp/less/installer/style.less
@@ -278,7 +278,7 @@ center {
         width: 100%;
     }
     .property-label {
-        min-width:170px;
+        min-width:190px;
         text-align:left;
         position: relative;
         a {


### PR DESCRIPTION
#### What does this PR do?
Adds internal hostname and port to the installer and reverts https://github.com/codice/ddf/pull/3841. 
Updates less because the titles are slightly longer. 
Should the behavior for ?dev=true remain the same?

#### Who is reviewing it? 
@mcalcote @oconnormi @austinsteffes 

#### Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann
@clockard

#### How should this be tested?
Walk through the installer and make sure that updating the external and internal ports takes effect. 
Verify you can still log in after using ?dev=true

#### What are the relevant tickets?
[DDF-4350 Installer doesn't allow users to input internal/system hostname and port](https://codice.atlassian.net/browse/DDF-4350)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
