### PR TITLE
[2.13.x]DDF-4392 Refactor DuplicationValidator to add reject duplicates configuration

### DIFF
--- a/catalog/validator/catalog-validator-metacardduplication/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/validator/catalog-validator-metacardduplication/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,19 +23,21 @@
         <argument ref="catalogFramework"/>
         <argument ref="filterBuilder"/>
         <property name="warnOnDuplicateAttributes">
-            <array>
-                <value>checksum</value>
-            </array>
+            <array/>
         </property>
         <property name="errorOnDuplicateAttributes">
             <array/>
+        </property>
+        <property name="rejectOnDuplicateAttributes">
+            <array>
+                <value>checksum</value>
+            </array>
         </property>
     </bean>
 
     <service ref="duplicateValidator">
         <interfaces>
-            <value>ddf.catalog.validation.MetacardValidator</value>
-            <value>ddf.catalog.validation.ReportingMetacardValidator</value>
+            <value>ddf.catalog.plugin.PreIngestPlugin</value>
         </interfaces>
     </service>
 

--- a/catalog/validator/catalog-validator-metacardduplication/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/validator/catalog-validator-metacardduplication/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,15 +23,15 @@
         <argument ref="catalogFramework"/>
         <argument ref="filterBuilder"/>
         <property name="warnOnDuplicateAttributes">
-            <array/>
+            <array>
+                <value>checksum</value>
+            </array>
         </property>
         <property name="errorOnDuplicateAttributes">
             <array/>
         </property>
         <property name="rejectOnDuplicateAttributes">
-            <array>
-                <value>checksum</value>
-            </array>
+            <array/>
         </property>
     </bean>
 

--- a/catalog/validator/catalog-validator-metacardduplication/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/validator/catalog-validator-metacardduplication/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,7 +24,11 @@
         <AD
                 description="A list of metacard attributes used in the duplication check against the local catalog.  If a duplicate is found, the ingest will cause a metacard validation WARNING, but the ingest will succeed."
                 name="Metacard attributes (duplicates cause a validation warning)"
-                id="warnOnDuplicateAttributes" required="true" type="String" cardinality="1000"
+                id="warnOnDuplicateAttributes" required="true" type="String" cardinality="1000"/>
+        <AD
+                description="A list of metacard attributes used in the duplication check against the local catalog.  If a duplicate is found, the ingest will be rejected."
+                name="Metacard attributes (duplicates are rejected)"
+                id="rejectOnDuplicateAttributes" required="true" type="String" cardinality="1000"
                 default="checksum"/>
     </OCD>
 

--- a/catalog/validator/catalog-validator-metacardduplication/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/validator/catalog-validator-metacardduplication/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,12 +24,12 @@
         <AD
                 description="A list of metacard attributes used in the duplication check against the local catalog.  If a duplicate is found, the ingest will cause a metacard validation WARNING, but the ingest will succeed."
                 name="Metacard attributes (duplicates cause a validation warning)"
-                id="warnOnDuplicateAttributes" required="true" type="String" cardinality="1000"/>
+                id="warnOnDuplicateAttributes" required="true" type="String" cardinality="1000"
+                default="checksum"/>
         <AD
                 description="A list of metacard attributes used in the duplication check against the local catalog.  If a duplicate is found, the ingest will be rejected."
                 name="Metacard attributes (duplicates are rejected)"
-                id="rejectOnDuplicateAttributes" required="true" type="String" cardinality="1000"
-                default="checksum"/>
+                id="rejectOnDuplicateAttributes" required="true" type="String" cardinality="1000"/>
     </OCD>
 
     <Designate

