### PR TITLE
[2.13.x]DDF-4377 Fix the dropped relevancy score when querying by id

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -547,13 +547,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
 
     private SourceResponse cloneResponse(SourceResponse sourceResponse) {
       List<Result> clonedResults =
-          sourceResponse
-              .getResults()
-              .stream()
-              .map(Result::getMetacard)
-              .map(m -> new MetacardImpl(m, m.getMetacardType()))
-              .map(ResultImpl::new)
-              .collect(Collectors.toList());
+          sourceResponse.getResults().stream().map(this::cloneResult).collect(Collectors.toList());
 
       return new QueryResponseImpl(
           sourceResponse.getRequest(),
@@ -561,6 +555,17 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
           true,
           sourceResponse.getHits(),
           sourceResponse.getProperties());
+    }
+
+    private Result cloneResult(Result result) {
+      Metacard metacard = result.getMetacard();
+      Metacard clonedMetacard = new MetacardImpl(metacard, metacard.getMetacardType());
+      ResultImpl clonedResult = new ResultImpl(clonedMetacard);
+
+      clonedResult.setDistanceInMeters(result.getDistanceInMeters());
+      clonedResult.setRelevanceScore(result.getRelevanceScore());
+
+      return clonedResult;
     }
   }
 

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CachingFederationStrategyTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CachingFederationStrategyTest.java
@@ -89,6 +89,10 @@ public class CachingFederationStrategyTest {
 
   private static final String MOCK_RESPONSE_TITLE = "mock response";
 
+  private static final double SAMPLE_DISTANCE = 50d;
+
+  private static final double SAMPLE_RELEVANCE = 100d;
+
   private ExecutorService cacheExecutor, queryExecutor;
 
   @Mock private Query mockQuery;
@@ -173,7 +177,9 @@ public class CachingFederationStrategyTest {
     metacard = new MetacardImpl();
     metacard.setId("mock metacard");
 
-    Result mockResult = new ResultImpl(metacard);
+    ResultImpl mockResult = new ResultImpl(metacard);
+    mockResult.setDistanceInMeters(SAMPLE_DISTANCE);
+    mockResult.setRelevanceScore(SAMPLE_RELEVANCE);
 
     List<Result> results = Arrays.asList(mockResult);
     when(mockResponse.getResults()).thenReturn(results);
@@ -204,6 +210,8 @@ public class CachingFederationStrategyTest {
     QueryResponse federateResponse = federateStrategy.federate(sourceList, fedQueryRequest);
 
     assertThat(federateResponse.getResults().size(), is(sourceList.size()));
+    assertThat(federateResponse.getResults().get(0).getDistanceInMeters(), is(SAMPLE_DISTANCE));
+    assertThat(federateResponse.getResults().get(0).getRelevanceScore(), is(SAMPLE_RELEVANCE));
   }
 
   @Test


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
`CachingFederationStrategy` was dropping distance & relevancy scores . This pr fixes that.

#### Who is reviewing it? 
@blen-desta 
@Kjames5269 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@brjeter
@coyotesqrl

#### How should this be tested?
Ask me for test steps.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4377](https://codice.atlassian.net/browse/DDF-4377)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
