### PR TITLE
DDF-4447 Patching metacards directly over HTTP should consider the context of sharing attribute changes

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/AccessControlAccessPlugin.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/AccessControlAccessPlugin.java
@@ -13,10 +13,16 @@
  */
 package org.codice.ddf.catalog.ui.security;
 
+import static org.codice.ddf.catalog.ui.forms.data.AttributeGroupType.ATTRIBUTE_GROUP_TAG;
+import static org.codice.ddf.catalog.ui.forms.data.QueryTemplateType.QUERY_TEMPLATE_TAG;
+import static org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceConstants.WORKSPACE_TAG;
 import static org.codice.ddf.catalog.ui.security.AccessControlUtil.ACCESS_ADMIN_HAS_CHANGED;
 import static org.codice.ddf.catalog.ui.security.AccessControlUtil.ACCESS_GROUPS_HAS_CHANGED;
+import static org.codice.ddf.catalog.ui.security.AccessControlUtil.ACCESS_GROUPS_READ_HAS_CHANGED;
 import static org.codice.ddf.catalog.ui.security.AccessControlUtil.ACCESS_INDIVIDUALS_HAS_CHANGED;
+import static org.codice.ddf.catalog.ui.security.AccessControlUtil.ACCESS_INDIVIDUALS_READ_HAS_CHANGED;
 import static org.codice.ddf.catalog.ui.security.AccessControlUtil.ATTRIBUTE_TO_SET;
+import static org.codice.ddf.catalog.ui.security.AccessControlUtil.OWNER_HAS_CHANGED;
 import static org.codice.ddf.catalog.ui.security.AccessControlUtil.isAnyObjectNull;
 
 import ddf.catalog.data.Metacard;
@@ -33,15 +39,25 @@ import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.plugin.AccessPlugin;
 import ddf.catalog.plugin.StopProcessingException;
 import ddf.security.SubjectIdentity;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.apache.shiro.SecurityUtils;
 
 public class AccessControlAccessPlugin implements AccessPlugin {
+
+  private static final String FAILURE_OWNER_CANNOT_CHANGE =
+      "Cannot update metacard(s). Owner cannot be changed.";
+
+  private static final String FAILURE_NOT_ADMIN_OR_OWNER =
+      "Cannot update metacard(s). "
+          + "Subject cannot change access control permissions because they are not in the assigned "
+          + "access-administrators list.";
 
   private Supplier<String> subjectSupplier;
 
@@ -49,22 +65,43 @@ public class AccessControlAccessPlugin implements AccessPlugin {
     this.subjectSupplier = () -> subjectIdentity.getUniqueIdentifier(SecurityUtils.getSubject());
   }
 
-  // Equivalent to doing a set intersection of the subject with the access-admin list
-  private final Predicate<Metacard> subjectIsAccessAdmin =
-      (newMetacard) ->
-          ATTRIBUTE_TO_SET
-              .apply(newMetacard, Security.ACCESS_ADMINISTRATORS)
-              .contains(subjectSupplier.get());
+  // Because embedding '!' in the following predicates might be easily overlooked
+  private static boolean invert(boolean b) {
+    return !b;
+  }
 
-  private final Predicate<Metacard> subjectIsOwner =
-      (newMetacard) ->
-          ATTRIBUTE_TO_SET.apply(newMetacard, Core.METACARD_OWNER).contains(subjectSupplier.get());
+  // Equivalent to doing a set intersection of the subject with the access-admin list
+  private final Predicate<Metacard> subjectIsNotAccessAdmin =
+      newMetacard ->
+          invert(
+              ATTRIBUTE_TO_SET
+                  .apply(newMetacard, Security.ACCESS_ADMINISTRATORS)
+                  .contains(subjectSupplier.get()));
+
+  private final Predicate<Metacard> subjectIsNotOwner =
+      newMetacard ->
+          invert(
+              ATTRIBUTE_TO_SET
+                  .apply(newMetacard, Core.METACARD_OWNER)
+                  .contains(subjectSupplier.get()));
+
+  private final Predicate<Metacard> hasIntrigueTag =
+      metacard ->
+          metacard.getTags().contains(WORKSPACE_TAG)
+              || metacard.getTags().contains(QUERY_TEMPLATE_TAG)
+              || metacard.getTags().contains(ATTRIBUTE_GROUP_TAG);
 
   private boolean isAccessControlUpdated(Metacard prev, Metacard updated) {
     return !isAnyObjectNull(prev, updated)
         && (ACCESS_ADMIN_HAS_CHANGED.apply(prev, updated)
             || ACCESS_INDIVIDUALS_HAS_CHANGED.apply(prev, updated)
-            || ACCESS_GROUPS_HAS_CHANGED.apply(prev, updated));
+            || ACCESS_INDIVIDUALS_READ_HAS_CHANGED.apply(prev, updated)
+            || ACCESS_GROUPS_HAS_CHANGED.apply(prev, updated)
+            || ACCESS_GROUPS_READ_HAS_CHANGED.apply(prev, updated));
+  }
+
+  private boolean isOwnerChanged(Metacard prev, Metacard updated) {
+    return !isAnyObjectNull(prev, updated) && OWNER_HAS_CHANGED.apply(prev, updated);
   }
 
   @Override
