### PR TITLE
DDF-4403 Remove PowerMock to support Java11

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/federation/base/AbstractFederationStrategy.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/federation/base/AbstractFederationStrategy.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.federation.base;
 
+import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.data.Result;
 import ddf.catalog.federation.FederationStrategy;
 import ddf.catalog.operation.Query;
@@ -131,7 +132,7 @@ public abstract class AbstractFederationStrategy implements FederationStrategy {
       offset = this.maxStartIndex;
     }
 
-    final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, null);
+    final QueryResponseImpl queryResponseQueue = getQueryResponseQueue(queryRequest);
 
     Map<Source, Future<SourceResponse>> futures = new HashMap<Source, Future<SourceResponse>>();
 
@@ -180,7 +181,7 @@ public abstract class AbstractFederationStrategy implements FederationStrategy {
     // transfer them into a different Queue. That is what the
     // OffsetResultHandler does.
     if (offset > 1 && sources.size() > 1) {
-      offsetResults = new QueryResponseImpl(queryRequest, null);
+      offsetResults = getQueryResponseQueue(queryRequest);
       queryExecutorService.submit(
           new OffsetResultHandler(queryResponseQueue, offsetResults, pageSize, offset));
     }
@@ -215,6 +216,9 @@ public abstract class AbstractFederationStrategy implements FederationStrategy {
 
     return queryResponse;
   }
+
+  @VisibleForTesting
+  protected abstract QueryResponseImpl getQueryResponseQueue(QueryRequest queryRequest);
 
   private Query getModifiedQuery(
       Query originalQuery, int numberOfSources, int offset, int pageSize) {

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/federation/base/AbstractFederationStrategy.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/federation/base/AbstractFederationStrategy.java
@@ -49,7 +49,7 @@ public abstract class AbstractFederationStrategy implements FederationStrategy {
   private static final String CLASS_NAME = AbstractFederationStrategy.class.getName();
 
   private static final int DEFAULT_MAX_START_INDEX = 50000;
-  private final Function<QueryRequest, QueryResponseImpl> queryResponseFactory;
+  private final Function<QueryRequest, QueryResponseImpl> queryResponseConverter;
 
   /**
    * The {@link List} of pre-federated query plugins to execute on the query request before the
@@ -76,12 +76,12 @@ public abstract class AbstractFederationStrategy implements FederationStrategy {
    */
   public AbstractFederationStrategy(
       ExecutorService queryExecutorService,
-      Function<QueryRequest, QueryResponseImpl> queryResponseFactory) {
+      Function<QueryRequest, QueryResponseImpl> queryResponseConverter) {
     this(
         queryExecutorService,
         new ArrayList<PreFederatedQueryPlugin>(),
         new ArrayList<PostFederatedQueryPlugin>(),
-        queryResponseFactory);
+        queryResponseConverter);
   }
 
   /**
@@ -93,12 +93,12 @@ public abstract class AbstractFederationStrategy implements FederationStrategy {
       ExecutorService queryExecutorService,
       List<PreFederatedQueryPlugin> preQuery,
       List<PostFederatedQueryPlugin> postQuery,
-      Function<QueryRequest, QueryResponseImpl> queryResponseFactory) {
+      Function<QueryRequest, QueryResponseImpl> queryResponseConverter) {
     this.queryExecutorService = queryExecutorService;
     this.preQuery = preQuery;
     this.postQuery = postQuery;
     this.maxStartIndex = DEFAULT_MAX_START_INDEX;
-    this.queryResponseFactory = queryResponseFactory;
+    this.queryResponseConverter = queryResponseConverter;
   }
 
   /**
@@ -138,7 +138,7 @@ public abstract class AbstractFederationStrategy implements FederationStrategy {
       offset = this.maxStartIndex;
     }
 
-    final QueryResponseImpl queryResponseQueue = queryResponseFactory.apply(queryRequest);
+    final QueryResponseImpl queryResponseQueue = queryResponseConverter.apply(queryRequest);
 
     Map<Source, Future<SourceResponse>> futures = new HashMap<Source, Future<SourceResponse>>();
 
@@ -187,7 +187,7 @@ public abstract class AbstractFederationStrategy implements FederationStrategy {
     // transfer them into a different Queue. That is what the
     // OffsetResultHandler does.
     if (offset > 1 && sources.size() > 1) {
-      offsetResults = queryResponseFactory.apply(queryRequest);
+      offsetResults = queryResponseConverter.apply(queryRequest);
       queryExecutorService.submit(
           new OffsetResultHandler(queryResponseQueue, offsetResults, pageSize, offset));
     }

--- a/catalog/core/catalog-core-camelcomponent/pom.xml
+++ b/catalog/core/catalog-core-camelcomponent/pom.xml
@@ -123,15 +123,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.codice.thirdparty</groupId>
             <artifactId>tika-bundle</artifactId>
             <scope>test</scope>

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/metacardtransformer/MetacardTransformerProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/metacardtransformer/MetacardTransformerProducer.java
@@ -13,6 +13,7 @@
  */
 package ddf.camel.component.catalog.metacardtransformer;
 
+import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.transform.MetacardTransformer;
@@ -77,7 +78,8 @@ public class MetacardTransformerProducer extends DefaultProducer {
     }
   }
 
-  private MetacardTransformer lookupTransformerReference(String metacardTransformerId) {
+  @VisibleForTesting
+  MetacardTransformer lookupTransformerReference(String metacardTransformerId) {
     Bundle bundle = FrameworkUtil.getBundle(this.getClass());
     if (bundle != null) {
       BundleContext bundleContext = bundle.getBundleContext();

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/metacardtransformer/MetacardTransformerProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/metacardtransformer/MetacardTransformerProducer.java
@@ -13,6 +13,7 @@
  */
 package ddf.camel.component.catalog.metacardtransformer;
 
+import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.transform.MetacardTransformer;
@@ -49,7 +50,8 @@ public class MetacardTransformerProducer extends DefaultProducer {
     this(endpoint, FrameworkUtil::getBundle);
   }
 
-  public MetacardTransformerProducer(Endpoint endpoint, Function<Class, Bundle> bundleLookup) {
+  @VisibleForTesting
+  MetacardTransformerProducer(Endpoint endpoint, Function<Class, Bundle> bundleLookup) {
     super(endpoint);
     this.bundleLookup = bundleLookup;
   }

--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/metacardtransformer/MetacardTransformerProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/metacardtransformer/MetacardTransformerProducer.java
@@ -13,13 +13,13 @@
  */
 package ddf.camel.component.catalog.metacardtransformer;
 
-import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.transform.MetacardTransformer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -43,8 +43,15 @@ public class MetacardTransformerProducer extends DefaultProducer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MetacardTransformerProducer.class);
 
+  private final Function<Class, Bundle> bundleLookup;
+
   public MetacardTransformerProducer(Endpoint endpoint) {
+    this(endpoint, FrameworkUtil::getBundle);
+  }
+
+  public MetacardTransformerProducer(Endpoint endpoint, Function<Class, Bundle> bundleLookup) {
     super(endpoint);
+    this.bundleLookup = bundleLookup;
   }
 
   @Override
@@ -78,9 +85,8 @@ public class MetacardTransformerProducer extends DefaultProducer {
     }
   }
 
-  @VisibleForTesting
-  MetacardTransformer lookupTransformerReference(String metacardTransformerId) {
-    Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+  private MetacardTransformer lookupTransformerReference(String metacardTransformerId) {
+    Bundle bundle = bundleLookup.apply(this.getClass());
     if (bundle != null) {
       BundleContext bundleContext = bundle.getBundleContext();
       try {

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/inputtransformer/InputTransformerProducerTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/inputtransformer/InputTransformerProducerTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import ddf.camel.component.catalog.CatalogEndpoint;
 import ddf.catalog.data.Metacard;

--- a/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/metacardtransformer/MetacardTransformerProducerTest.java
+++ b/catalog/core/catalog-core-camelcomponent/src/test/java/ddf/camel/component/catalog/metacardtransformer/MetacardTransformerProducerTest.java
@@ -11,42 +11,28 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package ddf.camel.component.catalog;
+package ddf.camel.component.catalog.metacardtransformer;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-import ddf.camel.component.catalog.metacardtransformer.MetacardTransformerProducer;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.transform.MetacardTransformer;
-import java.util.ArrayList;
-import java.util.Collection;
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
-@PrepareForTest({FrameworkUtil.class})
 public class MetacardTransformerProducerTest {
-
-  @Rule public PowerMockRule rule = new PowerMockRule();
 
   private static final String TEST_TRANSFORMER_ID = "metacard";
 
@@ -58,37 +44,23 @@ public class MetacardTransformerProducerTest {
 
   private Metacard mockMetacard = mock(Metacard.class);
 
-  private Bundle mockBundle = mock(Bundle.class);
-
-  private BundleContext mockBundleContext = mock(BundleContext.class);
-
   private MetacardTransformerProducer metacardTransformerProducer;
 
   private MetacardTransformer mockTransformer = mock(MetacardTransformer.class);
 
-  private ServiceReference mockServiceReference = mock(ServiceReference.class);
-
   private BinaryContent mockBinaryContent = mock(BinaryContent.class);
 
-  private Collection transformerReferences = new ArrayList<>();
-
   @Before
-  public void setUp() throws InvalidSyntaxException {
-    initMocks(this);
-    mockStatic(FrameworkUtil.class);
-    transformerReferences.add(mockServiceReference);
-
-    when(FrameworkUtil.getBundle(any(Class.class))).thenReturn(mockBundle);
-    when(mockBundle.getBundleContext()).thenReturn(mockBundleContext);
-    when(mockBundleContext.getServiceReferences(any(Class.class), any(String.class)))
-        .thenReturn(transformerReferences);
-    when(mockBundleContext.getService(any())).thenReturn(mockTransformer);
+  public void setUp() {
     when(mockExchange.getIn()).thenReturn(mockMessage);
     when(mockExchange.getOut()).thenReturn(mockMessage);
     when(mockMessage.getBody()).thenReturn(mockMetacard);
     when(mockMessage.getHeader(any(String.class), any(Class.class)))
         .thenReturn(TEST_TRANSFORMER_ID);
-    metacardTransformerProducer = new MetacardTransformerProducer(mockEndpoint);
+    metacardTransformerProducer = spy(new MetacardTransformerProducer(mockEndpoint));
+    doReturn(mockTransformer)
+        .when(metacardTransformerProducer)
+        .lookupTransformerReference(any(String.class));
   }
 
   @Test

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TransformersCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/TransformersCommandTest.java
@@ -73,7 +73,6 @@ public class TransformersCommandTest extends ConsoleOutputCommon {
             .filter(ref -> ref.getProperty(Constants.SERVICE_ID) != null)
             .collect(Collectors.toList());
 
-    when(serviceReference.getProperty(SERVICE_ID)).thenReturn(null);
     when(bundleContext.getServiceReferences(InputTransformer.class, FILTER))
         .thenReturn(serviceReferencesFiltered);
 
@@ -97,7 +96,6 @@ public class TransformersCommandTest extends ConsoleOutputCommon {
             .filter(ref -> ref.getProperty(Constants.SERVICE_ID) != null)
             .collect(Collectors.toList());
 
-    when(serviceReference.getProperty(SERVICE_ID)).thenReturn(null);
     when(bundleContext.getServiceReferences(MetacardTransformer.class, FILTER))
         .thenReturn(serviceReferencesFiltered);
 

--- a/catalog/core/catalog-core-federationstrategy/pom.xml
+++ b/catalog/core/catalog-core-federationstrategy/pom.xml
@@ -23,11 +23,6 @@
     <name>DDF :: Catalog :: Core :: Federation Strategy</name>
     <packaging>bundle</packaging>
 
-    <properties>
-        <!-- For maven-surefire-plugin -->
-        <surefire.argline.append>-javaagent:${powermock.agent}</surefire.argline.append>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
@@ -76,27 +71,6 @@
             <artifactId>slf4j-ext</artifactId>
         </dependency>
         <!-- Test dependencies -->
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>mockito-core</artifactId>
-                    <groupId>org.mockito</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-defaultvalues</artifactId>

--- a/catalog/core/catalog-core-federationstrategy/src/main/java/ddf/catalog/federation/impl/SortedFederationStrategy.java
+++ b/catalog/core/catalog-core-federationstrategy/src/main/java/ddf/catalog/federation/impl/SortedFederationStrategy.java
@@ -13,11 +13,13 @@
  */
 package ddf.catalog.federation.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.federation.base.AbstractFederationStrategy;
 import ddf.catalog.operation.ProcessingDetails;
 import ddf.catalog.operation.Query;
+import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.ProcessingDetailsImpl;
@@ -94,6 +96,12 @@ public class SortedFederationStrategy extends AbstractFederationStrategy {
       final Query query) {
 
     return new SortedQueryMonitor(pool, futures, returnResults, query);
+  }
+
+  @Override
+  @VisibleForTesting
+  protected QueryResponseImpl getQueryResponseQueue(QueryRequest queryRequest) {
+    return new QueryResponseImpl(queryRequest, null);
   }
 
   private static class SortedQueryMonitor implements Runnable {

--- a/catalog/core/catalog-core-federationstrategy/src/main/java/ddf/catalog/federation/impl/SortedFederationStrategy.java
+++ b/catalog/core/catalog-core-federationstrategy/src/main/java/ddf/catalog/federation/impl/SortedFederationStrategy.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.federation.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.federation.base.AbstractFederationStrategy;
@@ -91,16 +92,8 @@ public class SortedFederationStrategy extends AbstractFederationStrategy {
         queryExecutorService, preQuery, postQuery, request -> new QueryResponseImpl(request, null));
   }
 
-  /**
-   * Instantiates a {@code SortedFederationStrategy} with the provided {@link ExecutorService}.
-   *
-   * @param queryExecutorService the {@link ExecutorService} for queries
-   * @param preQuery the plugins to execute before the federated query
-   * @param postQuery the plugins to execute after the federated query
-   * @param queryResponseFactory a {@link Function} that returns a {@link QueryResponseImpl}, given
-   *     a {@link QueryRequest}
-   */
-  public SortedFederationStrategy(
+  @VisibleForTesting
+  SortedFederationStrategy(
       ExecutorService queryExecutorService,
       List<PreFederatedQueryPlugin> preQuery,
       List<PostFederatedQueryPlugin> postQuery,

--- a/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
+++ b/catalog/core/catalog-core-federationstrategy/src/test/java/ddf/catalog/federation/impl/FederationStrategyTest.java
@@ -413,22 +413,16 @@ public class FederationStrategyTest {
             mockSortedResult8);
     QueryResponseImpl offsetResultQueue = new QueryResponseImpl(queryRequest, null);
 
-    final boolean[] responseFactoryCalledOnce = {false};
-    Function<QueryRequest, QueryResponseImpl> returnResultsThenOffset =
-        request -> {
-          if (!responseFactoryCalledOnce[0]) {
-            responseFactoryCalledOnce[0] = true;
-            return mockOriginalResults;
-          } else {
-            return offsetResultQueue;
-          }
-        };
+    Function<QueryRequest, QueryResponseImpl> mockResponseFunction = mock(Function.class);
+    when(mockResponseFunction.apply(any(QueryRequest.class)))
+        .thenReturn(mockOriginalResults)
+        .thenReturn(offsetResultQueue);
     SortedFederationStrategy strategy =
         new SortedFederationStrategy(
             executor,
             new ArrayList<PreFederatedQueryPlugin>(),
             new ArrayList<PostFederatedQueryPlugin>(),
-            returnResultsThenOffset);
+            mockResponseFunction);
 
     // Run Test
     QueryResponse federatedResponse = strategy.federate(sources, queryRequest);

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -25,11 +25,6 @@
     <name>DDF :: Catalog :: Core :: Standard Framework</name>
     <packaging>bundle</packaging>
 
-    <properties>
-        <!-- For maven-surefire-plugin -->
-        <surefire.argline.append>-javaagent:${powermock.agent}</surefire.argline.append>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>ddf.platform.solr</groupId>
@@ -334,27 +329,6 @@
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-injectattribute</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>mockito-core</artifactId>
-                    <groupId>org.mockito</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/catalog/core/catalog-core-validationparser/pom.xml
+++ b/catalog/core/catalog-core-validationparser/pom.xml
@@ -87,36 +87,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-classloading-xstream</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/core/catalog-core-validationparser/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
+++ b/catalog/core/catalog-core-validationparser/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
@@ -17,6 +17,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.codice.gsonsupport.GsonTypeAdapters.LIST_STRING;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -146,7 +147,8 @@ public class ValidationParser implements ArtifactInstaller {
         FrameworkUtil::getBundle);
   }
 
-  public ValidationParser(
+  @VisibleForTesting
+  ValidationParser(
       AttributeRegistry attributeRegistry,
       AttributeValidatorRegistry attributeValidatorRegistry,
       DefaultAttributeValueRegistry defaultAttributeValueRegistry,

--- a/catalog/core/catalog-core-validationparser/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
+++ b/catalog/core/catalog-core-validationparser/src/main/java/ddf/catalog/validation/impl/ValidationParser.java
@@ -17,6 +17,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.codice.gsonsupport.GsonTypeAdapters.LIST_STRING;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -623,7 +624,8 @@ public class ValidationParser implements ArtifactInstaller {
         .collect(toList());
   }
 
-  private BundleContext getBundleContext() {
+  @VisibleForTesting
+  BundleContext getBundleContext() {
     return Optional.ofNullable(FrameworkUtil.getBundle(getClass()))
         .map(Bundle::getBundleContext)
         .orElseThrow(

--- a/catalog/core/catalog-core-validationparser/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpec.groovy
+++ b/catalog/core/catalog-core-validationparser/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpec.groovy
@@ -16,25 +16,18 @@ import ddf.catalog.validation.MetacardValidator
 import ddf.catalog.validation.ReportingMetacardValidator
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
-import org.osgi.framework.FrameworkUtil
 import org.osgi.framework.ServiceRegistration
-import org.powermock.core.classloader.annotations.PrepareForTest
-import org.powermock.modules.junit4.rule.PowerMockRule
 import spock.lang.Specification
 
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
 import static org.mockito.Matchers.isNull
-import static org.mockito.Mockito.when
-import static org.powermock.api.mockito.PowerMockito.mockStatic
+import static org.mockito.Mockito.doReturn
+import static org.mockito.Mockito.spy
 
-@PrepareForTest(FrameworkUtil.class)
 class ValidationParserSpec extends Specification {
-    @Rule
-    PowerMockRule powerMockRule = new PowerMockRule()
 
     @Rule
     TemporaryFolder temporaryFolder = new TemporaryFolder()
@@ -58,8 +51,8 @@ class ValidationParserSpec extends Specification {
 
         defaultAttributeValueRegistry = new DefaultAttributeValueRegistryImpl()
 
-        validationParser = new ValidationParser(attributeRegistry, attributeValidatorRegistry,
-                defaultAttributeValueRegistry)
+        validationParser = spy(new ValidationParser(attributeRegistry, attributeValidatorRegistry,
+                defaultAttributeValueRegistry))
 
 
         file = temporaryFolder.newFile("temp.json")
@@ -99,12 +92,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(valid) }
 
-        mockStatic(FrameworkUtil.class)
-        Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
         BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         ServiceRegistration<MetacardType> typeService1 = Mock(ServiceRegistration)
         ServiceRegistration<MetacardType> typeService2 = Mock(ServiceRegistration)
@@ -182,12 +171,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(valid) }
 
-        mockStatic(FrameworkUtil.class)
-        def Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
-        def BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        BundleContext mockBundleContext = Mock(BundleContext)
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         def ServiceRegistration<MetacardType> typeService1 = Mock(ServiceRegistration)
         def ServiceRegistration<MetacardType> typeService2 = Mock(ServiceRegistration)
@@ -297,8 +282,8 @@ class ValidationParserSpec extends Specification {
     def "test default values"() {
         setup:
         file.withPrintWriter { it.write(defaultValues) }
-        mockStatic(FrameworkUtil.class)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(Mock(Bundle))
+        BundleContext mockBundleContext = Mock(BundleContext)
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         when:
         validationParser.install(file)
@@ -357,12 +342,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(valid) }
 
-        mockStatic(FrameworkUtil.class)
-        def Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
-        def BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        BundleContext mockBundleContext = Mock(BundleContext)
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         when:
         validationParser.install(file)
@@ -383,12 +364,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(valid) }
 
-        mockStatic(FrameworkUtil.class)
-        Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
         BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         def attribute1Name = "attribute1";
         def attribute2Name = "attribute2";
@@ -418,12 +395,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(metacardValidator) }
 
-        mockStatic(FrameworkUtil.class)
-        Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
         BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         when:
         validationParser.install(file)
@@ -436,12 +409,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(invalidRequiredAttrMetacardValidator) }
 
-        mockStatic(FrameworkUtil.class)
-        def Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
-        def BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        BundleContext mockBundleContext = Mock(BundleContext)
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         when:
         validationParser.install(file)
@@ -454,12 +423,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(invalidMetacardValidator) }
 
-        mockStatic(FrameworkUtil.class)
-        Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
         BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         when:
         validationParser.install(file)
@@ -472,12 +437,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(matchAnyAttributeValidator) }
 
-        mockStatic(FrameworkUtil.class)
-        Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
         BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
 
         when:
         validationParser.install(file)
@@ -490,12 +451,8 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(relationshipAttributeValidator) }
 
-        mockStatic(FrameworkUtil.class)
-        Bundle mockBundle = Mock(Bundle)
-        when(FrameworkUtil.getBundle(ValidationParser.class)).thenReturn(mockBundle)
-
         BundleContext mockBundleContext = Mock(BundleContext)
-        mockBundle.getBundleContext() >> mockBundleContext
+        doReturn(mockBundleContext).when(validationParser).getBundleContext()
         when:
         validationParser.install(file)
 

--- a/catalog/core/catalog-core-validationparser/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpec.groovy
+++ b/catalog/core/catalog-core-validationparser/src/test/groovy/ddf/catalog/validation/impl/ValidationParserSpec.groovy
@@ -25,7 +25,6 @@ import java.time.ZoneOffset
 
 import static org.mockito.Matchers.isNull
 import static org.mockito.Mockito.doReturn
-import static org.mockito.Mockito.spy
 
 class ValidationParserSpec extends Specification {
 
@@ -50,9 +49,8 @@ class ValidationParserSpec extends Specification {
         attributeRegistry.registerMetacardType(new MetacardTypeImpl("testMetacard", Arrays.asList(new CoreAttributes())))
 
         defaultAttributeValueRegistry = new DefaultAttributeValueRegistryImpl()
-
-        validationParser = spy(new ValidationParser(attributeRegistry, attributeValidatorRegistry,
-                defaultAttributeValueRegistry))
+        validationParser = Spy(ValidationParser, constructorArgs: [attributeRegistry, attributeValidatorRegistry,
+                defaultAttributeValueRegistry])
 
 
         file = temporaryFolder.newFile("temp.json")
@@ -93,7 +91,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(valid) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         ServiceRegistration<MetacardType> typeService1 = Mock(ServiceRegistration)
         ServiceRegistration<MetacardType> typeService2 = Mock(ServiceRegistration)
@@ -172,7 +170,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(valid) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         def ServiceRegistration<MetacardType> typeService1 = Mock(ServiceRegistration)
         def ServiceRegistration<MetacardType> typeService2 = Mock(ServiceRegistration)
@@ -283,7 +281,7 @@ class ValidationParserSpec extends Specification {
         setup:
         file.withPrintWriter { it.write(defaultValues) }
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         when:
         validationParser.install(file)
@@ -343,7 +341,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(valid) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         when:
         validationParser.install(file)
@@ -365,7 +363,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(valid) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         def attribute1Name = "attribute1";
         def attribute2Name = "attribute2";
@@ -396,7 +394,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(metacardValidator) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         when:
         validationParser.install(file)
@@ -410,7 +408,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(invalidRequiredAttrMetacardValidator) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         when:
         validationParser.install(file)
@@ -424,7 +422,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(invalidMetacardValidator) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         when:
         validationParser.install(file)
@@ -438,7 +436,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(matchAnyAttributeValidator) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
 
         when:
         validationParser.install(file)
@@ -452,7 +450,7 @@ class ValidationParserSpec extends Specification {
         file.withPrintWriter { it.write(relationshipAttributeValidator) }
 
         BundleContext mockBundleContext = Mock(BundleContext)
-        doReturn(mockBundleContext).when(validationParser).getBundleContext()
+        validationParser.getBundleContext() >> mockBundleContext
         when:
         validationParser.install(file)
 

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -23,11 +23,6 @@
     <artifactId>core</artifactId>
     <packaging>pom</packaging>
     <name>DDF Catalog Core</name>
-    <properties>
-        <powermock.agent>
-            ${settings.localRepository}/org/powermock/powermock-module-javaagent/${powermock.version}/powermock-module-javaagent-${powermock.version}.jar
-        </powermock.agent>
-    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -71,23 +66,6 @@
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
                 <version>${tika.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4-rule-agent</artifactId>
-                <version>${powermock.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/catalog/plugin/catalog-plugin-security-audit/pom.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/pom.xml
@@ -23,14 +23,6 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
 
-    <properties>
-        <powermock.agent>
-            ${settings.localRepository}/org/powermock/powermock-module-javaagent/${powermock.version}/powermock-module-javaagent-${powermock.version}.jar
-        </powermock.agent>
-        <!-- For maven-surefire-plugin -->
-        <surefire.argline.append>-javaagent:${powermock.agent}</surefire.argline.append>
-    </properties>
-
 
     <name>DDF :: Catalog :: Plugin :: Security Audit</name>
     <artifactId>catalog-plugin-security-audit</artifactId>
@@ -51,21 +43,9 @@
             <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.6.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-            <version>1.6.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/java/org/codice/ddf/catalog/plugin/security/audit/SecurityAuditPlugin.java
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/java/org/codice/ddf/catalog/plugin/security/audit/SecurityAuditPlugin.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.catalog.plugin.security.audit;
 
+import com.google.common.annotations.VisibleForTesting;
 import ddf.catalog.Constants;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
@@ -70,10 +71,7 @@ public class SecurityAuditPlugin implements AccessPlugin {
               updateMetacard.getAttribute(descriptorName))) {
             String originalValue = getNonNullAttributeValues(existingMetacard, descriptorName);
             String updateValue = getNonNullAttributeValues(updateMetacard, descriptorName);
-            SecurityLogger.audit(
-                String.format(
-                    "Attribute %s on metacard %s with value(s) %s was updated to value(s) %s",
-                    descriptorName, updateMetacard.getId(), originalValue, updateValue));
+            auditMetacardUpdate(descriptorName, updateMetacard.getId(), originalValue, updateValue);
           }
         }
       }
@@ -168,5 +166,14 @@ public class SecurityAuditPlugin implements AccessPlugin {
     return props == null
         || props.get(Constants.LOCAL_DESTINATION_KEY) == null
         || (boolean) props.get(Constants.LOCAL_DESTINATION_KEY);
+  }
+
+  @VisibleForTesting
+  void auditMetacardUpdate(
+      String descriptorName, String metacardId, String originalValue, String updateValue) {
+    SecurityLogger.audit(
+        String.format(
+            "Attribute %s on metacard %s with value(s) %s was updated to value(s) %s",
+            descriptorName, metacardId, originalValue, updateValue));
   }
 }

--- a/catalog/plugin/catalog-plugin-security-audit/src/test/java/org/codice/ddf/catalog/plugin/security/audit/SecurityAuditPluginTest.java
+++ b/catalog/plugin/catalog-plugin-security-audit/src/test/java/org/codice/ddf/catalog/plugin/security/audit/SecurityAuditPluginTest.java
@@ -11,36 +11,29 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ddf.catalog.security.audit;
+package org.codice.ddf.catalog.plugin.security.audit;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import ddf.catalog.Constants;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.plugin.StopProcessingException;
-import ddf.security.common.audit.SecurityLogger;
 import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.codice.ddf.catalog.plugin.security.audit.SecurityAuditPlugin;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
-@PrepareForTest({SecurityLogger.class})
 public class SecurityAuditPluginTest {
-
-  @Rule public PowerMockRule rule = new PowerMockRule();
 
   private SecurityAuditPlugin securityAuditPlugin;
 
@@ -53,14 +46,12 @@ public class SecurityAuditPluginTest {
   public void setup() {
     List<String> auditAttributes = new ArrayList<>();
     auditAttributes.add(Metacard.TITLE);
-    securityAuditPlugin = new SecurityAuditPlugin();
+    securityAuditPlugin = spy(new SecurityAuditPlugin());
     securityAuditPlugin.setAuditAttributes(auditAttributes);
   }
 
   @Test
   public void testChangedAttributeInAuditConfigIsAudited() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
     MetacardImpl existingMetacard = new MetacardImpl();
     MetacardImpl updateMetacard = new MetacardImpl();
 
@@ -79,14 +70,11 @@ public class SecurityAuditPluginTest {
     UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards, Metacard.TITLE, null);
     securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
 
-    PowerMockito.verifyStatic(times(1));
-    SecurityLogger.audit(String.format(auditMessageFormat, Metacard.TITLE, "test", "A", "1"));
+    verify(securityAuditPlugin, times(1)).auditMetacardUpdate(Metacard.TITLE, "test", "A", "1");
   }
 
   @Test
   public void testUnchangedAttributeInAuditConfigIsNotAudited() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
     MetacardImpl existingMetacard = new MetacardImpl();
     MetacardImpl updateMetacard = new MetacardImpl();
 
@@ -105,14 +93,11 @@ public class SecurityAuditPluginTest {
     UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards, Metacard.TITLE, null);
     securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
 
-    PowerMockito.verifyStatic(never());
-    SecurityLogger.audit(String.format(auditMessageFormat, Metacard.TITLE, "test", "B", "B"));
+    verify(securityAuditPlugin, never()).auditMetacardUpdate(Metacard.TITLE, "test", "B", "B");
   }
 
   @Test
   public void testChangedAttributeNotInAuditConfigIsNotAudited() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
     MetacardImpl existingMetacard = new MetacardImpl();
     MetacardImpl updateMetacard = new MetacardImpl();
 
@@ -132,20 +117,12 @@ public class SecurityAuditPluginTest {
         new UpdateRequestImpl(updateMetacards, Metacard.METADATA, null);
     securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
 
-    PowerMockito.verifyStatic(never());
-    SecurityLogger.audit(
-        String.format(
-            auditMessageFormat,
-            Metacard.METADATA,
-            "test",
-            "A test string",
-            "A different test string"));
+    verify(securityAuditPlugin, never())
+        .auditMetacardUpdate(Metacard.METADATA, "test", "A test string", "A different test string");
   }
 
   @Test
   public void testUnchangedAttributeNotInAuditConfigIsNotAudited() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
     MetacardImpl existingMetacard = new MetacardImpl();
     MetacardImpl updateMetacard = new MetacardImpl();
 
@@ -165,16 +142,12 @@ public class SecurityAuditPluginTest {
         new UpdateRequestImpl(updateMetacards, Metacard.METADATA, null);
     securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
 
-    PowerMockito.verifyStatic(never());
-    SecurityLogger.audit(
-        String.format(
-            auditMessageFormat, Metacard.METADATA, "test", "A test string", "A test string"));
+    verify(securityAuditPlugin, never())
+        .auditMetacardUpdate(Metacard.METADATA, "test", "A test string", "A test string");
   }
 
   @Test
   public void testDeletedAttributeInAuditConfigIsAudited() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
     MetacardImpl existingMetacard = new MetacardImpl();
     MetacardImpl updateMetacard = new MetacardImpl();
 
@@ -192,15 +165,12 @@ public class SecurityAuditPluginTest {
     UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards, Metacard.TITLE, null);
     securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
 
-    PowerMockito.verifyStatic(times(1));
-    SecurityLogger.audit(
-        String.format(auditMessageFormat, Metacard.TITLE, "test", "A test string", "[NO VALUE]"));
+    verify(securityAuditPlugin, times(1))
+        .auditMetacardUpdate(Metacard.TITLE, "test", "A test string", "[NO VALUE]");
   }
 
   @Test
   public void testAddedAttributeInAuditConfigIsAudited() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
     MetacardImpl existingMetacard = new MetacardImpl();
     MetacardImpl updateMetacard = new MetacardImpl();
 
@@ -218,15 +188,12 @@ public class SecurityAuditPluginTest {
     UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards, Metacard.TITLE, null);
     securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
 
-    PowerMockito.verifyStatic(times(1));
-    SecurityLogger.audit(
-        String.format(auditMessageFormat, Metacard.TITLE, "test", "[NO VALUE]", "A test string"));
+    verify(securityAuditPlugin, times(1))
+        .auditMetacardUpdate(Metacard.TITLE, "test", "[NO VALUE]", "A test string");
   }
 
   @Test
   public void testNullAttributeInAuditConfigIsNotAudited() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
     MetacardImpl existingMetacard = new MetacardImpl();
     MetacardImpl updateMetacard = new MetacardImpl();
 
@@ -243,24 +210,20 @@ public class SecurityAuditPluginTest {
     UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards, Metacard.TITLE, null);
     securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
 
-    PowerMockito.verifyStatic(never());
-    SecurityLogger.audit(anyString());
+    verify(securityAuditPlugin, never())
+        .auditMetacardUpdate(anyString(), anyString(), anyString(), anyString());
   }
 
   @Test
-  public void testNullupdateRequest() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
+  public void testNullUpdateRequest() throws StopProcessingException {
     securityAuditPlugin.processPreUpdate(null, null);
 
-    PowerMockito.verifyStatic(never());
-    SecurityLogger.audit(anyString());
+    verify(securityAuditPlugin, never())
+        .auditMetacardUpdate(anyString(), anyString(), anyString(), anyString());
   }
 
   @Test
   public void testNotLocalRequest() throws StopProcessingException {
-    PowerMockito.mockStatic(SecurityLogger.class);
-
     MetacardImpl existingMetacard = new MetacardImpl();
     MetacardImpl updateMetacard = new MetacardImpl();
 
@@ -281,7 +244,7 @@ public class SecurityAuditPluginTest {
 
     securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
 
-    PowerMockito.verifyStatic(never());
-    SecurityLogger.audit(anyString());
+    verify(securityAuditPlugin, never())
+        .auditMetacardUpdate(anyString(), anyString(), anyString(), anyString());
   }
 }

--- a/platform/admin/core/admin-core-migration-commands/pom.xml
+++ b/platform/admin/core/admin-core-migration-commands/pom.xml
@@ -27,12 +27,6 @@
   <name>DDF :: Admin :: Core :: Migration :: Commands</name>
   <packaging>bundle</packaging>
 
-  <properties>
-    <powermock.agent>
-      ${settings.localRepository}/org/powermock/powermock-module-javaagent/${powermock.version}/powermock-module-javaagent-${powermock.version}.jar
-    </powermock.agent>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.karaf.shell</groupId>

--- a/platform/security/common/pom.xml
+++ b/platform/security/common/pom.xml
@@ -26,11 +26,6 @@
     <name>DDF :: Security :: Common</name>
     <packaging>jar</packaging>
 
-    <properties>
-        <!-- For maven-surefire-plugin -->
-        <surefire.argline.append>-javaagent:${powermock.agent}</surefire.argline.append>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -119,24 +114,6 @@
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ddf.security.encryption</groupId>

--- a/platform/security/core/security-core-impl/pom.xml
+++ b/platform/security/core/security-core-impl/pom.xml
@@ -61,24 +61,6 @@
             <artifactId>wss4j-ws-security-dom</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>opensaml-core</artifactId>
         </dependency>

--- a/platform/security/core/security-core-services/pom.xml
+++ b/platform/security/core/security-core-services/pom.xml
@@ -24,11 +24,6 @@
     <name>DDF :: Security :: Core :: Services</name>
     <packaging>bundle</packaging>
 
-    <properties>
-        <!-- For maven-surefire-plugin -->
-        <surefire.argline.append>-javaagent:${powermock.agent}</surefire.argline.append>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>
@@ -126,24 +121,6 @@
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ddf.security.encryption</groupId>

--- a/platform/security/pep/security-pep-interceptor/pom.xml
+++ b/platform/security/pep/security-pep-interceptor/pom.xml
@@ -23,11 +23,6 @@
     <name>DDF :: Security :: PEP :: Interceptor</name>
     <packaging>bundle</packaging>
 
-    <properties>
-        <!-- For maven-surefire-plugin -->
-        <surefire.argline.append>-javaagent:${powermock.agent}</surefire.argline.append>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.shiro</groupId>
@@ -56,18 +51,6 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <!-- Test dependencies -->
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-        </dependency>
         <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>

--- a/platform/security/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/PEPAuthorizingInterceptor.java
+++ b/platform/security/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/PEPAuthorizingInterceptor.java
@@ -13,6 +13,7 @@
  */
 package ddf.security.pep.interceptor;
 
+import com.google.common.annotations.VisibleForTesting;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
@@ -57,7 +58,8 @@ public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message>
     this(SecurityAssertionStore::getSecurityAssertion);
   }
 
-  public PEPAuthorizingInterceptor(Function<Message, SecurityAssertion> assertionRetriever) {
+  @VisibleForTesting
+  PEPAuthorizingInterceptor(Function<Message, SecurityAssertion> assertionRetriever) {
     super(Phase.PRE_INVOKE);
     addAfter(org.apache.cxf.ws.policy.PolicyVerificationInInterceptor.class.getName());
     this.assertionRetriever = assertionRetriever;

--- a/platform/security/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/PEPAuthorizingInterceptor.java
+++ b/platform/security/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/PEPAuthorizingInterceptor.java
@@ -13,6 +13,7 @@
  */
 package ddf.security.pep.interceptor;
 
+import com.google.common.annotations.VisibleForTesting;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
@@ -76,7 +77,7 @@ public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message>
     if (message != null) {
       // grab the SAML assertion associated with this Message from the
       // token store
-      SecurityAssertion assertion = SecurityAssertionStore.getSecurityAssertion(message);
+      SecurityAssertion assertion = getSecurityAssertion(message);
       boolean isPermitted = false;
 
       if ((assertion != null) && (assertion.getSecurityToken() != null)) {
@@ -139,6 +140,11 @@ public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message>
           "Unable to retrieve the current message associated with the web service call.");
       throw new AccessDeniedException("Unauthorized");
     }
+  }
+
+  @VisibleForTesting
+  SecurityAssertion getSecurityAssertion(Message message) {
+    return SecurityAssertionStore.getSecurityAssertion(message);
   }
 
   /**

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorActionsTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorActionsTest.java
@@ -17,16 +17,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
-import ddf.security.common.audit.SecurityLogger;
 import ddf.security.permission.CollectionPermission;
 import ddf.security.service.SecurityManager;
 import ddf.security.service.SecurityServiceException;
-import ddf.security.service.impl.SecurityAssertionStore;
 import javax.xml.namespace.QName;
 import javax.xml.ws.handler.MessageContext;
 import org.apache.cxf.binding.soap.model.SoapOperationInfo;
@@ -37,22 +37,15 @@ import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.MessageInfo;
 import org.apache.cxf.ws.addressing.Names;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
-import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
-@PrepareForTest({SecurityAssertionStore.class, SecurityLogger.class})
 public class PepInterceptorActionsTest {
-
-  @Rule public PowerMockRule rule = new PowerMockRule();
 
   @Test
   public void testMessageWithDefaultUriAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
@@ -63,10 +56,7 @@ public class PepInterceptorActionsTest {
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithAction))
-        .thenReturn(mockSecurityAssertion);
+    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -98,13 +88,11 @@ public class PepInterceptorActionsTest {
 
     // This should work.
     interceptor.handleMessage(messageWithAction);
-
-    PowerMockito.verifyStatic();
   }
 
   @Test
   public void testMessageWithDefaultUrlAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
@@ -115,10 +103,7 @@ public class PepInterceptorActionsTest {
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithAction))
-        .thenReturn(mockSecurityAssertion);
+    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -150,13 +135,11 @@ public class PepInterceptorActionsTest {
 
     // This should work.
     interceptor.handleMessage(messageWithAction);
-
-    PowerMockito.verifyStatic();
   }
 
   @Test
   public void testMessageWithMessageAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
@@ -167,10 +150,7 @@ public class PepInterceptorActionsTest {
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithAction))
-        .thenReturn(mockSecurityAssertion);
+    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -197,13 +177,11 @@ public class PepInterceptorActionsTest {
 
     // This should work.
     interceptor.handleMessage(messageWithAction);
-
-    PowerMockito.verifyStatic();
   }
 
   @Test
   public void testMessageWithOperationAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
@@ -214,10 +192,7 @@ public class PepInterceptorActionsTest {
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithAction))
-        .thenReturn(mockSecurityAssertion);
+    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -246,13 +221,11 @@ public class PepInterceptorActionsTest {
 
     // This should work.
     interceptor.handleMessage(messageWithAction);
-
-    PowerMockito.verifyStatic();
   }
 
   @Test(expected = AccessDeniedException.class)
   public void testMessageWithNoAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
@@ -263,10 +236,7 @@ public class PepInterceptorActionsTest {
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithoutAction))
-        .thenReturn(mockSecurityAssertion);
+    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithoutAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -283,7 +253,5 @@ public class PepInterceptorActionsTest {
 
     // This should throw an exception.
     interceptor.handleMessage(messageWithoutAction);
-
-    PowerMockito.verifyStatic();
   }
 }

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorActionsTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorActionsTest.java
@@ -17,9 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import ddf.security.Subject;
@@ -37,26 +35,32 @@ import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.MessageInfo;
 import org.apache.cxf.ws.addressing.Names;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class PepInterceptorActionsTest {
 
+  private PEPAuthorizingInterceptor interceptor;
+
+  private SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
+
+  @Before
+  public void setup() {
+    interceptor = new PEPAuthorizingInterceptor(m -> mockSecurityAssertion);
+  }
+
   @Test
   public void testMessageWithDefaultUriAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
-
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
 
     Message messageWithAction = mock(Message.class);
-    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     SecurityToken mockSecurityToken = mock(SecurityToken.class);
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -92,18 +96,14 @@ public class PepInterceptorActionsTest {
 
   @Test
   public void testMessageWithDefaultUrlAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
-
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
 
     Message messageWithAction = mock(Message.class);
-    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     SecurityToken mockSecurityToken = mock(SecurityToken.class);
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -139,18 +139,14 @@ public class PepInterceptorActionsTest {
 
   @Test
   public void testMessageWithMessageAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
-
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
 
     Message messageWithAction = mock(Message.class);
-    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     SecurityToken mockSecurityToken = mock(SecurityToken.class);
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -181,18 +177,14 @@ public class PepInterceptorActionsTest {
 
   @Test
   public void testMessageWithOperationAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
-
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
 
     Message messageWithAction = mock(Message.class);
-    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     SecurityToken mockSecurityToken = mock(SecurityToken.class);
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -225,18 +217,14 @@ public class PepInterceptorActionsTest {
 
   @Test(expected = AccessDeniedException.class)
   public void testMessageWithNoAction() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
-
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
 
     Message messageWithoutAction = mock(Message.class);
-    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     SecurityToken mockSecurityToken = mock(SecurityToken.class);
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    doReturn(mockSecurityAssertion).when(interceptor).getSecurityAssertion(messageWithoutAction);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorInvalidSubjectTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorInvalidSubjectTest.java
@@ -15,16 +15,16 @@ package ddf.security.pep.interceptor;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
-import ddf.security.common.audit.SecurityLogger;
 import ddf.security.permission.CollectionPermission;
 import ddf.security.service.SecurityManager;
 import ddf.security.service.SecurityServiceException;
-import ddf.security.service.impl.SecurityAssertionStore;
 import javax.xml.namespace.QName;
 import org.apache.cxf.binding.soap.model.SoapOperationInfo;
 import org.apache.cxf.interceptor.security.AccessDeniedException;
@@ -35,23 +35,17 @@ import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
-@PrepareForTest({SecurityAssertionStore.class, SecurityLogger.class})
 public class PepInterceptorInvalidSubjectTest {
 
-  @Rule public PowerMockRule rule = new PowerMockRule();
-
   @Rule
-  // CHECKSTYLE.OFF: VisibilityModifier - Needs to be public for PowerMockito
+  // CHECKSTYLE.OFF: VisibilityModifier - Needs to be public for Mockito
   public ExpectedException expectedExForInvalidSubject = ExpectedException.none();
   // CHECKSTYLE.ON: VisibilityModifier
 
   @Test
   public void testMessageInvalidSecurityAssertionToken() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
@@ -62,10 +56,9 @@ public class PepInterceptorInvalidSubjectTest {
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithInvalidSecurityAssertion))
-        .thenReturn(mockSecurityAssertion);
+    doReturn(mockSecurityAssertion)
+        .when(interceptor)
+        .getSecurityAssertion(messageWithInvalidSecurityAssertion);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -88,7 +81,5 @@ public class PepInterceptorInvalidSubjectTest {
     expectedExForInvalidSubject.expectMessage("Unauthorized");
     // This should throw
     interceptor.handleMessage(messageWithInvalidSecurityAssertion);
-
-    PowerMockito.verifyStatic();
   }
 }

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorInvalidSubjectTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorInvalidSubjectTest.java
@@ -15,7 +15,6 @@ package ddf.security.pep.interceptor;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -45,20 +44,18 @@ public class PepInterceptorInvalidSubjectTest {
 
   @Test
   public void testMessageInvalidSecurityAssertionToken() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
+    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
+    PEPAuthorizingInterceptor interceptor =
+        spy(new PEPAuthorizingInterceptor(m -> mockSecurityAssertion));
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
 
     Message messageWithInvalidSecurityAssertion = mock(Message.class);
-    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     SecurityToken mockSecurityToken = mock(SecurityToken.class);
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    doReturn(mockSecurityAssertion)
-        .when(interceptor)
-        .getSecurityAssertion(messageWithInvalidSecurityAssertion);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorNullAssertionTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorNullAssertionTest.java
@@ -13,7 +13,6 @@
  */
 package ddf.security.pep.interceptor;
 
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
@@ -28,10 +27,9 @@ public class PepInterceptorNullAssertionTest {
 
   @Test
   public void testMessageNullSecurityAssertion() {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor(m -> null));
 
     Message messageWithNullSecurityAssertion = mock(Message.class);
-    doReturn(null).when(interceptor).getSecurityAssertion(messageWithNullSecurityAssertion);
     // SecurityLogger is already stubbed out
     expectedExForNullMessage.expect(AccessDeniedException.class);
     expectedExForNullMessage.expectMessage("Unauthorized");

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorNullAssertionTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorNullAssertionTest.java
@@ -13,41 +13,28 @@
  */
 package ddf.security.pep.interceptor;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
 
-import ddf.security.common.audit.SecurityLogger;
-import ddf.security.service.impl.SecurityAssertionStore;
 import org.apache.cxf.interceptor.security.AccessDeniedException;
 import org.apache.cxf.message.Message;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
-@PrepareForTest({SecurityAssertionStore.class, SecurityLogger.class})
 public class PepInterceptorNullAssertionTest {
-
-  @Rule public PowerMockRule rule = new PowerMockRule();
-
   @Rule public ExpectedException expectedExForNullMessage = ExpectedException.none();
 
   @Test
   public void testMessageNullSecurityAssertion() {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     Message messageWithNullSecurityAssertion = mock(Message.class);
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithNullSecurityAssertion))
-        .thenReturn(null);
+    doReturn(null).when(interceptor).getSecurityAssertion(messageWithNullSecurityAssertion);
     // SecurityLogger is already stubbed out
     expectedExForNullMessage.expect(AccessDeniedException.class);
     expectedExForNullMessage.expectMessage("Unauthorized");
     interceptor.handleMessage(messageWithNullSecurityAssertion);
-
-    PowerMockito.verifyStatic();
   }
 }

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorNullAssertionTokenTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorNullAssertionTokenTest.java
@@ -14,7 +14,6 @@
 package ddf.security.pep.interceptor;
 
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -32,14 +31,12 @@ public class PepInterceptorNullAssertionTokenTest {
 
   @Test
   public void testMessageNullSecurityAssertionToken() {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     Message messageWithNullSecurityAssertion = mock(Message.class);
     SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     assertNotNull(mockSecurityAssertion);
-    doReturn(mockSecurityAssertion)
-        .when(interceptor)
-        .getSecurityAssertion(messageWithNullSecurityAssertion);
+    PEPAuthorizingInterceptor interceptor =
+        spy(new PEPAuthorizingInterceptor(m -> mockSecurityAssertion));
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(null);
     expectedExForNullMessage.expect(AccessDeniedException.class);

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorNullAssertionTokenTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorNullAssertionTokenTest.java
@@ -14,45 +14,36 @@
 package ddf.security.pep.interceptor;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import ddf.security.assertion.SecurityAssertion;
-import ddf.security.common.audit.SecurityLogger;
-import ddf.security.service.impl.SecurityAssertionStore;
 import org.apache.cxf.interceptor.security.AccessDeniedException;
 import org.apache.cxf.message.Message;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
-@PrepareForTest({SecurityAssertionStore.class, SecurityLogger.class})
 public class PepInterceptorNullAssertionTokenTest {
-
-  @Rule public PowerMockRule rule = new PowerMockRule();
 
   @Rule public ExpectedException expectedExForNullMessage = ExpectedException.none();
 
   @Test
   public void testMessageNullSecurityAssertionToken() {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     Message messageWithNullSecurityAssertion = mock(Message.class);
     SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     assertNotNull(mockSecurityAssertion);
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithNullSecurityAssertion))
-        .thenReturn(mockSecurityAssertion);
+    doReturn(mockSecurityAssertion)
+        .when(interceptor)
+        .getSecurityAssertion(messageWithNullSecurityAssertion);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(null);
     expectedExForNullMessage.expect(AccessDeniedException.class);
     expectedExForNullMessage.expectMessage("Unauthorized");
     interceptor.handleMessage(messageWithNullSecurityAssertion);
-
-    PowerMockito.verifyStatic();
   }
 }

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
@@ -15,7 +15,6 @@ package ddf.security.pep.interceptor;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -37,20 +36,18 @@ public class PepInterceptorValidSubjectTest {
 
   @Test
   public void testMessageValidSecurityAssertionToken() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
+    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
+    PEPAuthorizingInterceptor interceptor =
+        spy(new PEPAuthorizingInterceptor(m -> mockSecurityAssertion));
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
 
     Message messageWithValidSecurityAssertion = mock(Message.class);
-    SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
     SecurityToken mockSecurityToken = mock(SecurityToken.class);
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    doReturn(mockSecurityAssertion)
-        .when(interceptor)
-        .getSecurityAssertion(messageWithValidSecurityAssertion);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
@@ -15,36 +15,29 @@ package ddf.security.pep.interceptor;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import ddf.security.Subject;
 import ddf.security.assertion.SecurityAssertion;
-import ddf.security.common.audit.SecurityLogger;
 import ddf.security.permission.CollectionPermission;
 import ddf.security.service.SecurityManager;
 import ddf.security.service.SecurityServiceException;
-import ddf.security.service.impl.SecurityAssertionStore;
 import javax.xml.namespace.QName;
 import org.apache.cxf.binding.soap.model.SoapOperationInfo;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
-import org.junit.Rule;
 import org.junit.Test;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
-@PrepareForTest({SecurityAssertionStore.class, SecurityLogger.class})
 public class PepInterceptorValidSubjectTest {
-
-  @Rule public PowerMockRule rule = new PowerMockRule();
 
   @Test
   public void testMessageValidSecurityAssertionToken() throws SecurityServiceException {
-    PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+    PEPAuthorizingInterceptor interceptor = spy(new PEPAuthorizingInterceptor());
 
     SecurityManager mockSecurityManager = mock(SecurityManager.class);
     interceptor.setSecurityManager(mockSecurityManager);
@@ -55,10 +48,9 @@ public class PepInterceptorValidSubjectTest {
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
-    PowerMockito.mockStatic(SecurityAssertionStore.class);
-    PowerMockito.mockStatic(SecurityLogger.class);
-    when(SecurityAssertionStore.getSecurityAssertion(messageWithValidSecurityAssertion))
-        .thenReturn(mockSecurityAssertion);
+    doReturn(mockSecurityAssertion)
+        .when(interceptor)
+        .getSecurityAssertion(messageWithValidSecurityAssertion);
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
     when(mockSecurityToken.getToken()).thenReturn(null);
@@ -80,7 +72,5 @@ public class PepInterceptorValidSubjectTest {
 
     // This should work.
     interceptor.handleMessage(messageWithValidSecurityAssertion);
-
-    PowerMockito.verifyStatic();
   }
 }

--- a/platform/security/pom.xml
+++ b/platform/security/pom.xml
@@ -26,7 +26,6 @@
     <properties>
         <jasypt.version>1.9.2</jasypt.version>
         <opensaml.version>3.3.0</opensaml.version>
-        <powermock.agent>${settings.localRepository}/org/powermock/powermock-module-javaagent/${powermock.version}/powermock-module-javaagent-${powermock.version}.jar</powermock.agent>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -164,24 +163,6 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.classic.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4-rule-agent</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.wss4j</groupId>

--- a/platform/security/sts/security-sts-ldapclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-ldapclaimshandler/pom.xml
@@ -93,23 +93,6 @@
             <version>1.4.2</version>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4-rule-agent</artifactId>
-            <version>${powermock.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
         </dependency>

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/AttributeMapLoader.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/AttributeMapLoader.java
@@ -40,7 +40,7 @@ public class AttributeMapLoader {
    * @param attributeMapFile File of the listed attributes
    * @return Map containing the fully populated attributes or empty map if file does not exist.
    */
-  public static Map<String, String> buildClaimsMapFile(String attributeMapFile) {
+  public Map<String, String> buildClaimsMapFile(String attributeMapFile) {
     Map<String, String> map =
         PropertiesLoader.toMap(PropertiesLoader.loadProperties(attributeMapFile));
 
@@ -58,7 +58,7 @@ public class AttributeMapLoader {
    * @return the user name if the principal has one, null if no name is specified or if principal is
    *     null.
    */
-  public static String getUser(Principal principal) {
+  public String getUser(Principal principal) {
     String user = null;
     if (principal instanceof KerberosPrincipal) {
       KerberosPrincipal kp = (KerberosPrincipal) principal;
@@ -102,8 +102,7 @@ public class AttributeMapLoader {
    * @param defaultBaseDN the default DN to fall back to
    * @return the base DN
    */
-  public static String getBaseDN(
-      Principal principal, String defaultBaseDN, boolean overrideCertDn) {
+  public String getBaseDN(Principal principal, String defaultBaseDN, boolean overrideCertDn) {
     String baseDN = null;
     if (principal instanceof X500Principal && !overrideCertDn) {
       Predicate<RDN> predicate = rdn -> !rdn.getTypesAndValues()[0].getType().equals(BCStyle.CN);
@@ -117,7 +116,7 @@ public class AttributeMapLoader {
     return baseDN;
   }
 
-  public static String getCredentials(Principal principal) {
+  public String getCredentials(Principal principal) {
     String credential = null;
     if (principal instanceof X500Principal) {
       X500Principal x500p = (X500Principal) principal;
@@ -129,7 +128,7 @@ public class AttributeMapLoader {
     return credential;
   }
 
-  private static String logLdapClaimsMap(Map<String, String> map) {
+  private String logLdapClaimsMap(Map<String, String> map) {
     StringBuilder builder = new StringBuilder();
     builder.append("LDAP claims map:\n");
     for (Map.Entry<String, String> claim : map.entrySet()) {

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -306,7 +306,7 @@ public class ClaimsHandlerManager {
       String bindMethod,
       String realm,
       String kdcAddress) {
-    RoleClaimsHandler roleHandler = new RoleClaimsHandler();
+    RoleClaimsHandler roleHandler = new RoleClaimsHandler(new AttributeMapLoader());
     roleHandler.setLdapConnectionFactory(connection);
     roleHandler.setPropertyFileLocation(propertyFileLoc);
     roleHandler.setUserBaseDn(userBaseDn);
@@ -344,7 +344,7 @@ public class ClaimsHandlerManager {
       String bindMethod,
       String realm,
       String kdcAddress) {
-    LdapClaimsHandler ldapHandler = new LdapClaimsHandler();
+    LdapClaimsHandler ldapHandler = new LdapClaimsHandler(new AttributeMapLoader());
     ldapHandler.setLdapConnectionFactory(connection);
     ldapHandler.setPropertyFileLocation(propertyFileLoc);
     ldapHandler.setUserBaseDN(userBaseDn);

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/main/java/ddf/security/sts/claimsHandler/RoleClaimsHandler.java
@@ -45,6 +45,8 @@ public class RoleClaimsHandler implements ClaimsHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RoleClaimsHandler.class);
 
+  private final AttributeMapLoader attributeMapLoader;
+
   private boolean overrideCertDn = false;
 
   private Map<String, String> claimsLdapAttributeMapping;
@@ -81,6 +83,10 @@ public class RoleClaimsHandler implements ClaimsHandler {
 
   private String kdcAddress;
 
+  public RoleClaimsHandler(AttributeMapLoader attributeMapLoader) {
+    this.attributeMapLoader = attributeMapLoader;
+  }
+
   public URI getRoleURI() {
     URI uri = null;
     try {
@@ -101,7 +107,7 @@ public class RoleClaimsHandler implements ClaimsHandler {
     if (propertyFileLocation != null
         && !propertyFileLocation.isEmpty()
         && !propertyFileLocation.equals(this.propertyFileLocation)) {
-      setClaimsLdapAttributeMapping(AttributeMapLoader.buildClaimsMapFile(propertyFileLocation));
+      setClaimsLdapAttributeMapping(attributeMapLoader.buildClaimsMapFile(propertyFileLocation));
     }
     this.propertyFileLocation = propertyFileLocation;
   }
@@ -223,7 +229,7 @@ public class RoleClaimsHandler implements ClaimsHandler {
     try {
       Principal principal = parameters.getPrincipal();
 
-      String user = AttributeMapLoader.getUser(principal);
+      String user = attributeMapLoader.getUser(principal);
       if (user == null) {
         LOGGER.info(
             "Could not determine user name, possible authentication error. Returning no claims.");
@@ -241,7 +247,7 @@ public class RoleClaimsHandler implements ClaimsHandler {
 
         String membershipValue = user;
 
-        String baseDN = AttributeMapLoader.getBaseDN(principal, userBaseDn, overrideCertDn);
+        String baseDN = attributeMapLoader.getBaseDN(principal, userBaseDn, overrideCertDn);
         AndFilter filter = new AndFilter();
         filter.and(new EqualsFilter(this.getLoginUserAttribute(), user));
         ConnectionEntryReader entryReader =

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/AttributeMapLoaderTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/AttributeMapLoaderTest.java
@@ -51,6 +51,8 @@ public class AttributeMapLoaderTest {
     "OU=LDAP", "OU=DEFAULT", "O=DDF", "C=US"
   };
 
+  AttributeMapLoader attributeMapLoader = new AttributeMapLoader();
+
   /**
    * Tests loading the attributes from a file.
    *
@@ -58,7 +60,7 @@ public class AttributeMapLoaderTest {
    */
   @Test
   public void testAttributeFile() {
-    Map<String, String> returnedMap = AttributeMapLoader.buildClaimsMapFile(MAP_FILE);
+    Map<String, String> returnedMap = attributeMapLoader.buildClaimsMapFile(MAP_FILE);
     assertEquals(
         "uid",
         returnedMap.get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"));
@@ -70,7 +72,7 @@ public class AttributeMapLoaderTest {
   /** Tests Loading the attributes from a non-existing file. Should return an empty map. */
   @Test
   public void testNoAttributeFile() {
-    Map<String, String> returnedMap = AttributeMapLoader.buildClaimsMapFile(NO_MAP_FILE);
+    Map<String, String> returnedMap = attributeMapLoader.buildClaimsMapFile(NO_MAP_FILE);
     assertNotNull(returnedMap);
     assertTrue(returnedMap.isEmpty());
   }
@@ -80,28 +82,28 @@ public class AttributeMapLoaderTest {
     Principal principal = mock(Principal.class);
     when(principal.getName()).thenReturn(TEST_USER);
 
-    assertEquals(TEST_USER, AttributeMapLoader.getUser(principal));
+    assertEquals(TEST_USER, attributeMapLoader.getUser(principal));
   }
 
   @Test
   public void testKerberosGetUser() {
     Principal principal = new KerberosPrincipal(KERBEROS_PRINCIPAL);
 
-    assertEquals(TEST_USER, AttributeMapLoader.getUser(principal));
+    assertEquals(TEST_USER, attributeMapLoader.getUser(principal));
   }
 
   @Test
   public void testX500GetUser() {
     Principal principal = new X500Principal(X500_DN);
 
-    assertEquals(TEST_USER, AttributeMapLoader.getUser(principal));
+    assertEquals(TEST_USER, attributeMapLoader.getUser(principal));
   }
 
   @Test
   public void testGetBaseDnX500() {
     Principal principal = new X500Principal(X500_DN);
 
-    String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
+    String baseDN = attributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
 
     String[] split = baseDN.replaceAll("\\s", "").split(",");
     assertArrayEquals(X500_BASE_DN_ARR, split);
@@ -111,7 +113,7 @@ public class AttributeMapLoaderTest {
   public void testGetBaseDnX500Override() {
     Principal principal = new X500Principal(X500_DN);
 
-    String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, true);
+    String baseDN = attributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, true);
 
     String[] split = baseDN.replaceAll("\\s", "").split(",");
     assertArrayEquals(X500_DEFAULT_BASE_DN_ARR, split);
@@ -121,7 +123,7 @@ public class AttributeMapLoaderTest {
   public void testGetBaseDnX500EmptyDN() {
     Principal principal = new X500Principal("CN=FOOBAR");
 
-    String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
+    String baseDN = attributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
 
     String[] split = baseDN.replaceAll("\\s", "").split(",");
     assertArrayEquals(X500_DEFAULT_BASE_DN_ARR, split);
@@ -131,7 +133,7 @@ public class AttributeMapLoaderTest {
   public void testGetBaseDnNonX500() {
     Principal principal = new KerberosPrincipal(KERBEROS_PRINCIPAL);
 
-    String baseDN = AttributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
+    String baseDN = attributeMapLoader.getBaseDN(principal, DEFAULT_BASE_DN, false);
 
     String[] split = baseDN.replaceAll("\\s", "").split(",");
     assertArrayEquals(X500_DEFAULT_BASE_DN_ARR, split);

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
@@ -34,22 +34,17 @@ import org.apache.cxf.sts.claims.ProcessedClaim;
 import org.apache.cxf.sts.claims.ProcessedClaimCollection;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.forgerock.opendj.ldap.Connection;
+import org.forgerock.opendj.ldap.ConnectionFactory;
 import org.forgerock.opendj.ldap.DN;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.LinkedAttribute;
 import org.forgerock.opendj.ldap.SearchResultReferenceIOException;
 import org.forgerock.opendj.ldap.responses.BindResult;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
+import org.forgerock.util.promise.Promise;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({LDAPConnectionFactory.class})
 public class RoleClaimsHandlerTest {
   public static final String USER_CN = "tstark";
 
@@ -71,7 +66,6 @@ public class RoleClaimsHandlerTest {
     Connection connection = mock(Connection.class);
     ConnectionEntryReader membershipReader = mock(ConnectionEntryReader.class);
     ConnectionEntryReader groupNameReader = mock(ConnectionEntryReader.class);
-    LDAPConnectionFactory connectionFactory = PowerMockito.mock(LDAPConnectionFactory.class);
     LinkedAttribute membershipAttribute = new LinkedAttribute("uid");
     LinkedAttribute groupNameAttribute = new LinkedAttribute("cn");
     ProcessedClaimCollection processedClaims;
@@ -110,10 +104,8 @@ public class RoleClaimsHandlerTest {
     when(connection.search(anyString(), anyObject(), anyString(), matches("uid")))
         .thenReturn(membershipReader);
 
-    when(connectionFactory.getConnection()).thenReturn(connection);
-
     claimsHandler = new RoleClaimsHandler();
-    claimsHandler.setLdapConnectionFactory(connectionFactory);
+    claimsHandler.setLdapConnectionFactory(new MockConnectionFactory(connection));
     claimsHandler.setBindMethod("Simple");
     claimsHandler.setBindUserCredentials("foo");
     claimsHandler.setBindUserDN("bar");
@@ -137,7 +129,6 @@ public class RoleClaimsHandlerTest {
     Connection connection = mock(Connection.class);
     ConnectionEntryReader membershipReader = mock(ConnectionEntryReader.class);
     ConnectionEntryReader groupNameReader = mock(ConnectionEntryReader.class);
-    LDAPConnectionFactory connectionFactory = PowerMockito.mock(LDAPConnectionFactory.class);
     LinkedAttribute membershipAttribute = new LinkedAttribute("cn");
     LinkedAttribute groupNameAttribute = new LinkedAttribute("cn");
     ProcessedClaimCollection processedClaims;
@@ -177,10 +168,8 @@ public class RoleClaimsHandlerTest {
     when(connection.search(anyString(), anyObject(), anyString(), matches("cn")))
         .thenReturn(membershipReader);
 
-    when(connectionFactory.getConnection()).thenReturn(connection);
-
     claimsHandler = new RoleClaimsHandler();
-    claimsHandler.setLdapConnectionFactory(connectionFactory);
+    claimsHandler.setLdapConnectionFactory(new MockConnectionFactory(connection));
     claimsHandler.setBindMethod("Simple");
     claimsHandler.setBindUserCredentials("foo");
     claimsHandler.setBindUserDN("bar");
@@ -206,7 +195,6 @@ public class RoleClaimsHandlerTest {
     Connection connection = mock(Connection.class);
     ConnectionEntryReader membershipReader = mock(ConnectionEntryReader.class);
     ConnectionEntryReader groupNameReader = mock(ConnectionEntryReader.class);
-    LDAPConnectionFactory connectionFactory = PowerMockito.mock(LDAPConnectionFactory.class);
     LinkedAttribute membershipAttribute = new LinkedAttribute("uid");
     LinkedAttribute groupNameAttribute = new LinkedAttribute("cn");
     ProcessedClaimCollection processedClaims;
@@ -246,10 +234,8 @@ public class RoleClaimsHandlerTest {
     when(connection.search(anyString(), anyObject(), anyString(), matches("uid")))
         .thenReturn(membershipReader);
 
-    when(connectionFactory.getConnection()).thenReturn(connection);
-
     claimsHandler = new RoleClaimsHandler();
-    claimsHandler.setLdapConnectionFactory(connectionFactory);
+    claimsHandler.setLdapConnectionFactory(new MockConnectionFactory(connection));
     claimsHandler.setBindMethod("Simple");
     claimsHandler.setBindUserCredentials("foo");
     claimsHandler.setBindUserDN("bar");
@@ -270,5 +256,28 @@ public class RoleClaimsHandlerTest {
     RoleClaimsHandler claimsHandler = new RoleClaimsHandler();
     List<URI> uris = claimsHandler.getSupportedClaimTypes();
     assertThat(uris, hasSize(1));
+  }
+
+  private class MockConnectionFactory implements ConnectionFactory {
+    private Connection connection;
+
+    public MockConnectionFactory(Connection connection) {
+      this.connection = connection;
+    }
+
+    @Override
+    public void close() {
+      // no-op
+    }
+
+    @Override
+    public Promise<Connection, LdapException> getConnectionAsync() {
+      return null;
+    }
+
+    @Override
+    public Connection getConnection() throws LdapException {
+      return connection;
+    }
   }
 }

--- a/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-ldapclaimshandler/src/test/java/ddf/security/sts/claimsHandler/RoleClaimsHandlerTest.java
@@ -42,7 +42,6 @@ import org.forgerock.opendj.ldap.SearchResultReferenceIOException;
 import org.forgerock.opendj.ldap.responses.BindResult;
 import org.forgerock.opendj.ldap.responses.SearchResultEntry;
 import org.forgerock.opendj.ldif.ConnectionEntryReader;
-import org.forgerock.util.promise.Promise;
 import org.junit.Test;
 
 public class RoleClaimsHandlerTest {
@@ -50,7 +49,7 @@ public class RoleClaimsHandlerTest {
 
   @Test
   public void testRetrieveClaimsValuesNullPrincipal() {
-    RoleClaimsHandler claimsHandler = new RoleClaimsHandler();
+    RoleClaimsHandler claimsHandler = new RoleClaimsHandler(new AttributeMapLoader());
     ClaimsParameters claimsParameters = new ClaimsParameters();
     ClaimCollection claimCollection = new ClaimCollection();
     ProcessedClaimCollection processedClaims =
@@ -104,8 +103,10 @@ public class RoleClaimsHandlerTest {
     when(connection.search(anyString(), anyObject(), anyString(), matches("uid")))
         .thenReturn(membershipReader);
 
-    claimsHandler = new RoleClaimsHandler();
-    claimsHandler.setLdapConnectionFactory(new MockConnectionFactory(connection));
+    claimsHandler = new RoleClaimsHandler(new AttributeMapLoader());
+    ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
+    when(mockConnectionFactory.getConnection()).thenReturn(connection);
+    claimsHandler.setLdapConnectionFactory(mockConnectionFactory);
     claimsHandler.setBindMethod("Simple");
     claimsHandler.setBindUserCredentials("foo");
     claimsHandler.setBindUserDN("bar");
@@ -168,8 +169,10 @@ public class RoleClaimsHandlerTest {
     when(connection.search(anyString(), anyObject(), anyString(), matches("cn")))
         .thenReturn(membershipReader);
 
-    claimsHandler = new RoleClaimsHandler();
-    claimsHandler.setLdapConnectionFactory(new MockConnectionFactory(connection));
+    claimsHandler = new RoleClaimsHandler(new AttributeMapLoader());
+    ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
+    when(mockConnectionFactory.getConnection()).thenReturn(connection);
+    claimsHandler.setLdapConnectionFactory(mockConnectionFactory);
     claimsHandler.setBindMethod("Simple");
     claimsHandler.setBindUserCredentials("foo");
     claimsHandler.setBindUserDN("bar");
@@ -234,8 +237,10 @@ public class RoleClaimsHandlerTest {
     when(connection.search(anyString(), anyObject(), anyString(), matches("uid")))
         .thenReturn(membershipReader);
 
-    claimsHandler = new RoleClaimsHandler();
-    claimsHandler.setLdapConnectionFactory(new MockConnectionFactory(connection));
+    claimsHandler = new RoleClaimsHandler(new AttributeMapLoader());
+    ConnectionFactory mockConnectionFactory = mock(ConnectionFactory.class);
+    when(mockConnectionFactory.getConnection()).thenReturn(connection);
+    claimsHandler.setLdapConnectionFactory(mockConnectionFactory);
     claimsHandler.setBindMethod("Simple");
     claimsHandler.setBindUserCredentials("foo");
     claimsHandler.setBindUserDN("bar");
@@ -253,31 +258,8 @@ public class RoleClaimsHandlerTest {
 
   @Test
   public void testSupportClaimTypes() {
-    RoleClaimsHandler claimsHandler = new RoleClaimsHandler();
+    RoleClaimsHandler claimsHandler = new RoleClaimsHandler(new AttributeMapLoader());
     List<URI> uris = claimsHandler.getSupportedClaimTypes();
     assertThat(uris, hasSize(1));
-  }
-
-  private class MockConnectionFactory implements ConnectionFactory {
-    private Connection connection;
-
-    public MockConnectionFactory(Connection connection) {
-      this.connection = connection;
-    }
-
-    @Override
-    public void close() {
-      // no-op
-    }
-
-    @Override
-    public Promise<Connection, LdapException> getConnectionAsync() {
-      return null;
-    }
-
-    @Override
-    public Connection getConnection() throws LdapException {
-      return connection;
-    }
   }
 }

--- a/platform/security/sts/security-sts-ldaplogin/pom.xml
+++ b/platform/security/sts/security-sts-ldaplogin/pom.xml
@@ -210,18 +210,6 @@
             <version>1.4.2</version>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
             <version>1.16.1</version>
@@ -268,7 +256,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito-all.version}</version>
+            <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/SslLdapLoginModuleTest.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/test/java/ddf/ldap/ldaplogin/SslLdapLoginModuleTest.java
@@ -22,18 +22,12 @@ import static org.mockito.Mockito.when;
 
 import javax.security.auth.login.LoginException;
 import org.forgerock.opendj.ldap.Connection;
-import org.forgerock.opendj.ldap.LDAPConnectionFactory;
 import org.forgerock.opendj.ldap.LdapException;
 import org.forgerock.opendj.ldap.responses.BindResult;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(LDAPConnectionFactory.class)
 public class SslLdapLoginModuleTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SslLdapLoginModule.class);

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,6 @@
         <pax.url.version>2.5.4</pax.url.version>
         <pax.transx.version>0.2.0</pax.transx.version>
         <pax.web.version>7.2.3</pax.web.version>
-        <powermock.version>1.6.4</powermock.version>
         <restito.version>0.8.2</restito.version>
         <xmlunit.version>1.4</xmlunit.version>
         <xmlunit-matchers.version>2.5.1</xmlunit-matchers.version>


### PR DESCRIPTION
#### What does this PR do?
Refactors classes to allow for Mockito spying and method stubbing instead of using PowerMock.

#### Who is reviewing it? 
@blen-desta @paouelle 
#### Select relevant component teams: 
@codice/test 
#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl 
@lessarderic 
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4403](https://codice.atlassian.net/browse/DDF-4403)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
