### PR TITLE
DDF-4410 Fix issue where search form attribute names were being wrapped in double quotes

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -227,7 +227,7 @@ function generateFilter(type, property, value, metacardDefinitions) {
     default:
       const filter = {
         type,
-        property: '"' + property + '"',
+        property,
         value,
       }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.spec.js
@@ -68,7 +68,7 @@ describe('CQL Utils', () => {
         property: 'anyGeo',
         value: 'POLYGON((1 2,3 4,5 6,1 2))',
       })
-      expect(cql).to.equal('(INTERSECTS(anyGeo, POLYGON((1 2,3 4,5 6,1 2))))')
+      expect(cql).to.equal('(INTERSECTS("anyGeo", POLYGON((1 2,3 4,5 6,1 2))))')
     })
 
     it('transform compound AND filter to CQL', () => {
@@ -88,7 +88,7 @@ describe('CQL Utils', () => {
         ],
       })
       expect(cql).to.equal(
-        '((INTERSECTS(anyGeo, LINESTRING((1 2,3 4)))) AND (INTERSECTS(anyGeo, POLYGON((5 6,7 8,9 10,5 6)))))'
+        '((INTERSECTS("anyGeo", LINESTRING((1 2,3 4)))) AND (INTERSECTS("anyGeo", POLYGON((5 6,7 8,9 10,5 6)))))'
       )
     })
 
@@ -329,7 +329,7 @@ describe('CQL Utils', () => {
         mockMetacardDefinitions
       )
       expect(filter.type).equals('some type')
-      expect(filter.property).equals('"anyText"')
+      expect(filter.property).equals('anyText')
       expect(filter.value).equals('some value')
     })
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -250,8 +250,9 @@ function buildAst(tokens) {
     var tok = tokens.shift()
     switch (tok.type) {
       case 'PROPERTY':
-        //Remove single quotes if they exist in property name
+        // Remove single and double quotes if they exist in property name
         tok.text = tok.text.replace(/^'|'$/g, '')
+        tok.text = tok.text.replace(/^"|"$/g, '')
       case 'GEOMETRY':
       case 'VALUE':
       case 'TIME':
@@ -491,6 +492,17 @@ function buildAst(tokens) {
   return result
 }
 
+function wrap(property) {
+  var wrapped = property
+  if (!wrapped.startsWith('"')) {
+    wrapped = '"' + wrapped
+  }
+  if (!wrapped.endsWith('"')) {
+    wrapped = wrapped + '"'
+  }
+  return wrapped
+}
+
 function write(filter) {
   switch (classes[filter.type]) {
     case spatialClass:
@@ -502,7 +514,7 @@ function write(filter) {
             ymax = filter.value[3]
           return (
             'BBOX(' +
-            filter.property +
+            wrap(filter.property) +
             ',' +
             xmin +
             ',' +
@@ -516,7 +528,7 @@ function write(filter) {
         case 'DWITHIN':
           return (
             'DWITHIN(' +
-            filter.property +
+            wrap(filter.property) +
             ', ' +
             write(filter.value) +
             ', ' +
@@ -524,14 +536,24 @@ function write(filter) {
             ', meters)'
           )
         case 'WITHIN':
-          return 'WITHIN(' + filter.property + ', ' + write(filter.value) + ')'
+          return (
+            'WITHIN(' + wrap(filter.property) + ', ' + write(filter.value) + ')'
+          )
         case 'INTERSECTS':
           return (
-            'INTERSECTS(' + filter.property + ', ' + write(filter.value) + ')'
+            'INTERSECTS(' +
+            wrap(filter.property) +
+            ', ' +
+            write(filter.value) +
+            ')'
           )
         case 'CONTAINS':
           return (
-            'CONTAINS(' + filter.property + ', ' + write(filter.value) + ')'
+            'CONTAINS(' +
+            wrap(filter.property) +
+            ', ' +
+            write(filter.value) +
+            ')'
           )
         case 'GEOMETRY':
           return filter.value
@@ -561,7 +583,7 @@ function write(filter) {
     case comparisonClass:
       if (filter.type === 'BETWEEN') {
         return (
-          filter.property +
+          wrap(filter.property) +
           ' BETWEEN ' +
           write(filter.lowerBoundary) +
           ' AND ' +
@@ -571,7 +593,7 @@ function write(filter) {
         var property =
           typeof filter.property === 'object'
             ? write(filter.property)
-            : filter.property
+            : wrap(filter.property)
         return filter.value !== null
           ? property + ' ' + filter.type + ' ' + write(filter.value)
           : property + ' ' + filter.type
@@ -582,7 +604,7 @@ function write(filter) {
         case 'BEFORE':
         case 'AFTER':
           return (
-            filter.property +
+            wrap(filter.property) +
             ' ' +
             filter.type +
             ' ' +
@@ -590,7 +612,7 @@ function write(filter) {
           )
         case 'DURING':
           return (
-            filter.property +
+            wrap(filter.property) +
             ' ' +
             filter.type +
             ' ' +

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.spec.js
@@ -15,11 +15,11 @@ describe('tokenize', () => {
 
     filters.forEach(e => {
       switch (e.property) {
-        case '"metacard.modified"':
-        case '"metacard.created"':
-        case '"modified"':
-        case '"created"':
-        case '"effective"':
+        case 'metacard.modified':
+        case 'metacard.created':
+        case 'modified':
+        case 'created':
+        case 'effective':
           expect(e.value, 'Unexpected filter value.').to.equal(
             'RELATIVE(P0DT0H5M)'
           )
@@ -114,7 +114,7 @@ describe('tokenize', () => {
       }
       const result = cql.write(filter)
       expect(result).equals(
-        "anyText ILIKE 'this % is \\% a \\_ test _ \\* \\?'"
+        '"anyText" ILIKE \'this % is \\% a \\_ test _ \\* \\?\''
       )
     })
 
@@ -130,7 +130,7 @@ describe('tokenize', () => {
         value: '**%%__??\\*\\*\\?\\?',
       }
       const result = cql.write(filter)
-      expect(result).equals("anyText ILIKE '%%\\%\\%\\_\\___\\*\\*\\?\\?'")
+      expect(result).equals('"anyText" ILIKE \'%%\\%\\%\\_\\___\\*\\*\\?\\?\'')
     })
 
     it('parses single quote property name', () => {


### PR DESCRIPTION
#### What does this PR do?
Correctly maintains or removes double quotes around property names when swapping between CQL and the Filter AST / JSON. 

#### Who is reviewing it? 
@Variadicism 
@samuelechu 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler 
@bdeining 

#### How should this be tested?
Inspect the search forms network traffic and ensure attribute names on the Filter JSON are **not** wrapped in double quotes. 

Inspect regular query network traffic (turn off websockets) and ensure property names on the CQL string are always wrapped in double quotes. 

Ingest data and ensure querying still returns the expected results. Repeat the test with the local catalog turned off and an OpenSearch loopback source turned on. 

#### Any background context you want to provide?
As the UI evolves, the lack of adequate semantic validation for search forms is causing Solr to be polluted with heterogeneous or invalid values. This is a crucial step to fix an existing issue. Regression testing and validation will be done on a follow up (already open & blocked) PR. 

#### What are the relevant tickets?
[DDF-4410](https://codice.atlassian.net/browse/DDF-4410)
[DDF-4393](https://codice.atlassian.net/browse/DDF-4393)
[DDF-3852](https://codice.atlassian.net/browse/DDF-3852)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
