### PR TITLE
DDF-4375 Added classes to realign navigation buttons

### DIFF
--- a/ui/packages/ui/src/main/webapp/templates/installer/finish.handlebars
+++ b/ui/packages/ui/src/main/webapp/templates/installer/finish.handlebars
@@ -14,7 +14,7 @@
 <h3>Finished</h3>
 
 <div class="main-content">
-    <div class="well white">
+    <div class="well white inner-scroll scroll-area ps-container">
         <p class="lead">Congratulations! Your system is now configured.
             <br/>
             <br/>


### PR DESCRIPTION
#### What does this PR do? 
Realigns the "Restart now" and "Restart later" buttons on the last screen of the installer wizard.
 
#### Who is reviewing it? 
@mdang8  @pvargas @oconnormi @mcalcote 

#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@clockard

<!--(List steps with links to updated documentation)-->
#### What are the relevant tickets?
[DDF-4375](https://codice.atlassian.net/browse/DDF-4375)
#### Screenshots
<img width="906" alt="screenshot 2" src="https://user-images.githubusercontent.com/18688190/49468464-f5925180-f7d2-11e8-8ab7-b95cf1924621.png">

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
