### PR TITLE
DDF-4300 UI fix for advanced queries when anyText input is blank

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -157,7 +157,7 @@ module.exports = Marionette.LayoutView.extend({
     this.deleteInvalidFilters()
     var filter = this.getFilters()
     if (filter.filters.length === 0) {
-      return '("anyText" ILIKE \'*\')'
+      return '("anyText" ILIKE \'%\')'
     } else {
       return CQLUtils.transformFilterToCQL(filter)
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -124,7 +124,7 @@ module.exports = Marionette.LayoutView.extend({
         model: this.model,
         isForm: false,
         isFormBuilder: false,
-        isAdd: true
+        isAdd: true,
       })
     )
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -124,6 +124,7 @@ module.exports = Marionette.LayoutView.extend({
         model: this.model,
         isForm: false,
         isFormBuilder: false,
+        isAdd: true
       })
     )
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -69,7 +69,7 @@ module.exports = Marionette.LayoutView.extend({
         cql.simplify(JSON.parse(this.model.get('filterTree')))
       )
     } else if (this.options.isAdd) {
-      this.queryAdvanced.currentView.deserialize(cql.read("anyText ILIKE '%'"));
+      this.queryAdvanced.currentView.deserialize(cql.read("anyText ILIKE '%'"))
     } else if (this.model.get('cql')) {
       this.queryAdvanced.currentView.deserialize(
         cql.simplify(cql.read(this.model.get('cql')))

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -68,6 +68,8 @@ module.exports = Marionette.LayoutView.extend({
       this.queryAdvanced.currentView.deserialize(
         cql.simplify(JSON.parse(this.model.get('filterTree')))
       )
+    } else if (this.options.isAdd) {
+      this.queryAdvanced.currentView.deserialize(cql.read("anyText ILIKE '%'"));
     } else if (this.model.get('cql')) {
       this.queryAdvanced.currentView.deserialize(
         cql.simplify(cql.read(this.model.get('cql')))


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #4006 
____
-->

#### What does this PR do?

Forward ports #4006 

Applies UI fixes to Intrigue for handling anyText queries made with the different search forms to support legacy sources. Changes the default text input in basic and simple search forms to be blank. Changes the default `anyText` input in advanced forms to be `*`. For all three forms, the default query will be `anyText is like %`. Adding temporal/spatial criteria in basic forms will result in not defaulting to adding an `anyText is like %` filter in the query.

#### Who is reviewing it? 

@peterhuffer @pvargas @kcover @emmberk

<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 

@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@clockard

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

- Open Intrigue and start a search with an advanced form
  - Verify that there is a `*` value pre-filled in the `anyText` input
  - Click `Search` and verify that the resulting query is `anyText is like %`
  - Edit the search and clear the `anyText` input
  - Click `Search` and verify that the resulting query is `anyText is like ''`
- Start a search with a basic form
  - Verify that the text input box is blank
  - Click `Search` and verify that the resulting query is `anyText is like %`
  - Edit the search and verify that the text input box is still blank
- Start a search with a simple form
  - Verify that the text input box is blank
  - Click `Search` and verify that the resulting query is `anyText is like %`
  - Edit the search and verify that the text input box contains `*`

#### What are the relevant tickets?
[DDF-4300](https://codice.atlassian.net/browse/DDF-4300)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
