### PR TITLE
DDF-4428 Fix USNG/MGRS point-radius input box

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -556,7 +556,7 @@ module.exports = Backbone.AssociatedModel.extend({
       result = converter.USNGtoLL(usng, true)
     } catch (err) {}
 
-    if (isNaN(result.lat) || isNaN(result.lon)) {
+    if (!isNaN(result.lat) && !isNaN(result.lon)) {
       this.set(result)
 
       var utmUps = this.LLtoUtmUps(result.lat, result.lon)


### PR DESCRIPTION
#### What does this PR do?
Fixes a boolean condition that was erroneously inverted and caused Intrigue's USNG/MGRS point-radius input box to break.

#### Who is reviewing it? 
@samuelechu 
@Lambeaux 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining 

#### How should this be tested?
1. Ingest some records with location metadata.
2. Open Intrigue with either a 2D or 3D map view (or both).
3. Open Advanced Search.
4. Select the anyGeo field.
5. Select Point-Radius.
6. Select USNG/MGRS.
7. Type a valid USNG or MGRS string into the box.
8. Verify a circle is drawn on the map in the expected location.
9. Run the search and verify the results returned are within the circle.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4428](https://codice.atlassian.net/browse/DDF-4428)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
