### PR TITLE
[2.13.x] DDF-4473 Changes Latest Command to use Metacard.Modifed instead of Modified

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/LatestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/LatestCommand.java
@@ -17,8 +17,8 @@ import static ddf.catalog.util.impl.ResultIterable.resultIterable;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 import com.google.common.collect.Lists;
-import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.filter.impl.SortByImpl;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.impl.QueryImpl;
@@ -66,11 +66,11 @@ public class LatestCommand extends CatalogCommands {
     console.printf(formatString, "", "", "", "");
     printHeaderMessage(String.format(formatString, NUMBER, ID, DATE, TITLE));
 
-    Filter filter = filterBuilder.attribute(Metacard.MODIFIED).before().date(new Date());
+    Filter filter = filterBuilder.attribute(Core.METACARD_MODIFIED).before().date(new Date());
 
     QueryImpl query = new QueryImpl(filter);
     query.setPageSize(numberOfItems);
-    query.setSortBy(new SortByImpl(Metacard.MODIFIED, SortOrder.DESCENDING.name()));
+    query.setSortBy(new SortByImpl(Core.METACARD_MODIFIED, SortOrder.DESCENDING.name()));
 
     QueryRequest queryRequest = new QueryRequestImpl(query);
 
@@ -88,9 +88,10 @@ public class LatestCommand extends CatalogCommands {
       String postedDate = "";
       String title = "";
 
-      if (result.getMetacard().getModifiedDate() != null) {
+      if (result.getMetacard().getAttribute(Core.METACARD_MODIFIED) != null) {
         postedDate =
-            new DateTime(result.getMetacard().getModifiedDate()).toString(DATETIME_FORMATTER);
+            new DateTime(result.getMetacard().getAttribute(Core.METACARD_MODIFIED).getValue())
+                .toString(DATETIME_FORMATTER);
       }
 
       if (isNotBlank(result.getMetacard().getTitle())) {

--- a/distribution/docs/src/main/resources/content/_running/catalog-commands.adoc
+++ b/distribution/docs/src/main/resources/content/_running/catalog-commands.adoc
@@ -41,7 +41,7 @@ Provides a list of environment variables.
 |Provides the various fields of a metacard for inspection.
 
 |catalog:latest
-|Retrieves the latest records from the Catalog based on the Core.MODIFIED date.
+|Retrieves the latest records from the Catalog based on the Core.METACARD_MODIFIED date.
 
 |catalog:migrate
 |Allows two `CatalogProvider` s to be configured and migrates the data from the primary to the secondary.

--- a/distribution/docs/src/main/resources/content/_running/catalog-commands.adoc
+++ b/distribution/docs/src/main/resources/content/_running/catalog-commands.adoc
@@ -23,7 +23,7 @@ No pre/post plugins are executed and no message validation is performed if the `
 |catalog:describe
 |Provides a basic description of the Catalog implementation.
 
-|catlog:dump
+|catalog:dump
 |Exports metacards from the local Catalog. Does not remove them. See <<{managing-prefix}date_filtering_options,date filtering options>> below.
 
 |catalog:envlist


### PR DESCRIPTION
#### What does this PR do?
Currently, the Latest Command uses the modified time to determine the order for displaying the latest records which can be confusing since a record with an old modified time may show up out of order even though it is freshly ingested. 
It should be using the new taxonomy Metacard.Modified to show the records in the correct order.

#### Who is reviewing it? 
@Kjames5269 @AzGoalie 

#### Ask 2 committers to review/merge the PR and tag them here.
@emmberk
@ethantmanns 

#### How should this be tested?
Ingest anything. Run catalog:latest and verify the things you ingested show up.
Ingest the following (ingest -t xml) and verify it shows up at the top of the list despite having an older modified date:
```<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<metacard xmlns="urn:catalog:metacard">
    <type>ddf.metacard</type>
    <source>ddf.distribution</source>
    <string name="title">
        <value>sample metacard</value>
    </string>
	<dateTime name="modified">
		<value>2013-08-14T17:20:52.239-07:00</value>
	</dateTime>
</metacard>
```

#### Any background context you want to provide?
Modified means the resource but metacard modified means the metacard specifically. 
That's what we should be checking here. 
#### What are the relevant tickets?
[DDF-4473 The catalog:latest command should be based on the metacards not on the resource](https://codice.atlassian.net/browse/DDF-4473)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
