### PR TITLE
DDF-4470 added documentation for Content File System Storage Provider

### DIFF
--- a/distribution/docs/src/main/resources/content/_sources/default-storage-provider.adoc
+++ b/distribution/docs/src/main/resources/content/_sources/default-storage-provider.adoc
@@ -1,0 +1,27 @@
+:title: Content File System Storage Provider
+:type: source
+:status: published
+:link: {managing-prefix}content_file_system_storage_provider
+:summary:
+:federated:
+:connected:
+:catalogprovider:
+:storageprovider: x
+:catalogstore:
+
+== {title}
+
+The Content File System Storage Provider is the default Storage Provider included with ${branding}
+
+.Installing the Content File System Storage Provider
+The Content File System Storage Provider is installed by default with the ${ddf-catalog} application.
+
+.Configuring Content File System Storage Provider
+To configure the Content File System Storage Provider:
+
+. Navigate to the *${admin-console}*.
+. Select *${ddf-catalog}*.
+. Select *Configuration*.
+. Select *Content File System Storage Provider*.
+
+See <<{reference-prefix}org.codice.ddf.catalog.content.impl.FileSystemStorageProvider,Content File System Storage Provider configurations>> for all possible configurations.

--- a/distribution/docs/src/main/resources/content/_sources/registry-store.adoc
+++ b/distribution/docs/src/main/resources/content/_sources/registry-store.adoc
@@ -24,7 +24,7 @@ The Registry Store is installed by default with the ${ddf-registry} application.
 .Configuring Registry Store
 To configure the Registry store:
 
-. Navigate to the ${admin-console}.
+. Navigate to the *${admin-console}*.
 . Select *${ddf-registry}*.
 . Select the *Remote Registries* Tab and click the *Add* button.
 .. ALTERNATIVELY: Select the *Configuration* Tab and select *Registry Store*.


### PR DESCRIPTION
#### What does this PR do?

Adds configuration documentation for the default Content File System Storage Provider.

#### Who is reviewing it? 

@bakejeyner @austinsteffes @ahoffer 

#### Select relevant component teams: 

@codice/docs 

#### Committers

@brjeter
@clockard
@garrettfreibott
@lessarderic
@mcalcote
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?

new content included in a successful build

#### What are the relevant tickets?
[DDF-4470](https://codice.atlassian.net/browse/DDF-4470)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