--- a/catalog/validator/catalog-validator-metacardduplication/src/test/java/org/codice/ddf/validator/metacard/duplication/DuplicationValidatorTest.java
+++ b/catalog/validator/catalog-validator-metacardduplication/src/test/java/org/codice/ddf/validator/metacard/duplication/DuplicationValidatorTest.java
@@ -107,17 +107,18 @@ public class DuplicationValidatorTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testValidateMetacardNullInput() {
+  public void testValidateMetacardNullInput() throws StopProcessingException {
     validator.validateMetacard(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testValidateNullInput() throws ValidationException {
+  public void testValidateNullInput() throws ValidationException, StopProcessingException {
     validator.validate(null);
   }
 
   @Test
-  public void testValidateMetacardNullConfiguration() throws ValidationException {
+  public void testValidateMetacardNullConfiguration()
+      throws ValidationException, StopProcessingException {
 
     validator.setWarnOnDuplicateAttributes(null);
     validator.setErrorOnDuplicateAttributes(null);
@@ -127,7 +128,7 @@ public class DuplicationValidatorTest {
   }
 
   @Test
-  public void testValidateNullConfiguration() throws ValidationException {
+  public void testValidateNullConfiguration() throws ValidationException, StopProcessingException {
 
     validator.setWarnOnDuplicateAttributes(null);
     validator.setErrorOnDuplicateAttributes(null);
@@ -137,7 +138,8 @@ public class DuplicationValidatorTest {
   }
 
   @Test
-  public void testValidateMetacardBlankConfiguration() throws ValidationException {
+  public void testValidateMetacardBlankConfiguration()
+      throws ValidationException, StopProcessingException {
 
     validator.setWarnOnDuplicateAttributes(new String[0]);
     validator.setErrorOnDuplicateAttributes(new String[0]);
@@ -147,7 +149,7 @@ public class DuplicationValidatorTest {
   }
 
   @Test
-  public void testValidateBlankConfiguration() throws ValidationException {
+  public void testValidateBlankConfiguration() throws ValidationException, StopProcessingException {
 
     validator.setWarnOnDuplicateAttributes(new String[0]);
     validator.setErrorOnDuplicateAttributes(new String[0]);
@@ -157,7 +159,7 @@ public class DuplicationValidatorTest {
   }
 
   @Test
-  public void testValidateMetacardWithValidationErrorAndWarning() {
+  public void testValidateMetacardWithValidationErrorAndWarning() throws StopProcessingException {
 
     String[] checksumAttribute = {Metacard.CHECKSUM};
     String[] idAttribute = {Metacard.ID};
@@ -187,7 +189,8 @@ public class DuplicationValidatorTest {
   }
 
   @Test
-  public void testValidateWithValidationErrorAndWarning() throws ValidationException {
+  public void testValidateWithValidationErrorAndWarning()
+      throws ValidationException, StopProcessingException {
 
     String[] checksumAttribute = {Metacard.CHECKSUM};
     String[] idAttribute = {Metacard.ID};
@@ -243,5 +246,54 @@ public class DuplicationValidatorTest {
                   violation.getAttributes(), is(new HashSet<>(Arrays.asList(tagAttributes))));
               assertThat(violation.getMessage(), containsString(Metacard.TAGS));
             });
+  }
+
+  @Test
+  public void testRejectDuplicate() throws ValidationException, StopProcessingException {
+    String[] checksumAttribute = {Metacard.CHECKSUM};
+    StopProcessingException expectedException = null;
+
+    validator.setRejectOnDuplicateAttributes(checksumAttribute);
+
+    try {
+      validator.checkForDuplicates(testMetacard);
+    } catch (StopProcessingException e) {
+      expectedException = e;
+    }
+
+    assertThat(expectedException, is(not(nullValue())));
+
+    // do more assertions
+
+  }
+
+  @Test
+  public void testCheckForDuplicatesWithValidationErrorAndWarning()
+      throws ValidationException, StopProcessingException {
+    String[] checksumAttribute = {Metacard.CHECKSUM};
+    String[] idAttribute = {Metacard.ID};
+    ValidationException expectedException = null;
+
+    validator.setWarnOnDuplicateAttributes(checksumAttribute);
+    validator.setErrorOnDuplicateAttributes(idAttribute);
+    validator.checkForDuplicates(testMetacard);
+
+    // do assertions
+
+  }
+
+  @Test
+  public void testProcessCreate() throws ValidationException, StopProcessingException {
+    // to do
+  }
+
+  @Test
+  public void testProcessUpdate() throws ValidationException, StopProcessingException {
+    // to do
+  }
+
+  @Test
+  public void testProcessDelete() throws ValidationException, StopProcessingException {
+    // to do
   }
 }


### PR DESCRIPTION
#### What does this PR do?
This PR refactors DuplicationValidator from a Validation API to a PreIngest. By doing this, we were able to avoid using unnecessary exceptions to handle specific cases and to not use reports, but just add the warnings and errors when necessary. This PR also adds a new configuration that allows a user to define an array of attributes to check for duplicates with and reject those duplicates. 

#### Who is reviewing it? 
@ethantmanns 
@peterhuffer 
@jhunzik 

#### Select relevant component teams: 
@codice/data 

#### Ask 2 committers to review/merge the PR and tag them here.
@figliold 
@tbatie 

#### How should this be tested?
1. Test with UI that a duplicate product get marked with duplicate warnings and errors when configured to do so (default is to add warnings, so add errors and show marked errors as well)
2. Test with UI that product gets rejected when a duplicate is uploaded (when configured to reject)
3. Test with Content Directory Monitor set to delete that product gets rejected when a duplicate product is put into the CDM again (when configured to reject)


#### What are the relevant tickets?
DDF-4392

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
