### PR TITLE
 DDF-4452 Fix Confluence connected source blueprint constructor args

### DIFF
--- a/catalog/confluence/catalog-confluence-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/confluence/catalog-confluence-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -118,6 +118,7 @@
             <argument ref="confluenceTransformer"/>
             <argument ref="resourceReader"/>
             <argument ref="attributeRegistry"/>
+            <argument ref="clientFactoryFactory"/>
             <property name="username" value=""/>
             <property name="password" value=""/>
             <property name="includeArchivedSpaces" value="false"/>


### PR DESCRIPTION

#### What does this PR do?

DDF-4452 Fix Confluence connected source blueprint constructor args
#### Who is reviewing it? 
@kcover @peterhuffer 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->

@mcalcote
@vinamartin

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Install DDF and create a confluence connected source and verify it can connect to a confluence server (shows as available in AdminUI Sources tab)
#### Any background context you want to provide?
This blueprint update was missed when DDF-4047 worked
#### What are the relevant tickets?
[DDF-4452](https://codice.atlassian.net/browse/DDF-4452)
