### PR TITLE
DDF-4381 Fixing sorting order of recently used workspaces

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/workspaces-items-container/workspaces-items-container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/workspaces-items-container/workspaces-items-container.tsx
@@ -58,8 +58,8 @@ function sortWorkspaces(workspaces: Backbone.Model[]) {
       case 'Title':
         return workspace.get('title').toLowerCase()
       default:
-        //We want to sort in descending order. Parse the timestamp to a Date and find seconds since the epoch. Sort by the inverse of that.
-        return -(new Date(workspace.get('metacard.modified')).getTime())
+        // We want to sort in descending order. Parse the timestamp to a Date and find seconds since the epoch. Sort by the inverse of that.
+        return -new Date(workspace.get('metacard.modified')).getTime()
     }
   })
 }
@@ -96,7 +96,7 @@ class WorkspacesItemsContainer extends React.Component<
   componentDidMount() {
     this.props.listenTo(
       store.get('workspaces'),
-      'add reset remove',
+      'add reset remove change',
       this.updateWorkspaces.bind(this)
     )
     this.props.listenTo(

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/workspaces-items-container/workspaces-items-container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/workspaces-items-container/workspaces-items-container.tsx
@@ -58,7 +58,8 @@ function sortWorkspaces(workspaces: Backbone.Model[]) {
       case 'Title':
         return workspace.get('title').toLowerCase()
       default:
-        return -workspace.get('metacard.modified')
+        //We want to sort in descending order. Parse the timestamp to a Date and find seconds since the epoch. Sort by the inverse of that.
+        return -(new Date(workspace.get('metacard.modified')).getTime())
     }
   })
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug with work spaces not being sorted by last modified due to a change in how dates were formatted.

#### Who is reviewing it? 
@pvargas @mdang8 @oconnormi 
#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@vinamartin
#### How should this be tested?

1. In DDF Intrigue, create a new workspace named "Workspace 1".
2. Then repeat step 1, this time naming them "Workspace 2" and "Workspace 3".
3. On the workspaces screen set the sorting order to "last modified".
4. The order of the workspaces should be "Workspace 3", "Workspace 2", "Workspace 1".
5. Enter "Workspace 2" and execute a search, then hit save.
6. Back on the workspaces screen the order should now be "Workspace 2", "Workspace 3", "Workspace 1".

#### Any background context you want to provide?
The change from boon to GSON (#3986) meant that date format had changed as well. In this case a date that used to be a number (as seconds from the epoch) became a string (a timestamp). Taking the inverse to allow sorting in descending order worked for numbers, but returned NaN on the string. This caused it to sort on "NaN". This change accounts for the new date format, and should continue to work even if the date format changes again.

#### What are the relevant tickets?
[DDF-4381](https://codice.atlassian.net/browse/DDF-4381)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
