### PR TITLE
DDF-4382 XPathHelper print removes the tags and attributes from the results

### DIFF
--- a/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/XPathHelperTest.java
+++ b/catalog/core/catalog-core-commons/src/test/java/ddf/catalog/impl/XPathHelperTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class XPathHelperTest {
@@ -101,6 +102,46 @@ public class XPathHelperTest {
       assertEquals(6, nodeList.getLength());
     } catch (Exception e1) {
       LOGGER.error("Exception thrown during testXPathHelper_WithXmlFile", e1);
+    }
+  }
+
+  @Test
+  public void testXPathHelperPrintAttributeNode() throws Exception {
+    try {
+      String xmlString = getFileContentsAsString(TEST_DATA_PATH + INPUT_FILE);
+
+      XPathHelper xHelper = new XPathHelper(xmlString);
+      Node node =
+          (Node)
+              xHelper.evaluate(
+                  "//ddms:publisher/@ICISM:classification",
+                  XPathConstants.NODE,
+                  new MockNamespaceResolver());
+      String printNode = XPathHelper.print(node);
+      LOGGER.debug("testXPathHelperPrintAttributeNode() - string value = {}", printNode);
+      assertEquals("U", printNode);
+    } catch (Exception e1) {
+      LOGGER.error("Exception thrown during testXPathHelperPrintAttributeNode()", e1);
+    }
+  }
+
+  @Test
+  public void testXPathHelperPrintElementNode() throws Exception {
+    try {
+      String xmlString = getFileContentsAsString(TEST_DATA_PATH + INPUT_FILE);
+
+      XPathHelper xHelper = new XPathHelper(xmlString);
+      Node node =
+          (Node)
+              xHelper.evaluate(
+                  "//ddms:publisher/ddms:Organization/ddms:name/text()",
+                  XPathConstants.NODE,
+                  new MockNamespaceResolver());
+      String printNode = XPathHelper.print(node);
+      LOGGER.debug("testXPathHelperPrintElementNode() - string value = {}", printNode);
+      assertEquals("American Forces Press Service", printNode);
+    } catch (Exception e1) {
+      LOGGER.error("Exception thrown during testXPathHelperPrintElementNode()", e1);
     }
   }
 


### PR DESCRIPTION

ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #4106 


#### What does this PR do?
This PR allows XPathhelper print to analyze and print xml attributes
#### Who is reviewing it? 
@garrettfreibott @ahoffer @mcalcote 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->

@brjeter
@clockard
@vinamartin
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4382](https://codice.atlassian.net/browse/DDF-4382)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
