### PR TITLE
DDF-4351 Made visualization placement indicator visible again

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/router/router.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/router/router.less
@@ -10,6 +10,8 @@ html.open-lightbox {
 
 #router {
   .customElement;
+  position: relative;
+  z-index: 0;
 }
 
 body.has-header #router,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -953,7 +953,7 @@ alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
 
-amdefine@1.0.1, amdefine@>=0.0.4:
+amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 


### PR DESCRIPTION
#### What does this PR do?
Makes the indicator for visual placement visible again on the UI
#### Who is reviewing it? 
@Bdthomson @andrewzimmer 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?
- Drag visuals around as in the video below and ensure you can see an indicator 
![ddf-4351](https://user-images.githubusercontent.com/39737329/48871732-2e7a0180-eda3-11e8-81f6-e0584585c39e.gif)
#### Any background context you want to provide?
#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
