### PR TITLE
DDF-4465 Export metacards to a compressed file in a specified format

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -415,8 +415,6 @@ public class DumpCommand extends CqlCommands {
     try (FileOutputStream fileOutputStream = new FileOutputStream(filePath);
         ZipOutputStream zipOutputStream = new ZipOutputStream(fileOutputStream)) {
 
-      Map<String, Resource> resourceMap = new HashMap<>();
-
       // write the metacards to the zip
       ResultIterable.resultIterable(catalog::query, queryRequest)
           .stream()
@@ -426,16 +424,15 @@ public class DumpCommand extends CqlCommands {
                 writeMetacardToZip(zipOutputStream, metacard);
 
                 if (hasLocalResources(metacard)) {
-                  resourceMap.putAll(getAllMetacardContent(metacard));
+                  // write the resources to the zip
+                  Map<String, Resource> resourceMap = getAllMetacardContent(metacard);
+                  resourceMap.forEach(
+                      (filename, resource) ->
+                          writeResourceToZip(zipOutputStream, filename, resource));
                 }
 
                 resultCount.incrementAndGet();
               });
-
-      // write the resources to the zip
-      resourceMap.forEach(
-          (filename, resource) -> writeResourceToZip(zipOutputStream, filename, resource));
-
     } catch (IOException e) {
       throw new CatalogTransformerException(
           String.format(

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -102,7 +102,7 @@ public class DumpCommand extends CqlCommands {
 
   private static final String CONTENT = "content";
 
-  private static final int BUFFER_SIZE = 10000000;
+  private static final int BUFFER_SIZE = 10_000_000;
 
   private final PeriodFormatter timeFormatter =
       new PeriodFormatterBuilder()

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -536,14 +536,11 @@ public class DumpCommand extends CqlCommands {
   private void writeResourceToZip(
       ZipOutputStream zipOutputStream, String filename, Resource resource) {
 
-    try {
+    try (InputStream inputStream = resource.getInputStream()) {
       ZipEntry zipEntry = new ZipEntry(filename);
       zipOutputStream.putNextEntry(zipEntry);
 
-      InputStream inputStream = resource.getInputStream();
-
       IOUtils.copy(inputStream, zipOutputStream);
-      inputStream.close();
     } catch (IOException e) {
       LOGGER.debug("Failed to add resource with id {} to zip.", resource.getName(), e);
     }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -189,8 +189,6 @@ public class DumpCommand extends CqlCommands {
   )
   String zipFileName;
 
-  private Map<String, Serializable> zipArgs;
-
   @Override
   protected Object executeWithSubject() throws Exception {
     if (FilenameUtils.getExtension(dirPath).equals("") && !dirPath.endsWith(File.separator)) {
@@ -226,11 +224,6 @@ public class DumpCommand extends CqlCommands {
     SecurityLogger.audit("Called catalog:dump command with path : {}", dirPath);
 
     CatalogFacade catalog = getCatalog();
-
-    if (StringUtils.isNotBlank(zipFileName)) {
-      zipArgs = new HashMap<>();
-      zipArgs.put(FILE_PATH, dirPath + zipFileName);
-    }
 
     SortBy sort = new SortByImpl(Core.ID, SortOrder.ASCENDING);
 

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/DumpCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/DumpCommandTest.java
@@ -27,14 +27,13 @@ import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
-import ddf.catalog.transform.QueryResponseTransformer;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.fusesource.jansi.Ansi;
 import org.junit.Rule;
 import org.junit.Test;
@@ -214,20 +213,11 @@ public class DumpCommandTest extends CommandCatalogFrameworkCommon {
     // mock transformer to throw exception
     MetacardTransformer transformer = mock(MetacardTransformer.class);
     when(transformer.transform(any(), any())).thenThrow(CatalogTransformerException.class);
-    QueryResponseTransformer zipCompressionMock = mock(QueryResponseTransformer.class);
-    when(zipCompressionMock.transform(any(), any())).thenThrow(CatalogTransformerException.class);
     List<MetacardTransformer> transformers = new ArrayList<>();
     transformers.add(transformer);
 
-    // given
-    List<Result> resultList = getResultList("id1", "id2");
-    MetacardImpl metacard1 = new MetacardImpl(resultList.get(0).getMetacard());
-    MetacardImpl metacard2 = new MetacardImpl(resultList.get(1).getMetacard());
-    metacard1.setResourceURI(new URI("content:" + metacard1.getId()));
-    metacard2.setResourceURI(new URI("content:" + metacard2.getId() + "#preview"));
-
-    TestDumpCommand dumpCommand = new TestDumpCommand(transformers, zipCompressionMock);
-    dumpCommand.catalogFramework = givenCatalogFramework(resultList);
+    TestDumpCommand dumpCommand = new TestDumpCommand(transformers);
+    dumpCommand.catalogFramework = givenCatalogFramework(Collections.emptyList());
     dumpCommand.filterBuilder = new GeotoolsFilterBuilder();
     File outputDirectory = testFolder.newFolder("somedirectory");
     String outputDirectoryPath = outputDirectory.getAbsolutePath();
@@ -249,12 +239,6 @@ public class DumpCommandTest extends CommandCatalogFrameworkCommon {
 
     TestDumpCommand(List<MetacardTransformer> list) {
       this.list = list;
-    }
-
-    TestDumpCommand(
-        List<MetacardTransformer> list, QueryResponseTransformer queryResponseTransformer) {
-      this.list = list;
-      zipCompression = Optional.of(queryResponseTransformer);
     }
 
     @Override

--- a/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/DumpCommandTest.java
+++ b/catalog/core/catalog-core-commands/src/test/java/org/codice/ddf/commands/catalog/DumpCommandTest.java
@@ -15,7 +15,6 @@ package org.codice.ddf.commands.catalog;
 
 import static org.codice.ddf.commands.catalog.CommandSupport.ERROR_COLOR;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -29,10 +28,7 @@ import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
 import java.io.File;
 import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.fusesource.jansi.Ansi;
 import org.junit.Rule;
@@ -206,32 +202,6 @@ public class DumpCommandTest extends CommandCatalogFrameworkCommon {
 
     // then
     assertThat(consoleOutput.getOutput(), containsString(" 0 file(s) dumped in "));
-  }
-
-  @Test
-  public void testNoZipFileDumpedWhenTransformFails() throws Exception {
-    // mock transformer to throw exception
-    MetacardTransformer transformer = mock(MetacardTransformer.class);
-    when(transformer.transform(any(), any())).thenThrow(CatalogTransformerException.class);
-    List<MetacardTransformer> transformers = new ArrayList<>();
-    transformers.add(transformer);
-
-    TestDumpCommand dumpCommand = new TestDumpCommand(transformers);
-    dumpCommand.catalogFramework = givenCatalogFramework(Collections.emptyList());
-    dumpCommand.filterBuilder = new GeotoolsFilterBuilder();
-    File outputDirectory = testFolder.newFolder("somedirectory");
-    String outputDirectoryPath = outputDirectory.getAbsolutePath();
-    dumpCommand.dirPath = outputDirectoryPath;
-    dumpCommand.transformerId = "someOtherTransformer";
-    Path zipfilePath = Paths.get(outputDirectoryPath, "foo.zip");
-    dumpCommand.zipFileName = zipfilePath.toString();
-
-    // when
-    dumpCommand.executeWithSubject();
-
-    // then
-    assertThat(consoleOutput.getOutput(), containsString(" 0 file(s) dumped in "));
-    assertThat(zipfilePath.toFile().exists(), is(false));
   }
 
   private class TestDumpCommand extends DumpCommand {

--- a/catalog/transformer/catalog-transformer-zip/pom.xml
+++ b/catalog/transformer/catalog-transformer-zip/pom.xml
@@ -118,17 +118,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.89</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.71</minimum>
+                                            <minimum>0.91</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.92</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
+++ b/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
@@ -45,7 +45,7 @@ public class ZipCompression implements QueryResponseTransformer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ZipCompression.class);
 
-  static final String METACARD_PATH = "metacards" + File.separator;
+  private static final String METACARD_PATH = "metacards" + File.separator;
 
   private static final String TRANSFORMER_ID = "transformerId";
 
@@ -160,8 +160,7 @@ public class ZipCompression implements QueryResponseTransformer {
       throws CatalogTransformerException {
     return metacardTransformers
         .stream()
-        .filter(serviceRef -> serviceRef.getProperty("id") != null)
-        .filter(serviceRef -> serviceRef.getProperty("id").toString().equals(transformerId))
+        .filter(serviceRef -> transformerId.equals(serviceRef.getProperty("id")))
         .findFirst()
         .orElseThrow(
             () ->

--- a/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
+++ b/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
@@ -29,12 +29,11 @@ import ddf.catalog.resource.Resource;
 import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.resource.ResourceNotSupportedException;
 import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.MetacardTransformer;
 import ddf.catalog.transform.QueryResponseTransformer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,19 +41,24 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+import javax.activation.MimeType;
+import javax.activation.MimeTypeParseException;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,12 +68,36 @@ public class ZipCompression implements QueryResponseTransformer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ZipCompression.class);
 
+  private static final String TRANSFORMER_ID = "transformerId";
+
   private CatalogFramework catalogFramework;
 
   private JarSigner jarSigner;
 
-  public ZipCompression(JarSigner jarSigner) {
+  private List<ServiceReference> metacardTransformers;
+
+  private BundleContext bundleContext;
+
+  private static MimeType mimeType;
+
+  private static final File DEFAULT_PATH =
+      Paths.get(System.getProperty("ddf.home"), "data", "tmp", "export.zip").toFile();
+
+  static {
+    try {
+      mimeType = new MimeType("application/zip");
+    } catch (MimeTypeParseException e) {
+      LOGGER.warn("Failed to apply mimetype application/zip");
+    }
+  }
+
+  public ZipCompression(
+      JarSigner jarSigner,
+      List<ServiceReference> metacardTransformers,
+      BundleContext bundleContext) {
     this.jarSigner = jarSigner;
+    this.metacardTransformers = metacardTransformers;
+    this.bundleContext = bundleContext;
   }
 
   /**
@@ -88,23 +116,84 @@ public class ZipCompression implements QueryResponseTransformer {
       SourceResponse upstreamResponse, Map<String, Serializable> arguments)
       throws CatalogTransformerException {
 
-    checkArguments(upstreamResponse, arguments);
+    if (upstreamResponse == null || CollectionUtils.isEmpty(upstreamResponse.getResults())) {
+      throw new CatalogTransformerException(
+          "The source response does not contain any metacards to transform.");
+    }
 
-    String filePath = (String) arguments.get(ZipDecompression.FILE_PATH);
-    createZip(upstreamResponse, filePath);
+    String filePath =
+        (String) arguments.getOrDefault(ZipDecompression.FILE_PATH, DEFAULT_PATH.toString());
+    String transformerId = (String) arguments.getOrDefault(TRANSFORMER_ID, "");
+
+    if (StringUtils.isNotBlank(transformerId)) {
+      createZip(upstreamResponse, filePath, transformerId);
+    } else {
+      createZip(upstreamResponse, filePath);
+    }
 
     return getBinaryContentFromZip(filePath);
   }
 
-  private void checkArguments(SourceResponse upstreamResponse, Map<String, Serializable> arguments)
+  private void createZip(SourceResponse sourceResponse, String filePath, String transformerId)
       throws CatalogTransformerException {
-    if (upstreamResponse == null || CollectionUtils.isEmpty(upstreamResponse.getResults())) {
-      throw new CatalogTransformerException("No Metacards were found to transform.");
+    ServiceReference<MetacardTransformer> serviceRef =
+        getTransformerServiceReference(transformerId);
+    MetacardTransformer transformer = bundleContext.getService(serviceRef);
+
+    String extension = getFileExtensionFromService(serviceRef);
+
+    if (StringUtils.isNotBlank(extension)) {
+      extension = "." + extension;
     }
 
-    if (MapUtils.isEmpty(arguments) || !arguments.containsKey(ZipDecompression.FILE_PATH)) {
-      throw new CatalogTransformerException("No 'filePath' argument found in arguments map.");
+    try (FileOutputStream fileOutputStream = new FileOutputStream(filePath);
+        ZipOutputStream zipOutputStream = new ZipOutputStream(fileOutputStream)) {
+
+      for (Result result : sourceResponse.getResults()) {
+        Metacard metacard = result.getMetacard();
+
+        BinaryContent binaryContent = transformer.transform(metacard, Collections.emptyMap());
+        writeBinaryContentToZip(zipOutputStream, binaryContent, metacard.getId(), extension);
+      }
+
+    } catch (IOException e) {
+      throw new CatalogTransformerException(
+          String.format(
+              "Error occurred when initializing or closing ZipOutputStream with path %s.",
+              filePath),
+          e);
     }
+  }
+
+  private String getFileExtensionFromService(ServiceReference<MetacardTransformer> serviceRef) {
+    Object mimeTypeProperty = serviceRef.getProperty("mime-type");
+
+    if (mimeTypeProperty == null) {
+      return "";
+    }
+
+    String mimeTypeStr = mimeTypeProperty.toString();
+
+    try {
+      MimeType exportMimeType = new MimeType(mimeTypeStr);
+      return exportMimeType.getSubType();
+    } catch (MimeTypeParseException e) {
+      LOGGER.debug("Failed to parse mime type {}", mimeTypeStr, e);
+      return "";
+    }
+  }
+
+  private ServiceReference getTransformerServiceReference(String transformerId)
+      throws CatalogTransformerException {
+    return metacardTransformers
+        .stream()
+        .filter(serviceRef -> serviceRef.getProperty("id") != null)
+        .filter(serviceRef -> serviceRef.getProperty("id").toString().equals(transformerId))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new CatalogTransformerException(
+                    "The metacard transformer with ID " + transformerId + " could not be found."));
   }
 
   private void createZip(SourceResponse upstreamResponse, String filePath)
@@ -155,6 +244,24 @@ public class ZipCompression implements QueryResponseTransformer {
       inputStream.close();
     } catch (IOException e) {
       LOGGER.debug("Failed to add metacard with id {}.", metacard.getId(), e);
+    }
+  }
+
+  private void writeBinaryContentToZip(
+      ZipOutputStream zipOutputStream,
+      BinaryContent binaryContent,
+      String metacardId,
+      String extension) {
+    try {
+      ZipEntry zipEntry = new ZipEntry(METACARD_PATH + metacardId + extension);
+      zipOutputStream.putNextEntry(zipEntry);
+
+      InputStream inputStream = binaryContent.getInputStream();
+
+      IOUtils.copy(inputStream, zipOutputStream);
+      inputStream.close();
+    } catch (IOException e) {
+      LOGGER.debug("Failed to add metacard with id {}.", metacardId, e);
     }
   }
 
@@ -240,27 +347,36 @@ public class ZipCompression implements QueryResponseTransformer {
 
   private BinaryContent getBinaryContentFromZip(String filePath)
       throws CatalogTransformerException {
-    BinaryContent binaryContent;
-    InputStream fileInputStream;
+    byte[] bytes;
     File zipFile = new File(filePath);
     try {
-      fileInputStream = new ZipInputStream(new FileInputStream(zipFile));
-      binaryContent = new BinaryContentImpl(fileInputStream);
-    } catch (FileNotFoundException e) {
-      throw new CatalogTransformerException("Unable to get ZIP file from ZipInputStream.", e);
+      bytes = Files.readAllBytes(zipFile.toPath().toAbsolutePath());
+    } catch (IOException e) {
+      throw new CatalogTransformerException(
+          "An error occurred while streaming the temporary zip file", e);
     }
 
-    jarSigner.signJar(
-        zipFile,
-        AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty(SystemBaseUrl.EXTERNAL_HOST)),
-        AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("javax.net.ssl.keyStorePassword")),
-        AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("javax.net.ssl.keyStore")),
-        AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("javax.net.ssl.keyStorePassword")));
-    return binaryContent;
+    AccessController.doPrivileged(
+        (PrivilegedAction<Void>)
+            () -> {
+              jarSigner.signJar(
+                  zipFile,
+                  AccessController.doPrivileged(
+                      (PrivilegedAction<String>)
+                          () -> System.getProperty(SystemBaseUrl.EXTERNAL_HOST)),
+                  AccessController.doPrivileged(
+                      (PrivilegedAction<String>)
+                          () -> System.getProperty("javax.net.ssl.keyStorePassword")),
+                  AccessController.doPrivileged(
+                      (PrivilegedAction<String>)
+                          () -> System.getProperty("javax.net.ssl.keyStore")),
+                  AccessController.doPrivileged(
+                      (PrivilegedAction<String>)
+                          () -> System.getProperty("javax.net.ssl.keyStorePassword")));
+              return null;
+            });
+
+    return new BinaryContentImpl(new ByteArrayInputStream(bytes), mimeType);
   }
 
   public void setCatalogFramework(CatalogFramework catalogFramework) {

--- a/catalog/transformer/catalog-transformer-zip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-zip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,8 +27,17 @@
                   value="${ddf.etc}/ws-security/server/signature.properties"/>
     </bean>
 
+    <bean id="metacardTransformers" class="ddf.catalog.util.impl.SortedServiceReferenceList"/>
+    <reference-list id="metacardTransformerList" member-type="service-reference"
+      interface="ddf.catalog.transform.MetacardTransformer">
+        <reference-listener bind-method="bindService" unbind-method="unbindService"
+          ref="metacardTransformers"/>
+    </reference-list>
+
     <bean id="zipCompression" class="org.codice.ddf.catalog.transformer.zip.ZipCompression">
         <argument ref="jarSigner" />
+        <argument ref="metacardTransformers"/>
+        <argument ref="blueprintBundleContext"/>
         <property name="catalogFramework" ref="catalogFramework"/>
     </bean>
 
@@ -42,8 +51,8 @@
             <entry key="shortname" value="zipC"/>
             <entry key="mime-type" value="application/zip"/>
             <entry key="schema" value="urn:catalog:metacard"/>
-            <entry key="export-resultset" value="false"/>
             <entry key="displayName" value="Signed ZIP"/>
+            <entry key="export-resultset" value="true"/>
         </service-properties>
     </service>
 

--- a/catalog/transformer/catalog-transformer-zip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-zip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,10 +18,6 @@
 
     <ext:property-placeholder/>
 
-    <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework" />
-
-    <bean id="jarSigner" class="org.codice.ddf.catalog.transformer.zip.JarSigner"/>
-
     <bean id="zipValidation" class="org.codice.ddf.catalog.transformer.zip.ZipValidator" init-method="init">
         <property name="signaturePropertiesPath"
                   value="${ddf.etc}/ws-security/server/signature.properties"/>
@@ -35,10 +31,8 @@
     </reference-list>
 
     <bean id="zipCompression" class="org.codice.ddf.catalog.transformer.zip.ZipCompression">
-        <argument ref="jarSigner" />
         <argument ref="metacardTransformers"/>
         <argument ref="blueprintBundleContext"/>
-        <property name="catalogFramework" ref="catalogFramework"/>
     </bean>
 
     <bean id="zipDecompression" class="org.codice.ddf.catalog.transformer.zip.ZipDecompression">

--- a/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/ZipCompressionTest.java
+++ b/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/ZipCompressionTest.java
@@ -15,52 +15,36 @@ package org.codice.ddf.catalog.transformer.zip;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.BinaryContentImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
-import ddf.catalog.operation.ResourceResponse;
 import ddf.catalog.operation.SourceResponse;
-import ddf.catalog.operation.impl.ResourceRequestById;
-import ddf.catalog.operation.impl.ResourceResponseImpl;
 import ddf.catalog.operation.impl.SourceResponseImpl;
-import ddf.catalog.resource.Resource;
-import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -70,58 +54,13 @@ import org.osgi.framework.ServiceReference;
 @RunWith(MockitoJUnitRunner.class)
 public class ZipCompressionTest {
 
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  private static final String LOCAL_RESOURCE_FILENAME = "localresource.txt";
-
-  private static final String LOCAL_RESOURCE_PATH =
-      ZipCompressionTest.class.getClassLoader().getResource(LOCAL_RESOURCE_FILENAME).getPath();
-
-  private static final String CONTENT_SCHEME = "content:";
-
-  private static final String HTTP_SCHEME = "http://example.com";
-
-  private static final String CONTENT_PATH = "content" + File.separator;
-
-  private static final String PREVIEW_PATH = CONTENT_PATH + "preview" + File.separator;
-
-  private static final String ID_1 = "id1";
-
-  private static final String ID_2 = "id2";
-
-  private static final String ID_3 = "id3";
-
-  private static final String METACARD_1 = ZipCompression.METACARD_PATH + ID_1;
-
-  private static final String METACARD_2 = ZipCompression.METACARD_PATH + ID_2;
-
-  private static final String METACARD_3 = ZipCompression.METACARD_PATH + ID_3;
-
-  private static final String METACARD_3_CONTENT =
-      CONTENT_PATH + ID_3 + "-" + LOCAL_RESOURCE_FILENAME;
-
-  private static final String METACARD_3_DERIVED_CONTENT =
-      PREVIEW_PATH + ID_3 + "-" + LOCAL_RESOURCE_FILENAME;
-
-  private static final List<String> METACARD_ID_LIST = Arrays.asList(ID_1, ID_2, ID_3);
-
-  private static final List<String> METACARD_RESULT_LIST_NO_CONTENT =
-      Arrays.asList(METACARD_1, METACARD_2, METACARD_3);
-
-  private static final List<String> METACARD_RESULT_LIST_WITH_CONTENT =
-      Arrays.asList(METACARD_1, METACARD_2, METACARD_3, METACARD_3_CONTENT);
-
-  private static final List<String> METACARD_RESULT_LIST_WITH_CONTENT_AND_DERIVED_RESOURCES =
-      Arrays.asList(
-          METACARD_1, METACARD_2, METACARD_3, METACARD_3_CONTENT, METACARD_3_DERIVED_CONTENT);
-
   private ZipCompression zipCompression;
 
-  private SourceResponse sourceResponse;
+  private static final SourceResponse EMPTY_SOURCE_RESPONSE =
+      new SourceResponseImpl(null, Collections.emptyList());
 
-  private Map<String, Serializable> filePathArgument;
-
-  private CatalogFramework catalogFramework;
+  private static final SourceResponse SINGLE_RESULT_SOURCE_RESPONSE =
+      new SourceResponseImpl(null, ImmutableList.of(new ResultImpl()));
 
   @Mock private BundleContext bundleContext;
 
@@ -129,125 +68,20 @@ public class ZipCompressionTest {
 
   @Before
   public void setUp() throws Exception {
-    JarSigner jarSigner = mock(JarSigner.class);
-    doNothing()
-        .when(jarSigner)
-        .signJar(any(File.class), anyString(), anyString(), anyString(), anyString());
     List<ServiceReference> serviceReferences =
         ImmutableList.of(
             createMockServiceReference("html", "text/html"),
             createMockServiceReference(null, "foobar"),
-            createMockServiceReference("barfoo", null));
-    zipCompression = new ZipCompression(jarSigner, serviceReferences, bundleContext);
-    sourceResponse = createSourceResponseWithURISchemes(null, null);
-    filePathArgument = new HashMap<>();
-    filePathArgument.put(
-        "filePath", temporaryFolder.getRoot().getAbsolutePath() + File.separator + "signed.zip");
-    catalogFramework = mock(CatalogFramework.class);
-    Resource resource = mock(Resource.class);
-    InputStream resourceFileStream = new FileInputStream(new File(LOCAL_RESOURCE_PATH));
-    when(resource.getName()).thenReturn(LOCAL_RESOURCE_FILENAME);
-    when(resource.getInputStream()).thenReturn(resourceFileStream);
-    ResourceResponse resourceResponse = new ResourceResponseImpl(resource);
-    when(catalogFramework.getLocalResource(any(ResourceRequestById.class)))
-        .thenReturn(resourceResponse);
-    zipCompression.setCatalogFramework(catalogFramework);
-  }
+            createMockServiceReference("barfoo", null),
+            createMockServiceReference("hello", "world"));
 
-  @Test
-  public void testGetCatalogFramework() {
-    assertThat(catalogFramework, is(zipCompression.getCatalogFramework()));
-  }
+    zipCompression = new ZipCompression(bundleContext, serviceReferences);
 
-  @Test(expected = CatalogTransformerException.class)
-  public void testCompressionEmptyFilePathKeyArgument() throws Exception {
-    HashMap<String, Serializable> arguments = new HashMap<>();
-    arguments.put(ZipDecompression.FILE_PATH, "");
-    zipCompression.transform(sourceResponse, arguments);
-  }
+    when(bundleContext.getService(any(ServiceReference.class))).thenReturn(transformer);
 
-  @Test(expected = CatalogTransformerException.class)
-  public void testCompressionNullSourceResponse() throws Exception {
-    zipCompression.transform(null, filePathArgument);
-  }
-
-  @Test(expected = CatalogTransformerException.class)
-  public void testCompressioNullListInSourceResponse() throws Exception {
-    zipCompression.transform(new SourceResponseImpl(null, null), filePathArgument);
-  }
-
-  @Test(expected = CatalogTransformerException.class)
-  public void testCompressionEmptyListInSourceResponse() throws Exception {
-    zipCompression.transform(new SourceResponseImpl(null, new ArrayList<>()), filePathArgument);
-  }
-
-  @Test
-  public void testCompressionWithoutContent() throws Exception {
-    BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
-    assertThat(binaryContent, notNullValue());
-    assertZipContents(binaryContent, METACARD_RESULT_LIST_NO_CONTENT);
-  }
-
-  @Test
-  public void testCompressionWithRemoteContent() throws Exception {
-    SourceResponse sourceResponse = createSourceResponseWithURISchemes(HTTP_SCHEME, null);
-    BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
-    assertThat(binaryContent, notNullValue());
-    assertZipContents(binaryContent, METACARD_RESULT_LIST_NO_CONTENT);
-  }
-
-  @Test
-  public void testCompressionWithLocalContent() throws Exception {
-    SourceResponse sourceResponse = createSourceResponseWithURISchemes(CONTENT_SCHEME, null);
-    BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
-    assertThat(binaryContent, notNullValue());
-    assertZipContents(binaryContent, METACARD_RESULT_LIST_WITH_CONTENT);
-  }
-
-  @Test
-  public void testCompressionWithDerivedContent() throws Exception {
-    SourceResponse sourceResponse =
-        createSourceResponseWithURISchemes(CONTENT_SCHEME, "content:id3#preview");
-    BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
-    assertThat(binaryContent, notNullValue());
-    assertZipContents(binaryContent, METACARD_RESULT_LIST_WITH_CONTENT_AND_DERIVED_RESOURCES);
-  }
-
-  @Test
-  public void testCompressionWithNullResources() throws Exception {
-    when(catalogFramework.getLocalResource(any(ResourceRequestById.class)))
-        .thenThrow(ResourceNotFoundException.class);
-    SourceResponse sourceResponse =
-        createSourceResponseWithURISchemes(CONTENT_SCHEME, "content:1234#preview");
-    BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
-    assertThat(binaryContent, notNullValue());
-    assertZipContents(binaryContent, METACARD_RESULT_LIST_NO_CONTENT);
-  }
-
-  @Test
-  public void testCompressionWithDerivedContentInvalidURI() throws Exception {
-    String invalidUri = "^";
-    SourceResponse sourceResponse = createSourceResponseWithURISchemes(CONTENT_SCHEME, invalidUri);
-    BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
-    assertThat(binaryContent, notNullValue());
-    assertZipContents(binaryContent, METACARD_RESULT_LIST_WITH_CONTENT);
-  }
-
-  @Test
-  public void testCompressionWithDerivedContentNullFragment() throws Exception {
-    SourceResponse sourceResponse =
-        createSourceResponseWithURISchemes(CONTENT_SCHEME, "content:1234");
-    BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
-    assertThat(binaryContent, notNullValue());
-    assertZipContents(binaryContent, METACARD_RESULT_LIST_WITH_CONTENT);
-  }
-
-  @Test
-  public void testCompressionWithRemoteDerivedContent() throws Exception {
-    SourceResponse sourceResponse = createSourceResponseWithURISchemes(CONTENT_SCHEME, HTTP_SCHEME);
-    BinaryContent binaryContent = zipCompression.transform(sourceResponse, filePathArgument);
-    assertThat(binaryContent, notNullValue());
-    assertZipContents(binaryContent, METACARD_RESULT_LIST_WITH_CONTENT);
+    InputStream inputStream = ZipCompressionTest.class.getResourceAsStream("/export.html");
+    when(transformer.transform(any(Metacard.class), any(Map.class)))
+        .thenReturn(new BinaryContentImpl(inputStream));
   }
 
   @Test
@@ -258,16 +92,7 @@ public class ZipCompressionTest {
     SourceResponse sourceResponse = new SourceResponseImpl(null, results);
 
     Map<String, Serializable> arguments =
-        new ImmutableMap.Builder<String, Serializable>()
-            .putAll(filePathArgument)
-            .put("transformerId", "html")
-            .build();
-
-    when(bundleContext.getService(any(ServiceReference.class))).thenReturn(transformer);
-
-    InputStream inputStream = ZipCompressionTest.class.getResourceAsStream("/export.html");
-    when(transformer.transform(any(Metacard.class), any(Map.class)))
-        .thenReturn(new BinaryContentImpl(inputStream));
+        new ImmutableMap.Builder<String, Serializable>().put("transformerId", "html").build();
 
     BinaryContent binaryContent = zipCompression.transform(sourceResponse, arguments);
 
@@ -282,20 +107,60 @@ public class ZipCompressionTest {
     SourceResponse sourceResponse = new SourceResponseImpl(null, results);
 
     Map<String, Serializable> arguments =
-        new ImmutableMap.Builder<String, Serializable>()
-            .putAll(filePathArgument)
-            .put("transformerId", "barfoo")
-            .build();
-
-    when(bundleContext.getService(any(ServiceReference.class))).thenReturn(transformer);
-
-    InputStream inputStream = ZipCompressionTest.class.getResourceAsStream("/export.html");
-    when(transformer.transform(any(Metacard.class), any(Map.class)))
-        .thenReturn(new BinaryContentImpl(inputStream));
+        new ImmutableMap.Builder<String, Serializable>().put("transformerId", "barfoo").build();
 
     BinaryContent binaryContent = zipCompression.transform(sourceResponse, arguments);
 
     assertZipContents(binaryContent, Collections.singletonList("metacards/metacardId"));
+  }
+
+  @Test
+  public void testCompressionWithSpecifiedFormatMimeTypeParserError() throws Exception {
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setId("metacardId");
+    List<Result> results = Collections.singletonList(new ResultImpl(metacard));
+    SourceResponse sourceResponse = new SourceResponseImpl(null, results);
+
+    Map<String, Serializable> arguments =
+        new ImmutableMap.Builder<String, Serializable>().put("transformerId", "hello").build();
+
+    BinaryContent binaryContent = zipCompression.transform(sourceResponse, arguments);
+
+    assertZipContents(binaryContent, Collections.singletonList("metacards/metacardId"));
+  }
+
+  @Test(expected = CatalogTransformerException.class)
+  public void testCompressionNullSourceResponse() throws Exception {
+    zipCompression.transform(null, Collections.emptyMap());
+  }
+
+  @Test(expected = CatalogTransformerException.class)
+  public void testCompressionEmptySourceResponse() throws Exception {
+    zipCompression.transform(EMPTY_SOURCE_RESPONSE, null);
+  }
+
+  @Test(expected = CatalogTransformerException.class)
+  public void testCompressNullTransformerId() throws Exception {
+    Map<String, Serializable> arguments = new HashMap<>();
+    arguments.put("transformerId", null);
+
+    zipCompression.transform(SINGLE_RESULT_SOURCE_RESPONSE, arguments);
+  }
+
+  @Test(expected = CatalogTransformerException.class)
+  public void testCompressEmptyTransformerId() throws Exception {
+    Map<String, Serializable> arguments =
+        new ImmutableMap.Builder<String, Serializable>().put("transformerId", "").build();
+
+    zipCompression.transform(SINGLE_RESULT_SOURCE_RESPONSE, arguments);
+  }
+
+  @Test(expected = CatalogTransformerException.class)
+  public void testCompressBlankTransformerId() throws Exception {
+    Map<String, Serializable> arguments =
+        new ImmutableMap.Builder<String, Serializable>().put("transformerId", " ").build();
+
+    zipCompression.transform(SINGLE_RESULT_SOURCE_RESPONSE, arguments);
   }
 
   @Test(expected = CatalogTransformerException.class)
@@ -305,10 +170,7 @@ public class ZipCompressionTest {
     SourceResponse sourceResponse = new SourceResponseImpl(null, results);
 
     Map<String, Serializable> arguments =
-        new ImmutableMap.Builder<String, Serializable>()
-            .putAll(filePathArgument)
-            .put("transformerId", "foobar")
-            .build();
+        new ImmutableMap.Builder<String, Serializable>().put("transformerId", "foobar").build();
 
     zipCompression.transform(sourceResponse, arguments);
   }
@@ -328,30 +190,6 @@ public class ZipCompressionTest {
     for (String id : ids) {
       assertThat(entryNames, hasItem(id));
     }
-  }
-
-  private SourceResponse createSourceResponseWithURISchemes(
-      String scheme, String derivedResourceScheme) throws Exception {
-
-    List<Result> resultList = new ArrayList<>();
-
-    for (String string : METACARD_ID_LIST) {
-      MetacardImpl metacard = new MetacardImpl();
-      metacard.setId(string);
-
-      if (scheme != null && string.equals(METACARD_ID_LIST.get(METACARD_ID_LIST.size() - 1))) {
-
-        URI uri = new URI(scheme + metacard.getId());
-        metacard.setResourceURI(uri);
-        if (StringUtils.isNotBlank(derivedResourceScheme)) {
-          metacard.setAttribute(Metacard.DERIVED_RESOURCE_URI, derivedResourceScheme);
-        }
-      }
-      Result result = new ResultImpl(metacard);
-      resultList.add(result);
-    }
-
-    return new SourceResponseImpl(null, resultList);
   }
 
   private ServiceReference<MetacardTransformer> createMockServiceReference(

--- a/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/ZipCompressionTest.java
+++ b/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/ZipCompressionTest.java
@@ -38,7 +38,6 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
@@ -141,8 +140,7 @@ public class ZipCompressionTest {
 
   @Test(expected = CatalogTransformerException.class)
   public void testCompressNullTransformerId() throws Exception {
-    Map<String, Serializable> arguments = new HashMap<>();
-    arguments.put("transformerId", null);
+    Map<String, Serializable> arguments = Collections.singletonMap("transformerId", null);
 
     zipCompression.transform(SINGLE_RESULT_SOURCE_RESPONSE, arguments);
   }

--- a/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/ZipCompressionTest.java
+++ b/catalog/transformer/catalog-transformer-zip/src/test/java/org/codice/ddf/catalog/transformer/zip/ZipCompressionTest.java
@@ -173,6 +173,23 @@ public class ZipCompressionTest {
     zipCompression.transform(sourceResponse, arguments);
   }
 
+  @Test
+  public void testCompressionSingleTransformationFails() throws Exception {
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setId("metacardId");
+    List<Result> results = Collections.singletonList(new ResultImpl(metacard));
+    SourceResponse sourceResponse = new SourceResponseImpl(null, results);
+
+    Map<String, Serializable> arguments =
+        new ImmutableMap.Builder<String, Serializable>().put("transformerId", "hello").build();
+
+    when(transformer.transform(any(), any())).thenThrow(CatalogTransformerException.class);
+
+    BinaryContent binaryContent = zipCompression.transform(sourceResponse, arguments);
+
+    assertZipContents(binaryContent, Collections.emptyList());
+  }
+
   private void assertZipContents(BinaryContent binaryContent, List<String> ids) throws IOException {
     ZipInputStream zipInputStream =
         new ZipInputStream(new ByteArrayInputStream(binaryContent.getByteArray()));

--- a/catalog/transformer/catalog-transformer-zip/src/test/resources/export.html
+++ b/catalog/transformer/catalog-transformer-zip/src/test/resources/export.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Title</title>
+  </head>
+  <body>
+    <h1>Foobar</h1>
+  </body>
+</html>


### PR DESCRIPTION
#### What does this PR do?
- Modifies `ZipCompressor` so that it no longer requires an absolute file path to function properly. 
- Adds the ability to export the metacards with a different file format such as HTML. 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@GabrielFabian 
@cantstoptheunk 
@derekwilhelm 

#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith 
@rzwiefel 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Ingest a couple of metacards
- Invoke the query response transformer. You can use this postman request. 
- The CQL in the attached request matches everything. 
- Note that you may have to add a `.zip` onto the downloaded file to be able to unpack it. This is not a failure of the transformer but one of the client that you're using. 
- Verify that no regressions in the `catalog:dump` command exist. 

#### Any background context you want to provide?
- We wanted the ability to export a result set as a compressed file. 

#### What are the relevant tickets?
[DDF-4465](https://codice.atlassian.net/browse/DDF-4465)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
