### PR TITLE
DDF-4363 Allow admins to expose capabilities of sources through a new configuration

### DIFF
--- a/catalog/admin/catalog-admin-poller-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/admin/catalog-admin-poller-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -49,6 +49,7 @@
             <list>
                 <value>ddf.services.schematron.SchematronValidationService</value>
                 <value>ddf.catalog.impl.action.SourceActionProviderImpl</value>
+                <value>ddf.catalog.impl.capability.SourceCapabilityProviderImpl</value>
             </list>
         </property>
     </bean>

--- a/catalog/admin/catalog-admin-poller-service/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/admin/catalog-admin-poller-service/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -33,7 +33,7 @@
             will not be listed as a configurable source type in the Sources tab of the Admin UI. The pattern
             can be an exact, case-sensitive match, or '*' can be used as a wildcard.
             Ex: '*source*' will match anything containing 'source'."
-            type="String" default="ddf.services.schematron.SchematronValidationServicer,ddf.catalog.impl.action.SourceActionProviderImpl" cardinality="100"/>
+            type="String" default="ddf.services.schematron.SchematronValidationServicer,ddf.catalog.impl.action.SourceActionProviderImpl,ddf.catalog.impl.capability.SourceCapabilityProviderImpl" cardinality="100"/>
 
     </OCD>
 

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/source/impl/SourceCapabilityRegistryImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/source/impl/SourceCapabilityRegistryImpl.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.source.impl;
+
+import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceCapabilityProvider;
+import ddf.catalog.source.SourceCapabilityRegistry;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SourceCapabilityRegistryImpl implements SourceCapabilityRegistry {
+
+  private List<SourceCapabilityProvider> sourceCapabilityProviders;
+
+  public SourceCapabilityRegistryImpl(List<SourceCapabilityProvider> sourceCapabilityProviders) {
+    this.sourceCapabilityProviders = sourceCapabilityProviders;
+  }
+
+  public SourceCapabilityRegistryImpl() {
+    this.sourceCapabilityProviders = new LinkedList<>();
+  }
+
+  @Override
+  public List<String> list(Source source) {
+    return sourceCapabilityProviders
+        .stream()
+        .flatMap(
+            sourceCapabilityProvider ->
+                sourceCapabilityProvider.getSourceCapabilities(source).stream())
+        .collect(Collectors.toList());
+  }
+
+  public void addCapabilityProvider(SourceCapabilityProvider sourceCapabilityProvider) {
+    sourceCapabilityProviders.add(sourceCapabilityProvider);
+  }
+
+  public void removeCapabilityProvider(SourceCapabilityProvider sourceCapabilityProvider) {
+    sourceCapabilityProviders.removeIf(
+        capabilityProvider -> capabilityProvider.getId().equals(sourceCapabilityProvider.getId()));
+  }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/source/impl/SourceDescriptorImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/source/impl/SourceDescriptorImpl.java
@@ -36,6 +36,8 @@ public class SourceDescriptorImpl extends DescribableImpl implements SourceDescr
 
   private List<Action> actions;
 
+  private List<String> capabilities;
+
   /**
    * Instantiates a new SourceDescriptorImpl.
    *
@@ -58,6 +60,24 @@ public class SourceDescriptorImpl extends DescribableImpl implements SourceDescr
       String sourceId, Set<ContentType> catalogedTypes, List<Action> actions) {
     this(sourceId, catalogedTypes);
     this.actions = actions;
+  }
+
+  /**
+   * Instantiates a new SourceDescriptorImpl.
+   *
+   * @param sourceId the source's id
+   * @param catalogedTypes the cataloged types
+   * @param actions list of actions
+   * @param capabilities list of capabilities
+   */
+  public SourceDescriptorImpl(
+      String sourceId,
+      Set<ContentType> catalogedTypes,
+      List<Action> actions,
+      List<String> capabilities) {
+    this(sourceId, catalogedTypes);
+    this.actions = actions;
+    this.capabilities = capabilities;
   }
 
   @Override
@@ -113,6 +133,14 @@ public class SourceDescriptorImpl extends DescribableImpl implements SourceDescr
       return SourceDescriptor.super.getActions();
     }
     return actions;
