### PR TITLE
DDF-4395 User redirected and logged out when session countdown timer at zero

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/session-timeout/session-timeout.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/session-timeout/session-timeout.view.js
@@ -35,11 +35,11 @@ module.exports = Marionette.LayoutView.extend({
   },
   serializeData: function() {
     var countdownSeconds = sessionTimeoutModel.getIdleSeconds()
-    if(countdownSeconds < 1) {
-        sessionTimeoutModel.logout()
+    if (countdownSeconds < 1) {
+      sessionTimeoutModel.logout()
     }
     return {
-        timeLeft: countdownSeconds
+      timeLeft: countdownSeconds,
     }
   },
   renewSession: function() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/session-timeout/session-timeout.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/session-timeout/session-timeout.view.js
@@ -34,8 +34,12 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
   serializeData: function() {
+    var countdownSeconds = sessionTimeoutModel.getIdleSeconds()
+    if(countdownSeconds < 1) {
+        sessionTimeoutModel.logout()
+    }
     return {
-      timeLeft: sessionTimeoutModel.getIdleSeconds(),
+        timeLeft: countdownSeconds
     }
   },
   renewSession: function() {


### PR DESCRIPTION
#### What does this PR do?
Bug: User session logout warning countdown will continue into negative digits. 
This ticket monitors the countdown, and will log out the user and redirect to a "you have been logged out" page once countdown is exhausted. The user should no longer see the countdown continue below zero.

#### Who is reviewing it? 
@Corey-Collins 
@hayleynorton 
@bellcc 
@GabrielFabian 

#### Select relevant component teams: 
@codice/security 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
@coyotesqrl
@stustison
@djblue 

#### How should this be tested?
- Build and Install DDF
- Launch Admin UI and update session timeout timer to two minutes under Admin UI (this is the minimum configurable time to wait)
`Platform -> Platform UI Configuration -> Session Timeout`
- Launch Intrigue UI  
- Allow for one minute to pass before session timeout warning appears
- Observe countdown decline to zero
- Session ends, user is logged out and redirected

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/DDF-4395

#### Screenshots
<img width="637" alt="screen shot 2018-12-11 at 4 25 01 pm" src="https://user-images.githubusercontent.com/16792154/49836840-6c929180-fd61-11e8-90c1-a538ad3d2338.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
