### PR TITLE
DDF-4436 fixed queries to use default search forms

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -26,7 +26,6 @@ const store = require('../../js/store.js')
 const QueryConfirmationView = require('../confirmation/query/confirmation.query.view.js')
 const LoadingView = require('../loading/loading.view.js')
 const wreqr = require('../../js/wreqr.js')
-const user = require('../singletons/user-instance.js')
 const cql = require('../../js/cql.js')
 const announcement = require('../announcement/index.jsx')
 import { InvalidSearchFormMessage } from 'component/announcement/CommonMessages'
@@ -138,42 +137,7 @@ module.exports = Marionette.LayoutView.extend({
     )
   },
   focus: function() {
-    this.autoLoadDefaultIfSet()
     this.queryContent.currentView.focus()
-  },
-  autoLoadDefaultIfSet: function() {
-    let userDefaultTemplate = user.getQuerySettings().get('template')
-    if (userDefaultTemplate) {
-      let sorts =
-        userDefaultTemplate['querySettings'] &&
-        userDefaultTemplate['querySettings'].sorts
-      if (sorts) {
-        sorts = sorts.map(sort => ({
-          attribute: sort.split(',')[0],
-          direction: sort.split(',')[1],
-        }))
-      }
-      this.model.set({
-        type: 'custom',
-        title: userDefaultTemplate['name'],
-        filterTree: userDefaultTemplate['filterTemplate'],
-        src:
-          (userDefaultTemplate['querySettings'] &&
-            userDefaultTemplate['querySettings'].src) ||
-          '',
-        federation:
-          (userDefaultTemplate['querySettings'] &&
-            userDefaultTemplate['querySettings'].federation) ||
-          'enterprise',
-        sorts: sorts,
-        'detail-level':
-          (userDefaultTemplate['querySettings'] &&
-            userDefaultTemplate['querySettings']['detail-level']) ||
-          'allFields',
-      })
-
-      this.showCustom()
-    }
   },
   edit: function() {
     this.$el.addClass('is-editing')


### PR DESCRIPTION
#### What does this PR do?
Fix advanced queries so that they use search forms that have been marked as default.

#### Who is reviewing it? 
@djblue 
@leo-sakh 
@bellcc 
@brianfelix 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
#### How should this be tested?
NOTE: Do not refresh the page between the steps. Everything should work correctly without a page refresh. 
Create two search forms (call them "A" and "B"). Mark "A" as the default. Switch over to the workspace and open the search dialog to create an advanced query. The advanced query dialog should be pre-populated with "A".  Go back to the search forms and mark "B" as the default. Switch over to the workspace and open the search dialog to create an advanced query. The advanced query dialog should be pre-populated with "B". 
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4436](https://codice.atlassian.net/browse/DDF-4436)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
