### PR TITLE
[2.13.x] DDF-4369 Fixed permission to enable fallback audit logging

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.config.xml
@@ -14,14 +14,8 @@
 -->
 <Configuration status="FATAL">
     <Properties>
-        <Property name="color.fatal">bright red</Property>
-        <Property name="color.error">bright red</Property>
-        <Property name="color.warn">bright yellow</Property>
-        <Property name="color.info">bright green</Property>
-        <Property name="color.debug">cyan</Property>
-        <Property name="color.trace">cyan</Property>
-        <Property name="log-pattern">%-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n</Property>
-        <Property name="log-out-pattern">\u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable</Property>
+        <!--Common pattern layout for appenders-->
+        <Property name="log4j2.pattern">%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n</Property>
     </Properties>
 
     <Appenders>
@@ -36,13 +30,13 @@
         <Syslog name="syslog" facility="AUTH" host="localhost" protocol="UDP" port="514"/>
 
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} | ${log-pattern}"/>
+            <PatternLayout pattern="${log4j2.pattern}"/>
         </Console>
 
         <RollingFile name="out" append="true"
                      fileName="${sys:karaf.data}/log/${sys:org.codice.ddf.system.branding}.log"
                      filePattern="${sys:karaf.data}/log/${sys:org.codice.ddf.system.branding}.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
-            <PatternLayout pattern="%d{ISO8601} | ${log-out-pattern}"/>
+            <PatternLayout pattern="${log4j2.pattern}"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>
@@ -52,7 +46,7 @@
         <RollingFile name="ingestError" append="true"
                      fileName="${sys:karaf.data}/log/ingest_error.log"
                      filePattern="${sys:karaf.data}/log/ingest_error.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
-            <PatternLayout pattern="%d{ISO8601} | ${log-pattern}"/>
+            <PatternLayout pattern="${log4j2.pattern}"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>
@@ -90,7 +84,7 @@
         <RollingFile name="solr" append="true"
                      fileName="${sys:karaf.data}/log/solr.log"
                      filePattern="${sys:karaf.data}/log/solr.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
-            <PatternLayout pattern="%d{ISO8601} | ${log-pattern}"/>
+            <PatternLayout pattern="${log4j2.pattern}"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>
@@ -100,7 +94,7 @@
         <RollingFile name="artemis" append="true"
                      fileName="${sys:karaf.data}/log/artemis.log"
                      filePattern="${sys:karaf.data}/log/artemis.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
-            <PatternLayout pattern="%d{ISO8601} | ${log-pattern}"/>
+            <PatternLayout pattern="${log4j2.pattern}"/>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -25,17 +25,8 @@
 #
 # org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml
 
-# Colors for log level rendering
-color.fatal = bright red
-color.error = bright red
-color.warn = bright yellow
-color.info = bright green
-color.debug = cyan
-color.trace = cyan
-
 # Common pattern layout for appenders
-log4j2.pattern = %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
-log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
+log4j2.pattern = %d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
 
 # Root logger
 log4j2.rootLogger.level = INFO
@@ -155,7 +146,7 @@ log4j2.appender.stdout.type = Console
 log4j2.appender.stdout.name = stdout
 log4j2.appender.stdout.target = SYSTEM_OUT
 log4j2.appender.stdout.layout.type = PatternLayout
-log4j2.appender.stdout.layout.pattern = %d{ISO8601} | ${log4j2.pattern}
+log4j2.appender.stdout.layout.pattern = ${log4j2.pattern}
 
 # out
 log4j2.appender.out.type = RollingFile
