### PR TITLE
[2.13.x] DDF-4367 Fix search results merging in Intrigue

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -351,10 +351,10 @@ define([
                     return status.hits ? hits + status.hits : hits;
                 }, 0);
 
-                if (hits === 0) {
+                if (results === 0) {
                     return '0 results';
                 } else if (results > hits) {
-                    return hits + ' results';
+                    return results + ' results';
                 }
 
                 var clientState = resultsCollection.state || this.get('result').get('results').state;


### PR DESCRIPTION
<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?

Back-ports #4092 

Fixes an issue when making searches in Intrigue where there are 250+ results returned. The counts at the bottom of the result list now match with the expected number of results. The queued results are changed to reset instead of being added because the add operation is slow enough that it can cause partial merges to happen and results being removed. The issue was more commonly observed on Firefox browsers than Chrome because the operation was finishing outside of the default auto-merge time threshold.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

@emmberk @kcover @peterhuffer @pvargas @brianfelix 

#### Select relevant component teams: 
<!--

@codice/ui 

-->
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@clockard

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Open Intrigue in a Chrome browser
- Ingest 265 (or any number greater than 250) metacards using the UI uploader
- Start a wildcard search and verify that the results text at the top query details box reads `265 results`
- Verify that the results label text at the bottom of the results list reads `250 results` or `1-25 of 265`
- Click the arrow button to proceed to the next pages until it reaches the end and the button changes to `More`
- Verify that the results label text reads `226-250 of 265`
- Click the `More` button and verify that the results label text at the bottom of the results list reads `15 results` or `251-265 of 265`
- Re-run the search and verify that the results are consistent with the above
- Remove the uploaded metacards through the console
- Upload 600 (or any number greater than 500) new metacards, repeat the process, and verify it still works
- Duplicate the same process in a Firefox browser and verify that everything works

#### What are the relevant tickets?
[DDF-4367](https://codice.atlassian.net/browse/4367)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
