### PR TITLE
DDF-4357 Select the first item in menus when opened

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -21,20 +21,17 @@ class Menu extends React.Component {
   constructor(props) {
     super(props)
     const children = React.Children.toArray(props.children)
-    this.state = { active: this.chooseActive(children) || undefined }
+    this.state = { active: this.chooseActive(children) }
     this.onKeyDown = this.onKeyDown.bind(this)
   }
-  chooseActive(children) {
-    if (
-      (typeof this.state === 'undefined' ||
-        typeof this.state.active === 'undefined') &&
-      children.length > 0
-    ) {
+  chooseActive(children, active) {
+    const found = children.some(child => child.props.value === active)
+    if (found) {
+      return active
+    } else if (children.length > 0) {
       return children[0].props.value
-    } else if (children.length === 0) {
-      return null
     } else {
-      return this.state.active
+      return undefined
     }
   }
   onHover(active) {
@@ -78,7 +75,7 @@ class Menu extends React.Component {
   componentDidUpdate(previousProps) {
     if (previousProps.children !== this.props.children) {
       this.setState({
-        active: this.chooseActive(this.props.children) || undefined,
+        active: this.chooseActive(this.props.children, this.state.active),
       })
     }
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -67,6 +67,12 @@ class Menu extends React.Component {
   render() {
     const { value, children } = this.props
 
+    if (typeof this.state.active === 'undefined' && children.length > 0) {
+      this.state.active = children[0].props.value
+    } else if (children.length === 0) {
+      this.state.active = undefined
+    }
+
     const childrenWithProps = React.Children.map(children, (child, i) => {
       return React.cloneElement(child, {
         selected: value === child.props.value,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -25,7 +25,11 @@ class Menu extends React.Component {
     this.onKeyDown = this.onKeyDown.bind(this)
   }
   chooseActive(children) {
-    if ((typeof this.state === 'undefined' || typeof this.state.active === 'undefined') && children.length > 0) {
+    if (
+      (typeof this.state === 'undefined' ||
+        typeof this.state.active === 'undefined') &&
+      children.length > 0
+    ) {
       return children[0].props.value
     } else if (children.length === 0) {
       return null
@@ -73,7 +77,9 @@ class Menu extends React.Component {
   }
   componentDidUpdate(previousProps) {
     if (previousProps.children !== this.props.children) {
-      this.setState({ active: this.chooseActive(this.props.children) || undefined })
+      this.setState({
+        active: this.chooseActive(this.props.children) || undefined,
+      })
     }
   }
   render() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -21,10 +21,17 @@ class Menu extends React.Component {
   constructor(props) {
     super(props)
     const children = React.Children.toArray(props.children)
-    this.state = {
-      active: children.length > 0 ? children[0].props.value : undefined,
-    }
+    this.state = { active: this.chooseActive(children) || undefined }
     this.onKeyDown = this.onKeyDown.bind(this)
+  }
+  chooseActive(children) {
+    if ((typeof this.state === 'undefined' || typeof this.state.active === 'undefined') && children.length > 0) {
+      return children[0].props.value
+    } else if (children.length === 0) {
+      return null
+    } else {
+      return this.state.active
+    }
   }
   onHover(active) {
     this.setState({ active })
@@ -65,13 +72,8 @@ class Menu extends React.Component {
     }
   }
   componentDidUpdate(previousProps) {
-    const { children } = this.props
-    if (previousProps.children !== children) {
-      if (typeof this.state.active === 'undefined' && children.length > 0) {
-        this.setState({ active: children[0].props.value })
-      } else if (children.length === 0) {
-        this.setState({ active: undefined })
-      }
+    if (previousProps.children !== this.props.children) {
+      this.setState({ active: this.chooseActive(this.props.children) || undefined })
     }
   }
   render() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -64,14 +64,18 @@ class Menu extends React.Component {
         break
     }
   }
+  componentDidUpdate(previousProps) {
+    const { children } = this.props
+    if (previousProps.children !== children) {
+      if (typeof this.state.active === 'undefined' && children.length > 0) {
+        this.setState({ active: children[0].props.value })
+      } else if (children.length === 0) {
+        this.setState({ active: undefined })
+      }
+    }
+  }
   render() {
     const { value, children } = this.props
-
-    if (typeof this.state.active === 'undefined' && children.length > 0) {
-      this.state.active = children[0].props.value
-    } else if (children.length === 0) {
-      this.state.active = undefined
-    }
 
     const childrenWithProps = React.Children.map(children, (child, i) => {
       return React.cloneElement(child, {


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
This changes menu behavior to select the first item in the menu by default.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@Lambeaux 
@BernardIgiri  
#### Select relevant component teams: 
@codice/ui
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@djblue 
#### How should this be tested?
* Build and install.
* Open a workspace.
* Open the Gazetteer search box atop a map and type in two or more characters. The characters must result in one or more suggestions. Check that the first item in the list of suggestions that appears is highlighted.
* Hit Enter. The Gazetteer search suggestions dropdown should close and the first suggestion should now appear in the search box. The map should pan and zoom to the location of the selected Gazetteer geography.
* Change the characters inserted to generate new suggestions and hit Enter again. Ensure that the map now closes the search bar with your new first suggestion and pans and zooms to the new location.
* Ensure that hovering over menu items still highlights them. Ensure that clicking menu items causes the same menu close followed by panning and zooming.
* Ensure that when new suggestions appear, hitting the down arrow key causes the next item down the list to be selected. Ensure that hitting Enter on other items besides the first inserts the selected suggestion and pans and zooms to the selected location.
* Ensure that the same functionality occurs on the units dropdown menu. This can be found by opening a search editor in the Basic search form, selecting "Somewhere Specific" under "Located", and selecting "Point-Radius" under "Location". The "Radius" field has the dropdown.

However, this change does more than just allow the user to enter the first suggestion with the Enter key in the Gazetteer search box; it actually changes menu behavior to select the first option when any menu is opened. This may be intuitive behavior, but be aware that this change is further reaching than the ticket demands.

Alternatively, the menu could have a new property to allow only the Gazetteer suggestion menu to select the first suggestion.
#### What are the relevant tickets?
[DDF-4357](https://codice.atlassian.net/browse/DDF-4357)
#### Screenshots
Note that the menu is opened by clicking the blue box with the white triangle while other selections displayed in this GIF are being made my hitting Enter when an option is highlighted.
![select first menu](https://user-images.githubusercontent.com/1525813/49117298-6c709d00-f25d-11e8-8b81-415b509a659f.gif)

#### Checklist:
- [ ] Documentation Updated
- _*N/A*_ Update / Add Unit Tests
- _*N/A*_ Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
