### PR TITLE
DDF-4406 Removes references to unused solr.log file

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/log4j2.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.xml
@@ -81,16 +81,6 @@
             </Failovers>
         </Failover>
 
-        <RollingFile name="solr" append="true"
-                     fileName="${sys:karaf.data}/log/solr.log"
-                     filePattern="${sys:karaf.data}/log/solr.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
-            <PatternLayout pattern="${log4j2.pattern}"/>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-
         <RollingFile name="artemis" append="true"
                      fileName="${sys:karaf.data}/log/artemis.log"
                      filePattern="${sys:karaf.data}/log/artemis.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
@@ -128,19 +118,12 @@
         </Logger>
 
         <Logger name="org.apache.solr" level="info" additivity="false">
-            <AppenderRef ref="solr"/>
             <AppenderRef ref="syslog"/>
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>
 
         <Logger name="org.apache.activemq.artemis" level="info" additivity="false">
             <AppenderRef ref="artemis"/>
-            <AppenderRef ref="syslog"/>
-            <AppenderRef ref="osgi-platformLogging"/>
-        </Logger>
-
-        <Logger name="org.apache.lucene" level="info" additivity="false">
-            <AppenderRef ref="solr"/>
             <AppenderRef ref="syslog"/>
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>

--- a/distribution/ddf-common/src/main/resources/etc/log4j2.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.xml
@@ -128,6 +128,11 @@
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>
 
+        <Logger name="org.apache.lucene" level="info" additivity="false">
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
         <Logger name="org.apache.sshd" level="INFO"/>
 
         <!--START Suppress logging for miscellaneous packages-->

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -64,7 +64,6 @@ log4j2.logger.ingestLogger.appenderRef.osgi-platformLogging.ref = osgi-platformL
 log4j2.logger.org_apache_solr.name = org.apache.solr
 log4j2.logger.org_apache_solr.level = INFO
 log4j2.logger.org_apache_solr.additivity = false
-log4j2.logger.org_apache_solr.appenderRef.solr.ref = solr
 log4j2.logger.org_apache_solr.appenderRef.syslog.ref = syslog
 log4j2.logger.org_apache_solr.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
 
@@ -75,14 +74,6 @@ log4j2.logger.org_apache_activemq_artemis.additivity = false
 log4j2.logger.org_apache_activemq_artemis.appenderRef.artemis.ref = artemis
 log4j2.logger.org_apache_activemq_artemis.appenderRef.syslog.ref = syslog
 log4j2.logger.org_apache_activemq_artemis.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
-
-# org.apache.lucene
-log4j2.logger.org_apache_lucene.name = org.apache.lucene
-log4j2.logger.org_apache_lucene.level = INFO
-log4j2.logger.org_apache_lucene.additivity = false
-log4j2.logger.org_apache_lucene.appenderRef.solr.ref = solr
-log4j2.logger.org_apache_lucene.appenderRef.syslog.ref = syslog
-log4j2.logger.org_apache_lucene.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
 
 # START Suppress logging for miscellaneous packages
 # GraphqQL tends to log at warn/error level. This is not needed since we provide our own logging.
@@ -190,20 +181,6 @@ log4j2.appender.securityMain.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.securityMain.policies.size.size = 20MB
 log4j2.appender.securityMain.strategy.type = DefaultRolloverStrategy
 log4j2.appender.securityMain.strategy.max = 10
-
-# solr
-log4j2.appender.solr.type = RollingFile
-log4j2.appender.solr.name = solr
-log4j2.appender.solr.fileName = ${karaf.data}/log/solr.log
-log4j2.appender.solr.filePattern = ${karaf.data}/log/solr.log-%d{yyyy-MM-dd-HH}-%i.log.gz
-log4j2.appender.solr.append = true
-log4j2.appender.solr.layout.type = PatternLayout
-log4j2.appender.solr.layout.pattern = ${log4j2.pattern}
-log4j2.appender.solr.policies.type = Policies
-log4j2.appender.solr.policies.size.type = SizeBasedTriggeringPolicy
-log4j2.appender.solr.policies.size.size = 20MB
-log4j2.appender.solr.strategy.type = DefaultRolloverStrategy
-log4j2.appender.solr.strategy.max = 10
 
 # artemis
 log4j2.appender.artemis.type = RollingFile

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -75,6 +75,13 @@ log4j2.logger.org_apache_activemq_artemis.appenderRef.artemis.ref = artemis
 log4j2.logger.org_apache_activemq_artemis.appenderRef.syslog.ref = syslog
 log4j2.logger.org_apache_activemq_artemis.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
 
+# org.apache.lucene
+log4j2.logger.org_apache_lucene.name = org.apache.lucene
+log4j2.logger.org_apache_lucene.level = INFO
+log4j2.logger.org_apache_lucene.additivity = false
+log4j2.logger.org_apache_lucene.appenderRef.syslog.ref = syslog
+log4j2.logger.org_apache_lucene.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
+
 # START Suppress logging for miscellaneous packages
 # GraphqQL tends to log at warn/error level. This is not needed since we provide our own logging.
 log4j2.logger.graphql_execution.name = graphql.execution


### PR DESCRIPTION
#### What does this PR do?
The solr.log file “${karaf.data}/log/solr.log” is not used now that Solr runs as its own process.
This removes it from our logging configuration.

#### Who is reviewing it? 
@ahoffer @austinsteffes @ricklarsen @mcalcote 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@tbatie

#### How should this be tested?
Verify there is no longer a solr.log in the /data/log directory and that there are no errors in the log about the logging configuration on startup. 

#### What are the relevant tickets?
[DDF-4406 Remove references to unsed solr.log file](https://codice.atlassian.net/browse/DDF-4406)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
