### PR TITLE
[2.13.x] DDF-{4365, 4370, 4372, 4374} Minor bugfixes/improvements

### DIFF
--- a/catalog/core/catalog-core-eventcommands/pom.xml
+++ b/catalog/core/catalog-core-eventcommands/pom.xml
@@ -70,6 +70,44 @@
                     </instructions>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.96</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.81</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.76</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -400,7 +400,7 @@ grant codeBase "file:/platform-country-converter-local" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}fipsToIso.properties", "read";
 }
 
-grant codeBase "file:/admin-core-migration-commands/catalog-core-solrcommands/security-sts-attributequeryclaimshandler/catalog-confluence-source/org.eclipse.jetty.websocket.common/session-management-impl/security-sts-realm/security-core-impl/security-sts-server/org.eclipse.jetty.websocket.server/security-command-sessionmanager" {
+grant codeBase "file:/admin-core-migration-commands/catalog-core-solrcommands/security-sts-attributequeryclaimshandler/catalog-confluence-source/org.eclipse.jetty.websocket.common/session-management-impl/security-sts-realm/security-core-impl/security-sts-server/org.eclipse.jetty.websocket.server/security-command-sessionmanager/catalog-core-eventcommands" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}*", "read";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}*", "read";
 }

--- a/ui/packages/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
+++ b/ui/packages/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
@@ -33,17 +33,27 @@ define([
         Source.Model = Backbone.Model.extend({
             configUrl: "../jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui",
             idAttribute: 'name',
-            defaults: function() {
-              return {
-                currentUrl:     undefined,
-                isLoopbackUrl:   undefined,
-              };
+            defaults: {
+                currentUrl: undefined,
+                isLoopbackUrl: undefined,
             },
             initialize: function () {
                 this.set('currentConfiguration', undefined);
                 this.set('disabledConfigurations', new Source.ConfigurationList());
                 this.listenTo(this, 'change:currentConfiguration', this.updateCurrentBinding);
+                this.listenTo(this, 'remove', this.onRemove);
                 this.updateCurrentBinding();
+            },
+            onRemove: function() {
+                this.stopListening();
+                this.stopPolling();
+            },
+            stopPolling: function() {
+                var statusModel = this.get('statusModel');
+                if (statusModel) {
+                    statusModel.stopListening();
+                    poller.get(statusModel).destroy();
+                }
             },
             addDisabledConfiguration: function (configuration) {
                 if (this.get("disabledConfigurations") &&
@@ -57,29 +67,29 @@ define([
                     this.get("disabledConfigurations").remove(configuration);
                 } else if (configuration === this.get("currentConfiguration")) {
                     this.stopListening(configuration);
+                    this.stopPolling();
                     this.set("currentConfiguration", undefined);
                 }
             },
             setCurrentConfiguration: function (configuration) {
                 var sync = 'sync';
                 var statusUpdate = 'status:update-';
-                this.set({
-                    currentConfiguration: configuration
-                });
                 this.set({currentConfiguration: configuration});
 
                 var pid = configuration.id;
-                var statusModel = new Status.Model(pid);
-                statusModel.on(sync, function () {
-                    wreqr.vent.trigger(statusUpdate + pid, statusModel);
-                });
 
-                var options = {
-                    delay: 30000
-                };
+                var statusModel = this.get('statusModel');
+                if (statusModel) {
+                  statusModel.set({id: pid});
+                } else {
+                  statusModel = new Status.Model({id: pid});
+                  statusModel.on(sync, function () {
+                      wreqr.vent.trigger(statusUpdate + pid, statusModel);
+                  });
+                  this.set('statusModel', statusModel);
+                }
 
-                var statusPoller = poller.get(statusModel, options);
-                statusPoller.start();
+                poller.get(statusModel, { delay: 30000 }).start();
             },
             hasConfiguration: function (configuration) {
                 var id = configuration.get('id');
@@ -261,7 +271,7 @@ define([
                     return id.substring(httpIndex + 5);
                 }
                 return "GET";
-            }
+            },
         });
 
         Source.Collection = Backbone.Collection.extend({
@@ -288,8 +298,13 @@ define([
                 source.trigger('change');
             },
             removeSource: function (source) {
-                this.stopListening(source);
                 this.remove(source);
+            },
+            removeAllSources: function() {
+                var source;
+                while ((source = this.first())) {
+                  this.removeSource(source);
+                }
             },
             comparator: function (model) {
                 var str = model.get('name') || '';
@@ -311,7 +326,7 @@ define([
             parseServiceModel: function () {
                 var resModel = this;
                 var collection = resModel.get('collection');
-                collection.reset();
+                collection.removeAllSources();
                 if (this.model.get("value")) {
                     this.model.get("value").each(function (service) {
                         if (!_.isEmpty(service.get("configurations"))) {

--- a/ui/packages/catalog-admin-module-sources/src/main/webapp/js/model/Status.js
+++ b/ui/packages/catalog-admin-module-sources/src/main/webapp/js/model/Status.js
@@ -13,19 +13,15 @@
  *
  **/
 /*global define*/
-define(['backbone'], 
+define(['backbone'],
 function (Backbone) {
 
     var Status = {};
 
     Status.Model = Backbone.Model.extend({
-        url: "../jolokia/exec/org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean:service=admin-source-poller-service/sourceStatus/",
-            model: Status.Model,
-
-            initialize: function(pid) {
-                this.url += pid;
-            }
-        });
+        urlRoot: '../jolokia/exec/org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean:service=admin-source-poller-service/sourceStatus/',
+        model: Status.Model,
+    });
 
     return Status;
 });


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
* Fixes PAOS Interceptor to support backend HTTP DELETE requests to secured REST. This required changing the interceptor to compute the request content length correctly.
* Cleans up old source polling events when changes are made in the Sources UI. Previously, old events weren't removed and while using the Sources UI outdated events would spam the backend.
* Resolves an AccessControlException in the subscriptions:list command.
* Improves the output of the subscriptions:list command so an admin can tell whether it's an enterprise subscription or a source-specific subscription.

#### Who is reviewing it? 
@bakejeyner @blen-desta @Kjames5269 @brjeter 
#### Select relevant component teams: 
<!--
@codice/security @codice/ui 
-->
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@coyotesqrl
#### How should this be tested?
TEST 1: Sources UI
1. Create a new source in the sources UI, and open the browser dev tools to view the network tab.
2. Select and close the source edit modal a few times, and disable/re-enable the source a few times.
3. Verify there is still just a single request to the backend every 30 seconds.
4. Disable the source. Verify that the requests to the backend stop

TEST 2: subscriptions:list AccessControlException
1. Create a subscription pointing to a site that DDF does not trust, e.g. example.com
2. Run the subscriptions:list command and verify that there is no AccessControlException

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-4365](https://codice.atlassian.net/browse/DDF-4365)
[DDF-4370](https://codice.atlassian.net/browse/DDF-4370)
[DDF-4372](https://codice.atlassian.net/browse/DDF-4372)
[DDF-4374](https://codice.atlassian.net/browse/DDF-4374)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
