### PR TITLE
DDF-4441 Set date/time format in EndpointUtil

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/util/EndpointUtil.java
@@ -136,6 +136,7 @@ public class EndpointUtil {
           .disableHtmlEscaping()
           .serializeNulls()
           .registerTypeAdapterFactory(LongDoubleTypeAdapter.FACTORY)
+          .setDateFormat(ISO_8601_DATE_FORMAT)
           .create();
 
   private final Random random = new Random();

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -457,7 +457,7 @@ public class EndpointUtilTest {
   }
 
   @Test
-  public void testGsonUsesIsoDateTimeFormat() {
+  public void testGetJsonUsesIsoDateTimeFormat() {
     Date date = new Date(DATE_EPOCH);
     Map<String, Object> map = new HashMap<>();
     map.put("date", date);

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -455,4 +455,13 @@ public class EndpointUtilTest {
     Instant dateConverted = endpointUtil.parseDate("  ");
     assertThat(dateConverted, nullValue());
   }
+
+  @Test
+  public void testGsonUsesIsoDateTimeFormat() {
+    Date date = new Date(DATE_EPOCH);
+    Map<String, Object> map = new HashMap<>();
+    map.put("date", date);
+    String json = endpointUtil.getJson(map);
+    assertThat(json, is("{\"date\":\"2018-09-05T08:03:17.000-0600\"}"));
+  }
 }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -54,6 +54,7 @@ import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import java.io.Serializable;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -459,9 +460,11 @@ public class EndpointUtilTest {
   @Test
   public void testGetJsonUsesIsoDateTimeFormat() {
     Date date = new Date(DATE_EPOCH);
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    String dateIso = sdf.format(date);
     Map<String, Object> map = new HashMap<>();
     map.put("date", date);
     String json = endpointUtil.getJson(map);
-    assertThat(json, is("{\"date\":\"2018-09-05T08:03:17.000-0600\"}"));
+    assertThat(json, is("{\"date\":\"" + dateIso + "\"}"));
   }
 }


### PR DESCRIPTION
#### What does this PR do?
The GsonBuilder in EndpointUtil currently uses inconsistent time formats; this sets it to ISO
#### Who is reviewing it? 
@Bdthomson @andrewzimmer 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining
@djblue
#### How should this be tested?
- Create a workspace
- Look at the workspace network request
- Verify that the date formats match the second screenshot below, not the first
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4441](https://codice.atlassian.net/browse/DDF-4441)
#### Screenshots
**BEFORE**
![image](https://user-images.githubusercontent.com/39737329/51003243-362c6b80-14f3-11e9-8dfd-76ba8e6c3092.png)
**AFTER**
![image](https://user-images.githubusercontent.com/39737329/51003261-45abb480-14f3-11e9-9f62-568d0e867bfa.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