@@ -164,7 +155,7 @@ log4j2.appender.out.fileName = ${karaf.data}/log/${org.codice.ddf.system.brandin
 log4j2.appender.out.filePattern = ${karaf.data}/log/${org.codice.ddf.system.branding}.log-%d{yyyy-MM-dd-HH}-%i.log.gz
 log4j2.appender.out.append = true
 log4j2.appender.out.layout.type = PatternLayout
-log4j2.appender.out.layout.pattern = %d{ISO8601} | ${log4j2.pattern}
+log4j2.appender.out.layout.pattern = ${log4j2.pattern}
 log4j2.appender.out.policies.type = Policies
 log4j2.appender.out.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.out.policies.size.size = 20MB
@@ -178,7 +169,7 @@ log4j2.appender.ingestError.fileName = ${karaf.data}/log/ingest_error.log
 log4j2.appender.ingestError.filePattern = ${karaf.data}/log/ingest_error.log-%d{yyyy-MM-dd-HH}-%i.log.gz
 log4j2.appender.ingestError.append = true
 log4j2.appender.ingestError.layout.type = PatternLayout
-log4j2.appender.ingestError.layout.pattern = %d{ISO8601} | ${log4j2.pattern}
+log4j2.appender.ingestError.layout.pattern = ${log4j2.pattern}
 log4j2.appender.ingestError.policies.type = Policies
 log4j2.appender.ingestError.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.ingestError.policies.size.size = 20MB
@@ -207,7 +198,7 @@ log4j2.appender.solr.fileName = ${karaf.data}/log/solr.log
 log4j2.appender.solr.filePattern = ${karaf.data}/log/solr.log-%d{yyyy-MM-dd-HH}-%i.log.gz
 log4j2.appender.solr.append = true
 log4j2.appender.solr.layout.type = PatternLayout
-log4j2.appender.solr.layout.pattern = %d{ISO8601} | ${log4j2.pattern}
+log4j2.appender.solr.layout.pattern = ${log4j2.pattern}
 log4j2.appender.solr.policies.type = Policies
 log4j2.appender.solr.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.solr.policies.size.size = 20MB
@@ -221,7 +212,7 @@ log4j2.appender.artemis.fileName = ${karaf.data}/log/artemis.log
 log4j2.appender.artemis.filePattern = ${karaf.data}/log/artemis.log-%d{yyyy-MM-dd-HH}-%i.log.gz
 log4j2.appender.artemis.append = true
 log4j2.appender.artemis.layout.type = PatternLayout
-log4j2.appender.artemis.layout.pattern = %d{ISO8601} | ${log4j2.pattern}
+log4j2.appender.artemis.layout.pattern = ${log4j2.pattern}
 log4j2.appender.artemis.policies.type = Policies
 log4j2.appender.artemis.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.artemis.policies.size.size = 20MB

--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -1,20 +1,20 @@
 priority "grant";
 // Double forward slashes "//" indicate comments and have no effect on policies.
-
-// This policy file's intended usage is to contain appropriate sections for adding permissions related
-// to configurations. For example, the Content Directory Monitor requires read/write permissions to
-// the directory being monitored, and has an appropriate section below. Sections should contain
-// sufficient details about adding permissions required for the given configuration.
-
-// Instructions in this file may be duplicated in the documentation. Documentation provides better
-// formatting and readability.
-
-// When adding permissions for directories, trailing slashes have no effect on the permissions granted.
-// For example, adding a permission for "${/}test${/}path" and "${/}test${/}path${/}" are equivalent. The recursive forms
-// "${/}test${/}path${/}-", and "${/}test${/}path${/}${/}-" are also equivalent.
-
+//
+// This policy file's intended usage is to contain appropriate sections for adding permissions
+// related to configurations. For example, the Content Directory Monitor requires read/write
+// permissions to the directory being monitored, and has an appropriate section below. Sections
+// should contain sufficient details about adding permissions required for the given configuration.
+//
+// Instructions in this file should be duplicated in the Documentation. The Documentation provides
+// better formatting and readability and also prevents these directions from being modified.
+//
+// When adding permissions for directories, trailing slashes have no effect on the permissions
+// granted. For example, adding a permission for "${/}test${/}path" and "${/}test${/}path${/}" are
+// equivalent. The recursive forms "${/}test${/}path${/}-" and "${/}test${/}path${/}${/}-" are also
+// equivalent.
+//
 // IMPORTANT! - Adding new permissions requires a system restart to take affect.
-
 
 //                        Content Directory Monitor (CDM) Permissions
 // Adding required permissions for a new Content Directory Monitor.
@@ -45,16 +45,15 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
 //                        URL Resource Reader Permissions
 // Adding required permissions for the URL Resource Reader to retrieve file resources.
 //
-//
-// Configuring the URL Resource Reader requires adding read permissions to the directory being read from.
-// For the following 2 permissions are required:
+// Configuring the URL Resource Reader requires adding read permissions to the directory being read
+// from. For the following 2 permissions are required:
 //   1. permission java.io.FilePermission "<DIRECTORY_PATH>", "read";
 //   2. permission java.io.FilePermission "<DIRECTORY_PATH>${/}-", "read";
 // Replacing <DIRECTORY_PATH> with the path of the directory containing file resources.
 //
 // Line 1 gives the URL Resource Reader the permissions to read from the directory. Line 2 gives the
-// Resource Reader the permissions to recursively read from the directory path, specified
-// by the directory path's suffix "${/}-".
+// Resource Reader the permissions to recursively read from the directory path, specified by the
+// directory path's suffix "${/}-".
 //
 grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader" {
     // Add required URL Resource Reader permissions here.
@@ -65,12 +64,12 @@ grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader" {
 }
 
 //                       Security-Hardening: Backup Log File Permissions
