### PR TITLE
DDF-4450 Patching metacards directly over HTTP results in an NPE when the metacard to be patched does not exist

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -1191,7 +1191,7 @@ public class MetacardApplication implements SparkApplication {
 
           Function<Serializable, Serializable> mapFunc = Function.identity();
           if (isChangeTypeDate(attributeChange, resultMetacard)) {
-            mapFunc = mapFunc.andThen(util::parseDate);
+            mapFunc = mapFunc.andThen(serializable -> Date.from(util.parseDate(serializable)));
           }
 
           resultMetacard.setAttribute(

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/MetacardApplicationTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/MetacardApplicationTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.metacard;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.operation.UpdateRequest;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import javax.ws.rs.NotFoundException;
+import org.codice.ddf.catalog.ui.metacard.edit.AttributeChange;
+import org.codice.ddf.catalog.ui.metacard.edit.MetacardChanges;
+import org.codice.ddf.catalog.ui.util.EndpointUtil;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class MetacardApplicationTest {
+  private static final String ID = "000000000";
+
+  private static final String TITLE_A = "Title A";
+
+  private static final String TITLE_B = "Title B";
+
+  private final CatalogFramework mockFramework = mock(CatalogFramework.class);
+
+  private final EndpointUtil mockUtil = mock(EndpointUtil.class);
+
+  private final MetacardApplicationUnderTest app =
+      new MetacardApplicationUnderTest(mockFramework, mockUtil);
+
+  @Test(expected = NotFoundException.class)
+  public void testPatchMetacardsWhenIdNotFound() throws Exception {
+    doReturn(Collections.emptyMap()).when(mockUtil).getMetacardsWithTagById(any(), eq("*"));
+    app.doPatchMetacards(generateTitleChange());
+  }
+
+  @Test
+  public void testPatchMetacardsWhenAttributeIsString() throws Exception {
+    ArgumentCaptor<UpdateRequest> requestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+    when(mockFramework.update(requestCaptor.capture())).thenReturn(null);
+    doReturn(generateCatalogStateWithTitle())
+        .when(mockUtil)
+        .getMetacardsWithTagById(any(), eq("*"));
+
+    app.doPatchMetacards(generateTitleChange());
+
+    Metacard metacard = requestCaptor.getValue().getUpdates().get(0).getValue();
+    assertThat(metacard.getId(), is(ID));
+    assertThat(metacard.getTitle(), is(TITLE_B));
+  }
+
+  private static List<MetacardChanges> generateTitleChange() {
+    return generateChangeTestData(
+        attributeChange -> {
+          attributeChange.setAttribute(Core.TITLE);
+          attributeChange.setValues(Collections.singletonList(TITLE_B));
+        });
+  }
+
+  private static Map<String, Result> generateCatalogStateWithTitle() {
+    return generateCatalogState(metacard -> metacard.setTitle(TITLE_A));
+  }
+
+  private static List<MetacardChanges> generateChangeTestData(Consumer<AttributeChange> config) {
+    MetacardChanges metacardChanges = new MetacardChanges();
+    AttributeChange attributeChange = new AttributeChange();
+
+    config.accept(attributeChange);
+
+    metacardChanges.setIds(Collections.singletonList(ID));
+    metacardChanges.setAttributes(Collections.singletonList(attributeChange));
+
+    return Collections.singletonList(metacardChanges);
+  }
+
+  private static Map<String, Result> generateCatalogState(Consumer<MetacardImpl> config) {
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setId(ID);
+
+    config.accept(metacard);
+
+    Result result = new ResultImpl(metacard);
+    return Collections.singletonMap(ID, result);
+  }
+
+  /**
+   * Test class that exposes the protected {@link MetacardApplication#patchMetacards(List, String)}.
+   *
+   * <p>Note the original method returns an UpdateResponse but we're not testing the Catalog
+   * Framework's ability to return a good response; we're testing the app's ability to correctly
+   * write to the framework, so this return value is meaningless to propagate.
+   */
+  private class MetacardApplicationUnderTest extends MetacardApplication {
+    private MetacardApplicationUnderTest(
+        CatalogFramework catalogFramework, EndpointUtil endpointUtil) {
+      super(
+          catalogFramework,
+          null,
+          endpointUtil,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null);
+    }
+
+    private void doPatchMetacards(List<MetacardChanges> metacardChanges) throws Exception {
+      patchMetacards(metacardChanges, null);
+    }
+  }
+}


### PR DESCRIPTION
### Do not squash commits
These represent logically separate fixes (discovered with the same set of tests). 

#### What does this PR do?
Fixes an NPE in the metacard `PATCH` endpoint. Also adds unit tests and fixes a separate issue revealed by those tests. **Do not squash commits** when merging. They are logically separate fixes that compile independently. 

#### Who is reviewing it? 
@Schachte 
@dimitry-sherman 
@samuelechu 

#### Select relevant component teams: 
@codice/security 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@garrettfreibott 
@stustison

#### How should this be tested?
Attempt a `PATCH` request to `https://localhost:8993/search/catalog/internal/metacards` with a target metacard ID that: 
1. Does not exist
2. The user subject does not have permission to see

Verify the response is `404` and not `500`; also ensure the stacktrace is logged at DEBUG and is not an NPE logged at ERROR. 

Sample HTTP Body for the `PATCH` request: 
```
[
    {
        "ids": [
            "2029d29ebe66432d9abc8c0e7e8ad3ce"
        ],
        "attributes": [
            {
                "attribute": "security.access-individuals",
                "values": [
                ]
            },
            {
                "attribute": "security.access-individuals-read",
                "values": [
                ]
            },
            {
                "attribute": "security.access-groups",
                "values": [
                ]
            },
            {
                "attribute": "security.access-groups-read",
                "values": [
                ]
            },
            {
                "attribute": "security.access-administrators",
                "values": [
                ]
            },
            {
            	"attribute": "metacard.owner",
                "values": [
                	"kyle@localhost.local"
                ]
            }
        ]
    }
]
```

Also verify that temporal attributes (i.e. `created`) are actually updated when changed using the metacard `PATCH` endpoint. While it may report `200` for success, changes to temporal attributes were being ignored. 

Ingest a sample XML file (i.e. `DDF_HOME/etc/log4j2.xml`) using the Intrigue uploader, which is accessible via the left-hand menu. Grab the ID of this new metacard by using the inspector panel after running a wildcard `*` query. Then attempt a `PATCH` request to `https://localhost:8993/search/catalog/internal/metacards` targeting this metacard's `created` attribute. After this request is done (expected success `200 OK`), refresh the UI and open the metacard in the inspector again. Verify the `created` date actually changed. 

Sample HTTP Body for the `PATCH` request:
```
[
    {
        "ids": [
            "58102f049d604be0916b680a6c3b7931"
        ],
        "attributes": [
            {
                "attribute": "created",
                "values": [
                	"2019-02-22T00:49:52.541+00:00"
                ]
            }
        ]
    }
]
```

#### Any background context you want to provide?
Discovered while working https://github.com/codice/ddf/pull/4233

#### What are the relevant tickets?
[DDF-4450](https://codice.atlassian.net/browse/DDF-4450)
[DDF-4447](https://codice.atlassian.net/browse/DDF-4447)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
