### PR TITLE
DDF-4444 Fix for Relative Search – the units drop down selection changes from…

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/relative-time.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/relative-time.view.js
@@ -20,6 +20,7 @@ var PropertyView = require('../property/property.view.js')
 var Property = require('../property/property.js')
 var CQLUtils = require('../../js/CQLUtils.js')
 var Common = require('../../js/Common.js')
+import { serialize, deserialize } from './serial'
 
 /*
     For specifying a relative time.  It shows a number field and a units field.
@@ -61,38 +62,15 @@ module.exports = Marionette.LayoutView.extend({
     })
   },
   getViewValue: function() {
-    let timeLast = this.basicTimeRelativeValue.currentView.model.getValue()[0]
-    if (timeLast === '') {
-      timeLast = 0
+    let last = this.basicTimeRelativeValue.currentView.model.getValue()[0]
+    if (last === '') {
+      last = 0
     }
-    const timeUnit = this.basicTimeRelativeUnit.currentView.model.getValue()[0]
-    let duration
-    if (timeUnit === 'm' || timeUnit === 'h') {
-      duration = 'PT' + timeLast + timeUnit.toUpperCase()
-    } else {
-      duration = 'P' + timeLast + timeUnit.toUpperCase()
-    }
-    return `RELATIVE(${duration})`
+    const unit = this.basicTimeRelativeUnit.currentView.model.getValue()[0]
+    return serialize({ last, unit })
   },
   parseValue(value) {
-    if (!value)
-      return
-
-    const match = value.match(/RELATIVE\(Z?(.*)(\d+\.*\d*)(.)\)/)
-    if(!match)
-      return
-
-    let [, prefix, last, unit] = match
-    last = parseFloat(last)
-    unit = unit.toLowerCase()
-    if (prefix === 'P' && unit === 'm') {
-      //must capitalize months
-      unit = unit.toUpperCase()
-    }
-    return {
-      last,
-      unit,
-    }
+    return deserialize(value)
   },
   getModelValue() {
     const currentValue = this.model.toJSON().value[0]

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/relative-time.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/relative-time.view.js
@@ -75,21 +75,17 @@ module.exports = Marionette.LayoutView.extend({
     return `RELATIVE(${duration})`
   },
   parseValue(value) {
-    if (
-      value === null ||
-      value === undefined ||
-      value.indexOf('RELATIVE') !== 0
-    ) {
+    if (!value)
       return
-    }
-    const duration = value
-      .substring(9, value.length - 1)
-      .match(/(Z?\d+\.*\d*)./)[0]
-    let unit = duration.substring(duration.length - 1, duration.length)
-    let last = parseFloat(duration.match(/\d+\.*\d*/))
 
+    const match = value.match(/RELATIVE\(Z?(.*)(\d+\.*\d*)(.)\)/)
+    if(!match)
+      return
+
+    let [, prefix, last, unit] = match
+    last = parseFloat(last)
     unit = unit.toLowerCase()
-    if (duration.indexOf('T') === -1 && unit === 'm') {
+    if (prefix === 'P' && unit === 'm') {
       //must capitalize months
       unit = unit.toUpperCase()
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/serial.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/serial.js
@@ -1,0 +1,31 @@
+const serialize = time => {
+  if (!time || time.unit === undefined || time.last === undefined) {
+    return
+  }
+  const prefix = time.unit === 'm' || time.unit === 'h' ? 'PT' : 'P'
+  return `RELATIVE(${prefix + time.last + time.unit.toUpperCase()})`
+}
+const deserialize = value => {
+  if (!value) {
+    return
+  }
+
+  const match = value.match(/RELATIVE\(Z?([A-Z]*)(\d+\.*\d*)(.)\)/)
+  if (!match) {
+    return
+  }
+
+  let [, prefix, last, unit] = match
+  last = parseFloat(last)
+  unit = unit.toLowerCase()
+  if (prefix === 'P' && unit === 'm') {
+    //must capitalize months
+    unit = unit.toUpperCase()
+  }
+
+  return {
+    last,
+    unit,
+  }
+}
+export { serialize, deserialize }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/serial.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/serial.js
@@ -1,3 +1,4 @@
+/* loosely based on ISO 8601 time intervals */
 const serialize = time => {
   if (!time || time.unit === undefined || time.last === undefined) {
     return

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/serial.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/relative-time/serial.spec.js
@@ -1,0 +1,31 @@
+const expect = require('chai').expect
+import { serialize, deserialize } from './serial'
+
+const inputs = new Map([
+  [undefined, undefined],
+  [{ last: 1, unit: 'y' }, 'RELATIVE(P1Y)'],
+  [{ last: 1, unit: 'M' }, 'RELATIVE(P1M)'],
+  [{ last: 1, unit: 'd' }, 'RELATIVE(P1D)'],
+  [{ last: 1, unit: 'h' }, 'RELATIVE(PT1H)'],
+  [{ last: 1, unit: 'm' }, 'RELATIVE(PT1M)'],
+  [{ last: 1.1, unit: 'm' }, 'RELATIVE(PT1.1M)'],
+  [{ last: 1.1, unit: 'm' }, 'RELATIVE(PT1.1M)'],
+  [{ last: 123.45678, unit: 'm' }, 'RELATIVE(PT123.45678M)'],
+])
+
+describe('Parse relative time', function() {
+  it('serialize', function() {
+    for (let [input, expected] of inputs) {
+      expect(serialize(input)).to.deep.equal(expected)
+    }
+  })
+  it('deserialize', function() {
+    for (let [expected, input] of inputs) {
+      expect(deserialize(input)).to.deep.equal(expected)
+    }
+    expect(deserialize('RELATIVE()')).to.equal(undefined)
+    expect(deserialize('RELATIVE(PT)')).to.equal(undefined)
+    expect(deserialize('RELATIVE(PTM)')).to.equal(undefined)
+    expect(deserialize('(PTM)')).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
… “Minutes” to “Months” after the search

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@leo-sakh 
@andrewkfiedler 
#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@AzGoalie

#### How should this be tested?
Initiate an Advanced Search 
Select Date Revised 
Select RELATIVE 
Last: 1 
Units: Minutes 
Click the Search button 
Once the Search results are returned, Click on the pencil icon 
Unit should still say Minutes (not Months)

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4444](https://codice.atlassian.net/browse/DDF-4444)
#### Screenshots
![image](https://user-images.githubusercontent.com/37838624/51144979-8facd700-1820-11e9-8490-17579ae1689d.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
