### PR TITLE
DDF-4448 Normalized longitude in Map view

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -13,10 +13,11 @@
  *
  **/
 /*global require*/
+import wrapNum from '../../../react-component/utils/wrap-num/wrap-num.tsx'
+
 const Backbone = require('backbone')
 const MetacardModel = require('../../../js/model/Metacard.js')
 const mtgeo = require('mt-geo')
-const Common = require('../../../js/Common.js')
 const usngs = require('usng.js')
 const converter = new usngs.Converter()
 const usngPrecision = 6
@@ -54,7 +55,7 @@ module.exports = Backbone.AssociatedModel.extend({
     this.set({
       mouseLat: Number(coordinates.lat.toFixed(6)), // wrap in Number to chop off trailing zero
       mouseLon: Number(
-        Common.wrapMapCoordinates(coordinates.lon, [-180, 180]).toFixed(6)
+        wrapNum(coordinates.lon, -180, 180).toFixed(6)
       ),
     })
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -54,9 +54,7 @@ module.exports = Backbone.AssociatedModel.extend({
   updateMouseCoordinates: function(coordinates) {
     this.set({
       mouseLat: Number(coordinates.lat.toFixed(6)), // wrap in Number to chop off trailing zero
-      mouseLon: Number(
-        wrapNum(coordinates.lon, -180, 180).toFixed(6)
-      ),
+      mouseLon: Number(wrapNum(coordinates.lon, -180, 180).toFixed(6)),
     })
   },
   updateClickCoordinates: function() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -13,6 +13,8 @@
  *
  **/
 /*global require, setTimeout*/
+import wrapNum from '../../../react-component/utils/wrap-num/wrap-num.tsx'
+
 var wreqr = require('../../../js/wreqr.js')
 var template = require('./map.hbs')
 var Marionette = require('marionette')
@@ -36,13 +38,6 @@ var Common = require('../../../js/Common.js')
 
 const React = require('react')
 const Gazetteer = require('../../../react-component/location/gazetteer.js')
-
-function wrapNum(x, range) {
-  var max = range[1],
-    min = range[0],
-    d = max - min
-  return ((((x - min) % d) + d) % d) + min
-}
 
 function findExtreme({ objArray, property, comparator }) {
   if (objArray.length === 0) {
@@ -75,8 +70,8 @@ function getHomeCoordinates() {
           if (isNaN(lon) || isNaN(lat)) {
             return undefined
           }
-          lon = Common.wrapMapCoordinates(lon, [-180, 180])
-          lat = Common.wrapMapCoordinates(lat, [-90, 90])
+          lon = wrapNum(lon, -180, 180)
+          lat = wrapNum(lat, -90, 90)
           return {
             lon: lon,
             lat: lat,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -86,7 +86,15 @@ function unconvertPointCoordinate(point) {
 }
 
 function offMap([longitude, latitude]) {
-  return longitude < -180 || longitude > 180 || latitude < -90 || latitude > 90
+  const normalizedLongitude =
+    longitude -
+    Math.sign(longitude) * (360 * Math.floor((Math.abs(longitude) + 180) / 360))
+  return (
+    normalizedLongitude < -180 ||
+    normalizedLongitude > 180 ||
+    latitude < -90 ||
+    latitude > 90
+  )
 }
 
 module.exports = function OpenlayersMap(
@@ -264,12 +272,22 @@ module.exports = function OpenlayersMap(
     },
     getBoundingBox: function() {
       const extent = map.getView().calculateExtent(map.getSize())
-
+      let longitudeEast =
+        extent[2] -
+        Math.sign(extent[2]) *
+          (360 * Math.floor((Math.abs(extent[2]) + 180) / 360))
+      const longitudeWest =
+        extent[0] -
+        Math.sign(extent[0]) *
+          (360 * Math.floor((Math.abs(extent[0]) + 180) / 360))
+      if (longitudeEast < longitudeWest) {
+        longitudeEast += 360
+      }
       return {
         north: this.limit(extent[3], -90, 90),
-        east: this.limit(extent[2], -180, 180),
+        east: longitudeEast,
         south: this.limit(extent[1], -90, 90),
-        west: this.limit(extent[0], -180, 180),
+        west: this.limit(longitudeWest, -180, 180),
       }
     },
     overlayImage: function(model) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -268,6 +268,7 @@ module.exports = function OpenlayersMap(
       const extent = map.getView().calculateExtent(map.getSize())
       let longitudeEast = wrapNum(extent[2], -180, 180)
       const longitudeWest = wrapNum(extent[0], -180, 180)
+      //add 360 degrees to longitudeEast to accommodate bounding boxes that span across the anti-meridian
       if (longitudeEast < longitudeWest) {
         longitudeEast += 360
       }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -11,6 +11,8 @@
  **/
 /* global require, window */
 
+import wrapNum from '../../../../react-component/utils/wrap-num/wrap-num.tsx'
+
 var $ = require('jquery')
 var _ = require('underscore')
 var Map = require('../map')
@@ -86,15 +88,7 @@ function unconvertPointCoordinate(point) {
 }
 
 function offMap([longitude, latitude]) {
-  const normalizedLongitude =
-    longitude -
-    Math.sign(longitude) * (360 * Math.floor((Math.abs(longitude) + 180) / 360))
-  return (
-    normalizedLongitude < -180 ||
-    normalizedLongitude > 180 ||
-    latitude < -90 ||
-    latitude > 90
-  )
+  return latitude < -90 || latitude > 90
 }
 
 module.exports = function OpenlayersMap(
@@ -272,14 +266,8 @@ module.exports = function OpenlayersMap(
     },
     getBoundingBox: function() {
       const extent = map.getView().calculateExtent(map.getSize())
-      let longitudeEast =
-        extent[2] -
-        Math.sign(extent[2]) *
-          (360 * Math.floor((Math.abs(extent[2]) + 180) / 360))
-      const longitudeWest =
-        extent[0] -
-        Math.sign(extent[0]) *
-          (360 * Math.floor((Math.abs(extent[0]) + 180) / 360))
+      let longitudeEast = wrapNum(extent[2], -180, 180)
+      const longitudeWest = wrapNum(extent[0], -180, 180)
       if (longitudeEast < longitudeWest) {
         longitudeEast += 360
       }
@@ -287,7 +275,7 @@ module.exports = function OpenlayersMap(
         north: this.limit(extent[3], -90, 90),
         east: longitudeEast,
         south: this.limit(extent[1], -90, 90),
-        west: this.limit(longitudeWest, -180, 180),
+        west: longitudeWest,
       }
     },
     overlayImage: function(model) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/wrap-num/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/wrap-num/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './wrap-num'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/wrap-num/wrap-num.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/wrap-num/wrap-num.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+export default function wrapNum(
+  numberToWrap: number,
+  min: number,
+  max: number
+): number {
+  const d = max - min
+  return ((((numberToWrap - min) % d) + d) % d) + min
+}


### PR DESCRIPTION
#### What does this PR do?
Ensures that the longitude in `map.openlayers.js` is normalized to be within the valid range of [-180,180]
#### Who is reviewing it? 
@Bdthomson @andrewzimmer 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8
#### How should this be tested?
Verify that the tooltip is still working correctly with DMS and decimal on the 2D map
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4448](https://codice.atlassian.net/browse/DDF-4448)
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
