### PR TITLE
DDF-04262 Add the ability to set a default list

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.hbs
@@ -39,6 +39,23 @@
         Duplicate
     </div>
 </div>
+
+<div class="interaction interaction-default" data-help="Sets list as default. Causes new searches that contain lists to default to using this list.">
+    <div class="interaction-icon fa fa-star">
+    </div>
+    <div class="interaction-text">
+        Make Default List
+    </div>
+</div>
+
+<div class="interaction interaction-clear" data-help="Clears this list as default. Causes new searches that contain lists to not necessarily default to using this list.">
+    <div class="interaction-icon fa fa-eraser">
+    </div>
+    <div class="interaction-text">
+        Clear Default List
+    </div>
+</div>
+
 {{#each actions}}
 <div class="interaction interaction-action" title="{{title}}" data-help="{{description}}" data-url="{{{url}}}">
     <div class="interaction-icon fa fa-list">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.less
@@ -29,4 +29,17 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  .interaction-clear {
+    display: none;
+  }
+}
+
+@{customElementNamespace}list-interactions.is-default {
+  > .interaction-default {
+    display: none;
+  }
+  > .interaction-clear {
+    display: block;
+  }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.view.js
@@ -122,13 +122,13 @@ module.exports = Marionette.ItemView.extend({
       })
     }
   },
