### PR TITLE
[2.13.x] DDF-4445 Add logic to apply the correct Solr field suffix to the anyText equality queries

### DIFF
--- a/catalog/core/catalog-core-solr/pom.xml
+++ b/catalog/core/catalog-core-solr/pom.xml
@@ -312,17 +312,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.83</minimum>
+                                            <minimum>0.84</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.76</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.71</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
@@ -1218,6 +1218,21 @@ public class SolrProviderQuery {
             .text("Mary had a little l!@#$%^&*()_mb"),
         provider);
 
+    /* ANY_TEXT */
+
+    queryAndVerifyCount(
+        0,
+        getFilterBuilder().attribute(Metacard.ANY_TEXT).is().equalTo().text("Mary had a "),
+        provider);
+
+    queryAndVerifyCount(
+        1, getFilterBuilder().attribute(Metacard.ANY_TEXT).is().equalTo().text("Mary"), provider);
+
+    queryAndVerifyCount(
+        1,
+        getFilterBuilder().attribute(Metacard.ANY_TEXT).is().equalTo().text("Mary had a little"),
+        provider);
+
     /* DATES */
 
     queryAndVerifyCount(


### PR DESCRIPTION

#### What does this PR do?
Fixes a bug with anyText equality searches where results were still returned when searching with only part of the field value. Example: A metacard with Title="Look a title" would still be returned if you made a query with `anyText = "Look"`
#### Who is reviewing it? 
@Kjames5269 
@vinamartin 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/solr 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@emmberk
@pklinef

#### How should this be tested?
- Ingest a metacard with a title (or some other text field)
- Perform an anyText equality search on that field and verify you only get the result back when the search phrase matches the field exactly.

#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4445](https://codice.atlassian.net/browse/DDF-4445)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [n/a] Documentation Updated
- [ n/a] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
