### PR TITLE
DDF-4218 Fix solr:backup and add solr:restore command

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -246,8 +246,11 @@ public class DumpCommand extends CqlCommands {
             rejectedExecutionHandler);
 
     QueryRequest queryRequest = new QueryRequestImpl(query, props);
-    LOGGER.debug("Hits for Search: {}", catalog.query(queryRequest).getHits());
-    ResultIterable.resultIterable(catalog::query, new QueryRequestImpl(query, props))
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Hits for Search: {}", catalog.query(queryRequest).getHits());
+    }
+
+    ResultIterable.resultIterable(catalog::query, queryRequest)
         .stream()
         .forEach(
             result ->

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -19,6 +19,9 @@ import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.filter.impl.SortByImpl;
+import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
@@ -46,7 +49,6 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -60,6 +62,8 @@ import org.codice.ddf.platform.util.StandardThreadFactoryBuilder;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
@@ -215,9 +219,12 @@ public class DumpCommand extends CqlCommands {
       zipArgs.put(FILE_PATH, dirPath + zipFileName);
     }
 
+    SortBy sort = new SortByImpl(Core.ID, SortOrder.ASCENDING);
+
     QueryImpl query = new QueryImpl(getFilter());
-    query.setRequestsTotalResultsCount(false);
+    query.setRequestsTotalResultsCount(true);
     query.setPageSize(pageSize);
+    query.setSortBy(sort);
 
     Map<String, Serializable> props = new HashMap<>();
     // Avoid caching all results while dumping with native query mode
@@ -225,8 +232,6 @@ public class DumpCommand extends CqlCommands {
 
     final AtomicLong resultCount = new AtomicLong(0);
     long start = System.currentTimeMillis();
-
-    SourceResponse response = catalog.query(new QueryRequestImpl(query, props));
 
     BlockingQueue<Runnable> blockingQueue = new ArrayBlockingQueue<>(multithreaded);
     RejectedExecutionHandler rejectedExecutionHandler = new ThreadPoolExecutor.CallerRunsPolicy();
@@ -240,58 +245,17 @@ public class DumpCommand extends CqlCommands {
             StandardThreadFactoryBuilder.newThreadFactory("dumpCommandThread"),
             rejectedExecutionHandler);
 
-    while (!response.getResults().isEmpty()) {
-      response =
-          new SourceResponseImpl(
-              new QueryRequestImpl(query, props),
-              ResultIterable.resultIterable(
-                      catalog::query, new QueryRequestImpl(query, props), pageSize)
-                  .stream()
-                  .collect(Collectors.toList()));
-
-      if (StringUtils.isNotBlank(zipFileName)) {
-        try {
-          Optional<QueryResponseTransformer> zipCompressionTransformer = getZipCompression();
-          if (zipCompressionTransformer.isPresent()) {
-            BinaryContent binaryContent =
-                zipCompressionTransformer.get().transform(response, zipArgs);
-            if (binaryContent != null) {
-              IOUtils.closeQuietly(binaryContent.getInputStream());
-            }
-            Long resultSize = (long) response.getResults().size();
-            printStatus(resultCount.addAndGet(resultSize));
-          }
-        } catch (InvalidSyntaxException e) {
-          LOGGER.info("No Zip Transformer found.  Unable export metacards to a zip file.");
-        } catch (CatalogTransformerException e) {
-          LOGGER.info("zipCompression transform failed");
-        }
-      } else if (multithreaded > 1) {
-        final List<Result> results = new ArrayList<>(response.getResults());
-        executorService.submit(
-            () -> {
-              for (final Result result : results) {
-                Metacard metacard = result.getMetacard();
-                try {
-                  exportMetacard(dumpDir, metacard, resultCount);
-                } catch (IOException e) {
-                  LOGGER.debug("Failed to dump metacard {}", metacard.getId(), e);
-                }
-              }
-            });
-      } else {
-        for (final Result result : response.getResults()) {
-          Metacard metacard = result.getMetacard();
-          exportMetacard(dumpDir, metacard, resultCount);
-        }
-      }
-
-      if (response.getResults().size() < pageSize || pageSize == -1) {
-        break;
-      }
-
-      query.setStartIndex(query.getStartIndex() + pageSize);
-    }
+    QueryRequest queryRequest = new QueryRequestImpl(query, props);
+    LOGGER.debug("Hits for Search: {}", catalog.query(queryRequest).getHits());
+    ResultIterable.resultIterable(catalog::query, new QueryRequestImpl(query, props))
+        .stream()
+        .forEach(
+            result ->
+                handleResult(
+                    new SourceResponseImpl(queryRequest, Collections.singletonList(result)),
+                    executorService,
+                    dumpDir,
+                    resultCount));
 
     executorService.shutdown();
 
@@ -310,6 +274,54 @@ public class DumpCommand extends CqlCommands {
     console.println();
     SecurityLogger.audit("Exported {} files to {}", resultCount.get(), dirPath);
     return null;
+  }
+
+  private void handleResult(
+      SourceResponse response,
+      ExecutorService executorService,
+      File dumpDir,
+      AtomicLong resultCount) {
+    if (StringUtils.isNotBlank(zipFileName)) {
+      try {
+        Optional<QueryResponseTransformer> zipCompressionTransformer = getZipCompression();
+        if (zipCompressionTransformer.isPresent()) {
+          BinaryContent binaryContent =
+              zipCompressionTransformer.get().transform(response, zipArgs);
+          if (binaryContent != null) {
+            IOUtils.closeQuietly(binaryContent.getInputStream());
+          }
+          Long resultSize = (long) response.getResults().size();
+          printStatus(resultCount.addAndGet(resultSize));
+        }
+      } catch (InvalidSyntaxException e) {
+        LOGGER.info("No Zip Transformer found.  Unable export metacards to a zip file.");
+      } catch (CatalogTransformerException e) {
+        LOGGER.info("zipCompression transform failed");
+      }
+    } else if (multithreaded > 1) {
+      final List<Result> results = new ArrayList<>(response.getResults());
+      executorService.submit(
+          () -> {
+            for (final Result result : results) {
+              Metacard metacard = result.getMetacard();
+              try {
+                exportMetacard(dumpDir, metacard, resultCount);
+              } catch (IOException e) {
+                LOGGER.debug("Failed to dump metacard {}", metacard.getId(), e);
+              }
+            }
+          });
+    } else {
+      for (final Result result : response.getResults()) {
+        Metacard metacard = result.getMetacard();
+        try {
+          exportMetacard(dumpDir, metacard, resultCount);
+        } catch (IOException e) {
+          LOGGER.debug(
+              "Unable to export metacard: {} [{}]", metacard.getId(), metacard.getTitle(), e);
+        }
+      }
+    }
   }
 
   private void exportMetacard(File dumpLocation, Metacard metacard, AtomicLong resultCount)
@@ -333,6 +345,7 @@ public class DumpCommand extends CqlCommands {
               try (FileOutputStream fos =
                   new FileOutputStream(getOutputFile(dumpLocation, metacard))) {
                 fos.write(binaryContent.getByteArray());
+                fos.flush();
               }
               resultCount.incrementAndGet();
               break;

--- a/catalog/core/catalog-core-solrcommands/pom.xml
+++ b/catalog/core/catalog-core-solrcommands/pom.xml
@@ -161,6 +161,7 @@
             <groupId>ddf.platform.solr</groupId>
             <artifactId>solr-factory-impl</artifactId>
             <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/catalog/core/catalog-core-solrcommands/pom.xml
+++ b/catalog/core/catalog-core-solrcommands/pom.xml
@@ -161,7 +161,6 @@
             <groupId>ddf.platform.solr</groupId>
             <artifactId>solr-factory-impl</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/catalog/core/catalog-core-solrcommands/pom.xml
+++ b/catalog/core/catalog-core-solrcommands/pom.xml
@@ -232,17 +232,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.65</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.49</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.52</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-solrcommands/pom.xml
+++ b/catalog/core/catalog-core-solrcommands/pom.xml
@@ -107,8 +107,8 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
@@ -128,7 +128,7 @@ public class BackupCommand extends SolrCommands {
     }
 
     URI backupUri = uriBuilder.build();
-    processResponse(sendGetRequest(backupUri));
+    printResponse(sendGetRequest(backupUri));
   }
 
   private void performSolrCloudBackup() throws IOException {
@@ -148,7 +148,7 @@ public class BackupCommand extends SolrCommands {
     }
   }
 
-  private void processResponse(@Nullable HttpResponse response) {
+  private void printResponse(@Nullable HttpResponse response) {
     if (response != null) {
       StatusLine statusLine = response.getStatusLine();
       if (statusLine.getStatusCode() == HttpStatus.SC_OK) {

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
@@ -42,7 +42,7 @@ public class BackupCommand extends SolrCommands {
   private static final String DEFAULT_CORE_NAME = "catalog";
   private static final String SEE_COMMAND_USAGE_MESSAGE =
       "Invalid Argument(s). Please see command usage for details.";
-  @Reference EncryptionService encryptionService;
+  @Reference private EncryptionService encryptionService;
 
   @Option(
     name = "-d",

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
@@ -13,20 +13,15 @@
  */
 package org.codice.ddf.commands.solr;
 
-import com.google.common.annotations.VisibleForTesting;
 import ddf.security.encryption.EncryptionService;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.ext.Nullable;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Option;
@@ -36,9 +31,6 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
-import org.apache.solr.client.solrj.response.RequestStatusState;
-import org.apache.solr.client.solrj.response.UpdateResponse;
-import org.apache.solr.common.util.NamedList;
 
 @Service
 @Command(
@@ -47,9 +39,6 @@ import org.apache.solr.common.util.NamedList;
   description = "Makes a backup of the selected Solr core/collection."
 )
 public class BackupCommand extends SolrCommands {
-
-  private static final String SOLR_CLIENT_PROP = "solr.client";
-  private static final String CLOUD_SOLR_CLIENT_TYPE = "CloudSolrClient";
   private static final String DEFAULT_CORE_NAME = "catalog";
   private static final String SEE_COMMAND_USAGE_MESSAGE =
       "Invalid Argument(s). Please see command usage for details.";
@@ -58,12 +47,10 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-d",
     aliases = {"--dir"},
-    multiValued = false,
-    required = false,
     description =
-        "Full path to location where backups will be written. If this option is not supplied "
-            + " for single node Solr backups, the backup will be written in the data directory "
-            + " for the selected core. For SolrCloud  backups, the backup location must be shared "
+        "Full path to location where backups will be written. If this option is not supplied"
+            + " for single node Solr backups, the backup will be written in the data directory"
+            + " for the selected core. For SolrCloud backups, the backup location must be shared"
             + " by all Solr nodes."
   )
   String backupLocation;
@@ -71,8 +58,6 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-c",
     aliases = {"--coreName"},
-    multiValued = false,
-    required = false,
     description =
         "Name of the Solr core/collection to be backed up. If not specified, the 'catalog' core/collection will be backed up."
   )
@@ -81,8 +66,6 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-a",
     aliases = {"--asyncBackup"},
-    multiValued = false,
-    required = false,
     description = "Perform an asynchronous backup of SolrCloud."
   )
   boolean asyncBackup;
@@ -90,8 +73,6 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-s",
     aliases = {"--asyncBackupStatus"},
-    multiValued = false,
-    required = false,
     description =
         "Get the status of a SolrCloud asynchronous backup. Used in conjunction with --asyncBackupReqId."
   )
@@ -100,8 +81,6 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-i",
     aliases = {"--asyncBackupReqId"},
-    multiValued = false,
-    required = false,
     description =
         "Request Id returned after performing a SolrCloud asynchronous backup. This request Id is used to track"
             + " the status of a given backup. When requesting a backup status, --asyncBackupStatus and --asyncBackupReqId"
@@ -112,24 +91,20 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-n",
     aliases = {"--numToKeep"},
-    multiValued = false,
-    required = false,
     description =
-        "Number of backups to be maintained. If this backup opertion will result"
+        "Number of backups to be maintained. If this backup operation will result"
             + " in exceeding this threshold, the oldest backup will be deleted. This option is not supported"
             + " when backing up SolrCloud."
   )
   int numberToKeep = 0;
 
-  private org.codice.solr.factory.impl.HttpClientBuilder httpBuilder;
-
   @Override
   public Object execute() throws Exception {
-
     if (isSystemConfiguredWithSolrCloud()) {
+      LOGGER.trace("System configuration: Solr Cloud");
       performSolrCloudBackup();
-
     } else {
+      LOGGER.trace("System configuration: Single Node Solr Client");
       performSingleNodeSolrBackup();
     }
 
@@ -139,12 +114,8 @@ public class BackupCommand extends SolrCommands {
   private void performSingleNodeSolrBackup() throws URISyntaxException {
     verifySingleNodeBackupInput();
 
+    String backupUrl = getReplicationUrl(coreName);
     httpBuilder = new org.codice.solr.factory.impl.HttpClientBuilder(encryptionService);
-
-    String url =
-        AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("solr.http.url"));
-    String backupUrl = String.format("%s/%s/%s", url, coreName, "replication");
 
     URIBuilder uriBuilder = new URIBuilder(backupUrl);
     uriBuilder.addParameter("command", "backup");
@@ -160,23 +131,6 @@ public class BackupCommand extends SolrCommands {
     processResponse(sendGetRequest(backupUri));
   }
 
-  @VisibleForTesting
-  @Nullable
-  HttpResponse sendGetRequest(URI backupUri) {
-    HttpResponse httpResponse = null;
-    HttpGet get = new HttpGet(backupUri);
-    HttpClient client = httpBuilder.get().build();
-
-    try {
-      LOGGER.debug("Sending request to {}", backupUri);
-      httpResponse = client.execute(get);
-    } catch (IOException e) {
-      LOGGER.debug("Error during request. Returning null response.");
-    }
-
-    return httpResponse;
-  }
-
   private void performSolrCloudBackup() throws IOException {
     SolrClient client = null;
     try {
@@ -184,7 +138,7 @@ public class BackupCommand extends SolrCommands {
 
       if (asyncBackupStatus) {
         verifyCloudBackupStatusInput();
-        getBackupStatus(client, asyncBackupReqId);
+        printStatus(client, asyncBackupReqId);
       } else {
         verifyCloudBackupInput();
         performSolrCloudBackup(client);
@@ -208,20 +162,6 @@ public class BackupCommand extends SolrCommands {
       }
     } else {
       printErrorMessage(String.format("Could not communicate with Solr. %n"));
-    }
-  }
-
-  private boolean isSystemConfiguredWithSolrCloud() {
-    String solrClientType = System.getProperty(SOLR_CLIENT_PROP);
-    LOGGER.debug("solr client type: {}", solrClientType);
-    if (solrClientType != null) {
-      return StringUtils.equals(solrClientType, CLOUD_SOLR_CLIENT_TYPE);
-    } else {
-      printErrorMessage(
-          String.format(
-              "Could not determine Solr Client Type. Please verify that the system property %s is configured in %s.",
-              SOLR_CLIENT_PROP, SYSTEM_PROPERTIES_PATH));
-      return false;
     }
   }
 
@@ -252,65 +192,57 @@ public class BackupCommand extends SolrCommands {
     return requestId;
   }
 
-  private void getBackupStatus(SolrClient client, String requestId) {
-    try {
-      CollectionAdminRequest.RequestStatusResponse requestStatusResponse =
-          CollectionAdminRequest.requestStatus(requestId).process(client);
-      RequestStatusState requestStatus = requestStatusResponse.getRequestStatus();
-      printInfoMessage(
-          String.format(
-              "Backup status for request Id [%s] is [%s].",
-              asyncBackupReqId, requestStatus.getKey()));
-      LOGGER.debug("Async backup request status: {}", requestStatus.getKey());
-      if (requestStatus == RequestStatusState.FAILED) {
-        printErrorMessage("Backup status failed. ");
-        printResponseErrorMessages(requestStatusResponse);
-      }
-    } catch (Exception e) {
-      String message = e.getMessage() != null ? e.getMessage() : "Unable to get status of backup.";
-      printErrorMessage(String.format("Backup status failed. %s", message));
-    }
-  }
-
-  private void printResponseErrorMessages(CollectionAdminResponse response) {
-    NamedList<String> errorMessages = response.getErrorMessages();
-    if (errorMessages != null) {
-      for (int i = 0; i < errorMessages.size(); i++) {
-        String name = errorMessages.getName(i);
-        String value = errorMessages.getVal(i);
-        printErrorMessage(
-            String.format("\t%d. Error Name: %s; Error Value: %s", i + 1, name, value));
-      }
-    }
-  }
-
   private String getBackupName() {
     long timestamp = System.currentTimeMillis();
     return String.format("%s_%d", coreName, timestamp);
   }
 
   private void verifySingleNodeBackupInput() {
+    LOGGER.trace("Verifying single node backup input.");
     if (asyncBackup || asyncBackupStatus || StringUtils.isNotBlank(asyncBackupReqId)) {
       throw new IllegalArgumentException(SEE_COMMAND_USAGE_MESSAGE);
     }
   }
 
+  /** Verify that cloud backup input has all required options. */
   private void verifyCloudBackupInput() {
-    if (StringUtils.isBlank(backupLocation)
-        || asyncBackupStatus
-        || StringUtils.isNotBlank(asyncBackupReqId)
-        || numberToKeep > 0) {
-      throw new IllegalArgumentException(SEE_COMMAND_USAGE_MESSAGE);
+    LOGGER.trace("Verifying cloud backup input.");
+    if (StringUtils.isBlank(backupLocation)) {
+      throw new IllegalArgumentException(
+          "Backup location must be provided in Cloud Backup." + SEE_COMMAND_USAGE_MESSAGE);
+    } else if (StringUtils.isNotBlank(asyncBackupReqId)) {
+      throw new IllegalArgumentException(
+          "asyncBackupReqId provided without asyncBackupStatus option."
+              + SEE_COMMAND_USAGE_MESSAGE);
+    } else if (numberToKeep > 0) {
+      throw new IllegalArgumentException(
+          "numberToKeep provided but is not supported for Solr Cloud backups."
+              + SEE_COMMAND_USAGE_MESSAGE);
     }
   }
 
+  /** Verify that cloud backup status input has all required options. */
   private void verifyCloudBackupStatusInput() {
-    if (StringUtils.isBlank(asyncBackupReqId)
-        || numberToKeep > 0
-        || StringUtils.isNotBlank(backupLocation)
-        || !StringUtils.equals(coreName, DEFAULT_CORE_NAME)
-        || asyncBackup) {
-      throw new IllegalArgumentException(SEE_COMMAND_USAGE_MESSAGE);
+    LOGGER.trace("Verifying cloud backup status input.");
+    if (StringUtils.isNotBlank(backupLocation)) {
+      LOGGER.debug("Backup location provided during status check, ignoring option.");
+    }
+
+    if (asyncBackup) {
+      LOGGER.debug("asyncBackup option provided during status check, ignoring option.");
+    }
+
+    if (StringUtils.isBlank(asyncBackupReqId)) {
+      throw new IllegalArgumentException(
+          "asyncBackupReqId must not be empty when checking on async status of a backup.");
+    } else if (numberToKeep > 0) {
+      throw new IllegalArgumentException(
+          "numberToKeep provided but is not supported for Solr Cloud backups."
+              + SEE_COMMAND_USAGE_MESSAGE);
+    } else if (!StringUtils.equals(coreName, DEFAULT_CORE_NAME)) {
+      throw new IllegalArgumentException(
+          "coreName provided during status check but is not used. Use the async req id to check the status of your backup."
+              + SEE_COMMAND_USAGE_MESSAGE);
     }
   }
 
@@ -339,17 +271,6 @@ public class BackupCommand extends SolrCommands {
     } catch (Exception e) {
       String message = e.getMessage() != null ? e.getMessage() : "";
       printErrorMessage(String.format("Backup failed. %s", message));
-    }
-  }
-
-  private void optimizeCollection(SolrClient client, String collection)
-      throws IOException, SolrServerException {
-    LOGGER.debug("Optimization of collection [{}] is in progress.", collection);
-    printInfoMessage(String.format("Optimizing of collection [%s] is in progress.", collection));
-    UpdateResponse updateResponse = client.optimize(collection);
-    LOGGER.debug("Optimization status: {}", updateResponse.getStatus());
-    if (updateResponse.getStatus() != 0) {
-      throw new SolrServerException(String.format("Unable to optimize collection [%s].", coreName));
     }
   }
 }

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
@@ -144,7 +144,7 @@ public class BackupCommand extends SolrCommands {
     String url =
         AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> System.getProperty("solr.http.url"));
-    String backupUrl = String.format("%s/%s/replication", url, coreName);
+    String backupUrl = url + "/" + coreName;
 
     URIBuilder uriBuilder = new URIBuilder(backupUrl);
     uriBuilder.addParameter("command", "backup");
@@ -171,7 +171,7 @@ public class BackupCommand extends SolrCommands {
       LOGGER.debug("Sending request to {}", backupUri);
       httpResponse = client.execute(get);
     } catch (IOException e) {
-      LOGGER.debug("Error during request. Returning null response.", e);
+      LOGGER.debug("Error during request. Returning null response.");
     }
 
     return httpResponse;
@@ -195,19 +195,19 @@ public class BackupCommand extends SolrCommands {
   }
 
   private void processResponse(@Nullable HttpResponse response) {
-    if (response == null) {
-      printErrorMessage(String.format("Could not communicate with Solr. %n"));
-      return;
-    }
-    StatusLine statusLine = response.getStatusLine();
-    if (statusLine.getStatusCode() == HttpStatus.SC_OK) {
-      printSuccessMessage(String.format("%nBackup of [%s] complete.%n", coreName));
+    if (response != null) {
+      StatusLine statusLine = response.getStatusLine();
+      if (statusLine.getStatusCode() == HttpStatus.SC_OK) {
+        printSuccessMessage(String.format("%nBackup of [%s] complete.%n", coreName));
+      } else {
+        printErrorMessage(String.format("Error backing up Solr core: [%s]", coreName));
+        printErrorMessage(
+            String.format(
+                "Backup request failed: %d - %s %n",
+                statusLine.getStatusCode(), statusLine.getReasonPhrase()));
+      }
     } else {
-      printErrorMessage(String.format("Error backing up Solr core: [%s]", coreName));
-      printErrorMessage(
-          String.format(
-              "Backup request failed: %d - %s %n",
-              statusLine.getStatusCode(), statusLine.getReasonPhrase()));
+      printErrorMessage(String.format("Could not communicate with Solr. %n"));
     }
   }
 

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
@@ -13,19 +13,32 @@
  */
 package org.codice.ddf.commands.solr;
 
+import com.google.common.annotations.VisibleForTesting;
+import ddf.security.encryption.EncryptionService;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import org.apache.commons.lang3.StringUtils;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import org.apache.commons.lang.StringUtils;
+import org.apache.cxf.jaxrs.ext.Nullable;
+import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
+import org.apache.solr.client.solrj.response.RequestStatusState;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.common.util.NamedList;
 
 @Service
 @Command(
@@ -35,13 +48,22 @@ import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 )
 public class BackupCommand extends SolrCommands {
 
+  private static final String SOLR_CLIENT_PROP = "solr.client";
+  private static final String CLOUD_SOLR_CLIENT_TYPE = "CloudSolrClient";
+  private static final String DEFAULT_CORE_NAME = "catalog";
+  private static final String SEE_COMMAND_USAGE_MESSAGE =
+      "Invalid Argument(s). Please see command usage for details.";
+  @Reference EncryptionService encryptionService;
+
   @Option(
     name = "-d",
     aliases = {"--dir"},
+    multiValued = false,
+    required = false,
     description =
-        "Full path to location where backups will be written. If this option is not supplied"
-            + " for single node Solr backups, the backup will be written in the data directory"
-            + " for the selected core. For SolrCloud  backups, the backup location must be shared"
+        "Full path to location where backups will be written. If this option is not supplied "
+            + " for single node Solr backups, the backup will be written in the data directory "
+            + " for the selected core. For SolrCloud  backups, the backup location must be shared "
             + " by all Solr nodes."
   )
   String backupLocation;
@@ -49,6 +71,8 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-c",
     aliases = {"--coreName"},
+    multiValued = false,
+    required = false,
     description =
         "Name of the Solr core/collection to be backed up. If not specified, the 'catalog' core/collection will be backed up."
   )
@@ -57,6 +81,8 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-a",
     aliases = {"--asyncBackup"},
+    multiValued = false,
+    required = false,
     description = "Perform an asynchronous backup of SolrCloud."
   )
   boolean asyncBackup;
@@ -64,6 +90,8 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-s",
     aliases = {"--asyncBackupStatus"},
+    multiValued = false,
+    required = false,
     description =
         "Get the status of a SolrCloud asynchronous backup. Used in conjunction with --asyncBackupReqId."
   )
@@ -72,6 +100,8 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-i",
     aliases = {"--asyncBackupReqId"},
+    multiValued = false,
+    required = false,
     description =
         "Request Id returned after performing a SolrCloud asynchronous backup. This request Id is used to track"
             + " the status of a given backup. When requesting a backup status, --asyncBackupStatus and --asyncBackupReqId"
@@ -82,20 +112,24 @@ public class BackupCommand extends SolrCommands {
   @Option(
     name = "-n",
     aliases = {"--numToKeep"},
+    multiValued = false,
+    required = false,
     description =
-        "Number of backups to be maintained. If this backup operation will result"
+        "Number of backups to be maintained. If this backup opertion will result"
             + " in exceeding this threshold, the oldest backup will be deleted. This option is not supported"
             + " when backing up SolrCloud."
   )
   int numberToKeep = 0;
 
+  private org.codice.solr.factory.impl.HttpClientBuilder httpBuilder;
+
   @Override
   public Object execute() throws Exception {
+
     if (isSystemConfiguredWithSolrCloud()) {
-      LOGGER.trace("System configuration: Solr Cloud");
       performSolrCloudBackup();
+
     } else {
-      LOGGER.trace("System configuration: Single Node Solr Client");
       performSingleNodeSolrBackup();
     }
 
@@ -105,7 +139,12 @@ public class BackupCommand extends SolrCommands {
   private void performSingleNodeSolrBackup() throws URISyntaxException {
     verifySingleNodeBackupInput();
 
-    String backupUrl = getReplicationUrl(coreName);
+    httpBuilder = new org.codice.solr.factory.impl.HttpClientBuilder(encryptionService);
+
+    String url =
+        AccessController.doPrivileged(
+            (PrivilegedAction<String>) () -> System.getProperty("solr.http.url"));
+    String backupUrl = String.format("%s/%s/%s", url, coreName, "replication");
 
     URIBuilder uriBuilder = new URIBuilder(backupUrl);
     uriBuilder.addParameter("command", "backup");
@@ -118,11 +157,24 @@ public class BackupCommand extends SolrCommands {
     }
 
     URI backupUri = uriBuilder.build();
-    LOGGER.debug("Sending request to {}", backupUri);
+    processResponse(sendGetRequest(backupUri));
+  }
 
-    HttpWrapper httpClient = getHttpClient();
+  @VisibleForTesting
+  @Nullable
+  HttpResponse sendGetRequest(URI backupUri) {
+    HttpResponse httpResponse = null;
+    HttpGet get = new HttpGet(backupUri);
+    HttpClient client = httpBuilder.get().build();
 
-    processResponse(httpClient.execute(backupUri));
+    try {
+      LOGGER.debug("Sending request to {}", backupUri);
+      httpResponse = client.execute(get);
+    } catch (IOException e) {
+      LOGGER.debug("Error during request. Returning null response.");
+    }
+
+    return httpResponse;
   }
 
   private void performSolrCloudBackup() throws IOException {
@@ -132,7 +184,7 @@ public class BackupCommand extends SolrCommands {
 
       if (asyncBackupStatus) {
         verifyCloudBackupStatusInput();
-        printStatus(client, asyncBackupReqId);
+        getBackupStatus(client, asyncBackupReqId);
       } else {
         verifyCloudBackupInput();
         performSolrCloudBackup(client);
@@ -142,18 +194,34 @@ public class BackupCommand extends SolrCommands {
     }
   }
 
-  private void processResponse(ResponseWrapper responseWrapper) {
-
-    if (responseWrapper.getStatusCode() == HttpStatus.SC_OK) {
-      printSuccessMessage(String.format("%nBackup of [%s] complete.%n", coreName));
+  private void processResponse(@Nullable HttpResponse response) {
+    if (response != null) {
+      StatusLine statusLine = response.getStatusLine();
+      if (statusLine.getStatusCode() == HttpStatus.SC_OK) {
+        printSuccessMessage(String.format("%nBackup of [%s] complete.%n", coreName));
+      } else {
+        printErrorMessage(String.format("Error backing up Solr core: [%s]", coreName));
+        printErrorMessage(
+            String.format(
+                "Backup request failed: %d - %s %n",
+                statusLine.getStatusCode(), statusLine.getReasonPhrase()));
+      }
     } else {
-      printErrorMessage(String.format("Error backing up Solr core: [%s]", coreName));
+      printErrorMessage(String.format("Could not communicate with Solr. %n"));
+    }
+  }
+
+  private boolean isSystemConfiguredWithSolrCloud() {
+    String solrClientType = System.getProperty(SOLR_CLIENT_PROP);
+    LOGGER.debug("solr client type: {}", solrClientType);
+    if (solrClientType != null) {
+      return StringUtils.equals(solrClientType, CLOUD_SOLR_CLIENT_TYPE);
+    } else {
       printErrorMessage(
           String.format(
-              "Backup command failed due to: %d - %s %n Request: %s",
-              responseWrapper.getStatusCode(),
-              responseWrapper.getStatusPhrase(),
-              getReplicationUrl(coreName)));
+              "Could not determine Solr Client Type. Please verify that the system property %s is configured in %s.",
+              SOLR_CLIENT_PROP, SYSTEM_PROPERTIES_PATH));
+      return false;
     }
   }
 
@@ -184,57 +252,65 @@ public class BackupCommand extends SolrCommands {
     return requestId;
   }
 
+  private void getBackupStatus(SolrClient client, String requestId) {
+    try {
+      CollectionAdminRequest.RequestStatusResponse requestStatusResponse =
+          CollectionAdminRequest.requestStatus(requestId).process(client);
+      RequestStatusState requestStatus = requestStatusResponse.getRequestStatus();
+      printInfoMessage(
+          String.format(
+              "Backup status for request Id [%s] is [%s].",
+              asyncBackupReqId, requestStatus.getKey()));
+      LOGGER.debug("Async backup request status: {}", requestStatus.getKey());
+      if (requestStatus == RequestStatusState.FAILED) {
+        printErrorMessage("Backup status failed. ");
+        printResponseErrorMessages(requestStatusResponse);
+      }
+    } catch (Exception e) {
+      String message = e.getMessage() != null ? e.getMessage() : "Unable to get status of backup.";
+      printErrorMessage(String.format("Backup status failed. %s", message));
+    }
+  }
+
+  private void printResponseErrorMessages(CollectionAdminResponse response) {
+    NamedList<String> errorMessages = response.getErrorMessages();
+    if (errorMessages != null) {
+      for (int i = 0; i < errorMessages.size(); i++) {
+        String name = errorMessages.getName(i);
+        String value = errorMessages.getVal(i);
+        printErrorMessage(
+            String.format("\t%d. Error Name: %s; Error Value: %s", i + 1, name, value));
+      }
+    }
+  }
+
   private String getBackupName() {
     long timestamp = System.currentTimeMillis();
     return String.format("%s_%d", coreName, timestamp);
   }
 
   private void verifySingleNodeBackupInput() {
-    LOGGER.trace("Verifying single node backup input.");
     if (asyncBackup || asyncBackupStatus || StringUtils.isNotBlank(asyncBackupReqId)) {
       throw new IllegalArgumentException(SEE_COMMAND_USAGE_MESSAGE);
     }
   }
 
-  /** Verify that cloud backup input has all required options. */
   private void verifyCloudBackupInput() {
-    LOGGER.trace("Verifying cloud backup input.");
-    if (StringUtils.isBlank(backupLocation)) {
-      throw new IllegalArgumentException(
-          "Backup location must be provided in Cloud Backup." + SEE_COMMAND_USAGE_MESSAGE);
-    } else if (StringUtils.isNotBlank(asyncBackupReqId)) {
-      throw new IllegalArgumentException(
-          "asyncBackupReqId provided without asyncBackupStatus option."
-              + SEE_COMMAND_USAGE_MESSAGE);
-    } else if (numberToKeep > 0) {
-      throw new IllegalArgumentException(
-          "numberToKeep provided but is not supported for Solr Cloud backups."
-              + SEE_COMMAND_USAGE_MESSAGE);
+    if (StringUtils.isBlank(backupLocation)
+        || asyncBackupStatus
+        || StringUtils.isNotBlank(asyncBackupReqId)
+        || numberToKeep > 0) {
+      throw new IllegalArgumentException(SEE_COMMAND_USAGE_MESSAGE);
     }
   }
 
-  /** Verify that cloud backup status input has all required options. */
   private void verifyCloudBackupStatusInput() {
-    LOGGER.trace("Verifying cloud backup status input.");
-    if (StringUtils.isNotBlank(backupLocation)) {
-      LOGGER.debug("Backup location provided during status check, ignoring option.");
-    }
-
-    if (asyncBackup) {
-      LOGGER.debug("asyncBackup option provided during status check, ignoring option.");
-    }
-
-    if (StringUtils.isBlank(asyncBackupReqId)) {
-      throw new IllegalArgumentException(
-          "asyncBackupReqId must not be empty when checking on async status of a backup.");
-    } else if (numberToKeep > 0) {
-      throw new IllegalArgumentException(
-          "numberToKeep provided but is not supported for Solr Cloud backups."
-              + SEE_COMMAND_USAGE_MESSAGE);
-    } else if (!StringUtils.equals(coreName, DEFAULT_CORE_NAME)) {
-      throw new IllegalArgumentException(
-          "coreName provided during status check but is not used. Use the async req id to check the status of your backup."
-              + SEE_COMMAND_USAGE_MESSAGE);
+    if (StringUtils.isBlank(asyncBackupReqId)
+        || numberToKeep > 0
+        || StringUtils.isNotBlank(backupLocation)
+        || !StringUtils.equals(coreName, DEFAULT_CORE_NAME)
+        || asyncBackup) {
+      throw new IllegalArgumentException(SEE_COMMAND_USAGE_MESSAGE);
     }
   }
 
@@ -263,6 +339,17 @@ public class BackupCommand extends SolrCommands {
     } catch (Exception e) {
       String message = e.getMessage() != null ? e.getMessage() : "";
       printErrorMessage(String.format("Backup failed. %s", message));
+    }
+  }
+
+  private void optimizeCollection(SolrClient client, String collection)
+      throws IOException, SolrServerException {
+    LOGGER.debug("Optimization of collection [{}] is in progress.", collection);
+    printInfoMessage(String.format("Optimizing of collection [%s] is in progress.", collection));
+    UpdateResponse updateResponse = client.optimize(collection);
+    LOGGER.debug("Optimization status: {}", updateResponse.getStatus());
+    if (updateResponse.getStatus() != 0) {
+      throw new SolrServerException(String.format("Unable to optimize collection [%s].", coreName));
     }
   }
 }

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/BackupCommand.java
@@ -153,15 +153,21 @@ public class BackupCommand extends SolrCommands {
       StatusLine statusLine = response.getStatusLine();
       if (statusLine.getStatusCode() == HttpStatus.SC_OK) {
         printSuccessMessage(String.format("%nBackup of [%s] complete.%n", coreName));
+        LOGGER.trace("Backup of {} complete.", coreName);
       } else {
         printErrorMessage(String.format("Error backing up Solr core: [%s]", coreName));
         printErrorMessage(
             String.format(
                 "Backup request failed: %d - %s %n",
                 statusLine.getStatusCode(), statusLine.getReasonPhrase()));
+        LOGGER.debug(
+            "Backup request failed: {} - {}",
+            statusLine.getStatusCode(),
+            statusLine.getReasonPhrase());
       }
     } else {
-      printErrorMessage(String.format("Could not communicate with Solr. %n"));
+      printErrorMessage("Could not communicate with Solr. %n");
+      LOGGER.debug("Could not communicate with Solr, response was null");
     }
   }
 
@@ -173,7 +179,7 @@ public class BackupCommand extends SolrCommands {
     CollectionAdminResponse response = backup.process(client, collection);
     LOGGER.debug("Backup status: {}", response.getStatus());
     if (response.getStatus() != 0) {
-      printErrorMessage("Backup failed. ");
+      printErrorMessage("Backup failed.");
       printResponseErrorMessages(response);
     }
     return response.isSuccess();
@@ -257,20 +263,27 @@ public class BackupCommand extends SolrCommands {
         String.format(
             "Backing up collection [%s] to shared location [%s] using backup name [%s].",
             coreName, backupLocation, backupName));
+    LOGGER.trace(
+        "Backing up collection {} to shared location {} using backup name {}.",
+        coreName,
+        backupLocation,
+        backupName);
     try {
       optimizeCollection(client, coreName);
       if (asyncBackup) {
         String requestId = backupAsync(client, coreName, backupLocation, backupName);
         printInfoMessage("Solr Cloud backup request Id: " + requestId);
+        LOGGER.trace("Solr Cloud backup request Id: {}", requestId);
       } else {
         boolean isSuccess = backup(client, coreName, backupLocation, backupName);
         if (isSuccess) {
           printInfoMessage("Backup complete.");
+          LOGGER.trace("Backup complete.");
         }
       }
     } catch (Exception e) {
-      String message = e.getMessage() != null ? e.getMessage() : "";
-      printErrorMessage(String.format("Backup failed. %s", message));
+      printErrorMessage("Backup failed.");
+      LOGGER.debug("Backup failed.", e);
     }
   }
 }

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/RestoreCommand.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/RestoreCommand.java
@@ -20,7 +20,6 @@ import java.net.URISyntaxException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
@@ -264,14 +263,6 @@ public class RestoreCommand extends SolrCommands {
             .setMaxConnTotal(128)
             .setMaxConnPerRoute(32);
 
-    if (StringUtils.startsWithIgnoreCase(url, "https")) {
-      builder.setSSLSocketFactory(
-          new SSLConnectionSocketFactory(
-              HttpSolrClientFactory.getSslContext(),
-              HttpSolrClientFactory.getProtocols(),
-              HttpSolrClientFactory.getCipherSuites(),
-              SSLConnectionSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER));
-    }
     final String solrDataDir = HttpSolrClientFactory.getSolrDataDir();
     if (solrDataDir != null) {
       ConfigurationStore.getInstance().setDataDirectoryPath(solrDataDir);

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/RestoreCommand.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/RestoreCommand.java
@@ -1,0 +1,310 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.solr;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.response.CollectionAdminResponse;
+import org.codice.solr.factory.impl.ConfigurationStore;
+import org.codice.solr.factory.impl.HttpSolrClientFactory;
+
+@Service
+@Command(
+  scope = SolrCommands.NAMESPACE,
+  name = "restore",
+  description = "Restores a selected Solr core/collection from backup."
+)
+public class RestoreCommand extends SolrCommands {
+
+  @Option(
+    name = "-d",
+    aliases = {"--dir"},
+    description = "The location of the backup files to be restored."
+  )
+  @VisibleForTesting
+  protected String backupLocation;
+
+  @Option(
+    name = "-n",
+    aliases = {"--name"},
+    description =
+        "The name of the backed up index snapshot to be restored. If the name is not provided it looks for backups with snapshot.<timestamp> format in the location directory. It picks the latest timestamp backup in that case."
+  )
+  @VisibleForTesting
+  protected String backupName;
+
+  @Option(
+    name = "-c",
+    aliases = {"--core"},
+    description =
+        "Specify the Solr core to operate on (e.g. catalog). Defaults to catalog if one isn't provided."
+  )
+  @VisibleForTesting
+  protected String coreName = DEFAULT_CORE_NAME;
+
+  @Option(
+    name = "-s",
+    aliases = {"--restoreStatus"},
+    description =
+        "Get the status of a SolrCloud asynchronous restore. Used in conjunction with --requestId."
+  )
+  @VisibleForTesting
+  protected boolean status;
+
+  @Option(
+    name = "-i",
+    aliases = {"--requestId"},
+    description =
+        "Request Id returned after performing a restore. This request Id is used to track"
+            + " the status of a given restore. When requesting a restore status, --restoreStatus and --requestId"
+            + " are both required options."
+  )
+  @VisibleForTesting
+  protected String requestId;
+
+  @Option(
+    name = "-a",
+    aliases = {"--asyncRestore"},
+    description = "Perform an asynchronous restore."
+  )
+  @VisibleForTesting
+  protected boolean asyncRestore;
+
+  @Option(
+    name = "-f",
+    aliases = {"--force"},
+    description = "Forces the restore. Will delete the collection if it already exists"
+  )
+  @VisibleForTesting
+  protected boolean force = false;
+
+  @Override
+  public Object execute() throws Exception {
+    if (isSystemConfiguredWithSolrCloud()) {
+      performSolrCloudRestore();
+    } else {
+      performSingleNodeSolrRestore();
+    }
+
+    return null;
+  }
+
+  private void performSingleNodeSolrRestore() throws URISyntaxException {
+    String restoreUrl = getReplicationUrl(coreName);
+
+    try {
+      createSolrCore();
+
+      URIBuilder uriBuilder = new URIBuilder(restoreUrl);
+      uriBuilder.addParameter("command", "restore");
+
+      if (StringUtils.isNotBlank(backupLocation)) {
+        uriBuilder.addParameter("location", backupLocation);
+      }
+
+      URI restoreUri = uriBuilder.build();
+      LOGGER.debug("Sending request to {}", restoreUri);
+
+      HttpWrapper httpClient = getHttpClient();
+
+      processResponse(httpClient.execute(restoreUri));
+    } catch (IOException | SolrServerException e) {
+      LOGGER.info("Unable to perform single node Solr restore, core: {}", coreName, e);
+    }
+  }
+
+  private void performSolrCloudRestore() throws IOException {
+    SolrClient client = null;
+    try {
+      client = getCloudSolrClient();
+      if (status) {
+        verifyStatusInput();
+        printStatus(client, requestId);
+      } else {
+        verifyRestoreInput();
+        performSolrCloudRestore(client);
+      }
+    } finally {
+      shutdown(client);
+    }
+  }
+
+  private void processResponse(ResponseWrapper responseWrapper) {
+    if (responseWrapper.getStatusCode() == HttpStatus.SC_OK) {
+      printSuccessMessage(String.format("%nRestore of [%s] complete.%n", coreName));
+    } else {
+      printErrorMessage(String.format("Error restoring Solr core: [%s]", coreName));
+      printErrorMessage(
+          String.format(
+              "Restore command failed due to: %d - %s",
+              responseWrapper.getStatusCode(), responseWrapper.getStatusPhrase()));
+      printErrorMessage(String.format("Request: %s", getReplicationUrl(coreName)));
+    }
+  }
+
+  private boolean restore(
+      SolrClient client, String collection, String backupLocation, String backupName)
+      throws IOException, SolrServerException {
+    if (canRestore(client, collection)) {
+      CollectionAdminRequest.Restore restore =
+          CollectionAdminRequest.restoreCollection(collection, backupName)
+              .setLocation(backupLocation);
+
+      CollectionAdminResponse response = restore.process(client, collection);
+      LOGGER.debug("Restore status: {}", response.getStatus());
+      boolean success = response.getStatus() == 0;
+      if (!success) {
+        printErrorMessage("Restore failed. ");
+        printResponseErrorMessages(response);
+      }
+      return success;
+    } else {
+      LOGGER.warn("Unable to restore collection {}", collection);
+      return false;
+    }
+  }
+
+  private String restoreAsync(
+      SolrClient client, String collection, String backupLocation, String backupName)
+      throws IOException, SolrServerException {
+
+    if (canRestore(client, collection)) {
+      CollectionAdminRequest.Restore restore =
+          CollectionAdminRequest.AsyncCollectionAdminRequest.restoreCollection(
+                  collection, backupName)
+              .setLocation(backupLocation);
+
+      String requestId = restore.processAsync(client);
+      LOGGER.debug("Restore request Id: {}", requestId);
+      return requestId;
+    } else {
+      printErrorMessage(
+          String.format("Unable to restore %s, collection already exists.", collection));
+      LOGGER.debug("Unable to restore: {}, collection already exists", collection);
+      return null;
+    }
+  }
+
+  private void performSolrCloudRestore(SolrClient client) {
+    LOGGER.debug("Restoring collection {} from {} / {}.", coreName, backupLocation, backupName);
+    printInfoMessage(
+        String.format(
+            "Restoring collection [%s] from [%s] / [%s].", coreName, backupLocation, backupName));
+    try {
+      if (asyncRestore) {
+        String requestId = restoreAsync(client, coreName, backupLocation, backupName);
+        printInfoMessage("Restore request Id: " + requestId);
+      } else {
+        boolean isSuccess = restore(client, coreName, backupLocation, backupName);
+        if (isSuccess) {
+          printInfoMessage("Restore complete.");
+        }
+      }
+    } catch (Exception e) {
+      String message = e.getMessage() != null ? e.getMessage() : "";
+      printErrorMessage(String.format("Restore failed. %s", message));
+      LOGGER.debug("Restore failed for core: {}.", coreName, e);
+    }
+  }
+
+  private boolean canRestore(SolrClient client, String collection)
+      throws IOException, SolrServerException {
+
+    LOGGER.trace("Checking restoration capability of collection {}", collection);
+    if (collectionExists(client, collection)) {
+      LOGGER.trace("Collection {} already exists", collection);
+      if (force) {
+        LOGGER.trace("Force option set, deleting existing {} collection", collection);
+        CollectionAdminRequest.Delete delete = CollectionAdminRequest.deleteCollection(collection);
+        CollectionAdminResponse response = delete.process(client);
+        return response.isSuccess();
+      } else {
+        printErrorMessage(
+            String.format(
+                "Force option not set, cannot restore %s collection. Use --force to restore when the collection exists.",
+                collection));
+        LOGGER.trace("Force option not set, cannot restore {} collection", collection);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void createSolrCore() throws IOException, SolrServerException {
+    String url = HttpSolrClientFactory.getDefaultHttpsAddress();
+    final HttpClientBuilder builder =
+        HttpClients.custom()
+            .setDefaultCookieStore(new BasicCookieStore())
+            .setMaxConnTotal(128)
+            .setMaxConnPerRoute(32);
+
+    if (StringUtils.startsWithIgnoreCase(url, "https")) {
+      builder.setSSLSocketFactory(
+          new SSLConnectionSocketFactory(
+              HttpSolrClientFactory.getSslContext(),
+              HttpSolrClientFactory.getProtocols(),
+              HttpSolrClientFactory.getCipherSuites(),
+              SSLConnectionSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER));
+    }
+    final String solrDataDir = HttpSolrClientFactory.getSolrDataDir();
+    if (solrDataDir != null) {
+      ConfigurationStore.getInstance().setDataDirectoryPath(solrDataDir);
+    }
+    HttpSolrClientFactory.createSolrCore(url, coreName, null, builder.build());
+  }
+
+  private void verifyStatusInput() {
+    if (status && StringUtils.isBlank(requestId)) {
+      throw new IllegalArgumentException(
+          "Status request is missing requestId." + SEE_COMMAND_USAGE_MESSAGE);
+    }
+
+    if (asyncRestore) {
+      throw new IllegalArgumentException(
+          "asyncRestore passed to status request." + SEE_COMMAND_USAGE_MESSAGE);
+    }
+  }
+
+  private void verifyRestoreInput() {
+
+    if (StringUtils.isNotBlank(requestId)) {
+      LOGGER.debug("requestId option given without asyncStatus option, ignoring.");
+    }
+
+    if (StringUtils.isBlank(backupLocation)) {
+      throw new IllegalArgumentException(
+          "backupLocation must be provided. " + SEE_COMMAND_USAGE_MESSAGE);
+    }
+
+    if (StringUtils.isBlank(backupName)) {
+      throw new IllegalArgumentException(
+          "backupName must be provided. " + SEE_COMMAND_USAGE_MESSAGE);
+    }
+  }
+}

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/SolrCommands.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/SolrCommands.java
@@ -13,8 +13,10 @@
  */
 package org.codice.ddf.commands.solr;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -24,6 +26,10 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.cxf.jaxrs.ext.Nullable;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.solr.client.solrj.SolrClient;
@@ -76,6 +82,8 @@ public abstract class SolrCommands implements Action {
   private static final Color SUCCESS_COLOR = Ansi.Color.GREEN;
 
   private static final Color INFO_COLOR = Ansi.Color.CYAN;
+
+  protected org.codice.solr.factory.impl.HttpClientBuilder httpBuilder;
 
   public void setConfigurationAdmin(ConfigurationAdmin configurationAdmin) {
     LOGGER.debug("setConfigurationAdmin: {}", configurationAdmin);
@@ -245,5 +253,22 @@ public abstract class SolrCommands implements Action {
       return existingCollections.contains(collection);
     }
     return false;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  HttpResponse sendGetRequest(URI backupUri) {
+    HttpResponse httpResponse = null;
+    HttpGet get = new HttpGet(backupUri);
+    HttpClient client = httpBuilder.get().build();
+
+    try {
+      LOGGER.debug("Sending request to {}", backupUri);
+      httpResponse = client.execute(get);
+    } catch (IOException e) {
+      LOGGER.debug("Error during request. Returning null response.");
+    }
+
+    return httpResponse;
   }
 }

--- a/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/SolrCommands.java
+++ b/catalog/core/catalog-core-solrcommands/src/main/java/org/codice/ddf/commands/solr/SolrCommands.java
@@ -216,7 +216,7 @@ public abstract class SolrCommands implements Action {
     } catch (Exception e) {
       String message = e.getMessage() != null ? e.getMessage() : "Unable to get status.";
       printErrorMessage(String.format("Status failed. %s", message));
-      LOGGER.debug("Unable to get status.", e);
+      LOGGER.debug("Unable to get status for request id: {}", requestId, e);
     }
   }
 

--- a/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/BackupCommandTest.java
+++ b/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/BackupCommandTest.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.commands.solr;
 
+import static org.codice.ddf.commands.solr.SolrCommands.SOLR_CLIENT_PROP;
+import static org.codice.ddf.commands.solr.SolrCommands.ZOOKEEPER_HOSTS_PROP;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -25,30 +27,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHttpResponse;
-import org.apache.http.message.BasicStatusLine;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.embedded.JettyConfig;
-import org.apache.solr.client.solrj.request.CollectionAdminRequest;
-import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.RequestStatusState;
 import org.apache.solr.client.solrj.response.UpdateResponse;
-import org.apache.solr.cloud.MiniSolrCloudCluster;
-import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -58,23 +48,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BackupCommandTest extends SolrCommandTest {
 
-  private static final String DEFAULT_CORE_NAME = "catalog";
-
   private static final String INVALID_COLLECTION_NAME = "myInvalidCollection";
-
-  private static final String DEFAULT_CONFIGSET = "collection_configset_1";
 
   private static final Pattern ASCII_COLOR_CODES_REGEX = Pattern.compile("\u001B\\[[;\\d]*m");
 
   private static final long TIMEOUT_IN_MINUTES = 1;
-
-  private static final Path SYSTEM_PROPERTIES_PATH =
-      Paths.get(DEFAULT_DDF_HOME, "etc", "custom.system.properties");
 
   private static final String SEE_COMMAND_USAGE_MESSAGE =
       "Invalid Argument(s). Please see command usage for details.";
@@ -85,6 +69,8 @@ public class BackupCommandTest extends SolrCommandTest {
 
   @Rule public ExpectedException expectedException = ExpectedException.none();
 
+  @Mock SolrClient mockSolrClient;
+
   @BeforeClass
   public static void beforeClass() throws Exception {
     setDdfHome();
@@ -93,26 +79,33 @@ public class BackupCommandTest extends SolrCommandTest {
     addDocument("1");
   }
 
+  @AfterClass
+  public static void afterClass() throws Exception {
+    if (miniSolrCloud != null) {
+      miniSolrCloud.getSolrClient().close();
+      miniSolrCloud.shutdown();
+    }
+  }
+
   @Before
-  public void before() throws Exception {
+  public void setUp() throws Exception {
     cipherSuites = System.getProperty("https.cipherSuites");
     System.setProperty(
         "https.cipherSuites",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA");
     protocols = System.getProperty("https.protocols");
     System.setProperty("https.protocols", "TLSv1.1, TLSv1.2");
+    System.setProperty("solr.http.url", "https://localhost:8994/solr");
     consoleOutput = new ConsoleOutput();
     consoleOutput.interceptSystemOut();
-
-    mockHttpWrapper = mock(HttpWrapper.class);
   }
 
   @After
-  public void after() {
+  public void tearDown() {
     consoleOutput.resetSystemOut();
 
-    System.clearProperty(SolrCommands.SOLR_CLIENT_PROP);
-    System.clearProperty(SolrCommands.ZOOKEEPER_HOSTS_PROP);
+    System.clearProperty(SOLR_CLIENT_PROP);
+    System.clearProperty(ZOOKEEPER_HOSTS_PROP);
 
     if (cipherSuites != null) {
       System.setProperty("https.cipherSuites", cipherSuites);
@@ -126,26 +119,16 @@ public class BackupCommandTest extends SolrCommandTest {
     }
   }
 
-  @AfterClass
-  public static void afterClass() throws Exception {
-    if (miniSolrCloud != null) {
-      miniSolrCloud.getSolrClient().close();
-      miniSolrCloud.shutdown();
-    }
-  }
-
   @Test
   public void testNoArgBackup() throws Exception {
 
-    when(mockHttpWrapper.execute(any(URI.class))).thenReturn(mockResponse(HttpStatus.SC_OK, ""));
-
     BackupCommand backupCommand =
         new BackupCommand() {
-          @Override
-          protected HttpWrapper getHttpClient() {
-            return mockHttpWrapper;
+          HttpResponse sendGetRequest(URI backupUri) {
+            return mockResponse(HttpStatus.SC_OK, "");
           }
         };
+
     backupCommand.execute();
 
     assertThat(
@@ -157,13 +140,10 @@ public class BackupCommandTest extends SolrCommandTest {
   public void testBackupSpecificCore() throws Exception {
     final String coreName = "core";
 
-    when(mockHttpWrapper.execute(any(URI.class))).thenReturn(mockResponse(HttpStatus.SC_OK, ""));
-
     BackupCommand backupCommand =
         new BackupCommand() {
-          @Override
-          protected HttpWrapper getHttpClient() {
-            return mockHttpWrapper;
+          HttpResponse sendGetRequest(URI backupUri) {
+            return mockResponse(HttpStatus.SC_OK, "");
           }
         };
 
@@ -179,14 +159,10 @@ public class BackupCommandTest extends SolrCommandTest {
   public void testBackupInvalidCore() throws Exception {
     final String coreName = "badCoreName";
 
-    when(mockHttpWrapper.execute(any(URI.class)))
-        .thenReturn(mockResponse(HttpStatus.SC_NOT_FOUND, ""));
-
     BackupCommand backupCommand =
         new BackupCommand() {
-          @Override
-          protected HttpWrapper getHttpClient() {
-            return mockHttpWrapper;
+          HttpResponse sendGetRequest(URI backupUri) {
+            return mockResponse(HttpStatus.SC_NOT_FOUND, "");
           }
         };
 
@@ -195,7 +171,7 @@ public class BackupCommandTest extends SolrCommandTest {
 
     assertThat(
         consoleOutput.getOutput(),
-        containsString(String.format("Backup command failed due to: %d", HttpStatus.SC_NOT_FOUND)));
+        containsString(String.format("Backup request failed: %d", HttpStatus.SC_NOT_FOUND)));
   }
 
   @Test
@@ -205,24 +181,14 @@ public class BackupCommandTest extends SolrCommandTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage(SEE_COMMAND_USAGE_MESSAGE);
 
-    when(mockHttpWrapper.execute(any(URI.class))).thenReturn(mockResponse(HttpStatus.SC_OK, ""));
-
     BackupCommand backupCommand =
         new BackupCommand() {
-          @Override
-          protected HttpWrapper getHttpClient() {
-            return mockHttpWrapper;
+          HttpResponse sendGetRequest(URI backupUri) {
+            return mockResponse(HttpStatus.SC_OK, "");
           }
         };
     backupCommand.asyncBackup = true;
 
-    backupCommand.execute();
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testSystemPropertiesNotSet() throws Exception {
-
-    BackupCommand backupCommand = new BackupCommand();
     backupCommand.execute();
   }
 
@@ -478,11 +444,8 @@ public class BackupCommandTest extends SolrCommandTest {
   public void testGetCloudSolrClientNoZkHosts() throws Exception {
 
     // Setup exception expectations
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        String.format(
-            "Could not determine Zookeeper Hosts. Please verify that the system property %s is configured in %s.",
-            SolrCommands.ZOOKEEPER_HOSTS_PROP, SYSTEM_PROPERTIES_PATH));
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage("Couldn't initialize a HttpClusterStateProvider");
 
     // Set the solr client type system property so that the
     // BackupCommand knows that it needs to backup solr cloud.
@@ -744,70 +707,6 @@ public class BackupCommandTest extends SolrCommandTest {
     return mockOptimizationResponse;
   }
 
-  private ResponseWrapper mockResponse(int statusCode, String responseBody) {
-    return new ResponseWrapper(prepareResponse(statusCode, responseBody));
-  }
-
-  private HttpResponse prepareResponse(int statusCode, String responseBody) {
-    HttpResponse httpResponse =
-        new BasicHttpResponse(
-            new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), statusCode, ""));
-    httpResponse.setStatusCode(statusCode);
-    try {
-      httpResponse.setEntity(new StringEntity(responseBody));
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalArgumentException(e);
-    }
-
-    return httpResponse;
-  }
-
-  private static void createDefaultMiniSolrCloudCluster() throws Exception {
-    createMiniSolrCloudCluster();
-    uploadDefaultConfigset();
-    createDefaultCollection();
-  }
-
-  private static void createMiniSolrCloudCluster() throws Exception {
-    miniSolrCloud =
-        new MiniSolrCloudCluster(
-            1, getBaseDirPath(), JettyConfig.builder().setContext("/solr").build());
-    miniSolrCloud.getSolrClient().connect();
-  }
-
-  private static void uploadDefaultConfigset() throws Exception {
-    miniSolrCloud.uploadConfigSet(
-        new File(BackupCommandTest.class.getClassLoader().getResource("configset").getPath())
-            .toPath(),
-        DEFAULT_CONFIGSET);
-  }
-
-  private static void createDefaultCollection() throws Exception {
-    CollectionAdminRequest.Create create =
-        CollectionAdminRequest.createCollection(DEFAULT_CORE_NAME, DEFAULT_CONFIGSET, 1, 1);
-    CollectionAdminResponse response = create.process(miniSolrCloud.getSolrClient());
-    if (response.getStatus() != 0 || response.getErrorMessages() != null) {
-      fail("Could not create collection. Response: " + response.toString());
-    }
-
-    List<String> collections =
-        CollectionAdminRequest.listCollections(miniSolrCloud.getSolrClient());
-    assertThat(collections.size(), is(1));
-    miniSolrCloud.getSolrClient().setDefaultCollection(DEFAULT_CORE_NAME);
-  }
-
-  private static void addDocument(String uniqueId) throws Exception {
-    SolrInputDocument doc = new SolrInputDocument();
-    doc.setField("id", uniqueId);
-    miniSolrCloud.getSolrClient().add(doc);
-    miniSolrCloud.getSolrClient().commit();
-  }
-
-  private BackupCommand getSynchronousBackupCommand(
-      String backupLocation, String collection, SolrClient solrClient) {
-    return getBackupCommand(backupLocation, collection, false, false, null, solrClient);
-  }
-
   private BackupCommand getAsnychronousBackupCommand(
       String backupLocation, String collection, SolrClient solrClient) {
     return getBackupCommand(backupLocation, collection, true, false, null, solrClient);
@@ -815,47 +714,6 @@ public class BackupCommandTest extends SolrCommandTest {
 
   private BackupCommand getStatusBackupCommand(String requestId, SolrClient solrClient) {
     return getBackupCommand(null, null, false, true, requestId, solrClient);
-  }
-
-  private BackupCommand getBackupCommand(
-      String backupLocation,
-      String collection,
-      boolean asyncBackup,
-      boolean asyncBackupStatus,
-      String requestId,
-      SolrClient solrClient) {
-    BackupCommand backupCommand =
-        new BackupCommand() {
-          @Override
-          protected SolrClient getCloudSolrClient() {
-            return solrClient;
-          }
-
-          // We get the solr client from the MiniSolrCloudCluster, so we don't
-          // want to shut it down after each test as there is no way to restart it.
-          // We don't create a MiniSolrCloudCluster for each test to reduce the
-          // time it takes to run the tests.
-          @Override
-          protected void shutdown(SolrClient client) {
-            // do nothing
-          }
-        };
-    if (backupLocation != null) {
-      backupCommand.backupLocation = getBackupLocation();
-    }
-    if (collection != null) {
-      backupCommand.coreName = collection;
-    }
-    if (asyncBackup) {
-      backupCommand.asyncBackup = true;
-    }
-    if (asyncBackupStatus) {
-      backupCommand.asyncBackupStatus = true;
-    }
-    if (requestId != null) {
-      backupCommand.asyncBackupReqId = requestId;
-    }
-    return backupCommand;
   }
 
   // Replace ASCII color codes in console output and get the request Id

--- a/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/BackupCommandTest.java
+++ b/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/BackupCommandTest.java
@@ -307,10 +307,7 @@ public class BackupCommandTest extends SolrCommandTest {
         containsString(
             String.format(
                 "Optimizing of collection [%s] is in progress.", INVALID_COLLECTION_NAME)));
-    assertThat(
-        consoleOutput.getOutput(),
-        containsString(
-            String.format("Backup failed. Collection not found: %s", INVALID_COLLECTION_NAME)));
+    assertThat(consoleOutput.getOutput(), containsString("Backup failed."));
   }
 
   @Test
@@ -598,10 +595,7 @@ public class BackupCommandTest extends SolrCommandTest {
         consoleOutput.getOutput(),
         containsString(
             String.format("Optimizing of collection [%s] is in progress.", DEFAULT_CORE_NAME)));
-    assertThat(
-        consoleOutput.getOutput(),
-        containsString(
-            String.format("Backup failed. Unable to optimize collection [%s]", DEFAULT_CORE_NAME)));
+    assertThat(consoleOutput.getOutput(), containsString("Backup failed."));
   }
 
   /**

--- a/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/RestoreCommandTest.java
+++ b/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/RestoreCommandTest.java
@@ -13,6 +13,9 @@
  */
 package org.codice.ddf.commands.solr;
 
+import static org.codice.ddf.commands.solr.SolrCommands.SOLR_CLIENT_PROP;
+import static org.codice.ddf.commands.solr.SolrCommands.ZOOKEEPER_HOSTS_PROP;
+import static org.codice.ddf.commands.solr.SolrCommands.collectionExists;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -24,29 +27,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHttpResponse;
-import org.apache.http.message.BasicStatusLine;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.embedded.JettyConfig;
-import org.apache.solr.client.solrj.request.CollectionAdminRequest;
-import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.RequestStatusState;
 import org.apache.solr.client.solrj.response.UpdateResponse;
-import org.apache.solr.cloud.MiniSolrCloudCluster;
-import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -58,10 +50,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RestoreCommandTest extends SolrCommandTest {
-
-  private static final String DEFAULT_CORE_NAME = "catalog";
-
-  private static final String DEFAULT_CONFIGSET = "collection_configset_1";
 
   private static final String SOLR_STANDALONE_TYPE = "SolrStandalone";
 
@@ -84,27 +72,30 @@ public class RestoreCommandTest extends SolrCommandTest {
 
   @Before
   public void setUp() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
     cipherSuites = System.getProperty("https.cipherSuites");
     System.setProperty(
         "https.cipherSuites",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA");
     protocols = System.getProperty("https.protocols");
     System.setProperty("https.protocols", "TLSv1.1, TLSv1.2");
+    System.setProperty("solr.http.url", "https://localhost:8994/solr");
     consoleOutput = new ConsoleOutput();
     consoleOutput.interceptSystemOut();
 
-    mockHttpWrapper = mock(HttpWrapper.class);
-    createDefaultCollection();
-    addDocument("1");
-    backupSolr(miniSolrCloud.getSolrClient());
+    if (backupFile == null) {
+      backupSolr();
+    }
+
+    consoleOutput.reset();
   }
 
   @After
   public void tearDown() {
     consoleOutput.resetSystemOut();
 
-    System.clearProperty(SolrCommands.SOLR_CLIENT_PROP);
-    System.clearProperty(SolrCommands.ZOOKEEPER_HOSTS_PROP);
+    System.clearProperty(SOLR_CLIENT_PROP);
+    System.clearProperty(ZOOKEEPER_HOSTS_PROP);
 
     if (cipherSuites != null) {
       System.setProperty("https.cipherSuites", cipherSuites);
@@ -128,24 +119,13 @@ public class RestoreCommandTest extends SolrCommandTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testNoArgRestore() throws Exception {
-    BackupCommand backupCommand =
-        new BackupCommand() {
-          @Override
-          protected HttpWrapper getHttpClient() {
-            return mockHttpWrapper;
-          }
-        };
-    backupCommand.execute();
-
     setupSystemProperties(SOLR_STANDALONE_TYPE);
-
-    when(mockHttpWrapper.execute(any(URI.class))).thenReturn(mockResponse(HttpStatus.SC_OK, ""));
 
     RestoreCommand restoreCommand =
         new RestoreCommand() {
           @Override
-          protected HttpWrapper getHttpClient() {
-            return mockHttpWrapper;
+          HttpResponse sendGetRequest(URI backupUri) {
+            return mockResponse(HttpStatus.SC_OK, "");
           }
         };
     restoreCommand.execute();
@@ -153,15 +133,12 @@ public class RestoreCommandTest extends SolrCommandTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testSingleNodeRestoreAsyncOptionSupplied() throws Exception {
-    when(mockHttpWrapper.execute(any(URI.class))).thenReturn(mockResponse(HttpStatus.SC_OK, ""));
-
     setupSystemProperties(SOLR_STANDALONE_TYPE);
 
     RestoreCommand restoreCommand =
         new RestoreCommand() {
-          @Override
-          protected HttpWrapper getHttpClient() {
-            return mockHttpWrapper;
+          HttpResponse sendGetRequest(URI backupUri) {
+            return mockResponse(HttpStatus.SC_OK, "");
           }
         };
     restoreCommand.asyncRestore = true;
@@ -177,7 +154,6 @@ public class RestoreCommandTest extends SolrCommandTest {
 
   @Test
   public void testPerformSolrCloudSynchronousRestore() throws Exception {
-    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
     RestoreCommand restoreCommand =
         getSynchronousRestoreCommand(
             getBackupLocation(), DEFAULT_CORE_NAME, miniSolrCloud.getSolrClient());
@@ -215,17 +191,13 @@ public class RestoreCommandTest extends SolrCommandTest {
         getSynchronousRestoreCommand(getBackupLocation(), null, miniSolrCloud.getSolrClient());
     restoreCommand.execute();
 
-    String backupName = getBackupName(consoleOutput.getOutput());
-    File backupFile =
-        Paths.get(restoreCommand.backupLocation, backupName).toAbsolutePath().toFile();
     assertThat(
         consoleOutput.getOutput(),
         containsString(
             String.format(
                 "Restoring collection [%s] from [%s] / [%s",
-                DEFAULT_CORE_NAME, restoreCommand.backupLocation, backupName)));
+                DEFAULT_CORE_NAME, restoreCommand.backupLocation, backupFile.getName())));
     assertThat(consoleOutput.getOutput(), containsString("Restore complete."));
-    assertThat(backupFile.exists(), is(true));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -241,23 +213,6 @@ public class RestoreCommandTest extends SolrCommandTest {
             "myRequestId1",
             miniSolrCloud.getSolrClient());
     restoreCommand.execute();
-  }
-
-  @Test
-  public void testPerformSolrCloudAsynchronousRestore() throws Exception {
-    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
-    RestoreCommand restoreCommand =
-        getAsnychronousRestoreCommand(
-            getBackupLocation(), DEFAULT_CORE_NAME, miniSolrCloud.getSolrClient());
-    restoreCommand.execute();
-
-    assertThat(
-        consoleOutput.getOutput(),
-        containsString(
-            String.format(
-                "Restoring collection [%s] from [%s] / [%s_",
-                DEFAULT_CORE_NAME, restoreCommand.backupLocation, DEFAULT_CORE_NAME)));
-    assertThat(consoleOutput.getOutput(), containsString("Restore request Id:"));
   }
 
   @Test
@@ -301,7 +256,8 @@ public class RestoreCommandTest extends SolrCommandTest {
   @Test
   public void testSolrCloudRestoreFailsWithErrorMessages() throws Exception {
     setupSolrClientType(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
-    setupMockSolrClientForRestoreFailure(DEFAULT_CORE_NAME, getErrorMessages(2));
+    SolrClient mockSolrClient =
+        getMockSolrClientForRestoreFailure(DEFAULT_CORE_NAME, getErrorMessages(2));
     RestoreCommand restoreCommand =
         getSynchronousRestoreCommand(getBackupLocation(), DEFAULT_CORE_NAME, mockSolrClient);
     restoreCommand.execute();
@@ -312,17 +268,7 @@ public class RestoreCommandTest extends SolrCommandTest {
             String.format(
                 "Restoring collection [%s] from [%s] / [%s_",
                 DEFAULT_CORE_NAME, restoreCommand.backupLocation, DEFAULT_CORE_NAME)));
-    assertThat(
-        consoleOutput.getOutput(),
-        containsString(
-            String.format("Optimizing of collection [%s] is in progress.", DEFAULT_CORE_NAME)));
     assertThat(consoleOutput.getOutput(), containsString("Restore failed."));
-    assertThat(
-        consoleOutput.getOutput(),
-        containsString("1. Error Name: error name 1; Error Value: error value 1"));
-    assertThat(
-        consoleOutput.getOutput(),
-        containsString("2. Error Name: error name 2; Error Value: error value 2"));
   }
 
   @Test
@@ -334,7 +280,7 @@ public class RestoreCommandTest extends SolrCommandTest {
     restoreCommand.execute();
 
     String requestId = getRequestId(consoleOutput.getOutput());
-    setupMockSolrClientForRestoreStatusFailure(getErrorMessages(1));
+    SolrClient mockSolrClient = getMockSolrClientForRestoreStatusFailure(getErrorMessages(1));
     RestoreCommand restoreStatusCommand = getStatusRestoreCommand(requestId, mockSolrClient);
     restoreStatusCommand.execute();
 
@@ -347,16 +293,15 @@ public class RestoreCommandTest extends SolrCommandTest {
     assertThat(
         consoleOutput.getOutput(),
         containsString(
-            String.format("Optimizing of collection [%s] is in progress.", DEFAULT_CORE_NAME)));
-    assertThat(
-        consoleOutput.getOutput(),
-        containsString(
             String.format(
                 "Status for request Id [%s] is [%s].",
                 requestId, RequestStatusState.FAILED.getKey())));
     assertThat(
         consoleOutput.getOutput(),
         containsString("1. Error Name: error name 1; Error Value: error value 1"));
+
+    restoreStatusCommand = getStatusRestoreCommand(requestId, miniSolrCloud.getSolrClient());
+    waitForCompletedStatusOrFail(restoreStatusCommand, consoleOutput);
   }
 
   @Test
@@ -368,11 +313,13 @@ public class RestoreCommandTest extends SolrCommandTest {
     restoreCommand.execute();
 
     String requestId = getRequestId(consoleOutput.getOutput());
-    setupMockSolrClientForStatusThrowsException();
+    SolrClient mockSolrClient = getMockSolrClientForStatusThrowsException();
     RestoreCommand restoreStatusCommand = getStatusRestoreCommand(requestId, mockSolrClient);
     restoreStatusCommand.execute();
 
     assertThat(consoleOutput.getOutput(), containsString("Status failed."));
+    restoreStatusCommand = getStatusRestoreCommand(requestId, miniSolrCloud.getSolrClient());
+    waitForCompletedStatusOrFail(restoreStatusCommand, consoleOutput);
   }
 
   private NamedList<String> getErrorMessages(int numberOfMessages) {
@@ -383,9 +330,9 @@ public class RestoreCommandTest extends SolrCommandTest {
     return errorMessages;
   }
 
-  private void setupMockSolrClientForRestoreFailure(
+  private SolrClient getMockSolrClientForRestoreFailure(
       String collection, NamedList<String> restoreErrorMessages) throws Exception {
-    setupMockSolrClientForRestore(
+    return getMockSolrClientForRestore(
         collection, SUCCESS_STATUS_CODE, FAILURE_STATUS_CODE, restoreErrorMessages);
   }
 
@@ -394,13 +341,14 @@ public class RestoreCommandTest extends SolrCommandTest {
    * https://cwiki.apache.org/confluence/display/solr/Collections+API#CollectionsAPI-BACKUP:BackupCollection
    * for requests and responses.
    */
-  private void setupMockSolrClientForRestore(
+  private SolrClient getMockSolrClientForRestore(
       String collection,
       int optimizationStatusCode,
       int restoreStatusCode,
       NamedList<String> restoreErrorMessages)
       throws Exception {
 
+    SolrClient mockSolrClient = mock(SolrClient.class);
     UpdateResponse optimizationResponse = getMockOptimizationResponse(optimizationStatusCode);
     when(mockSolrClient.optimize(eq(collection))).thenReturn(optimizationResponse);
 
@@ -417,92 +365,29 @@ public class RestoreCommandTest extends SolrCommandTest {
     if (collection != null) {
       when(mockSolrClient.request(any(SolrRequest.class), eq(collection))).thenReturn(mockResponse);
     }
+    return mockSolrClient;
   }
 
-  private void setupMockSolrClientForRestoreStatusFailure(NamedList<String> restoreErrorMessages)
-      throws Exception {
+  private SolrClient getMockSolrClientForRestoreStatusFailure(
+      NamedList<String> restoreErrorMessages) throws Exception {
+    SolrClient mockSolrClient = mock(SolrClient.class);
     NamedList<Object> response =
         getResponseForStatus(FAILURE_STATUS_CODE, RequestStatusState.FAILED, restoreErrorMessages);
     when(mockSolrClient.request(any(SolrRequest.class), isNull(String.class))).thenReturn(response);
+    return mockSolrClient;
   }
 
-  private void setupMockSolrClientForStatusThrowsException() throws Exception {
+  private SolrClient getMockSolrClientForStatusThrowsException() throws Exception {
+    SolrClient mockSolrClient = mock(SolrClient.class);
     when(mockSolrClient.request(any(SolrRequest.class), isNull(String.class)))
         .thenThrow(SolrServerException.class);
+    return mockSolrClient;
   }
 
   private UpdateResponse getMockOptimizationResponse(int status) {
     UpdateResponse mockOptimizationResponse = mock(UpdateResponse.class);
     when(mockOptimizationResponse.getStatus()).thenReturn(status);
     return mockOptimizationResponse;
-  }
-
-  private ResponseWrapper mockResponse(int statusCode, String responseBody) {
-    return new ResponseWrapper(prepareResponse(statusCode, responseBody));
-  }
-
-  private HttpResponse prepareResponse(int statusCode, String responseBody) {
-    HttpResponse httpResponse =
-        new BasicHttpResponse(
-            new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), statusCode, ""));
-    httpResponse.setStatusCode(statusCode);
-    try {
-      httpResponse.setEntity(new StringEntity(responseBody));
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalArgumentException(e);
-    }
-
-    return httpResponse;
-  }
-
-  private static void createDefaultMiniSolrCloudCluster() throws Exception {
-    createMiniSolrCloudCluster();
-    uploadDefaultConfigset();
-  }
-
-  private static void createMiniSolrCloudCluster() throws Exception {
-    miniSolrCloud =
-        new MiniSolrCloudCluster(
-            1, getBaseDirPath(), JettyConfig.builder().setContext("/solr").build());
-    miniSolrCloud.getSolrClient().connect();
-  }
-
-  private static void uploadDefaultConfigset() throws Exception {
-    miniSolrCloud.uploadConfigSet(
-        new File(RestoreCommandTest.class.getClassLoader().getResource("configset").getPath())
-            .toPath(),
-        DEFAULT_CONFIGSET);
-  }
-
-  private static void createDefaultCollection() throws Exception {
-    cleanupCollections();
-    CollectionAdminRequest.Create create =
-        CollectionAdminRequest.createCollection(DEFAULT_CORE_NAME, DEFAULT_CONFIGSET, 1, 1);
-    CollectionAdminResponse response = create.process(miniSolrCloud.getSolrClient());
-    if (response.getStatus() != 0 || response.getErrorMessages() != null) {
-      fail("Could not create collection. Response: " + response.toString());
-    }
-
-    List<String> collections =
-        CollectionAdminRequest.listCollections(miniSolrCloud.getSolrClient());
-    assertThat(collections.size(), is(1));
-    miniSolrCloud.getSolrClient().setDefaultCollection(DEFAULT_CORE_NAME);
-  }
-
-  private static void cleanupCollections() throws Exception {
-    List<String> collections =
-        CollectionAdminRequest.listCollections(miniSolrCloud.getSolrClient());
-    for (String collection : collections) {
-      CollectionAdminRequest.Delete delete = CollectionAdminRequest.deleteCollection(collection);
-      delete.process(miniSolrCloud.getSolrClient());
-    }
-  }
-
-  private static void addDocument(String uniqueId) throws Exception {
-    SolrInputDocument doc = new SolrInputDocument();
-    doc.setField("id", uniqueId);
-    miniSolrCloud.getSolrClient().add(doc);
-    miniSolrCloud.getSolrClient().commit();
   }
 
   private RestoreCommand getSynchronousRestoreCommand(
@@ -549,15 +434,15 @@ public class RestoreCommandTest extends SolrCommandTest {
     if (collection != null) {
       restoreCommand.coreName = collection;
     }
-    if (asyncRestore) {
-      restoreCommand.asyncRestore = true;
-    }
-    if (status) {
-      restoreCommand.status = true;
-    }
+
+    restoreCommand.asyncRestore = asyncRestore;
+
+    restoreCommand.status = status;
+
     if (requestId != null) {
       restoreCommand.requestId = requestId;
     }
+
     if (backupFile != null && backupFile.exists()) {
       restoreCommand.backupName = backupFile.getName();
     }
@@ -606,24 +491,30 @@ public class RestoreCommandTest extends SolrCommandTest {
     return status;
   }
 
-  private void backupSolr(SolrClient solrClient) throws Exception {
-    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
-    BackupCommand backupCommand =
-        new BackupCommand() {
-          @Override
-          protected SolrClient getCloudSolrClient() {
-            return solrClient;
-          }
+  private void waitForCollectionOrFail(SolrClient solrClient, String core) throws Exception {
+    long startTime = System.currentTimeMillis();
+    long endTime = startTime + TimeUnit.MINUTES.toMillis(TIMEOUT_IN_MINUTES);
+    boolean exists = collectionExists(solrClient, core);
 
-          @Override
-          protected void shutdown(SolrClient client) {
-            // do nothing
-          }
-        };
-    backupCommand.backupLocation = getBackupLocation();
-    backupCommand.asyncBackup = false;
-    backupCommand.asyncBackupStatus = false;
-    backupCommand.coreName = DEFAULT_CORE_NAME;
+    while (!exists) {
+      if (System.currentTimeMillis() >= endTime) {
+        fail(
+            String.format(
+                "The restore status command did not complete within %s minute(s).",
+                TIMEOUT_IN_MINUTES));
+      }
+      TimeUnit.SECONDS.sleep(1);
+      exists = collectionExists(solrClient, core);
+    }
+  }
+
+  private void backupSolr() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    SolrClient solrClient = miniSolrCloud.getSolrClient();
+    waitForCollectionOrFail(solrClient, DEFAULT_CORE_NAME);
+    miniSolrCloud.waitForAllNodes((int) TimeUnit.SECONDS.toMillis(1));
+    BackupCommand backupCommand =
+        getSynchronousBackupCommand(getBackupLocation(), DEFAULT_CORE_NAME, solrClient);
     backupCommand.execute();
     String backupName = getBackupName(consoleOutput.getOutput());
     backupFile = Paths.get(backupCommand.backupLocation, backupName).toAbsolutePath().toFile();

--- a/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/RestoreCommandTest.java
+++ b/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/RestoreCommandTest.java
@@ -1,0 +1,639 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.solr;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.embedded.JettyConfig;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.response.CollectionAdminResponse;
+import org.apache.solr.client.solrj.response.RequestStatusState;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.cloud.MiniSolrCloudCluster;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.NamedList;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RestoreCommandTest extends SolrCommandTest {
+
+  private static final String DEFAULT_CORE_NAME = "catalog";
+
+  private static final String DEFAULT_CONFIGSET = "collection_configset_1";
+
+  private static final String SOLR_STANDALONE_TYPE = "SolrStandalone";
+
+  private static final Pattern ASCII_COLOR_CODES_REGEX = Pattern.compile("\u001B\\[[;\\d]*m");
+
+  private static final long TIMEOUT_IN_MINUTES = 1;
+
+  private static final int SUCCESS_STATUS_CODE = 0;
+
+  private static final int FAILURE_STATUS_CODE = 500;
+
+  private File backupFile;
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    setDdfHome();
+    setDdfEtc();
+    createDefaultMiniSolrCloudCluster();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    cipherSuites = System.getProperty("https.cipherSuites");
+    System.setProperty(
+        "https.cipherSuites",
+        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA");
+    protocols = System.getProperty("https.protocols");
+    System.setProperty("https.protocols", "TLSv1.1, TLSv1.2");
+    consoleOutput = new ConsoleOutput();
+    consoleOutput.interceptSystemOut();
+
+    mockHttpWrapper = mock(HttpWrapper.class);
+    createDefaultCollection();
+    addDocument("1");
+    backupSolr(miniSolrCloud.getSolrClient());
+  }
+
+  @After
+  public void tearDown() {
+    consoleOutput.resetSystemOut();
+
+    System.clearProperty(SolrCommands.SOLR_CLIENT_PROP);
+    System.clearProperty(SolrCommands.ZOOKEEPER_HOSTS_PROP);
+
+    if (cipherSuites != null) {
+      System.setProperty("https.cipherSuites", cipherSuites);
+    } else {
+      System.clearProperty("https.cipherSuites");
+    }
+    if (protocols != null) {
+      System.setProperty("https.protocols", protocols);
+    } else {
+      System.clearProperty("https.protocols");
+    }
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    if (miniSolrCloud != null) {
+      miniSolrCloud.getSolrClient().close();
+      miniSolrCloud.shutdown();
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNoArgRestore() throws Exception {
+    BackupCommand backupCommand =
+        new BackupCommand() {
+          @Override
+          protected HttpWrapper getHttpClient() {
+            return mockHttpWrapper;
+          }
+        };
+    backupCommand.execute();
+
+    setupSystemProperties(SOLR_STANDALONE_TYPE);
+
+    when(mockHttpWrapper.execute(any(URI.class))).thenReturn(mockResponse(HttpStatus.SC_OK, ""));
+
+    RestoreCommand restoreCommand =
+        new RestoreCommand() {
+          @Override
+          protected HttpWrapper getHttpClient() {
+            return mockHttpWrapper;
+          }
+        };
+    restoreCommand.execute();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSingleNodeRestoreAsyncOptionSupplied() throws Exception {
+    when(mockHttpWrapper.execute(any(URI.class))).thenReturn(mockResponse(HttpStatus.SC_OK, ""));
+
+    setupSystemProperties(SOLR_STANDALONE_TYPE);
+
+    RestoreCommand restoreCommand =
+        new RestoreCommand() {
+          @Override
+          protected HttpWrapper getHttpClient() {
+            return mockHttpWrapper;
+          }
+        };
+    restoreCommand.asyncRestore = true;
+
+    restoreCommand.execute();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSystemPropertiesNotSet() throws Exception {
+    RestoreCommand restoreCommand = new RestoreCommand();
+    restoreCommand.execute();
+  }
+
+  @Test
+  public void testPerformSolrCloudSynchronousRestore() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getSynchronousRestoreCommand(
+            getBackupLocation(), DEFAULT_CORE_NAME, miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format(
+                "Restoring collection [%s] from [%s] / [%s",
+                DEFAULT_CORE_NAME, restoreCommand.backupLocation, backupFile.getName())));
+    assertThat(consoleOutput.getOutput(), containsString("Restore complete."));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPerformSolrCloudSynchronousRestoreNoOptions() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getSynchronousRestoreCommand(null, null, miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPerformSolrCloudSynchronousRestoreNoBackupLocation() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getSynchronousRestoreCommand(null, DEFAULT_CORE_NAME, miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+  }
+
+  @Test
+  public void testPerformSolrCloudSynchronousRestoreNoCollection() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getSynchronousRestoreCommand(getBackupLocation(), null, miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+
+    String backupName = getBackupName(consoleOutput.getOutput());
+    File backupFile =
+        Paths.get(restoreCommand.backupLocation, backupName).toAbsolutePath().toFile();
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format(
+                "Restoring collection [%s] from [%s] / [%s",
+                DEFAULT_CORE_NAME, restoreCommand.backupLocation, backupName)));
+    assertThat(consoleOutput.getOutput(), containsString("Restore complete."));
+    assertThat(backupFile.exists(), is(true));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPerformSolrCloudAsynchronousRestoreWithAsyncStatusOptionsSupplied()
+      throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getRestoreCommand(
+            getBackupLocation(),
+            DEFAULT_CORE_NAME,
+            true,
+            true,
+            "myRequestId1",
+            miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+  }
+
+  @Test
+  public void testPerformSolrCloudAsynchronousRestore() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getAsnychronousRestoreCommand(
+            getBackupLocation(), DEFAULT_CORE_NAME, miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format(
+                "Restoring collection [%s] from [%s] / [%s_",
+                DEFAULT_CORE_NAME, restoreCommand.backupLocation, DEFAULT_CORE_NAME)));
+    assertThat(consoleOutput.getOutput(), containsString("Restore request Id:"));
+  }
+
+  @Test
+  public void testPerformSolrCloudAsynchronousRestoreStatus() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getAsnychronousRestoreCommand(
+            getBackupLocation(), DEFAULT_CORE_NAME, miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+
+    String requestId = getRequestId(consoleOutput.getOutput());
+    RestoreCommand statusRestoreCommand =
+        getStatusRestoreCommand(requestId, miniSolrCloud.getSolrClient());
+    consoleOutput.reset();
+    statusRestoreCommand.execute();
+    String status = waitForCompletedStatusOrFail(statusRestoreCommand, consoleOutput);
+
+    assertThat(status, is(RequestStatusState.COMPLETED.getKey()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetSolrCloudAsynchronousRestoreStatusNoRequestId() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand statusRestoreCommand =
+        getStatusRestoreCommand(null, miniSolrCloud.getSolrClient());
+    statusRestoreCommand.execute();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetSolrCloudAsynchronousRestoreStatusNoStatusOption() throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand invalidRestoreStatusCommand =
+        getRestoreCommand(null, null, false, false, "myRequestId0", miniSolrCloud.getSolrClient());
+    invalidRestoreStatusCommand.execute();
+  }
+
+  /**
+   * Verify that restore failure messages are printed to the console. In this test, the collection
+   * optimization succeeds but the restore fails.
+   */
+  @Test
+  public void testSolrCloudRestoreFailsWithErrorMessages() throws Exception {
+    setupSolrClientType(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    setupMockSolrClientForRestoreFailure(DEFAULT_CORE_NAME, getErrorMessages(2));
+    RestoreCommand restoreCommand =
+        getSynchronousRestoreCommand(getBackupLocation(), DEFAULT_CORE_NAME, mockSolrClient);
+    restoreCommand.execute();
+
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format(
+                "Restoring collection [%s] from [%s] / [%s_",
+                DEFAULT_CORE_NAME, restoreCommand.backupLocation, DEFAULT_CORE_NAME)));
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format("Optimizing of collection [%s] is in progress.", DEFAULT_CORE_NAME)));
+    assertThat(consoleOutput.getOutput(), containsString("Restore failed."));
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString("1. Error Name: error name 1; Error Value: error value 1"));
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString("2. Error Name: error name 2; Error Value: error value 2"));
+  }
+
+  @Test
+  public void testSolrCloudRestoreStatusRequestFailsWithErrorMessages() throws Exception {
+    setupSolrClientType(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getAsnychronousRestoreCommand(
+            getBackupLocation(), DEFAULT_CORE_NAME, miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+
+    String requestId = getRequestId(consoleOutput.getOutput());
+    setupMockSolrClientForRestoreStatusFailure(getErrorMessages(1));
+    RestoreCommand restoreStatusCommand = getStatusRestoreCommand(requestId, mockSolrClient);
+    restoreStatusCommand.execute();
+
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format(
+                "Restoring collection [%s] from [%s] / [%s_",
+                DEFAULT_CORE_NAME, restoreCommand.backupLocation, DEFAULT_CORE_NAME)));
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format("Optimizing of collection [%s] is in progress.", DEFAULT_CORE_NAME)));
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format(
+                "Status for request Id [%s] is [%s].",
+                requestId, RequestStatusState.FAILED.getKey())));
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString("1. Error Name: error name 1; Error Value: error value 1"));
+  }
+
+  @Test
+  public void testSolrCloudRestoreStatusRequestThrowsException() throws Exception {
+    setupSolrClientType(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    RestoreCommand restoreCommand =
+        getAsnychronousRestoreCommand(
+            getBackupLocation(), DEFAULT_CORE_NAME, miniSolrCloud.getSolrClient());
+    restoreCommand.execute();
+
+    String requestId = getRequestId(consoleOutput.getOutput());
+    setupMockSolrClientForStatusThrowsException();
+    RestoreCommand restoreStatusCommand = getStatusRestoreCommand(requestId, mockSolrClient);
+    restoreStatusCommand.execute();
+
+    assertThat(consoleOutput.getOutput(), containsString("Status failed."));
+  }
+
+  private NamedList<String> getErrorMessages(int numberOfMessages) {
+    NamedList<String> errorMessages = new NamedList<>();
+    for (int i = 0; i < numberOfMessages; i++) {
+      errorMessages.add("error name " + (i + 1), "error value " + (i + 1));
+    }
+    return errorMessages;
+  }
+
+  private void setupMockSolrClientForRestoreFailure(
+      String collection, NamedList<String> restoreErrorMessages) throws Exception {
+    setupMockSolrClientForRestore(
+        collection, SUCCESS_STATUS_CODE, FAILURE_STATUS_CODE, restoreErrorMessages);
+  }
+
+  /**
+   * See
+   * https://cwiki.apache.org/confluence/display/solr/Collections+API#CollectionsAPI-BACKUP:BackupCollection
+   * for requests and responses.
+   */
+  private void setupMockSolrClientForRestore(
+      String collection,
+      int optimizationStatusCode,
+      int restoreStatusCode,
+      NamedList<String> restoreErrorMessages)
+      throws Exception {
+
+    UpdateResponse optimizationResponse = getMockOptimizationResponse(optimizationStatusCode);
+    when(mockSolrClient.optimize(eq(collection))).thenReturn(optimizationResponse);
+
+    NamedList<Object> responseHeader = getResponseHeader(restoreStatusCode);
+
+    NamedList<Object> mockResponse = new NamedList<>();
+    mockResponse.add("responseHeader", responseHeader);
+    if (restoreErrorMessages != null) {
+      mockResponse.add("failure", restoreErrorMessages);
+    } else {
+      mockResponse.add("success", new Object());
+    }
+
+    if (collection != null) {
+      when(mockSolrClient.request(any(SolrRequest.class), eq(collection))).thenReturn(mockResponse);
+    }
+  }
+
+  private void setupMockSolrClientForRestoreStatusFailure(NamedList<String> restoreErrorMessages)
+      throws Exception {
+    NamedList<Object> response =
+        getResponseForStatus(FAILURE_STATUS_CODE, RequestStatusState.FAILED, restoreErrorMessages);
+    when(mockSolrClient.request(any(SolrRequest.class), isNull(String.class))).thenReturn(response);
+  }
+
+  private void setupMockSolrClientForStatusThrowsException() throws Exception {
+    when(mockSolrClient.request(any(SolrRequest.class), isNull(String.class)))
+        .thenThrow(SolrServerException.class);
+  }
+
+  private UpdateResponse getMockOptimizationResponse(int status) {
+    UpdateResponse mockOptimizationResponse = mock(UpdateResponse.class);
+    when(mockOptimizationResponse.getStatus()).thenReturn(status);
+    return mockOptimizationResponse;
+  }
+
+  private ResponseWrapper mockResponse(int statusCode, String responseBody) {
+    return new ResponseWrapper(prepareResponse(statusCode, responseBody));
+  }
+
+  private HttpResponse prepareResponse(int statusCode, String responseBody) {
+    HttpResponse httpResponse =
+        new BasicHttpResponse(
+            new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), statusCode, ""));
+    httpResponse.setStatusCode(statusCode);
+    try {
+      httpResponse.setEntity(new StringEntity(responseBody));
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalArgumentException(e);
+    }
+
+    return httpResponse;
+  }
+
+  private static void createDefaultMiniSolrCloudCluster() throws Exception {
+    createMiniSolrCloudCluster();
+    uploadDefaultConfigset();
+  }
+
+  private static void createMiniSolrCloudCluster() throws Exception {
+    miniSolrCloud =
+        new MiniSolrCloudCluster(
+            1, getBaseDirPath(), JettyConfig.builder().setContext("/solr").build());
+    miniSolrCloud.getSolrClient().connect();
+  }
+
+  private static void uploadDefaultConfigset() throws Exception {
+    miniSolrCloud.uploadConfigSet(
+        new File(RestoreCommandTest.class.getClassLoader().getResource("configset").getPath())
+            .toPath(),
+        DEFAULT_CONFIGSET);
+  }
+
+  private static void createDefaultCollection() throws Exception {
+    cleanupCollections();
+    CollectionAdminRequest.Create create =
+        CollectionAdminRequest.createCollection(DEFAULT_CORE_NAME, DEFAULT_CONFIGSET, 1, 1);
+    CollectionAdminResponse response = create.process(miniSolrCloud.getSolrClient());
+    if (response.getStatus() != 0 || response.getErrorMessages() != null) {
+      fail("Could not create collection. Response: " + response.toString());
+    }
+
+    List<String> collections =
+        CollectionAdminRequest.listCollections(miniSolrCloud.getSolrClient());
+    assertThat(collections.size(), is(1));
+    miniSolrCloud.getSolrClient().setDefaultCollection(DEFAULT_CORE_NAME);
+  }
+
+  private static void cleanupCollections() throws Exception {
+    List<String> collections =
+        CollectionAdminRequest.listCollections(miniSolrCloud.getSolrClient());
+    for (String collection : collections) {
+      CollectionAdminRequest.Delete delete = CollectionAdminRequest.deleteCollection(collection);
+      delete.process(miniSolrCloud.getSolrClient());
+    }
+  }
+
+  private static void addDocument(String uniqueId) throws Exception {
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", uniqueId);
+    miniSolrCloud.getSolrClient().add(doc);
+    miniSolrCloud.getSolrClient().commit();
+  }
+
+  private RestoreCommand getSynchronousRestoreCommand(
+      String backupLocation, String collection, SolrClient solrClient) {
+    return getRestoreCommand(backupLocation, collection, false, false, null, solrClient);
+  }
+
+  private RestoreCommand getAsnychronousRestoreCommand(
+      String backupLocation, String collection, SolrClient solrClient) {
+    return getRestoreCommand(backupLocation, collection, true, false, null, solrClient);
+  }
+
+  private RestoreCommand getStatusRestoreCommand(String requestId, SolrClient solrClient) {
+    return getRestoreCommand(null, null, false, true, requestId, solrClient);
+  }
+
+  private RestoreCommand getRestoreCommand(
+      String backupLocation,
+      String collection,
+      boolean asyncRestore,
+      boolean status,
+      String requestId,
+      SolrClient solrClient) {
+    RestoreCommand restoreCommand =
+        new RestoreCommand() {
+          @Override
+          protected SolrClient getCloudSolrClient() {
+            return solrClient;
+          }
+
+          // We get the solr client from the MiniSolrCloudCluster, so we don't
+          // want to shut it down after each test as there is no way to restart it.
+          // We don't create a MiniSolrCloudCluster for each test to reduce the
+          // time it takes to run the tests.
+          @Override
+          protected void shutdown(SolrClient client) {
+            // do nothing
+          }
+        };
+    restoreCommand.force = true;
+    if (backupLocation != null) {
+      restoreCommand.backupLocation = getBackupLocation();
+    }
+    if (collection != null) {
+      restoreCommand.coreName = collection;
+    }
+    if (asyncRestore) {
+      restoreCommand.asyncRestore = true;
+    }
+    if (status) {
+      restoreCommand.status = true;
+    }
+    if (requestId != null) {
+      restoreCommand.requestId = requestId;
+    }
+    if (backupFile != null && backupFile.exists()) {
+      restoreCommand.backupName = backupFile.getName();
+    }
+    return restoreCommand;
+  }
+
+  // Replace ASCII color codes in console output and get the request Id
+  private String getRequestId(String consoleOutput) {
+    return StringUtils.trim(
+        StringUtils.substringAfterLast(
+            ASCII_COLOR_CODES_REGEX.matcher(consoleOutput).replaceAll(""), ":"));
+  }
+
+  // Replace ASCII color codes in console output and get the status
+  private String getRequestStatus(String consoleOutput) {
+    return StringUtils.trim(
+        StringUtils.substringsBetween(
+            ASCII_COLOR_CODES_REGEX.matcher(consoleOutput).replaceAll(""), "[", "]")[1]);
+  }
+
+  private String getBackupName(String consoleOutput) {
+    return StringUtils.trim(
+        StringUtils.substringsBetween(
+            ASCII_COLOR_CODES_REGEX.matcher(consoleOutput).replaceAll(""), "[", "]")[2]);
+  }
+
+  private String waitForCompletedStatusOrFail(
+      RestoreCommand statusRestoreCommand, ConsoleOutput consoleOutput) throws Exception {
+    long startTime = System.currentTimeMillis();
+    long endTime = startTime + TimeUnit.MINUTES.toMillis(TIMEOUT_IN_MINUTES);
+    String status = getRequestStatus(consoleOutput.getOutput());
+
+    while (!StringUtils.equals(status, RequestStatusState.COMPLETED.getKey())) {
+      if (System.currentTimeMillis() >= endTime) {
+        fail(
+            String.format(
+                "The restore status command did not complete within %s minute(s). Current restore status: %s.",
+                TIMEOUT_IN_MINUTES, status));
+      }
+      TimeUnit.SECONDS.sleep(1);
+      consoleOutput.reset();
+      statusRestoreCommand.execute();
+      status = getRequestStatus(consoleOutput.getOutput());
+    }
+
+    return status;
+  }
+
+  private void backupSolr(SolrClient solrClient) throws Exception {
+    setupSystemProperties(SolrCommands.CLOUD_SOLR_CLIENT_TYPE);
+    BackupCommand backupCommand =
+        new BackupCommand() {
+          @Override
+          protected SolrClient getCloudSolrClient() {
+            return solrClient;
+          }
+
+          @Override
+          protected void shutdown(SolrClient client) {
+            // do nothing
+          }
+        };
+    backupCommand.backupLocation = getBackupLocation();
+    backupCommand.asyncBackup = false;
+    backupCommand.asyncBackupStatus = false;
+    backupCommand.coreName = DEFAULT_CORE_NAME;
+    backupCommand.execute();
+    String backupName = getBackupName(consoleOutput.getOutput());
+    backupFile = Paths.get(backupCommand.backupLocation, backupName).toAbsolutePath().toFile();
+    assertThat(
+        consoleOutput.getOutput(),
+        containsString(
+            String.format(
+                "Backing up collection [%s] to shared location [%s] using backup name [%s",
+                DEFAULT_CORE_NAME, backupCommand.backupLocation, backupName)));
+    assertThat(consoleOutput.getOutput(), containsString("Backup complete."));
+    assertThat(backupFile.exists(), is(true));
+  }
+}

--- a/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/SolrCommandTest.java
+++ b/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/SolrCommandTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.commands.solr;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.response.RequestStatusState;
+import org.apache.solr.cloud.MiniSolrCloudCluster;
+import org.apache.solr.common.util.NamedList;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+
+public abstract class SolrCommandTest {
+  protected static final String DEFAULT_ZK_HOSTS =
+      "zookeeperhost1:2181,zookeeperhost2:2181,zookeeperhost3:2181";
+
+  protected static final String DDF_HOME_PROP = "ddf.home";
+
+  protected static final String DDF_ETC_PROP = "ddf.etc";
+
+  protected static final String DEFAULT_DDF_HOME = "/opt/ddf";
+
+  @Mock protected SolrClient mockSolrClient;
+
+  @Rule @ClassRule public static TemporaryFolder baseDir = new TemporaryFolder();
+
+  @Rule @ClassRule public static TemporaryFolder backupLocation = new TemporaryFolder();
+
+  protected HttpWrapper mockHttpWrapper;
+
+  protected ConsoleOutput consoleOutput;
+
+  protected static MiniSolrCloudCluster miniSolrCloud;
+
+  protected static String cipherSuites;
+
+  protected static String protocols;
+
+  protected static Path getBaseDirPath() {
+    return baseDir.getRoot().toPath();
+  }
+
+  protected String getBackupLocation() {
+    return backupLocation.getRoot().getPath();
+  }
+
+  protected void setupSystemProperties(String solrClientType) {
+    setupSolrClientType(solrClientType);
+    setupZkHost();
+  }
+
+  protected static void setDdfHome() {
+    System.setProperty(DDF_HOME_PROP, DEFAULT_DDF_HOME);
+  }
+
+  protected static void setDdfEtc() {
+    System.setProperty(DDF_ETC_PROP, Paths.get(DEFAULT_DDF_HOME, "etc").toString());
+  }
+
+  protected void setupSolrClientType(String solrClientType) {
+    System.setProperty(SolrCommands.SOLR_CLIENT_PROP, solrClientType);
+  }
+
+  protected void setupZkHost() {
+    System.setProperty(SolrCommands.ZOOKEEPER_HOSTS_PROP, DEFAULT_ZK_HOSTS);
+  }
+
+  /**
+   * See
+   * https://cwiki.apache.org/confluence/display/solr/Collections+API#CollectionsAPI-BACKUP:BackupCollection
+   * for requests and responses.
+   */
+  protected NamedList<Object> getResponseHeader(int statusCode) {
+    NamedList<Object> responseHeader = new NamedList<>();
+    responseHeader.add("status", statusCode);
+    responseHeader.add("QTime", 345);
+    return responseHeader;
+  }
+
+  /**
+   * See
+   * https://cwiki.apache.org/confluence/display/solr/Collections+API#CollectionsAPI-BACKUP:BackupCollection
+   * for requests and responses.
+   */
+  protected NamedList<Object> getResponseForStatus(
+      int statusCode, RequestStatusState requestStatusState, NamedList<String> errorMessages) {
+    NamedList<Object> responseHeader = getResponseHeader(statusCode);
+    NamedList<String> status = getStatus(requestStatusState);
+    NamedList<Object> response = new NamedList<>();
+    response.add("status", status);
+    response.add("responseHeader", responseHeader);
+    if (errorMessages != null) {
+      response.add("failure", errorMessages);
+    } else {
+      response.add("success", new Object());
+    }
+
+    return response;
+  }
+
+  /**
+   * On https://github.com/apache/lucene-solr see
+   * CollectionAdminRequest.RequestStatusResponse.getRequestStatus() for example usage.
+   * https://github.com/apache/lucene-solr/blob/master/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java#L1343-L1346
+   */
+  protected NamedList<String> getStatus(RequestStatusState requestStatusState) {
+    NamedList<String> status = new NamedList();
+    status.add("state", requestStatusState.getKey());
+    return status;
+  }
+}

--- a/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/SolrCommandTest.java
+++ b/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/SolrCommandTest.java
@@ -13,20 +13,37 @@
  */
 package org.codice.ddf.commands.solr;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.embedded.JettyConfig;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.client.solrj.response.RequestStatusState;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.NamedList;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mock;
 
 public abstract class SolrCommandTest {
   protected static final String DEFAULT_ZK_HOSTS =
       "zookeeperhost1:2181,zookeeperhost2:2181,zookeeperhost3:2181";
+
+  protected static final String DEFAULT_CONFIGSET = "collection_configset_1";
+
+  protected static final String DEFAULT_CORE_NAME = "catalog";
 
   protected static final String DDF_HOME_PROP = "ddf.home";
 
@@ -34,21 +51,17 @@ public abstract class SolrCommandTest {
 
   protected static final String DEFAULT_DDF_HOME = "/opt/ddf";
 
-  @Mock protected SolrClient mockSolrClient;
-
   @Rule @ClassRule public static TemporaryFolder baseDir = new TemporaryFolder();
 
   @Rule @ClassRule public static TemporaryFolder backupLocation = new TemporaryFolder();
 
-  protected HttpWrapper mockHttpWrapper;
-
   protected ConsoleOutput consoleOutput;
-
-  protected static MiniSolrCloudCluster miniSolrCloud;
 
   protected static String cipherSuites;
 
   protected static String protocols;
+
+  protected static MiniSolrCloudCluster miniSolrCloud;
 
   protected static Path getBaseDirPath() {
     return baseDir.getRoot().toPath();
@@ -121,5 +134,118 @@ public abstract class SolrCommandTest {
     NamedList<String> status = new NamedList();
     status.add("state", requestStatusState.getKey());
     return status;
+  }
+
+  protected HttpResponse mockResponse(int statusCode, String responseBody) {
+    StatusLine mockStatusLine = mock(StatusLine.class);
+    doReturn(statusCode).when(mockStatusLine).getStatusCode();
+    doReturn(responseBody).when(mockStatusLine).getReasonPhrase();
+    HttpResponse mockResponse = mock(HttpResponse.class);
+    doReturn(mockStatusLine).when(mockResponse).getStatusLine();
+    return mockResponse;
+  }
+
+  protected static void createMiniSolrCloudCluster() throws Exception {
+    miniSolrCloud =
+        new MiniSolrCloudCluster(
+            1, getBaseDirPath(), JettyConfig.builder().setContext("/solr").build());
+    miniSolrCloud.getSolrClient().connect();
+    System.setProperty("solr.cloud.shardCount", "1");
+    System.setProperty("solr.cloud.replicationFactor", "1");
+    System.setProperty("solr.cloud.maxShardPerNode", "1");
+    System.setProperty("solr.cloud.zookeeper.chroot", "/solr");
+    System.setProperty("solr.cloud.zookeeper", miniSolrCloud.getZkServer().getZkHost());
+    // Set soft commit and hard commit times high, so they will not impact the tests.
+    System.setProperty("solr.autoSoftCommit.maxTime", String.valueOf(100));
+    System.setProperty("solr.autoCommit.maxTime", String.valueOf(100));
+  }
+
+  protected static void uploadDefaultConfigset() throws Exception {
+    miniSolrCloud.uploadConfigSet(
+        new File(BackupCommandTest.class.getClassLoader().getResource("configset").getPath())
+            .toPath(),
+        DEFAULT_CONFIGSET);
+  }
+
+  protected static void createDefaultCollection() throws Exception {
+    CollectionAdminRequest.Create create =
+        CollectionAdminRequest.createCollection(DEFAULT_CORE_NAME, DEFAULT_CONFIGSET, 1, 1);
+    CollectionAdminResponse response = create.process(miniSolrCloud.getSolrClient());
+    if (response.getStatus() != 0 || response.getErrorMessages() != null) {
+      fail("Could not create collection. Response: " + response.toString());
+    }
+
+    List<String> collections =
+        CollectionAdminRequest.listCollections(miniSolrCloud.getSolrClient());
+    assertThat(collections.size(), is(1));
+    miniSolrCloud.getSolrClient().setDefaultCollection(DEFAULT_CORE_NAME);
+  }
+
+  protected static void createDefaultMiniSolrCloudCluster() throws Exception {
+    createMiniSolrCloudCluster();
+    uploadDefaultConfigset();
+    createDefaultCollection();
+  }
+
+  protected static void addDocument(String uniqueId) throws Exception {
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", uniqueId);
+    miniSolrCloud.getSolrClient().add(doc);
+    miniSolrCloud.getSolrClient().commit();
+  }
+
+  protected BackupCommand getBackupCommand(
+      String backupLocation,
+      String collection,
+      boolean asyncBackup,
+      boolean asyncBackupStatus,
+      String requestId,
+      SolrClient solrClient) {
+    BackupCommand backupCommand =
+        new BackupCommand() {
+          @Override
+          protected SolrClient getCloudSolrClient() {
+            return solrClient;
+          }
+
+          // We get the solr client from the MiniSolrCloudCluster, so we don't
+          // want to shut it down after each test as there is no way to restart it.
+          // We don't create a MiniSolrCloudCluster for each test to reduce the
+          // time it takes to run the tests.
+          @Override
+          protected void shutdown(SolrClient client) {
+            // do nothing
+          }
+        };
+    if (backupLocation != null) {
+      backupCommand.backupLocation = getBackupLocation();
+    }
+    if (collection != null) {
+      backupCommand.coreName = collection;
+    }
+    if (asyncBackup) {
+      backupCommand.asyncBackup = true;
+    }
+    if (asyncBackupStatus) {
+      backupCommand.asyncBackupStatus = true;
+    }
+    if (requestId != null) {
+      backupCommand.asyncBackupReqId = requestId;
+    }
+    return backupCommand;
+  }
+
+  protected BackupCommand getSynchronousBackupCommand(
+      String backupLocation, String collection, SolrClient solrClient) {
+    return getBackupCommand(backupLocation, collection, false, false, null, solrClient);
+  }
+
+  protected static void cleanupCollections() throws Exception {
+    List<String> collections =
+        CollectionAdminRequest.listCollections(miniSolrCloud.getSolrClient());
+    for (String collection : collections) {
+      CollectionAdminRequest.Delete delete = CollectionAdminRequest.deleteCollection(collection);
+      delete.process(miniSolrCloud.getSolrClient());
+    }
   }
 }

--- a/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/SolrCommandTest.java
+++ b/catalog/core/catalog-core-solrcommands/src/test/java/org/codice/ddf/commands/solr/SolrCommandTest.java
@@ -154,7 +154,7 @@ public abstract class SolrCommandTest {
     System.setProperty("solr.cloud.replicationFactor", "1");
     System.setProperty("solr.cloud.maxShardPerNode", "1");
     System.setProperty("solr.cloud.zookeeper.chroot", "/solr");
-    System.setProperty("solr.cloud.zookeeper", miniSolrCloud.getZkServer().getZkHost());
+    System.setProperty(SolrCommands.ZOOKEEPER_HOSTS_PROP, miniSolrCloud.getZkServer().getZkHost());
     // Set soft commit and hard commit times high, so they will not impact the tests.
     System.setProperty("solr.autoSoftCommit.maxTime", String.valueOf(100));
     System.setProperty("solr.autoCommit.maxTime", String.valueOf(100));

--- a/distribution/docs/src/main/resources/content/_managing/_running/available-console-commands.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/available-console-commands.adoc
@@ -24,8 +24,7 @@ For example, type `catalog`, then press *TAB*.
 |Description
 
 |<<{managing-prefix}catalog_command_descriptions, catalog>>
-|The Catalog Shell Commands are meant to be used with any `CatalogProvider` implementations.
-They provide general useful queries and functions against the Catalog API that can be used for debugging, printing, or scripting.
+|The Catalog Shell Commands are meant to be used with any `CatalogProvider` implementations. They provide general useful queries and functions against the Catalog API that can be used for debugging, printing, or scripting.
 
 |<<{managing-prefix}migrate_command_descriptions, migrate>>
 |The Migrate Shell Commands provide functions to perform data migrations.
@@ -38,5 +37,9 @@ They provide general useful queries and functions against the Catalog API that c
 
 |<<{managing-prefix}subscription_command_descriptions, subscription>>
 |The ${branding} PubSub shell commands provide functions to list the registered subscriptions in ${branding} and to delete subscriptions.
+
+|<<{managing-prefix}solr_command_descriptions, solr>>
+|The Solr commands are used for the Solr `CatalogProvider` implementation. They provide commands specific to that provider.
+
 
 |===

--- a/distribution/docs/src/main/resources/content/_managing/_running/solr-commands.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/solr-commands.adoc
@@ -1,0 +1,29 @@
+:title: Solr Commands
+:type: subMaintaining
+:status: published
+:parent: Available Console Commands
+:summary: Solr commands available.
+:order: 00
+
+== {title}
+
+.[[_solr_command_descriptions]]Solr Command Descriptions
+[cols="1m,9a" options="header"]
+|===
+
+|Command
+|Description
+
+|solr:backup
+|Creates a backup of the selected Solr core/collection. This uses the Solr interface for creating
+the backup. In Solr Cloud deployments the selected backup directory must exist and be shared on all
+Solr nodes.
+
+|solr:restore
+|Restores a Solr backup to the selected core/collection. This uses the Solr interfaces for restoring
+the backup. In Solr Cloud deployments the directory containing the files to restore must exist and be
+ shared on all Solr nodes.
+
+
+|===
+

--- a/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/HttpSolrClientFactory.java
+++ b/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/HttpSolrClientFactory.java
@@ -51,7 +51,6 @@ public final class HttpSolrClientFactory implements SolrClientFactory {
   public static final String DEFAULT_SCHEMA_XML = "schema.xml";
   public static final String DEFAULT_SOLRCONFIG_XML = "solrconfig.xml";
 
-  private static final String SOLR_CONTEXT = "/solr";
   private static final String SOLR_DATA_DIR = "solr.data.dir";
   private static final String SOLR_HTTP_URL = "solr.http.url";
 
@@ -65,26 +64,6 @@ public final class HttpSolrClientFactory implements SolrClientFactory {
       SolrPasswordUpdate solrPasswordUpdate) {
     this.httpClientBuilder = httpClientBuilder;
     this.solrPasswordUpdate = solrPasswordUpdate;
-  }
-
-  /**
-   * Gets the default Solr server secure HTTP address.
-   *
-   * @return Solr server secure HTTP address
-   */
-  public static String getDefaultHttpsAddress() {
-    return AccessController.doPrivileged(
-        (PrivilegedAction<String>) () -> System.getProperty(SOLR_HTTP_URL));
-  }
-
-  /**
-   * Gets the Solr Data directory
-   *
-   * @return
-   */
-  public static String getSolrDataDir() {
-    return AccessController.doPrivileged(
-        (PrivilegedAction<String>) () -> System.getProperty(SOLR_DATA_DIR));
   }
 
   public static void createSolrCore(
@@ -184,5 +163,10 @@ public final class HttpSolrClientFactory implements SolrClientFactory {
 
       return closer.returning(new PingAwareSolrClientProxy(retryClient, noRetryClient));
     }
+  }
+
+  private static String getDefaultHttpsAddress() {
+    return AccessController.doPrivileged(
+        (PrivilegedAction<String>) () -> System.getProperty(SOLR_HTTP_URL));
   }
 }

--- a/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/HttpSolrClientFactory.java
+++ b/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/HttpSolrClientFactory.java
@@ -60,10 +60,6 @@ public final class HttpSolrClientFactory implements SolrClientFactory {
   private final org.codice.solr.factory.impl.HttpClientBuilder httpClientBuilder;
   private final SolrPasswordUpdate solrPasswordUpdate;
 
-  private String getDefaultHttpsAddress() {
-    return SystemBaseUrl.INTERNAL.constructUrl("https", SOLR_CONTEXT);
-  }
-
   public HttpSolrClientFactory(
       org.codice.solr.factory.impl.HttpClientBuilder httpClientBuilder,
       SolrPasswordUpdate solrPasswordUpdate) {
@@ -71,7 +67,27 @@ public final class HttpSolrClientFactory implements SolrClientFactory {
     this.solrPasswordUpdate = solrPasswordUpdate;
   }
 
-  private static void createSolrCore(
+  /**
+   * Gets the default Solr server secure HTTP address.
+   *
+   * @return Solr server secure HTTP address
+   */
+  public static String getDefaultHttpsAddress() {
+    return AccessController.doPrivileged(
+        (PrivilegedAction<String>) () -> System.getProperty(SOLR_HTTP_URL));
+  }
+
+  /**
+   * Gets the Solr Data directory
+   *
+   * @return
+   */
+  public static String getSolrDataDir() {
+    return AccessController.doPrivileged(
+        (PrivilegedAction<String>) () -> System.getProperty(SOLR_DATA_DIR));
+  }
+
+  public static void createSolrCore(
       String url, String coreName, String configFileName, CloseableHttpClient httpClient)
       throws IOException, SolrServerException {
 

--- a/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/HttpSolrClientFactory.java
+++ b/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/HttpSolrClientFactory.java
@@ -29,7 +29,6 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CoreAdminRequest;
 import org.apache.solr.client.solrj.response.CoreAdminResponse;
-import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.solr.factory.SolrClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,10 +75,10 @@ public final class HttpSolrClientFactory implements SolrClientFactory {
       String url, String coreName, String configFileName, CloseableHttpClient httpClient)
       throws IOException, SolrServerException {
 
-    try (CloseableHttpClient closeableHttpClient = httpClient; // to make sure it gets closed
+    try (CloseableHttpClient closeableHttpClient = httpClient;
         HttpSolrClient client =
             (httpClient != null
-                ? new HttpSolrClient.Builder(url).withHttpClient(httpClient).build()
+                ? new HttpSolrClient.Builder(url).withHttpClient(closeableHttpClient).build()
                 : new HttpSolrClient.Builder(url).build())) {
 
       HttpResponse ping = client.getHttpClient().execute(new HttpHead(url));

--- a/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/SolrCloudClientFactory.java
+++ b/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/SolrCloudClientFactory.java
@@ -114,7 +114,7 @@ public class SolrCloudClientFactory implements SolrClientFactory {
     return new RetryPolicy().withMaxRetries(30).withDelay(1, TimeUnit.SECONDS);
   }
 
-  private void createCollection(String collection, CloudSolrClient client)
+  public void createCollection(String collection, CloudSolrClient client)
       throws SolrFactoryException {
     try {
       CollectionAdminResponse response = new CollectionAdminRequest.List().process(client);

--- a/platform/solr/solr-factory-impl/src/test/groovy/org/codice/solr/factory/impl/HttpSolrClientFactorySpec.groovy
+++ b/platform/solr/solr-factory-impl/src/test/groovy/org/codice/solr/factory/impl/HttpSolrClientFactorySpec.groovy
@@ -42,7 +42,6 @@ class HttpSolrClientFactorySpec extends Specification {
   static final String CORE_URL = "$SOLR_URL/$CORE"
   static final String SOLR_URL2 = "https://$SOLR_HOST2:$SOLR_PORT/$SOLR_CONTEXT"
   static final String CORE_URL2 = "$SOLR_URL2/$CORE"
-
   static final String CONFIG_XML = "solrconfig.xml"
   static final String SCHEMA_XML = "schema.xml"
   static final int AVAILABLE_TIMEOUT_IN_SECS = 25
@@ -109,8 +108,6 @@ class HttpSolrClientFactorySpec extends Specification {
     where:
       solr_url_is   || solr_http_url | system_host | system_port | system_context || solr_url  | core_url
       'defined'     || SOLR_URL      | null        | null        | null           || SOLR_URL  | CORE_URL
-      'not defined' || null          | SOLR_HOST2  | SOLR_PORT   | SOLR_CONTEXT   || SOLR_URL2 | CORE_URL2
-      'blank'       || ''            | SOLR_HOST2  | SOLR_PORT   | SOLR_CONTEXT   || SOLR_URL2 | CORE_URL2
   }
 
   @Timeout(HttpSolrClientFactorySpec.AVAILABLE_TIMEOUT_IN_SECS)


### PR DESCRIPTION
#### What does this PR do?
This fixes the catalog:dump command to work correctly for Solr cloud. Updates the solr:backup for Solr 7 cloud and also refactors the code slightly to support the addition of the solr:restore command.

#### Who is reviewing it? 
@Bdthomson 
@rymach 
@dannythk 
@mcalcote 
@ahoffer 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@pklinef
@ricklarsen 

#### How should this be tested?
Full build with tests.
Manual testing would require a Solr 7 cloud instance that you can backup/restore various cores. 

#### Any background context you want to provide?
*Merged* This PR includes changes in https://github.com/codice/ddf/pull/4160. Once that PR has been merged, this one will be rebased. 

#### What are the relevant tickets?
[DDF-4218](https://codice.atlassian.net/browse/DDF-4218)

#### Screenshots

#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
