### PR TITLE
DDF-4480 Add permission for feature install command

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -92,7 +92,7 @@ grant codeBase "file:/org.apache.felix.configadmin" {
     permission org.osgi.framework.BundlePermission "*", "provide, require, host, fragment";
 }
 
-grant codeBase "file:/org.apache.karaf.features.core/sync-installer-impl" {
+grant codeBase "file:/org.apache.karaf.features.core/sync-installer-impl/org.apache.karaf.features.command" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}-", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}examples", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}examples${/}-", "read,write";


### PR DESCRIPTION
#### What does this PR do?
When using the feature install command for a feature that drops a config file in etc, an `AccessControlException` was occurring. This fixes that.
#### Who is reviewing it? 
@ahoffer @tyler30clemens 
#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl 
@emmberk 

#### How should this be tested?
- Install through the UI
- Restart, using the "Restart Now" button
- When the system is back up: `feature:install broker-app`
- Verify the command completes successfully without printing an `AccessControlException` to stdout.
#### Any background context you want to provide?
#### What are the relevant tickets?
[DDF-4480](https://codice.atlassian.net/browse/DDF-4480)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