-//  Adding required permissions to the logger for read and write access to modified backup log files
+// Adding required permissions to the logger for read and write access to modified backup log files.
 //
-//  If you want to change the default location of the backup security log files, add a new permission
-//  allowing the logger to create and modify the files within the new directory.
-//  If you haven't already done so, follow the Enabling Fallback Audit Logging steps in the security hardening
-//  checklist to finish configuring backup logging
+// If you want to change the default location of the backup security log files, add new permissions
+// allowing the logger to read and modify the files within the new directory. If you haven't
+// already done so, follow the Enabling Fallback Audit Logging steps in the security hardening
+// checklist to finish configuring backup logging.
 //
 grant codeBase "file:/pax-logging-log4j2" {
     //  Add required permissions here.

--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -11,7 +11,7 @@ priority "grant";
 //
 // When adding permissions for directories, trailing slashes have no effect on the permissions
 // granted. For example, adding a permission for "${/}test${/}path" and "${/}test${/}path${/}" are
-// equivalent. The recursive forms "${/}test${/}path${/}-" and "${/}test${/}path${/}${/}-" are also
+// equivalent. The recursive forms "${/}test${/}path${/}-" and "${/}test${/}path${/}-${/}" are also
 // equivalent.
 //
 // IMPORTANT! - Adding new permissions requires a system restart to take affect.

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -205,7 +205,7 @@ grant codeBase "file:/pax-logging-log4j2" {
 }
 
 grant codebase "file:/org.apache.karaf.log.core" {
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}log4j2.xml", "read,write";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}log4j2.config.xml", "read,write";
 }
 
 grant codeBase "file:/woodstox-core/broker-topic-logger/platform-solr-server-standalone/catalog-core-downloadaction/platform-http-proxy/platform-scheduler/catalog-validator-metacardduplication/org.apache.cxf.cxf-rt-bindings-soap" {

--- a/distribution/docs/src/main/resources/content/_securing/auditing.adoc
+++ b/distribution/docs/src/main/resources/content/_securing/auditing.adoc
@@ -69,8 +69,8 @@ If you want to change the location of your systems security backup log from the 
 [source,xml,linenums]
 ----
 <RollingFile name="securityBackup" append="true" ignoreExceptions="false"
-                     fileName="${sys:karaf.data}/log/<NEW_LOG_FILE>"
-                     filePattern="${sys:karaf.data}/log/<NEW_LOG_FILE>-%d{yyyy-MM-dd-HH}-%i.log.gz">
+                     fileName="<NEW_LOG_FILE>"
+                     filePattern="<NEW_LOG_FILE>-%d{yyyy-MM-dd-HH}-%i.log.gz">
 ----
 
 [WARNING]


### PR DESCRIPTION
#### What does this PR do?
This PR
* Updates ddf.log pattern in log4j2.config.xml to match org.ops4j.pax.logging.cfg
* Updates formatting in the Enabling Fallback Audit Logging documentation
* Fixes a permission to read log4j2.config.xml. The permission was back-ported in #3828 without reverting the file name change made in #3609.
#### Who is reviewing it?
@brjeter @bakejeyner @blen-desta @Kjames5269
#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@vinamartin
#### How should this be tested?
* With a fresh zip, unzip, and start up DDF. (You do not need to install.)
  1. Confirm that log commands work (`log:set`, `log:tail`, `log:get`).
  2. Confirm that the format of log files look correct.
* With a fresh zip, unzip, and follow the `Enabling Fallback Audit Logging` of the documentation to use the log4j2.config.xml log configuration file instead of the org.ops4j.pax.logging.cfg log configuration file. (You do not need to test that the failover logging works.)
  1. Confirm that log commands work (`log:set`, `log:tail`, `log:get`).
  2. Confirm that the format of the log files (specifically `data/log/ddf.log`) look correct.
#### What are the relevant tickets?
[DDF-4369](https://codice.atlassian.net/browse/DDF-4369)
#### Screenshots
![image](https://user-images.githubusercontent.com/8041246/49244397-effccc00-f3cc-11e8-8757-b07debaa4eff.png)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.