@@ -75,34 +112,36 @@ public class AccessControlAccessPlugin implements AccessPlugin {
   @Override
   public UpdateRequest processPreUpdate(
       UpdateRequest input, Map<String, Metacard> existingMetacards) throws StopProcessingException {
-
-    Function<Metacard, Metacard> oldVersionOfMetacard =
-        (update) -> {
-          Optional<Metacard> oldMetacard =
-              Optional.ofNullable(existingMetacards.get(update.getId()));
-          if (oldMetacard.isPresent()) {
-            return oldMetacard.get();
-          }
-          return null;
-        };
-
-    boolean foundInaccessibleMetacard =
-        input
-            .getUpdates()
+    Map<String, Metacard> filteredExistingMetacards =
+        existingMetacards
+            .values()
             .stream()
-            .map(Map.Entry::getValue)
-            .filter(
-                newVersionOfMetacard ->
-                    isAccessControlUpdated(
-                        oldVersionOfMetacard.apply(newVersionOfMetacard), newVersionOfMetacard))
-            .filter(Objects::nonNull)
-            .filter(mc -> !subjectIsAccessAdmin.test(mc) && !subjectIsOwner.test(mc))
-            .findFirst()
-            .isPresent();
+            .filter(hasIntrigueTag)
+            .collect(Collectors.toMap(Metacard::getId, Function.identity()));
 
-    if (foundInaccessibleMetacard) {
-      throw new StopProcessingException(
-          "Cannot update metacard(s). Subject cannot change access control permissions because they are not in the assigned access-administrators list.");
+    Function<Metacard, Metacard> oldMetacard =
+        update ->
+            Optional.ofNullable(update.getId()).map(filteredExistingMetacards::get).orElse(null);
+
+    List<Metacard> newMetacards =
+        input.getUpdates().stream().map(Map.Entry::getValue).collect(Collectors.toList());
+
+    if (newMetacards.stream().anyMatch(m -> isOwnerChanged(oldMetacard.apply(m), m))) {
+      throw new StopProcessingException(FAILURE_OWNER_CANNOT_CHANGE);
+    }
+
+    if (newMetacards
+        .stream()
+        .filter(
+            newVersionOfMetacard ->
+                isAccessControlUpdated(
+                    oldMetacard.apply(newVersionOfMetacard), newVersionOfMetacard))
+        .filter(Objects::nonNull)
+        .map(oldMetacard)
+        .filter(Objects::nonNull)
+        .filter(subjectIsNotOwner)
+        .anyMatch(subjectIsNotAccessAdmin)) {
+      throw new StopProcessingException(FAILURE_NOT_ADMIN_OR_OWNER);
     }
 
     return input;

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AccessControlAccessPluginTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AccessControlAccessPluginTest.java
@@ -13,154 +13,363 @@
  */
 package org.codice.ddf.catalog.ui.security;
 
+import static org.codice.ddf.catalog.ui.forms.data.AttributeGroupType.ATTRIBUTE_GROUP_TAG;
+import static org.codice.ddf.catalog.ui.forms.data.QueryTemplateType.QUERY_TEMPLATE_TAG;
+import static org.codice.ddf.catalog.ui.metacard.workspace.WorkspaceConstants.WORKSPACE_TAG;
+import static org.codice.ddf.catalog.ui.security.AclTestSupport.metacardFromAttributes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Security;
 import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.plugin.AccessPlugin;
 import ddf.catalog.plugin.StopProcessingException;
 import ddf.security.SubjectIdentity;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Map;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 
+/**
+ * Verify enforcement of the ACL list. Some tests may at first look incorrect, since a few of the
+ * verifications do not reflect how the system actually behaves, but instead how this plugin should
+ * decide to allow or deny the request within the context of everything else that happens.
+ *
+ * <p>Note the default subject is {@link #USER_EINSTEIN}, but that can be overridden in a test by
+ * first calling {@link #setSubject(String)}.
+ */
 public class AccessControlAccessPluginTest {
 
-  private static final String MOCK_IDENTITY_ATTR = "user@email";
+  private static final String USER_NEWTON = "newton@localhost.local";
 
-  private static final String MOCK_METACARD_ID = "100";
+  private static final String USER_EINSTEIN = "einstein@localhost.local";
+
+  private static final String USER_DIJKSTRA = "dijkstra@localhost.local";
+
+  private static final String METACARD_ID = "100";
+
+  private static final String RESOURCE_TAG = "resource";
 
   private AccessPlugin accessPlugin;
 
-  @Mock private Attribute mockAttribute;
-
-  @Mock private Metacard mockMetacard;
-
-  @Mock private Subject subject;
-
-  private SubjectIdentity subjectIdentity = mock(SubjectIdentity.class);
-
   @Before
   public void setUp() {
-    initMocks(this);
-    when(mockMetacard.getId()).thenReturn(MOCK_METACARD_ID);
-    when(subjectIdentity.getUniqueIdentifier(subject)).thenReturn(MOCK_IDENTITY_ATTR);
-    when(mockMetacard.getAttribute(Security.ACCESS_ADMINISTRATORS)).thenReturn(mockAttribute);
-    when(mockAttribute.getValues()).thenReturn(Collections.singletonList(MOCK_IDENTITY_ATTR));
+    setSubject(USER_EINSTEIN);
+  }
+
+  private void setSubject(String user) {
+    ThreadContext.unbindSubject();
+    Subject subject = mock(Subject.class);
+    SubjectIdentity subjectIdentity = mock(SubjectIdentity.class);
+    when(subjectIdentity.getUniqueIdentifier(subject)).thenReturn(user);
     ThreadContext.bind(subject);
 
     accessPlugin = new AccessControlAccessPlugin(subjectIdentity);
   }
 
-  private UpdateRequest mockUpdateRequest(Map<String, Metacard> updates) {
-    UpdateRequest update = mock(UpdateRequest.class);
-    doReturn(new ArrayList(updates.entrySet())).when(update).getUpdates();
-    return update;
+  private UpdateRequest getUpdateRequest(String id, Metacard metacard) {
+    return new UpdateRequestImpl(id, metacard);
   }
 
   @Test
-  public void testAccessibleMetacardsSucceed() throws Exception {
-    Map<String, Metacard> updates = ImmutableMap.of(MOCK_METACARD_ID, mockMetacard);
-    UpdateRequest update = mockUpdateRequest(updates);
+  public void testOwnerCanModify() throws StopProcessingException {
+    verifyUserWithAttributeCanModifyUnprotectedAttribute(Core.METACARD_OWNER);
+  }
 
-    // User updating metacard perms is in the ACL, so we allow them to pass through the access
-    // plugin
+  @Test
+  public void testAccessIndividualsReadCanModify() throws StopProcessingException {
+    verifyUserWithAttributeCanModifyUnprotectedAttribute(Security.ACCESS_INDIVIDUALS_READ);
+  }
+
+  @Test
+  public void testAccessIndividualsCanModify() throws StopProcessingException {
+    verifyUserWithAttributeCanModifyUnprotectedAttribute(Security.ACCESS_INDIVIDUALS);
+  }
+
+  @Test
+  public void testAccessAdminsCanModify() throws StopProcessingException {
+    verifyUserWithAttributeCanModifyUnprotectedAttribute(Security.ACCESS_ADMINISTRATORS);
+  }
+
+  /**
+   * If an unprotected attribute was modified, then the plugin does not care who modified it and
+   * allows the request to continue. As of this writing, the {@code FilterPlugin} handles instances
+   * of a user with {@link Security#ACCESS_INDIVIDUALS_READ} attempting to modify any attributes on
+   * the metacard.
+   *
+   * <p>The choice of {@link Core#TITLE} for this set of tests was arbitrary. It is not an ACL
+   * attribute and therefore is sufficient for the needs of the test.
+   */
+  private void verifyUserWithAttributeCanModifyUnprotectedAttribute(String securityAttribute)
+      throws StopProcessingException {
+    Metacard before =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                securityAttribute,
+                ImmutableSet.of(USER_EINSTEIN),
+                Core.TITLE,
+                "title1",
+                Core.METACARD_TAGS,
+                WORKSPACE_TAG));
+    Metacard after =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                securityAttribute,
+                ImmutableSet.of(USER_EINSTEIN),
+                Core.TITLE,
+                "title2",
+                Core.METACARD_TAGS,
+                WORKSPACE_TAG));
+
+    UpdateRequest update = getUpdateRequest(METACARD_ID, after);
+    accessPlugin.processPreUpdate(update, ImmutableMap.of(METACARD_ID, before));
+  }
+
+  @Test
+  public void testPluginIgnoresNoOpForOwner() throws StopProcessingException {
+    verifyPluginIgnoresNoOpForAttribute(Core.METACARD_OWNER);
+  }
+
+  @Test
+  public void testPluginIgnoresNoOpForIndividualsRead() throws StopProcessingException {
+    verifyPluginIgnoresNoOpForAttribute(Security.ACCESS_INDIVIDUALS_READ);
+  }
+
+  @Test
+  public void testPluginIgnoresNoOpForIndividuals() throws StopProcessingException {
+    verifyPluginIgnoresNoOpForAttribute(Security.ACCESS_INDIVIDUALS);
+  }
+
+  @Test
+  public void testPluginIgnoresNoOpForAdmins() throws StopProcessingException {
+    verifyPluginIgnoresNoOpForAttribute(Security.ACCESS_ADMINISTRATORS);
+  }
+
+  /**
+   * If the metacard didn't change, then it doesn't matter who invoked the operation. The plugin
+   * will allow the request to continue.
+   */
+  private void verifyPluginIgnoresNoOpForAttribute(String securityAttribute)
+      throws StopProcessingException {
+    Metacard metacard =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                securityAttribute,
+                USER_NEWTON,
+                Core.METACARD_TAGS,
+                WORKSPACE_TAG));
+
+    Map<String, Metacard> updates = ImmutableMap.of(METACARD_ID, metacard);
+    UpdateRequest update = getUpdateRequest(METACARD_ID, metacard);
+
     assertThat(accessPlugin.processPreUpdate(update, updates), is(update));
   }
 
   @Test(expected = StopProcessingException.class)
