### PR TITLE
#DDF-4360 MGRS suggestions still appear when zone numbers are out of bounds

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessor.java
@@ -45,10 +45,14 @@ import org.slf4j.LoggerFactory;
 public class MgrsCoordinateProcessor {
   private static final Logger LOGGER = LoggerFactory.getLogger(MgrsCoordinateProcessor.class);
 
-  private static final Pattern PATTERN_MGRS_ZONE = Pattern.compile("\\d\\d?[C-HJ-NP-X]");
-
-  private static final Pattern PATTERN_MGRS_100KM = Pattern.compile("[A-HJ-NP-Z][A-HJ-NP-V]");
-
+  private static final Pattern PATTERN_MGRS_ZONE_AND_LATITUDE_BAND =
+      Pattern.compile(
+          "("
+              + UsngCoordinate.ZONE_REGEX_STRING
+              + ")"
+              + UsngCoordinate.LATITUDE_BAND_PART_ONE_REGEX_STRING);
+  private static final Pattern PATTERN_MGRS_100KM =
+      Pattern.compile(UsngCoordinate.LATITUDE_BAND_PART_TWO_REGEX_STRING);
   private static final Pattern PATTERN_MGRS_NUMERIC =
       Pattern.compile("((\\d){1,5}(\\h)+(\\d){1,5}(\\W)+)|((\\d){2,10})");
 
@@ -56,7 +60,7 @@ public class MgrsCoordinateProcessor {
       Pattern.compile(
           format(
               "(%s)|(%s)|(%s)",
-              PATTERN_MGRS_ZONE.pattern(),
+              PATTERN_MGRS_ZONE_AND_LATITUDE_BAND.pattern(),
               PATTERN_MGRS_100KM.pattern(),
               PATTERN_MGRS_NUMERIC.pattern()),
           Pattern.CASE_INSENSITIVE);
@@ -334,7 +338,7 @@ public class MgrsCoordinateProcessor {
   }
 
   private static MgrsPartType getPartType(String mgrsPart) {
-    if (PATTERN_MGRS_ZONE.matcher(mgrsPart).matches()) return MgrsPartType.ZONE;
+    if (PATTERN_MGRS_ZONE_AND_LATITUDE_BAND.matcher(mgrsPart).matches()) return MgrsPartType.ZONE;
     if (PATTERN_MGRS_100KM.matcher(mgrsPart).matches()) return MgrsPartType.HUNDRED_KM;
     if (PATTERN_MGRS_NUMERIC.matcher(mgrsPart).matches()) return MgrsPartType.NUMERIC;
     return MgrsPartType.NONE;

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessorTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/MgrsCoordinateProcessorTest.java
@@ -300,6 +300,16 @@ public class MgrsCoordinateProcessorTest {
   }
 
   @Test
+  public void testProcessorIgnoresInvalidZoneNumbers() {
+    List<String> zoneZero = processor.getMgrsCoordinateStrings("0D");
+    List<String> zoneSixtyOne = processor.getMgrsCoordinateStrings("61D");
+    List<String> zoneThreeDigits = processor.getMgrsCoordinateStrings("100D");
+    assertThat(zoneZero, hasSize(0));
+    assertThat(zoneSixtyOne, hasSize(0));
+    assertThat(zoneThreeDigits, hasSize(0));
+  }
+
+  @Test
   public void testProcessorIgnoresInvalid100KmLetters() {
     List<String> kmIJ = processor.getMgrsCoordinateStrings("14Q IJ");
     List<String> kmOJ = processor.getMgrsCoordinateStrings("14Q OJ");

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <spring-osgi.version>1.2.1</spring-osgi.version>
         <tika.thirdparty.bundle.version>1.18.0_3</tika.thirdparty.bundle.version>
         <tika.version>1.18</tika.version>
-        <usng4j.version>0.4</usng4j.version>
+        <usng4j.version>0.3</usng4j.version>
         <validation.version>1.1.0.Final</validation.version>
         <woodstox.core.version>5.1.0</woodstox.core.version>
         <woodstox.stax2-api.version>4.1</woodstox.stax2-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <spring-osgi.version>1.2.1</spring-osgi.version>
         <tika.thirdparty.bundle.version>1.18.0_3</tika.thirdparty.bundle.version>
         <tika.version>1.18</tika.version>
-        <usng4j.version>0.1</usng4j.version>
+        <usng4j.version>0.4</usng4j.version>
         <validation.version>1.1.0.Final</validation.version>
         <woodstox.core.version>5.1.0</woodstox.core.version>
         <woodstox.stax2-api.version>4.1</woodstox.stax2-api.version>


### PR DESCRIPTION
#### What does this PR do?
Zones such as 67Q or 90K will still produce suggestions and the map will pan to some location, but it will be nonsense. In a typical scenario this isn't too bad because users familiar with MGRS realize these values don't have significance.
However, the suggestion itself is still misleading. Revise the suggester so that MGRS with invalid zone numbers do not appear as suggestions.

#### Who is reviewing it?
@millerw8
@Variadicism 
@bdeining 
@Lambeaux 
@samuelechu 


#### How should this be tested?
Try entering an invalid MGRS zone such as 0 or 64, no suggestion should be displayed.

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
