### PR TITLE
[2.13.x] DDF-4378 Making store:list options consistent across --help and -t

### DIFF
--- a/platform/persistence/platform-persistence-commands/src/main/java/org/codice/ddf/persistence/commands/AbstractStoreCommand.java
+++ b/platform/persistence/platform-persistence-commands/src/main/java/org/codice/ddf/persistence/commands/AbstractStoreCommand.java
@@ -39,7 +39,7 @@ public abstract class AbstractStoreCommand implements Action {
     aliases = {"-t", "--type"},
     required = true,
     description =
-        "Type of entry in the persistence store to perform the current operation on.\nOptions: attributes, preferences, metacard, saved_query, notification, activity, subscriptions or workspace",
+        "Type of entry in the persistence store to perform the current operation on.\nOptions: metacard, saved_query, notification, activity, workspace, preferences, attributes, subscriptions, event_subscriptions, alerts, or decanter",
     multiValued = false
   )
   protected String type;


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

Backports #4102 

#### What does this PR do?
Changes the store:list --help output for "-t" to output the same choices as it does when given an invalid input.

From
> attributes, preferences, metacard, saved_query, notification, activity, subscriptions or workspace

to
> metacard, saved_query, notification, activity, workspace, preferences, attributes, subscriptions, event_subscriptions, alerts, or decanter

#### Who is reviewing it? 
@pvargas @mdang8 @oconnormi 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

Ask 2 committers to review/merge the PR and tag them here.
@clockard
@vinamartin

#### What are the relevant tickets?
[DDF-4378](https://codice.atlassian.net/browse/DDF-4378)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.