### PR TITLE
DDF-4412 Cannot save new workspace created from another workspace

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -571,6 +571,17 @@ public class MetacardApplication implements SparkApplication {
         (req, res) -> {
           Map<String, Object> incoming =
               GSON.fromJson(util.safeGetBody(req), MAP_STRING_TO_OBJECT_TYPE);
+
+          List<Metacard> queries =
+              ((List<Map<String, Object>>)
+                      incoming.getOrDefault(
+                          WorkspaceConstants.WORKSPACE_QUERIES, Collections.emptyList()))
+                  .stream()
+                  .map(transformer::transform)
+                  .collect(Collectors.toList());
+
+          queryMetacardsHandler.create(Collections.emptyList(), queries);
+
           Metacard saved = saveMetacard(transformer.transform(incoming));
           Map<String, Object> response = transformer.transform(saved);
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -335,6 +335,23 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
     assertThat(body.get("src"), is(sources));
   }
 
+  @Test
+  public void testCreateWorkspaceWithQueries() {
+    String queryId = "98a7c244e0c8461a87b5e0b253d6505c";
+
+    Map<String, Object> query = ImmutableMap.of("id", queryId);
+    Map<String, Object> workspace = ImmutableMap.of(WORKSPACE_QUERIES, ImmutableList.of(query));
+
+    Response res =
+        expect(asAdmin().header("Origin", workspacesApi()).body(stringify(workspace)), 201)
+            .post(workspacesApi());
+
+    Map body = parse(res);
+    String id = (String) body.get("id");
+    assertThat(id, is(queryId));
+    assertThat(body.get(WORKSPACE_QUERIES), is(ImmutableList.of(query)));
+  }
+
   @SuppressWarnings("squid:S1607" /* Feature is off by default */)
   @Ignore
   @Test

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -337,9 +337,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
 
   @Test
   public void testCreateWorkspaceWithQueries() {
-    String queryId = "98a7c244e0c8461a87b5e0b253d6505c";
-
-    Map<String, Object> query = ImmutableMap.of("id", queryId);
+    Map<String, Object> query = ImmutableMap.of("id", "queryId");
     Map<String, Object> workspace = ImmutableMap.of(WORKSPACE_QUERIES, ImmutableList.of(query));
 
     Response res =
@@ -348,7 +346,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
 
     Map body = parse(res);
     String id = (String) body.get("id");
-    assertThat(id, is(queryId));
+    assertNotNull(id);
     assertThat(body.get(WORKSPACE_QUERIES), is(ImmutableList.of(query)));
   }
 


### PR DESCRIPTION
#### What does this PR do?
- Fixes a bug where a workspace created from another workspace that already has 10 queries cannot be saved. 
- Updates integration tests for this use case. 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@mojogitoverhere 
@GabrielFabian 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl 
@vinamartin

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Create a workspace with 10 metacards.
- Add another query and select `Create New Workspace From Search`
- Save this newly created workspace. 
- Verify that the workspace and query are properly associated by refreshing the page.

#### Any background context you want to provide?
The workspace/query metacard separation changed the data model. Previously `POST /workspaces` was never called with any existing queries. Consequently this endpoint wasn't creating the query metacards it needed so it was created a detached association. 

#### What are the relevant tickets?
[DDF-4412](https://codice.atlassian.net/browse/DDF-4412)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
