### PR TITLE
[2.13.x] DDF-4409 Fixing CSS to keep text breaking out of popovers

### DIFF
--- a/ui/packages/registry-admin-remote-ui/src/main/webapp/less/styles.less
+++ b/ui/packages/registry-admin-remote-ui/src/main/webapp/less/styles.less
@@ -45,6 +45,10 @@ table.align-middle {
     color: red;
     display: block;
   }
+  .popover-content {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+  }
   .control-group {
     [class*='col-md-'] {
       padding-left: 10px;

--- a/ui/packages/registry-admin-remote-ui/src/main/webapp/less/styles.less
+++ b/ui/packages/registry-admin-remote-ui/src/main/webapp/less/styles.less
@@ -46,7 +46,6 @@ table.align-middle {
     display: block;
   }
   .popover-content {
-    overflow-wrap: break-word;
     word-wrap: break-word;
   }
   .control-group {


### PR DESCRIPTION
#### What does this PR do?
Adds a CSS fix to keep long texts from breaking out their textboxes in popovers.

#### Who is reviewing it? 
@pvargas 
@mdang8 
@emmberk 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
<!--
@codice/ui 
-->
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@clockard 

#### How should this be tested?
Verify in downstream project.
Implement a popover with a long unbreaking string of text. Verify it does not break out of the popover.

#### What are the relevant tickets?
[DDF-4409](https://codice.atlassian.net/browse/DDF-4409)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.


#### Screenshots
![screenshot 8](https://user-images.githubusercontent.com/18688190/50176864-876b8580-02ce-11e9-9ecd-6c93eeb230e4.png)
![screenshot 6](https://user-images.githubusercontent.com/18688190/50176865-876b8580-02ce-11e9-8a62-852272ac8b79.png)
