### PR TITLE
DDF-4366 Make the default active element upon opening a menu the selected item if there is one

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -26,7 +26,7 @@ class Menu extends React.Component {
   chooseActive() {
     const selection = this.props.value
     const active = this.state ? this.state.active : undefined
-    const itemNames = this.props.children.map(child => child.props.value)
+    const itemNames = (this.props.children || []).map(child => child.props.value)
     if (itemNames.includes(active)) {
       return active
     } else if (itemNames.includes(selection)) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -21,13 +21,15 @@ class Menu extends React.Component {
   constructor(props) {
     super(props)
     const children = React.Children.toArray(props.children)
-    this.state = { active: this.chooseActive(children) }
+    this.state = { active: this.chooseActive(children, props.value) }
     this.onKeyDown = this.onKeyDown.bind(this)
   }
-  chooseActive(children, active) {
+  chooseActive(children, selection, active) {
     const found = children.some(child => child.props.value === active)
     if (found) {
       return active
+    } else if (selection) {
+      return selection
     } else if (children.length > 0) {
       return children[0].props.value
     } else {
@@ -75,7 +77,7 @@ class Menu extends React.Component {
   componentDidUpdate(previousProps) {
     if (previousProps.children !== this.props.children) {
       this.setState({
-        active: this.chooseActive(this.props.children, this.state.active),
+        active: this.chooseActive(this.props.children, this.props.value, this.state.active),
       })
     }
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -26,7 +26,9 @@ class Menu extends React.Component {
   chooseActive() {
     const selection = this.props.value
     const active = this.state ? this.state.active : undefined
-    const itemNames = (this.props.children || []).map(child => child.props.value)
+    const itemNames = (this.props.children || []).map(
+      child => child.props.value
+    )
     if (itemNames.includes(active)) {
       return active
     } else if (itemNames.includes(selection)) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.js
@@ -20,18 +20,19 @@ class DocumentListener extends React.Component {
 class Menu extends React.Component {
   constructor(props) {
     super(props)
-    const children = React.Children.toArray(props.children)
-    this.state = { active: this.chooseActive(children, props.value) }
+    this.state = { active: this.chooseActive() }
     this.onKeyDown = this.onKeyDown.bind(this)
   }
-  chooseActive(children, selection, active) {
-    const found = children.some(child => child.props.value === active)
-    if (found) {
+  chooseActive() {
+    const selection = this.props.value
+    const active = this.state ? this.state.active : undefined
+    const itemNames = this.props.children.map(child => child.props.value)
+    if (itemNames.includes(active)) {
       return active
-    } else if (selection) {
+    } else if (itemNames.includes(selection)) {
       return selection
-    } else if (children.length > 0) {
-      return children[0].props.value
+    } else if (itemNames.length > 0) {
+      return itemNames[0]
     } else {
       return undefined
     }
@@ -76,9 +77,7 @@ class Menu extends React.Component {
   }
   componentDidUpdate(previousProps) {
     if (previousProps.children !== this.props.children) {
-      this.setState({
-        active: this.chooseActive(this.props.children, this.props.value, this.state.active),
-      })
+      this.setState({ active: this.chooseActive() })
     }
   }
   render() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.spec.js
@@ -56,23 +56,23 @@ describe('<Menu />', () => {
   const table = [
     {
       events: [],
-      state: 'one',
-    },
-    {
-      events: ['ArrowDown'],
       state: 'two',
     },
     {
-      events: ['ArrowUp'],
+      events: ['ArrowDown'],
       state: 'three',
+    },
+    {
+      events: ['ArrowUp'],
+      state: 'one',
     },
     {
       events: ['ArrowDown', 'ArrowDown'],
-      state: 'three',
+      state: 'one',
     },
     {
       events: ['ArrowDown', 'ArrowDown', 'ArrowDown'],
-      state: 'one',
+      state: 'two',
     },
   ]
 
@@ -113,8 +113,8 @@ describe('<Menu />', () => {
         <MenuItem value="three" />
       </Menu>
     )
-    expect(wrapper.state('active')).to.equal('one')
-    wrapper.find({ value: 'two' }).prop('onHover')()
     expect(wrapper.state('active')).to.equal('two')
+    wrapper.find({ value: 'one' }).prop('onHover')()
+    expect(wrapper.state('active')).to.equal('one')
   })
 })


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
When a menu is opened or its children are changed, it has to select an active element if an element still existing there was not active before. In this case, if a menu item is selected, then it is intuitive to make the same element active.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@BernardIgiri 
@samuelechu 
#### Select relevant component teams:
@codice/ui
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@djblue
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
* Navigate to a units selection menu. One can be found for the "Radius" field in the search editor by selecting "Somewhere Specific" under "Located", then "Point Radius" under "Location".
* Open the menu. Ensure that the selected unit value (the one with a :white_check_mark: next to it) is also active. Active elements often but don't always have a thin blue box around them. If it does not, use the arrow keys to shift the active element to locate it.
* Open the Gazetteer search box on the top border of the 3D or 2D map and type in two or more characters that result in suggestions. Ensure that when the suggestions appeared, the first suggestion is active. This is a regression test.
#### Any background context you want to provide?
**_This pull request depends on #4075 to avoid conflicts and replication of logic. Please only review commits after commit `1f17178`._**
#### What are the relevant tickets?
[DDF-4366](https://codice.atlassian.net/browse/DDF-4366)
#### Screenshots
This demonstrates how the selected unit in the menu is made active when the menu is opened. Arrow keys are used to shift between active menu items and Enter is used to make a selection.
![activate menu selection](https://user-images.githubusercontent.com/1525813/49241249-824ca200-f3c4-11e8-8bff-4554153a5eb3.gif)
#### Checklist:
- [ ] Documentation Updated
- _N/A_ Update / Add Unit Tests
- _N/A_ Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