-  public void testUnauthorizedUserFailsUpdate() throws Exception {
-
-    Metacard before =
-        AccessControlUtil.metacardFromAttributes(
-            ImmutableMap.of(
-                Core.ID,
-                MOCK_METACARD_ID,
-                Core.METACARD_OWNER,
-                "before",
-                SecurityAttributes.ACCESS_INDIVIDUALS,
-                ImmutableSet.of("admin")));
-
-    Metacard after =
-        AccessControlUtil.metacardFromAttributes(
-            ImmutableMap.of(
-                Core.ID,
-                MOCK_METACARD_ID,
-                Core.METACARD_OWNER,
-                "before",
-                SecurityAttributes.ACCESS_INDIVIDUALS,
-                ImmutableSet.of("admin", "guest")));
-
-    UpdateRequest update = mockUpdateRequest(ImmutableMap.of(MOCK_METACARD_ID, after));
-    accessPlugin.processPreUpdate(update, ImmutableMap.of(MOCK_METACARD_ID, before));
+  public void testUserNotOnAclCannotUpdateIndividualsRead() throws StopProcessingException {
+    verifyUserNotOnAclCannotUpdateAttribute(Security.ACCESS_INDIVIDUALS_READ);
   }
 
   @Test(expected = StopProcessingException.class)
-  public void testBasicUpdateFailsWithMissingAdmin() throws Exception {
-    Metacard before =
-        AccessControlUtil.metacardFromAttributes(
-            ImmutableMap.of(
-                Core.ID,
-                MOCK_METACARD_ID,
-                Core.METACARD_OWNER,
-                "before",
-                SecurityAttributes.ACCESS_INDIVIDUALS,
-                ImmutableSet.of("admin")));
-
-    Metacard after =
-        AccessControlUtil.metacardFromAttributes(
-            ImmutableMap.of(
-                Core.ID,
-                MOCK_METACARD_ID,
-                Core.METACARD_OWNER,
-                "before",
-                SecurityAttributes.ACCESS_INDIVIDUALS,
-                ImmutableSet.of("admin", "guest")));
-
-    UpdateRequest update = mockUpdateRequest(ImmutableMap.of(MOCK_METACARD_ID, after));
-    accessPlugin.processPreUpdate(update, ImmutableMap.of(MOCK_METACARD_ID, before));
+  public void testUserNotOnAclCannotUpdateIndividuals() throws StopProcessingException {
+    verifyUserNotOnAclCannotUpdateAttribute(Security.ACCESS_INDIVIDUALS);
   }
 
   @Test(expected = StopProcessingException.class)
-  public void testStopProcessingWhenNotAdmin() throws Exception {
+  public void testUserNotOnAclCannotUpdateAdmins() throws StopProcessingException {
+    verifyUserNotOnAclCannotUpdateAttribute(Security.ACCESS_ADMINISTRATORS);
+  }
 
+  /**
+   * Parameterized test for verifying behavior when ACL attributes themselves are changed by a user
+   * not found on any of the ACL attributes. These operations should <b>never</b> be allowed to
+   * succeed.
+   */
+  private void verifyUserNotOnAclCannotUpdateAttribute(String securityAttribute)
+      throws StopProcessingException {
     Metacard before =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
-                MOCK_METACARD_ID,
+                METACARD_ID,
                 Core.METACARD_OWNER,
-                "before",
-                SecurityAttributes.ACCESS_ADMINISTRATORS,
-                ImmutableSet.of("admin")));
-
+                USER_NEWTON,
+                securityAttribute,
+                ImmutableSet.of(USER_DIJKSTRA),
+                Core.METACARD_TAGS,
+                WORKSPACE_TAG));
     Metacard after =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
