### PR TITLE
[2.13.x] DDF-4432 Enforce CRLF for .cmd files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 
 # Declare files that will always have CRLF line endings on checkout.
 *.bat text eol=crlf
+*.cmd text eol=crlf
 
 # Denote all files that are truly binary and should not be modified.
 *.ts binary

--- a/distribution/ddf-common/src/main/resources/etc/certs/CertNew.cmd
+++ b/distribution/ddf-common/src/main/resources/etc/certs/CertNew.cmd
@@ -34,4 +34,4 @@ set KEYTYPE=JKS
 CALL java -Djavax.net.ssl.keyStore=%KEYFILE% -Djavax.net.ssl.keyStorePassword=%PASSWORD% -Djavax.net.ssl.keyStoreType=%KEYTYPE% -jar %JARFILE% %*
 
 echo Finished generating certificate for %*
-@echo on
+@echo on


### PR DESCRIPTION
#### What does this PR do?

Changes line endings for `.cmd` files

#### Who is reviewing it? 
@aperullo @ahoffer 

#### Select relevant component teams: 

@codice/build @codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.

@rzwiefel @vinamartin

#### How should this be tested?

Test running the `.cmd` files on windows, verify they don't fail and don't require changing line endings

#### Any background context you want to provide?

We had a setting that enforced CRLF for `.bat` files only, we need to also enforce CRLF for `.cmd` files and fix any that had LF instead of CRLF.

#### What are the relevant tickets?
[DDF-4432](https://codice.atlassian.net/browse/DDF-4432)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