+  }
+
+  @Override
+  public List<String> getCapabilities() {
+    if (capabilities == null) {
+      return SourceDescriptor.super.getCapabilities();
+    }
+    return capabilities;
   }
 
   /**

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/operation/SourceInfoResponseImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/operation/SourceInfoResponseImplTest.java
@@ -38,9 +38,12 @@ public class SourceInfoResponseImplTest {
 
   @Before
   public void setup() {
-    firstSource = new SourceDescriptorImpl("aSource", null, Collections.emptyList());
-    nextSource = new SourceDescriptorImpl("BSource", null, Collections.emptyList());
-    lastSource = new SourceDescriptorImpl("cSource", null, Collections.emptyList());
+    firstSource =
+        new SourceDescriptorImpl("aSource", null, Collections.emptyList(), Collections.emptyList());
+    nextSource =
+        new SourceDescriptorImpl("BSource", null, Collections.emptyList(), Collections.emptyList());
+    lastSource =
+        new SourceDescriptorImpl("cSource", null, Collections.emptyList(), Collections.emptyList());
 
     sourceDescriptors = new TreeSet<SourceDescriptor>(new SourceDescriptorComparator());
     sourceDescriptors.add(lastSource);
@@ -62,7 +65,8 @@ public class SourceInfoResponseImplTest {
 
   @Test
   public void testSourceInfoResponseNullSourceId() {
-    SourceDescriptor desc = new SourceDescriptorImpl(null, null, Collections.emptyList());
+    SourceDescriptor desc =
+        new SourceDescriptorImpl(null, null, Collections.emptyList(), Collections.emptyList());
     sourceDescriptors.add(desc);
 
     SourceDescriptor[] expectedDescriptorArr =

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/source/impl/SourceDescriptorImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/source/impl/SourceDescriptorImplTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 
 import ddf.action.Action;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 
 public class SourceDescriptorImplTest {
@@ -27,7 +28,16 @@ public class SourceDescriptorImplTest {
   public void testGetActions() {
     Action action = mock(Action.class);
     SourceDescriptorImpl sourceDescriptor =
-        new SourceDescriptorImpl("", Collections.emptySet(), Collections.singletonList(action));
+        new SourceDescriptorImpl(
+            "", Collections.emptySet(), Collections.singletonList(action), Collections.emptyList());
     assertThat(sourceDescriptor.getActions(), is(Collections.singletonList(action)));
+  }
+
+  @Test
+  public void testGetCapabilities() {
+    List<String> capabilities = Collections.singletonList("capability");
+    SourceDescriptorImpl sourceDescriptor =
+        new SourceDescriptorImpl("", Collections.emptySet(), Collections.emptyList(), capabilities);
+    assertThat(sourceDescriptor.getCapabilities(), is(capabilities));
   }
 }

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/util/impl/SourceDescriptorComparatorTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/util/impl/SourceDescriptorComparatorTest.java
@@ -32,10 +32,14 @@ public class SourceDescriptorComparatorTest {
 
   @Before
   public void setup() throws Exception {
-    firstSource = new SourceDescriptorImpl("aSource", null, Collections.emptyList());
-    nextSource = new SourceDescriptorImpl("bSource", null, Collections.emptyList());
-    lastSource = new SourceDescriptorImpl("cSource", null, Collections.emptyList());
-    nullSource = new SourceDescriptorImpl(null, null, Collections.emptyList());
+    firstSource =
+        new SourceDescriptorImpl("aSource", null, Collections.emptyList(), Collections.emptyList());
+    nextSource =
+        new SourceDescriptorImpl("bSource", null, Collections.emptyList(), Collections.emptyList());
+    lastSource =
+        new SourceDescriptorImpl("cSource", null, Collections.emptyList(), Collections.emptyList());
+    nullSource =
+        new SourceDescriptorImpl(null, null, Collections.emptyList(), Collections.emptyList());
   }
 
   @Test

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceCapabilityProvider.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceCapabilityProvider.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.source;
+
+import java.util.List;
+
+/**
+ * This class provides capabilities for a given source.
+ *
+ * @see SourceCapabilityRegistry
+ */
+public interface SourceCapabilityProvider {
+
+  /**
+   * @param source - the {@link Source} for which the {@link SourceCapabilityProvider} is requested
+   *     to provide a list of strings representing capabilities
+   * @return a {@link List<String>} of capabilities. If there are no capabilities associated with
+   *     the source, then an empty List shall be returned
+   */
+  public List<String> getSourceCapabilities(Source source);
+
+  /**
+   * @return a unique identifier to distinguish the type of service this {@link
+   *     SourceCapabilityProvider} provides
+   */
+  public String getId();
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceCapabilityRegistry.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceCapabilityRegistry.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.source;
+
+import java.util.List;
+
+/** This class is used to find all capabilities that correspond to a certain source. */
+public interface SourceCapabilityRegistry {
+
+  /**
+   * Used to retrieve all capabilities that can be applied to a given {@link Source}.
+   *
+   * @param source - the {@link Source} in which a capability is accociated
+   * @return {@link List<String>} containing capabilities that can be applied from the given source,
+   *     otherwise an empty list if no capabilities can be applied.
+   */
+  public List<String> list(Source source);
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceDescriptor.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/source/SourceDescriptor.java
@@ -61,4 +61,13 @@ public interface SourceDescriptor extends Describable {
   default List<Action> getActions() {
     return Collections.emptyList();
   }
+
+  /**
+   * Get the list of capabilities associated with the {@link Source}.
+   *
+   * @return list of String
+   */
+  default List<String> getCapabilities() {
+    return Collections.emptyList();
+  }
 }

--- a/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
+++ b/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
@@ -62,6 +62,7 @@ import ddf.catalog.plugin.PreFederatedQueryPlugin;
 import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceCapabilityRegistry;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.util.impl.SourcePoller;
@@ -112,12 +113,17 @@ public class FederationStrategyTest {
 
   private ActionRegistry sourceActionRegistry;
 
+  private SourceCapabilityRegistry sourceCapabilityRegistry;
+
   @Rule public PowerMockRule rule = new PowerMockRule();
 
   @Before
   public void setup() throws Exception {
     sourceActionRegistry = mock(ActionRegistry.class);
     when(sourceActionRegistry.list(any())).thenReturn(Collections.emptyList());
+
+    sourceCapabilityRegistry = mock(SourceCapabilityRegistry.class);
+    when(sourceCapabilityRegistry.list(any())).thenReturn(Collections.emptyList());
 
     mockQuery = mock(Query.class);
     when(mockQuery.getTimeoutMillis()).thenReturn(LONG_TIMEOUT);
@@ -169,7 +175,8 @@ public class FederationStrategyTest {
     Historian historian = new Historian();
     historian.setHistoryEnabled(false);
 
-    SourceOperations sourceOperations = new SourceOperations(props, sourceActionRegistry);
+    SourceOperations sourceOperations =
+        new SourceOperations(props, sourceActionRegistry, sourceCapabilityRegistry);
 
     QueryOperations queryOperations =
         new QueryOperations(props, sourceOperations, opsSecurity, opsMetacard);

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -406,6 +406,7 @@
                             ddf.catalog.history,
                             ddf.catalog.impl.operations,
                             ddf.catalog.impl.action,
+                            ddf.catalog.impl.capability,
                             ddf.catalog.operation.impl,
                             ddf.catalog.resource.actions,
                             ddf.catalog.resource.download,

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/capability/SourceCapabilityProviderImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/capability/SourceCapabilityProviderImpl.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.impl.capability;
+
+import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceCapabilityProvider;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SourceCapabilityProviderImpl implements SourceCapabilityProvider {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SourceCapabilityProviderImpl.class);
+
+  private String capabilityProviderId;
+
+  private List<String> capabilities;
+
+  private String sourceId;
+
+  public SourceCapabilityProviderImpl(String capabilityProviderId) {
+    this.capabilityProviderId = capabilityProviderId;
+  }
+
+  @Override
+  public List<String> getSourceCapabilities(Source source) {
+    if (source.getId().equals(sourceId)) {
+      return capabilities;
+    }
+
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String getId() {
+    return capabilityProviderId;
+  }
+
+  public void setSourceId(String sourceId) {
+    this.sourceId = sourceId;
+  }
+
+  public void setCapabilities(List<String> capabilities) {
+    this.capabilities = capabilities;
+  }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -103,4 +103,16 @@
         </cm:managed-component>
     </cm:managed-service-factory>
 
+    <cm:managed-service-factory id="ddf.catalog.impl.capability.SourceCapabilityProviderImpl"
+                                factory-pid="ddf.catalog.impl.capability.SourceCapabilityProviderImpl" interface="ddf.catalog.source.SourceCapabilityProvider">
+        <service-properties>
+            <entry key="id" value="catalog.data.source.simple"/>
+        </service-properties>
+        <cm:managed-component class="ddf.catalog.impl.capability.SourceCapabilityProviderImpl">
+            <argument value="catalog.data.source.simple"/>
+            <cm:managed-properties persistent-id=""
+                                   update-strategy="container-managed" />
+        </cm:managed-component>
+    </cm:managed-service-factory>
+
 </blueprint>

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/delegate-operators.xml
@@ -53,6 +53,12 @@
         <property name="historian" ref="historian"/>
     </bean>
 
+    <reference-list id="sourceCapabilityProviders" interface="ddf.catalog.source.SourceCapabilityProvider"
+                    filter="(id=catalog.data.source.*)" availability="optional" member-type="service-object">
+        <reference-listener bind-method="addCapabilityProvider"
+                            unbind-method="removeCapabilityProvider" ref="sourceCapabilityRegistry"/>
+    </reference-list>
+
     <reference-list id="sourceActionProviders" interface="ddf.action.ActionProvider"
                     filter="(id=catalog.data.source.*)" availability="optional" member-type="service-object">
         <reference-listener bind-method="addActionProvider"
@@ -67,9 +73,12 @@
 
     <bean id="sourceActionRegistry" class="ddf.action.impl.ActionRegistryImpl"/>
 
+    <bean id="sourceCapabilityRegistry" class="ddf.catalog.source.impl.SourceCapabilityRegistryImpl"/>
+
     <bean id="cfSourceOps" class="ddf.catalog.impl.operations.SourceOperations">
         <argument ref="frameworkProperties"/>
         <argument ref="sourceActionRegistry"/>
+        <argument ref="sourceCapabilityRegistry"/>
     </bean>
 
     <bean id="cfQueryOps" class="ddf.catalog.impl.operations.QueryOperations">

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -61,8 +61,17 @@
         <AD name="URL" id="url" type="String"/>
     </OCD>
 
+    <OCD name="Source Capabilities" id="ddf.catalog.impl.capability.SourceCapabilityProviderImpl">
+        <AD name="Source ID" id="sourceId" type="String"/>
+        <AD name="Capabilities" id="capabilities" type="String" cardinality="100"/>
+    </OCD>
+
     <Designate pid="ddf.catalog.impl.action.SourceActionProviderImpl">
         <Object ocdref="ddf.catalog.impl.action.SourceActionProviderImpl"/>
+    </Designate>
+
+    <Designate pid="ddf.catalog.impl.capability.SourceCapabilityProviderImpl">
+        <Object ocdref="ddf.catalog.impl.capability.SourceCapabilityProviderImpl"/>
     </Designate>
 
     <Designate

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/SourceOperationsSpec.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/SourceOperationsSpec.groovy
@@ -22,6 +22,7 @@ import ddf.catalog.source.CatalogProvider
 import ddf.catalog.source.FederatedSource
 import ddf.catalog.source.Source
 import ddf.catalog.source.SourceUnavailableException
+import ddf.catalog.source.SourceCapabilityRegistry
 import ddf.catalog.util.impl.CachedSource
 import ddf.catalog.util.impl.SourcePoller
 import ddf.catalog.util.impl.SourcePollerRunner
@@ -76,7 +77,7 @@ class SourceOperationsSpec extends Specification {
             federatedSources = fedSources
             sourcePoller = this.sourcePoller
         }
-        sourceOperations = new SourceOperations(frameworkProperties, Mock(ActionRegistry))
+        sourceOperations = new SourceOperations(frameworkProperties, Mock(ActionRegistry), Mock(SourceCapabilityRegistry))
         sourceOperations.setId(SOURCE_ID)
         sourceOperations.bind(catalogProviders.get(0))
     }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkImplTest.java
@@ -130,6 +130,7 @@ import ddf.catalog.source.CatalogStore;
 import ddf.catalog.source.FederatedSource;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceCapabilityRegistry;
 import ddf.catalog.source.SourceDescriptor;
 import ddf.catalog.source.SourceMonitor;
 import ddf.catalog.source.SourceUnavailableException;
@@ -234,6 +235,8 @@ public class CatalogFrameworkImplTest {
   RemoteDeleteOperations mockRemoteDeleteOperations;
 
   private ActionRegistry sourceActionRegistry;
+
+  private SourceCapabilityRegistry sourceCapabilityRegistry;
 
   UuidGenerator uuidGenerator;
 
@@ -400,13 +403,16 @@ public class CatalogFrameworkImplTest {
     sourceActionRegistry = mock(ActionRegistry.class);
     when(sourceActionRegistry.list(any())).thenReturn(Collections.emptyList());
 
+    sourceCapabilityRegistry = mock(SourceCapabilityRegistry.class);
+    when(sourceCapabilityRegistry.list(any())).thenReturn(Collections.emptyList());
+
     OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
     MetacardFactory metacardFactory =
         new MetacardFactory(mimeTypeToTransformerMapper, uuidGenerator);
     OperationsMetacardSupport opsMetacard =
         new OperationsMetacardSupport(frameworkProperties, metacardFactory);
     SourceOperations sourceOperations =
-        new SourceOperations(frameworkProperties, sourceActionRegistry);
+        new SourceOperations(frameworkProperties, sourceActionRegistry, sourceCapabilityRegistry);
     TransformOperations transformOperations = new TransformOperations(frameworkProperties);
     Historian historian = new Historian();
     historian.setHistoryEnabled(false);
@@ -1399,7 +1405,7 @@ public class CatalogFrameworkImplTest {
     OperationsMetacardSupport opsMetacard =
         new OperationsMetacardSupport(frameworkProperties, metacardFactory);
     SourceOperations sourceOperations =
-        new SourceOperations(frameworkProperties, sourceActionRegistry);
+        new SourceOperations(frameworkProperties, sourceActionRegistry, sourceCapabilityRegistry);
     QueryOperations queryOperations =
         new QueryOperations(frameworkProperties, sourceOperations, opsSecurity, opsMetacard);
     OperationsStorageSupport opsStorage =
@@ -2774,7 +2780,8 @@ public class CatalogFrameworkImplTest {
     frameworkProperties.setFederationStrategy(strategy);
     frameworkProperties.setCatalogProviders(Collections.singletonList(provider));
 
-    SourceOperations sourceOps = new SourceOperations(frameworkProperties, sourceActionRegistry);
+    SourceOperations sourceOps =
+        new SourceOperations(frameworkProperties, sourceActionRegistry, sourceCapabilityRegistry);
     QueryOperations queryOps = new QueryOperations(frameworkProperties, sourceOps, null, null);
     ResourceOperations resOps = new ResourceOperations(frameworkProperties, queryOps, null);
     resOps.setId(DDF);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkQueryTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/CatalogFrameworkQueryTest.java
@@ -50,6 +50,7 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.plugin.PostIngestPlugin;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceCapabilityRegistry;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.util.impl.CachedSource;
@@ -107,11 +108,15 @@ public class CatalogFrameworkQueryTest {
     ActionRegistry sourceActionRegistry = mock(ActionRegistry.class);
     when(sourceActionRegistry.list(any())).thenReturn(Collections.emptyList());
 
+    SourceCapabilityRegistry sourceCapabilityRegistry = mock(SourceCapabilityRegistry.class);
+    when(sourceCapabilityRegistry.list(any())).thenReturn(Collections.emptyList());
+
     OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
     MetacardFactory metacardFactory =
         new MetacardFactory(props.getMimeTypeToTransformerMapper(), uuidGenerator);
     OperationsMetacardSupport opsMetacard = new OperationsMetacardSupport(props, metacardFactory);
-    SourceOperations sourceOperations = new SourceOperations(props, sourceActionRegistry);
+    SourceOperations sourceOperations =
+        new SourceOperations(props, sourceActionRegistry, sourceCapabilityRegistry);
     QueryOperations queryOperations =
         new QueryOperations(props, sourceOperations, opsSecurity, opsMetacard);
     ResourceOperations resourceOperations =

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/FanoutCatalogFrameworkTest.java
@@ -72,6 +72,7 @@ import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.ConnectedSource;
 import ddf.catalog.source.FederatedSource;
 import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceCapabilityRegistry;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.transform.InputTransformer;
 import ddf.catalog.util.impl.SourcePoller;
@@ -106,6 +107,8 @@ public class FanoutCatalogFrameworkTest {
 
   private ActionRegistry sourceActionRegistry;
 
+  private SourceCapabilityRegistry sourceCapabilityRegistry;
+
   private UuidGenerator uuidGenerator;
 
   @Before
@@ -126,6 +129,9 @@ public class FanoutCatalogFrameworkTest {
     sourceActionRegistry = mock(ActionRegistry.class);
     when(sourceActionRegistry.list(any())).thenReturn(Collections.emptyList());
 
+    sourceCapabilityRegistry = mock(SourceCapabilityRegistry.class);
+    when(sourceCapabilityRegistry.list(any())).thenReturn(Collections.emptyList());
+
     framework = createCatalogFramework(frameworkProperties);
   }
 
@@ -136,7 +142,7 @@ public class FanoutCatalogFrameworkTest {
     OperationsMetacardSupport opsMetacard =
         new OperationsMetacardSupport(frameworkProperties, metacardFactory);
     SourceOperations sourceOperations =
-        new SourceOperations(frameworkProperties, sourceActionRegistry);
+        new SourceOperations(frameworkProperties, sourceActionRegistry, sourceCapabilityRegistry);
     TransformOperations transformOperations = new TransformOperations(frameworkProperties);
     QueryOperations queryOperations =
         new QueryOperations(frameworkProperties, sourceOperations, opsSecurity, opsMetacard);
@@ -432,7 +438,7 @@ public class FanoutCatalogFrameworkTest {
     OperationsMetacardSupport opsMetacard =
         new OperationsMetacardSupport(frameworkProperties, metacardFactory);
     SourceOperations sourceOperations =
-        new SourceOperations(frameworkProperties, sourceActionRegistry);
+        new SourceOperations(frameworkProperties, sourceActionRegistry, sourceCapabilityRegistry);
     sourceOperations.bind(catalogProvider);
     sourceOperations.bind(storageProvider);
 
@@ -497,7 +503,7 @@ public class FanoutCatalogFrameworkTest {
     OperationsMetacardSupport opsMetacard =
         new OperationsMetacardSupport(frameworkProperties, metacardFactory);
     SourceOperations sourceOperations =
-        new SourceOperations(frameworkProperties, sourceActionRegistry);
+        new SourceOperations(frameworkProperties, sourceActionRegistry, sourceCapabilityRegistry);
     sourceOperations.bind(catalogProvider);
     sourceOperations.bind(storageProvider);
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/capability/SourceCapabilityProviderImplTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/capability/SourceCapabilityProviderImplTest.java
@@ -1,0 +1,56 @@
+package ddf.catalog.impl.capability;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ddf.catalog.source.Source;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SourceCapabilityProviderImplTest {
+
+  private static final String PROVIDER_ID = "id";
+
+  private SourceCapabilityProviderImpl sourceCapabilityProvider;
+
+  @Before
+  public void setup() {
+    sourceCapabilityProvider = new SourceCapabilityProviderImpl(PROVIDER_ID);
+  }
+
+  @Test
+  public void testGetCapabilities() {
+
+    String sourceId = "ddf.distribution";
+    List<String> capabilities = Collections.singletonList("capabilty");
+
+    sourceCapabilityProvider.setCapabilities(capabilities);
+    sourceCapabilityProvider.setSourceId(sourceId);
+
+    Source source = mock(Source.class);
+    when(source.getId()).thenReturn(sourceId);
+
+    assertThat(sourceCapabilityProvider.getSourceCapabilities(source), is(capabilities));
+  }
+
+  @Test
+  public void testGetId() {
+    assertThat(sourceCapabilityProvider.getId(), is(PROVIDER_ID));
+  }
+
+  @Test
+  public void testGetCapabilitiesWithDifferentSourceId() {
+
+    sourceCapabilityProvider.setSourceId("sourceId");
+
+    Source source = mock(Source.class);
+    when(source.getId()).thenReturn("difSourceId");
+
+    assertThat(sourceCapabilityProvider.getSourceCapabilities(source), nullValue());
+  }
+}

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/impl/operations/RemoteDeleteOperationsTest.java
@@ -41,6 +41,7 @@ import ddf.catalog.source.CatalogProvider;
 import ddf.catalog.source.CatalogStore;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceCapabilityRegistry;
 import ddf.catalog.source.SourceMonitor;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
@@ -101,6 +102,8 @@ public class RemoteDeleteOperationsTest {
   List<PostResourcePlugin> mockPostResourcePlugins;
 
   private ActionRegistry mockSourceActionRegistry;
+
+  private SourceCapabilityRegistry mockSourceSourceCapabilityRegistry;
 
   UuidGenerator uuidGenerator;
 
@@ -318,6 +321,9 @@ public class RemoteDeleteOperationsTest {
 
     mockSourceActionRegistry = mock(ActionRegistry.class);
     when(mockSourceActionRegistry.list(any())).thenReturn(Collections.emptyList());
+
+    mockSourceSourceCapabilityRegistry = mock(SourceCapabilityRegistry.class);
+    when(mockSourceSourceCapabilityRegistry.list(any())).thenReturn(Collections.emptyList());
   }
 
   private void setUpDeleteRequest() {
@@ -352,7 +358,8 @@ public class RemoteDeleteOperationsTest {
 
   private void setUpDeleteOperations() {
     SourceOperations sourceOperations =
-        new SourceOperations(frameworkProperties, mockSourceActionRegistry);
+        new SourceOperations(
+            frameworkProperties, mockSourceActionRegistry, mockSourceSourceCapabilityRegistry);
     OperationsSecuritySupport opsSecurity = new OperationsSecuritySupport();
     MetacardFactory metacardFactory =
         new MetacardFactory(mimeTypeToTransformerMapper, uuidGenerator);

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/CatalogServiceImpl.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/CatalogServiceImpl.java
@@ -305,6 +305,10 @@ public class CatalogServiceImpl implements CatalogService {
 
         sourceObj.put("sourceActions", sourceActions);
 
+        JSONArray capabilities = new JSONArray();
+        capabilities.addAll(source.getCapabilities());
+        sourceObj.put("capabilities", capabilities);
+
         JSONArray contentTypesObj = new JSONArray();
         if (source.getContentTypes() != null) {
           for (ContentType contentType : source.getContentTypes()) {

--- a/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/CatalogServiceImplTest.java
+++ b/catalog/rest/catalog-rest-impl/src/test/java/org/codice/ddf/rest/impl/CatalogServiceImplTest.java
@@ -786,15 +786,18 @@ public class CatalogServiceImplTest {
 
     Set<SourceDescriptor> sourceDescriptors = new HashSet<>();
     SourceDescriptorImpl localDescriptor =
-        new SourceDescriptorImpl(localSourceId, contentTypes, Collections.emptyList());
+        new SourceDescriptorImpl(
+            localSourceId, contentTypes, Collections.emptyList(), Collections.emptyList());
     localDescriptor.setVersion(version);
     localDescriptor.setAvailable(true);
     SourceDescriptorImpl fed1Descriptor =
-        new SourceDescriptorImpl(fed1SourceId, contentTypes, Collections.emptyList());
+        new SourceDescriptorImpl(
+            fed1SourceId, contentTypes, Collections.emptyList(), Collections.emptyList());
     fed1Descriptor.setVersion(version);
     fed1Descriptor.setAvailable(true);
     SourceDescriptorImpl fed2Descriptor =
-        new SourceDescriptorImpl(fed2SourceId, null, Collections.emptyList());
+        new SourceDescriptorImpl(
+            fed2SourceId, null, Collections.emptyList(), Collections.emptyList());
     fed2Descriptor.setAvailable(true);
 
     sourceDescriptors.add(localDescriptor);

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/KmlEndpointTest.java
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/src/test/java/org/codice/ddf/spatial/kml/endpoint/KmlEndpointTest.java
@@ -112,9 +112,11 @@ public class KmlEndpointTest {
     when(mockFramework.getSourceInfo(any(SourceInfoRequest.class)))
         .thenReturn(mockSourceInfoResponse);
     SourceDescriptorImpl localDescriptor =
-        new SourceDescriptorImpl(LOCAL_SITE_NAME, null, Collections.emptyList());
+        new SourceDescriptorImpl(
+            LOCAL_SITE_NAME, null, Collections.emptyList(), Collections.emptyList());
     SourceDescriptorImpl remoteDescriptor =
-        new SourceDescriptorImpl(REMOTE_SITE_NAME, null, Collections.emptyList());
+        new SourceDescriptorImpl(
+            REMOTE_SITE_NAME, null, Collections.emptyList(), Collections.emptyList());
     descriptors.add(localDescriptor);
     descriptors.add(remoteDescriptor);
     when(mockSourceInfoResponse.getSourceInfo()).thenReturn(descriptors);


### PR DESCRIPTION
#### What does this PR do?
Allows admins to expose capabilities of sources through a new configuration. These capabilities will be available over the existing sources endpoint.
#### Who is reviewing it? 
@Bdthomson @hayleynorton @lamhuy 
#### Select relevant component teams: 
@codice/core-apis 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@bdeining
#### How should this be tested?
- build/run
- in admin > catalog create a few sources
- open the main UI and inspect for the "sources" network call
- verify that "capabilities" is an empty array for every source
- in admin > system > Source Capabilities, add a new config that matches a source id and anything can be entered for capabilities. save the config
- refresh the main UI and verify that the source now displays those capabilities in the network response
- add and delete more source capabilities for other sources in the same manner and verify no unexpected behavior
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4363](https://codice.atlassian.net/browse/DDF-4363)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