-                MOCK_METACARD_ID,
+                METACARD_ID,
                 Core.METACARD_OWNER,
-                "before",
-                SecurityAttributes.ACCESS_ADMINISTRATORS,
-                ImmutableSet.of("admin", "guest")));
+                USER_NEWTON,
+                securityAttribute,
+                ImmutableSet.of(),
+                Core.METACARD_TAGS,
+                WORKSPACE_TAG));
 
-    UpdateRequest update = mockUpdateRequest(ImmutableMap.of(MOCK_METACARD_ID, after));
-    accessPlugin.processPreUpdate(update, ImmutableMap.of(MOCK_METACARD_ID, before));
+    UpdateRequest update = getUpdateRequest(METACARD_ID, after);
+    accessPlugin.processPreUpdate(update, ImmutableMap.of(METACARD_ID, before));
+  }
+
+  @Test
+  public void testIndividualCanBecomeAdminOnResources() throws StopProcessingException {
+    verifyIndividualTryingToBecomeAdminForTag(RESOURCE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testIndividualCannotBecomeAdminOnWorkspaces() throws StopProcessingException {
+    verifyIndividualTryingToBecomeAdminForTag(WORKSPACE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testIndividualCannotBecomeAdminOnSearchForms() throws StopProcessingException {
+    verifyIndividualTryingToBecomeAdminForTag(QUERY_TEMPLATE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testIndividualCannotBecomeAdminOnResultForms() throws StopProcessingException {
+    verifyIndividualTryingToBecomeAdminForTag(ATTRIBUTE_GROUP_TAG);
+  }
+
+  private void verifyIndividualTryingToBecomeAdminForTag(String metacardTag)
+      throws StopProcessingException {
+    Metacard before =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                Core.METACARD_OWNER,
+                USER_NEWTON,
+                Security.ACCESS_INDIVIDUALS,
+                ImmutableSet.of(USER_EINSTEIN),
+                Core.METACARD_TAGS,
+                metacardTag));
+    Metacard after =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                Core.METACARD_OWNER,
+                USER_NEWTON,
+                Security.ACCESS_ADMINISTRATORS,
+                ImmutableSet.of(USER_EINSTEIN),
+                Core.METACARD_TAGS,
+                metacardTag));
+
+    UpdateRequest update = getUpdateRequest(METACARD_ID, after);
+    accessPlugin.processPreUpdate(update, ImmutableMap.of(METACARD_ID, before));
+  }
+
+  @Test
+  public void testIndividualCanBecomeOwnerOnResources() throws StopProcessingException {
+    verifyIndividualTryingToBecomeOwnerForTag(RESOURCE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testIndividualCannotBecomeOwnerOnWorkspaces() throws StopProcessingException {
+    verifyIndividualTryingToBecomeOwnerForTag(WORKSPACE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testIndividualCannotBecomeOwnerOnSearchForms() throws StopProcessingException {
+    verifyIndividualTryingToBecomeOwnerForTag(QUERY_TEMPLATE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testIndividualCannotBecomeOwnerOnResultForms() throws StopProcessingException {
+    verifyIndividualTryingToBecomeOwnerForTag(ATTRIBUTE_GROUP_TAG);
+  }
+
+  private void verifyIndividualTryingToBecomeOwnerForTag(String metacardTag)
+      throws StopProcessingException {
+    Metacard before =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                Core.METACARD_OWNER,
+                USER_NEWTON,
+                Security.ACCESS_INDIVIDUALS,
+                ImmutableSet.of(USER_EINSTEIN),
+                Core.METACARD_TAGS,
+                metacardTag));
+    Metacard after =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                Core.METACARD_OWNER,
+                USER_EINSTEIN,
+                Core.METACARD_TAGS,
+                metacardTag));
+
+    UpdateRequest update = getUpdateRequest(METACARD_ID, after);
+    accessPlugin.processPreUpdate(update, ImmutableMap.of(METACARD_ID, before));
+  }
+
+  @Test
+  public void testAdminCanBecomeOwnerOnResources() throws StopProcessingException {
+    verifyAdminTryingToBecomeOwnerForTag(RESOURCE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testAdminCannotBecomeOwnerOnWorkspaces() throws StopProcessingException {
+    verifyAdminTryingToBecomeOwnerForTag(WORKSPACE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testAdminCannotBecomeOwnerOnSearchForms() throws StopProcessingException {
+    verifyAdminTryingToBecomeOwnerForTag(QUERY_TEMPLATE_TAG);
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testAdminCannotBecomeOwnerOnResultForms() throws StopProcessingException {
+    verifyAdminTryingToBecomeOwnerForTag(ATTRIBUTE_GROUP_TAG);
+  }
+
+  private void verifyAdminTryingToBecomeOwnerForTag(String metacardTag)
+      throws StopProcessingException {
+    Metacard before =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                Core.METACARD_OWNER,
+                USER_NEWTON,
+                Security.ACCESS_ADMINISTRATORS,
+                ImmutableSet.of(USER_EINSTEIN),
+                Core.METACARD_TAGS,
+                metacardTag));
+    Metacard after =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                METACARD_ID,
+                Core.METACARD_OWNER,
+                USER_EINSTEIN,
+                Security.ACCESS_ADMINISTRATORS,
+                ImmutableSet.of(USER_EINSTEIN),
+                Core.METACARD_TAGS,
+                metacardTag));
+
+    UpdateRequest update = getUpdateRequest(METACARD_ID, after);
+    accessPlugin.processPreUpdate(update, ImmutableMap.of(METACARD_ID, before));
   }
 }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AccessControlPolicyPluginTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AccessControlPolicyPluginTest.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.catalog.ui.security;
 
+import static org.codice.ddf.catalog.ui.security.AclTestSupport.metacardFromAttributes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
@@ -58,7 +59,7 @@ public class AccessControlPolicyPluginTest {
   @Test
   public void testAdminOnCreateWithAccessControl() throws Exception {
     Metacard metacard =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
                 MOCK_ID,
@@ -90,7 +91,7 @@ public class AccessControlPolicyPluginTest {
   @Test
   public void testPolicyMapForReadPerms() throws Exception {
     Metacard metacard =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
                 MOCK_ID,

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AccessControlUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AccessControlUtilTest.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.catalog.ui.security;
 
+import static org.codice.ddf.catalog.ui.security.AclTestSupport.metacardFromAttributes;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -22,7 +23,6 @@ import com.google.common.collect.ImmutableSet;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
-import ddf.catalog.data.types.Security;
 import org.junit.Test;
 
 public class AccessControlUtilTest {
@@ -30,7 +30,7 @@ public class AccessControlUtilTest {
   @Test
   public void getAccessIndividuals() {
     Metacard metacard =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
                 "123",
@@ -46,7 +46,7 @@ public class AccessControlUtilTest {
   @Test
   public void getAccessGroups() {
     Metacard metacard =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
                 "123",
@@ -61,7 +61,7 @@ public class AccessControlUtilTest {
   @Test
   public void getAccessAdministrators() {
     Metacard metacard =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
                 "123",
@@ -77,9 +77,8 @@ public class AccessControlUtilTest {
   @Test
   public void setOwner() {
     String id = "0";
-
     Metacard before =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
                 id,
@@ -96,7 +95,7 @@ public class AccessControlUtilTest {
   @Test
   public void getOwner() {
     Metacard metacard =
-        AccessControlUtil.metacardFromAttributes(
+        metacardFromAttributes(
             ImmutableMap.of(
                 Core.ID,
                 "123",
@@ -105,25 +104,6 @@ public class AccessControlUtilTest {
                 SecurityAttributes.ACCESS_ADMINISTRATORS,
                 "owner"));
     assertThat(metacard.getAttribute(Core.METACARD_OWNER).getValue(), is("owner"));
-  }
-
-  @Test
-  public void metacardFromAttributes() {
-    Metacard metacard =
-        AccessControlUtil.metacardFromAttributes(
-            ImmutableMap.of(
-                Core.ID,
-                "123",
-                Core.METACARD_OWNER,
-                "owner",
-                SecurityAttributes.ACCESS_ADMINISTRATORS,
-                "owner"));
-
-    assertThat(metacard.getAttribute(Core.ID).getValue(), is("123"));
-    assertThat(metacard.getAttribute(Core.METACARD_OWNER).getValue(), is("owner"));
-    assertThat(
-        metacard.getAttribute(Security.ACCESS_ADMINISTRATORS).getValues(),
-        is(ImmutableList.of("owner")));
   }
 
   @Test

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AclTestSupport.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AclTestSupport.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.security;
+
+import com.google.common.collect.ImmutableSet;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.SecurityAttributes;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class AclTestSupport {
+  private AclTestSupport() {
+    // Should not be instantiated
+  }
+
+  /** Creates a metacard from a map of desired attributes */
+  public static Metacard metacardFromAttributes(Map<String, Serializable> attributes) {
+    Metacard metacard =
+        new MetacardImpl(
+            new MetacardTypeImpl(
+                "type",
+                ImmutableSet.<AttributeDescriptor>builder()
+                    .addAll(new SecurityAttributes().getAttributeDescriptors())
+                    .build()));
+
+    attributes.forEach((key, value) -> metacard.setAttribute(createAttribute(key, value)));
+    return metacard;
+  }
+
+  private static Attribute createAttribute(String key, Serializable value) {
+    return new AttributeImpl(
+        key, value instanceof Collection ? new ArrayList<>((Collection<?>) value) : value);
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AclTestSupportTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/AclTestSupportTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.security;
+
+import static org.codice.ddf.catalog.ui.security.AclTestSupport.metacardFromAttributes;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.types.SecurityAttributes;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Security;
+import org.junit.Test;
+
+public class AclTestSupportTest {
+
+  @Test
+  public void testMetacardFromAttributes() {
+    Metacard metacard =
+        metacardFromAttributes(
+            ImmutableMap.of(
+                Core.ID,
+                "123",
+                Core.METACARD_OWNER,
+                "owner",
+                SecurityAttributes.ACCESS_ADMINISTRATORS,
+                "owner"));
+
+    assertThat(metacard.getAttribute(Core.ID).getValue(), is("123"));
+    assertThat(metacard.getAttribute(Core.METACARD_OWNER).getValue(), is("owner"));
+    assertThat(
+        metacard.getAttribute(Security.ACCESS_ADMINISTRATORS).getValues(),
+        is(ImmutableList.of("owner")));
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where direct use of the metacard `PATCH` endpoint could result in sharing permissions being changed incorrectly. 

#### Who is reviewing it? 
@Schachte 
@dimitry-sherman 
@samuelechu 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@garrettfreibott 
@stustison

#### How should this be tested?
Setup the DDF distro with two new users, by modifying `users.properties` and `users.attributes` respectively:

_users.properties_
```
kyle=kyle,group,viewer
steve=steve,group,viewer
```

_users.attributes_
```
"steve" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"steve@localhost.local"
    },
    "kyle" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"kyle@localhost.local"
    }
```

Have user `steve` create two search forms and share them with `kyle` at the READ/WRITE level, **not** READ-ONLY or READ/WRITE/SHARE levels (kyle's email should appear on the `access-individuals` attribute if this was done correctly). Use the Karaf CLI or Solr UI to obtain the metacard IDs for these search forms (Solr query: `metacard-tags_txt:query-template`). 

Using the UI, ensure that sharing operations work as expected. `steve` should be able to elevate `kyle`'s privilege to READ/WRITE/SHARE and `kyle` should then be able to share the search form with others. But under no circumstances should `kyle` be able to replace `steve` as owner of the metacard. 

Ensure `kyle` is an `access-individual` on the search form under test. Construct a `PATCH` request to `https://localhost:8993/search/catalog/internal/metacards`, using Postman or another tool, with the following body and **verify failure**:
```
[
    {
        "ids": [
            "2029d29ebe66432d9abc8c0e7e8ad3ce"
        ],
        "attributes": [
            {
                "attribute": "security.access-individuals",
                "values": [
                ]
            },
            {
                "attribute": "security.access-individuals-read",
                "values": [
                ]
            },
            {
                "attribute": "security.access-groups",
                "values": [
                ]
            },
            {
                "attribute": "security.access-groups-read",
                "values": [
                ]
            },
            {
                "attribute": "security.access-administrators",
                "values": [
                	"kyle@localhost.local"
                ]
            },
            {
            	"attribute": "metacard.owner",
                "values": [
                	"steve@localhost.local"
                ]
            }
        ]
    }
]
```

Ensure `kyle` is an `access-individual` on the search form under test. Construct a `PATCH` request to `https://localhost:8993/search/catalog/internal/metacards`, using Postman or another tool, with the following body and **verify failure**:
```
[
    {
        "ids": [
            "2029d29ebe66432d9abc8c0e7e8ad3ce"
        ],
        "attributes": [
            {
                "attribute": "security.access-individuals",
                "values": [
                ]
            },
            {
                "attribute": "security.access-individuals-read",
                "values": [
                ]
            },
            {
                "attribute": "security.access-groups",
                "values": [
                ]
            },
            {
                "attribute": "security.access-groups-read",
                "values": [
                ]
            },
            {
                "attribute": "security.access-administrators",
                "values": [
                ]
            },
            {
            	"attribute": "metacard.owner",
                "values": [
                	"kyle@localhost.local"
                ]
            }
        ]
    }
]
```

#### Any background context you want to provide?
This is only an issue due to the new security attributes that were added on master: 
https://github.com/codice/ddf/pull/3655
Other exposed usages of the catalog framework's update capabilities will be analyzed and tested to ensure no other defects exist. 

#### What are the relevant tickets?
[DDF-4447](https://codice.atlassian.net/browse/DDF-4447)
[DDF-4034](https://codice.atlassian.net/browse/DDF-4034)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
