### PR TITLE
DDF-4411 Making search form settings persist after refresh

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -104,6 +104,32 @@ module.exports = Marionette.LayoutView.extend({
         user.getQuerySettings().set('type', 'text')
         break
       case 'custom':
+        let sorts =
+          this.model.get('querySettings') &&
+          this.model.get('querySettings').sorts
+        if (sorts) {
+          sorts = sorts.map(sort => ({
+            attribute: sort.split(',')[0],
+            direction: sort.split(',')[1],
+          }))
+        }
+        const sharedAttributes = {
+          title: this.model.get('title'),
+          filterTree: this.model.get('filterTemplate'),
+          src:
+            (this.model.get('querySettings') &&
+              this.model.get('querySettings').src) ||
+            '',
+          federation:
+            (this.model.get('querySettings') &&
+              this.model.get('querySettings').federation) ||
+            'enterprise',
+          sorts: sorts,
+          'detail-level':
+            (this.model.get('querySettings') &&
+              this.model.get('querySettings')['detail-level']) ||
+            'allFields',
+        }
         if (
           Router.attributes.path === 'forms(/)' &&
           this.model.get('createdBy') !== 'system'
@@ -124,8 +150,7 @@ module.exports = Marionette.LayoutView.extend({
           }
 
           this.model.set({
-            title: this.model.get('name'),
-            filterTree: this.model.get('filterTemplate'),
+            ...sharedAttributes,
             id: this.model.get('id'),
             accessGroups: this.model.get('accessGroups'),
             accessIndividuals: this.model.get('accessIndividuals'),
@@ -133,32 +158,9 @@ module.exports = Marionette.LayoutView.extend({
           })
           this.routeToSearchFormEditor(this.model.get('id'))
         } else {
-          let sorts =
-            this.model.get('querySettings') &&
-            this.model.get('querySettings').sorts
-          if (sorts) {
-            sorts = sorts.map(sort => ({
-              attribute: sort.split(',')[0],
-              direction: sort.split(',')[1],
-            }))
-          }
           this.options.queryModel.set({
             type: 'custom',
-            title: this.model.get('name'),
-            filterTree: this.model.get('filterTemplate'),
-            src:
-              (this.model.get('querySettings') &&
-                this.model.get('querySettings').src) ||
-              '',
-            federation:
-              (this.model.get('querySettings') &&
-                this.model.get('querySettings').federation) ||
-              'enterprise',
-            sorts: sorts,
-            'detail-level':
-              (this.model.get('querySettings') &&
-                this.model.get('querySettings')['detail-level']) ||
-              'allFields',
+            ...sharedAttributes,
           })
           if (oldType === 'custom') {
             this.options.queryModel.trigger('change:type')


### PR DESCRIPTION
#### What does this PR do?
Changes to search form settings (Sorts, Source and Result Form) were being saved on the backend, but weren't being properly displayed in the editor after refresh. This PR moves the flattening of these attributes, which are nested in `querySettings`, so that they can be accessed in the search form editor
#### Who is reviewing it? 
@Bdthomson @andrewzimmer 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?
- Create and save a search form with settings different from the defaults
- Refresh the page
- Open that search form in the editor
- Verify that the correct settings are displayed
#### Any background context you want to provide?
This PR depends on [DDF-4368](https://github.com/codice/ddf/pull/4135)
#### What are the relevant tickets?
[DDF-4411](https://codice.atlassian.net/browse/DDF-4411)
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
