### PR TITLE
DDF-4471 Disabling sources sometimes causes them to disappear from the sources tab in the Admin UI

### DIFF
--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -17,10 +17,12 @@ import ddf.catalog.data.Metacard;
 import java.io.IOException;
 import java.security.PrivilegedActionException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -28,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ServiceBindingType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
 import org.apache.commons.collections.CollectionUtils;
@@ -586,6 +589,9 @@ public class SourceConfigurationHandler implements EventHandler, RegistrySourceC
     Dictionary<String, Object> copiedProperties = new Hashtable<>();
     ObjectClassDefinition objectClassDefinition = getObjectClassDefinition(factoryPid);
     if (objectClassDefinition == null) {
+      LOGGER.debug(
+          "ObjectClassDefinition not found for factoryPid: {}. Unable to copy properties.",
+          factoryPid);
       return copiedProperties;
     }
     Stream.of(objectClassDefinition)

--- a/platform/admin/core/admin-core-impl/pom.xml
+++ b/platform/admin/core/admin-core-impl/pom.xml
@@ -115,11 +115,6 @@
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.codice.ddf.registry</groupId>
-            <artifactId>registry-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/admin/core/admin-core-impl/pom.xml
+++ b/platform/admin/core/admin-core-impl/pom.xml
@@ -115,6 +115,11 @@
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
@@ -763,7 +763,11 @@ public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.Con
   private Dictionary<String, Object> copyConfigProperties(
       Dictionary<String, Object> properties, String factoryPid) {
     Dictionary<String, Object> copiedProperties = new Hashtable<>();
-    Stream.of(getObjectClassDefinition(factoryPid))
+    ObjectClassDefinition objectClassDefinition = getObjectClassDefinition(factoryPid);
+    if (objectClassDefinition == null) {
+      return copiedProperties;
+    }
+    Stream.of(objectClassDefinition)
         .map(ocd -> ocd.getAttributeDefinitions(ObjectClassDefinition.ALL))
         .flatMap(Arrays::stream)
         .map(AttributeDefinition::getID)

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
@@ -13,9 +13,27 @@
  */
 package org.codice.ddf.admin.core.impl;
 
+import static org.osgi.framework.Constants.SERVICE_PID;
+import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_FACTORYPID;
+
 import com.google.common.collect.Sets;
 import ddf.security.permission.KeyValueCollectionPermission;
 import ddf.security.permission.KeyValuePermission;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.Subject;
@@ -44,25 +62,6 @@ import org.osgi.service.metatype.ObjectClassDefinition;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Dictionary;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.osgi.framework.Constants.SERVICE_PID;
-import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_FACTORYPID;
 
 public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.ConfigurationAdmin {
 

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
@@ -43,7 +43,6 @@ import org.codice.ddf.admin.core.api.ConfigurationStatus;
 import org.codice.ddf.admin.core.api.Metatype;
 import org.codice.ddf.admin.core.api.MetatypeAttribute;
 import org.codice.ddf.admin.core.api.Service;
-import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.ui.admin.api.plugin.ConfigurationAdminPlugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -87,6 +86,8 @@ public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.Con
   private final ConfigurationAdmin configurationAdmin;
 
   private final Map<String, ServiceTracker> services = new HashMap<String, ServiceTracker>();
+
+  private final String CONFIGURATION_REGISTRY_ID_PROPERTY = "registry-id";
 
   private List<ConfigurationAdminPlugin> configurationAdminPluginList;
 
@@ -777,8 +778,7 @@ public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.Con
         .flatMap(Arrays::stream)
         .map(AttributeDefinition::getID)
         .forEach(id -> copyIfDefined(id, properties, copiedProperties));
-    copyIfDefined(
-        RegistryConstants.CONFIGURATION_REGISTRY_ID_PROPERTY, properties, copiedProperties);
+    copyIfDefined(CONFIGURATION_REGISTRY_ID_PROPERTY, properties, copiedProperties);
     return copiedProperties;
   }
 

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
@@ -83,11 +83,11 @@ public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.Con
 
   private static final Map<Long, String> BUNDLE_LOCATIONS = new ConcurrentHashMap<>();
 
+  private static final String CONFIGURATION_REGISTRY_ID_PROPERTY = "registry-id";
+
   private final ConfigurationAdmin configurationAdmin;
 
   private final Map<String, ServiceTracker> services = new HashMap<String, ServiceTracker>();
-
-  private final String CONFIGURATION_REGISTRY_ID_PROPERTY = "registry-id";
 
   private List<ConfigurationAdminPlugin> configurationAdminPluginList;
 

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImpl.java
@@ -765,6 +765,9 @@ public class ConfigurationAdminImpl implements org.codice.ddf.admin.core.api.Con
     Dictionary<String, Object> copiedProperties = new Hashtable<>();
     ObjectClassDefinition objectClassDefinition = getObjectClassDefinition(factoryPid);
     if (objectClassDefinition == null) {
+      LOGGER.debug(
+          "ObjectClassDefinition not found for factoryPid: {}. Unable to copy properties.",
+          factoryPid);
       return copiedProperties;
     }
     Stream.of(objectClassDefinition)

--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImplTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/ConfigurationAdminImplTest.java
@@ -33,6 +33,7 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.shiro.subject.Subject;
 import org.codice.ddf.admin.core.api.ConfigurationStatus;
@@ -251,7 +252,8 @@ public class ConfigurationAdminImplTest {
   @Test(expected = IllegalStateException.class)
   public void testEnableConfigurationsException() throws Exception {
     setUpListServices();
-    when(testMTI.getObjectClassDefinition(anyString(), anyString())).thenReturn(null);
+    when(testMTI.getObjectClassDefinition(TEST_FACTORY_PID, Locale.getDefault().toString()))
+        .thenReturn(null);
 
     org.osgi.service.cm.ConfigurationAdmin testConfigAdmin =
         mock(org.osgi.service.cm.ConfigurationAdmin.class);


### PR DESCRIPTION
#### What does this PR do?
Disabling sources that are created with a configuration file will cause the source to be deleted. This is because the property `felix.fileinstall.filename` is being copied to the disabled when it should not be. This pr fixes this and ensures only the correct properties are copied.
#### Who is reviewing it? 
@Bdthomson @Lambeaux 
#### Ask 2 committers to review/merge the PR and tag them here.
@troymohl @bdeining 
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4471](https://codice.atlassian.net/browse/DDF-4471)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