-  triggerMakeDefault: function() {
+  triggerMakeDefault() {
     const prefs = user.get('user').getPreferences()
     prefs.set('defaultListId', this.model.get('id'))
     prefs.savePreferences()
     this.$el.toggleClass('is-default', true)
   },
-  triggerClearDefault: function() {
+  triggerClearDefault() {
     const prefs = user.get('user').getPreferences()
     prefs.set('defaultListId', {})
     prefs.savePreferences()
@@ -140,7 +140,7 @@ module.exports = Marionette.ItemView.extend({
       this.model.get('query').get('result') !== undefined
     )
   },
-  handleDefault: function() {
+  handleDefault() {
     const prefs = user.get('user').getPreferences()
     this.$el.toggleClass(
       'is-default',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.view.js
@@ -17,6 +17,7 @@ const Marionette = require('marionette')
 const template = require('./list-interactions.hbs')
 const CustomElements = require('../../js/CustomElements.js')
 const announcement = require('../../component/announcement')
+const user = require('../../component/singletons/user-instance')
 import fetch from '../../react-component/utils/fetch'
 import saveFile, {
   getFilenameFromContentDisposition,
@@ -32,6 +33,8 @@ module.exports = Marionette.ItemView.extend({
     'click .interaction-delete': 'triggerDelete',
     'click .interaction-duplicate': 'triggerDuplicate',
     'click .interaction-action': 'triggerAction',
+    'click .interaction-default': 'triggerMakeDefault',
+    'click .interaction-clear': 'triggerClearDefault',
     click: 'triggerClick',
   },
   modelEvents: {
@@ -39,6 +42,12 @@ module.exports = Marionette.ItemView.extend({
   },
   onRender() {
     this.handleResult()
+    this.handleDefault()
+    this.listenTo(
+      user.get('user').getPreferences(),
+      'change:defaultListId',
+      this.handleDefault
+    )
   },
   initialize() {
     if (!this.model.get('query').get('result')) {
@@ -113,10 +122,29 @@ module.exports = Marionette.ItemView.extend({
       })
     }
   },
+  triggerMakeDefault: function() {
+    const prefs = user.get('user').getPreferences()
+    prefs.set('defaultListId', this.model.get('id'))
+    prefs.savePreferences()
+    this.$el.toggleClass('is-default', true)
+  },
+  triggerClearDefault: function() {
+    const prefs = user.get('user').getPreferences()
+    prefs.set('defaultListId', {})
+    prefs.savePreferences()
+    this.$el.toggleClass('is-default', false)
+  },
   handleResult() {
     this.$el.toggleClass(
       'has-results',
       this.model.get('query').get('result') !== undefined
+    )
+  },
+  handleDefault: function() {
+    const prefs = user.get('user').getPreferences()
+    this.$el.toggleClass(
+      'is-default',
+      prefs.get('defaultListId') === this.model.get('id')
     )
   },
   triggerClick() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-interactions/list-interactions.view.js
@@ -42,18 +42,18 @@ module.exports = Marionette.ItemView.extend({
   },
   onRender() {
     this.handleResult()
-    this.handleDefault()
-    this.listenTo(
-      user.get('user').getPreferences(),
-      'change:defaultListId',
-      this.handleDefault
-    )
   },
   initialize() {
     if (!this.model.get('query').get('result')) {
       this.startListeningToSearch()
     }
     this.handleResult()
+    this.handleDefault()
+    this.listenTo(
+      user.get('user').getPreferences(),
+      'change:defaultListId',
+      this.handleDefault
+    )
   },
   startListeningToSearch() {
     this.listenToOnce(

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.collection.view.js
@@ -16,10 +16,26 @@
 var Marionette = require('marionette')
 var CustomElements = require('../../js/CustomElements.js')
 var ListItemView = require('./list-item.view')
+const user = require('../../component/singletons/user-instance')
 
 module.exports = Marionette.CollectionView.extend({
   setDefaultCollection: function() {
     this.collection = this.options.workspaceLists
+  },
+  viewComparator: function(list1, list2) {
+    const defaultListId = user
+      .get('user')
+      .getPreferences()
+      .get('defaultListId')
+    if (list1.get('id') === defaultListId) {
+      return -1
+    }
+
+    if (list2.get('id') === defaultListId) {
+      return 1
+    }
+
+    return list1.get('title') < list2.get('title') ? -1 : 1
   },
   tagName: CustomElements.register('list-item-collection'),
   childView: ListItemView,
@@ -27,5 +43,10 @@ module.exports = Marionette.CollectionView.extend({
     if (!options.collection) {
       this.setDefaultCollection()
     }
+    this.listenTo(
+      user.get('user').getPreferences(),
+      'change:defaultListId',
+      this.render
+    )
   },
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.collection.view.js
@@ -22,7 +22,7 @@ module.exports = Marionette.CollectionView.extend({
   setDefaultCollection: function() {
     this.collection = this.options.workspaceLists
   },
-  viewComparator: function(list1, list2) {
+  viewComparator(list1, list2) {
     const defaultListId = user
       .get('user')
       .getPreferences()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.hbs
@@ -22,6 +22,7 @@
             <span class="header-title" data-help="The name you've given to the list.">
                 {{bind selector=".details-header > .header-title" event="change:title" key=(path "title")}}
             </span>
+            <span class="default-icon"><span class="fa fa-star"></span></span>
         </div>
         <div class="details-empty" data-help="Shows the list is empty.">
             Empty

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.less
@@ -111,6 +111,11 @@
   .list-refresh {
     display: none;
   }
+
+  .default-icon {
+    float: right;
+    display: none;
+  }
 }
 
 @{customElementNamespace}list-item.is-out-of-date:not(.is-empty) {
@@ -152,5 +157,11 @@
   }
   .list-run {
     display: none;
+  }
+}
+
+@{customElementNamespace}list-item.is-default {
+  .default-icon {
+    display: block;
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.view.js
@@ -26,6 +26,7 @@ var QueryFeedView = require('../query-feed/query-feed.view.js')
 var ListInteractionsView = require('../list-interactions/list-interactions.view.js')
 var lightboxInstance = require('../lightbox/lightbox.view.instance.js')
 var ListAddTabsView = require('../tabs/list-add/tabs-list-add.view.js')
+const user = require('../../component/singletons/user-instance')
 
 module.exports = Marionette.LayoutView.extend({
   tagName: CustomElements.register('list-item'),
@@ -92,6 +93,12 @@ module.exports = Marionette.LayoutView.extend({
   },
   onRender: function() {
     this.setupFeed()
+    this.handleDefault()
+    this.listenTo(
+      user.get('user').getPreferences(),
+      'change:defaultListId',
+      this.handleDefault
+    )
   },
   setupFeed: function() {
     this.queryFeed.show(
@@ -181,6 +188,13 @@ module.exports = Marionette.LayoutView.extend({
       {
         icon: this.model.getIcon(),
       }
+    )
+  },
+  handleDefault: function() {
+    const prefs = user.get('user').getPreferences()
+    this.$el.toggleClass(
+      'is-default',
+      prefs.get('defaultListId') === this.model.get('id')
     )
   },
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.view.js
@@ -84,6 +84,12 @@ module.exports = Marionette.LayoutView.extend({
     this.listenTo(this.model, 'change:list.bookmarks', this.handleEmptyList)
     this.handleEmptyList()
     this.handleOutOfDate()
+    this.handleDefault()
+    this.listenTo(
+      user.get('user').getPreferences(),
+      'change:defaultListId',
+      this.handleDefault
+    )
   },
   handleOutOfDate: function() {
     this.$el.toggleClass('is-out-of-date', this.model.get('query>isOutdated'))
@@ -93,12 +99,6 @@ module.exports = Marionette.LayoutView.extend({
   },
   onRender: function() {
     this.setupFeed()
-    this.handleDefault()
-    this.listenTo(
-      user.get('user').getPreferences(),
-      'change:defaultListId',
-      this.handleDefault
-    )
   },
   setupFeed: function() {
     this.queryFeed.show(

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.view.js
@@ -190,7 +190,7 @@ module.exports = Marionette.LayoutView.extend({
       }
     )
   },
-  handleDefault: function() {
+  handleDefault() {
     const prefs = user.get('user').getPreferences()
     this.$el.toggleClass(
       'is-default',


### PR DESCRIPTION
Setting the ID of the List to user preferences for the List chosen as default
Adding the 'Make Default List' option to the 3 dot menu of each List
Adding the 'Clear Default List' option to the 3 dot menu of the List set as default
Adding a comparator to the list-item.collection.view to set default List to top of list

<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
This PR adds the ability to set a list as default. The default list will move to the top of the list and have the star icon.

#### Who is reviewing it? 
@Schachte @middlets719 @zta6 @adimka @djblue @bdeining 
#### Select relevant component teams: 
<!--
@codice/ui 
-->
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@bdeining
@djblue

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Install DDF
Open Intrigue.
Open a workspace
Select the Lists tab
Create a few new lists
Verify they are ordered by name
Open the 3 dot menu of a List and select `Make Default List`
Verify the List is moved to the top of the lists and it has the star icon
Open the 3 dot menu of the default list and select `Clear Default List`
Verify the list is ordered by name again and the there is no longer the star icon


#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4262 

#### Screenshots
![image](https://user-images.githubusercontent.com/14877145/51917772-7fa70280-239d-11e9-85d2-0a55970a8047.png)
`ccccc` has been selected as default in the image above.
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
