### PR TITLE
DDF-4415 Initializes upload editor to not show validation issues on load

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/ingest-editor/ingest-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/ingest-editor/ingest-editor.view.js
@@ -35,6 +35,9 @@ module.exports = Marionette.LayoutView.extend({
         this.editorProperties.show(PropertyCollectionView.generateFilteredPropertyCollectionView(
             properties.editorAttributes,
             [],
+            {
+                showValidationIssues: false
+            },
         ));
         this.editorProperties.currentView.$el.addClass("is-list");
         this.editorProperties.currentView.turnOnEditing();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/property/property.collection.view.js
@@ -235,7 +235,7 @@ define([
             PropertyCollectionView.listenTo(user.get('user').get('preferences'), 'change:inspector-detailsOrder', PropertyCollectionView.updateSort);
             return PropertyCollectionView;
         },
-        generateFilteredPropertyCollectionView: function(propertyNames, metacards) {
+        generateFilteredPropertyCollectionView: function(propertyNames, metacards, options) {
             var propertyArray = [];
             propertyNames.forEach(function(property) {
                 if (metacardDefinitions.metacardTypes.hasOwnProperty(property)) {
@@ -250,7 +250,8 @@ define([
                         values: {},
                         multivalued: metacardDefinitions.metacardTypes[property].multivalued,
                         required: properties.requiredAttributes.includes(property),
-                        initializeToDefault: true
+                        initializeToDefault: true,
+                        ...options
                     });
                 }
             });


### PR DESCRIPTION
#### What does this PR do?
Before this change we were initializing the upload editor properties to the default which has showValidationIssues to true. This caused values with a list of suggested attributes to become required and as a result unable to be saved without selecting an option.
This sets showValidationIssues to false on load since we validate before trying to upload. 

#### Who is reviewing it? 
@SmithJosh @mcalcote @austinsteffes @rzwiefel 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@brendan-hofmann

#### How should this be tested?
Navigate to the Admin UI -> Search UI -> Configuration -> Catalog UI Search.
Configure a few attributes, one with some provided values and another without any. (As shown in this screenshot for example). 
<img width="460" alt="screen shot 2018-12-24 at 10 49 34" src="https://user-images.githubusercontent.com/9013407/50404827-cafc3e80-0769-11e9-91a6-60211d7b2fe1.png">
Navigate to Intrigue and select Upload. 
Verify that you don't see any errors on load. 
<img width="425" alt="screen shot 2018-12-24 at 10 53 08" src="https://user-images.githubusercontent.com/9013407/50404864-20d0e680-076a-11e9-9050-eeb1fb6e7090.png">
Upload an item without selecting any values for either of the upload editor attributes. 
Verify that it uploads without any errors and that everything looks fine.
Then, upload an item and select items for the upload editor attributes and verify again that the upload is correct (the attributes are overridden). 

Next, test configuring a required attribute.
Navigate back to the upload editor configuration and add a required attribute. (As shown in this screenshot for example)
<img width="457" alt="screen shot 2018-12-24 at 10 55 47" src="https://user-images.githubusercontent.com/9013407/50404910-88873180-076a-11e9-8ef6-fa547e14c5dc.png">
Navigate to Intrigue and select Upload. 
Verify that you don't see any errors on load. 
Verify that you see a red star next to the attribute you've configured as required. (As shown in this screenshot)
<img width="415" alt="screen shot 2018-12-24 at 10 57 44" src="https://user-images.githubusercontent.com/9013407/50404924-c71cec00-076a-11e9-8cf3-2d5557cb03ed.png">
Upload an item and verify that you can't complete uploading without selecting a value for the required attribute. 
Verify that you can upload once you've selected an attribute. Verify that it uploads without any errors and that everything looks fine (the attributes are overridden). 

#### What are the relevant tickets?
[DDF-4415  Non-required Upload Editor Attributes become required if a list of values is defined.](https://codice.atlassian.net/browse/DDF-4415)
_Navigate to the Catalog UI Search configuration (org.codice.ddf.catalog.ui.config) and update the Upload Editor: Attribute Configuration to include an attribute with several values. For example `title=Title1,Title2,Title3`. Navigate to the Upload UI in Intrigue and attempt to ingest a file.

Not selecting a value from the drop down caused an error message stating "Some fields need attention, Please address validation issues before uploading"._

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
