### PR TITLE
DDF-4449 Advanced Search - Intermittent Search button disappears from the template

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -92,7 +92,6 @@ module.exports = Marionette.LayoutView.extend({
         if (oldType === 'new-form') {
           this.options.queryModel.trigger('change:type')
         }
-        user.getQuerySettings().set('type', 'new-form')
         this.routeToSearchFormEditor('create')
         break
       case 'basic':


### PR DESCRIPTION
#### What does this PR do?
Fixes intermittent search button disappearance. 

#### Who is reviewing it? 
@Schachte 
@adimka 
@middlets719 

<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining

#### How should this be tested?
Follow defect reproduction steps in [DDF-4449](https://codice.atlassian.net/browse/DDF-4449) and verify that defect does not manifest. Test for regressions in search form + workspace functionality, specifically related to persistence of user's choices of workspace/search forms after refreshing the browser. 

<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-4449](https://codice.atlassian.net/browse/DDF-4449)

#### Screenshots
<!--(if appropriate)-->
![image](https://user-images.githubusercontent.com/14204943/51218946-ce5b9380-18eb-11e9-86c8-d8f8c551ca78.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
