### PR TITLE
[2.13.x] DDF-4067 Tabs in Intrigue are hidden after adding an attribute

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.less
@@ -269,6 +269,7 @@
         z-index: @zIndexContent;
         background: inherit;
         transform: translateY(100%);
+        height: 0;
 
         > span {
             display: none;


### PR DESCRIPTION
Set golden-layout-toolbar height to 0

#### What does this PR do?
Fixes a CSS problem where Search UI tabs disappear when adding attributes in the inspector.

#### Who is reviewing it? 
@pvargas 
@mdang8 
@rfding
@aperullo 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@emmberk
@oconnormi

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Pull and build DDF
2. Ingest records into DDF.
3. Go to the Search UI, search for the documents.
4. In the **Inspector** window, select the **Details** tab. Select **Actions -> Add**, and add any attribute from the dropdown.
5. Verify that the tab for the **Inspector** window is still visible. Test that the tab remains visible for different configurations of the window within the layout.

#### What are the relevant tickets?
[DDF-4067](https://codice.atlassian.net/browse/DDF-4067)
#### Screenshots
Before
![image](https://user-images.githubusercontent.com/11358088/51410098-a1002700-1b31-11e9-95f7-e0b33574e3a6.png)

After
![image](https://user-images.githubusercontent.com/11358088/51409988-4ebf0600-1b31-11e9-9fbd-7c1382c6cc4b.png)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.