### PR TITLE
[2.13.x] DDF-04273 Implement DoSFilter

### DIFF
--- a/platform/platform-paxweb-jettyconfig/pom.xml
+++ b/platform/platform-paxweb-jettyconfig/pom.xml
@@ -143,17 +143,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.63</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.56</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/platform-paxweb-jettyconfig/pom.xml
+++ b/platform/platform-paxweb-jettyconfig/pom.xml
@@ -93,6 +93,11 @@
             <version>${spring-osgi.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -138,17 +143,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.65</minimum>
+                                            <minimum>0.70</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.58</minimum>
+                                            <minimum>0.63</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/DelegateServletFilter.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/DelegateServletFilter.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.pax.web.jetty;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.concurrent.CopyOnWriteArraySet;
+import javax.annotation.Nonnull;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link DelegateServletFilter} is meant to detect any {@link Filter}s and doFilter through those
+ * before continuing on its {@link FilterChain}. If no {@link Filter}s are found, it becomes a
+ * pass-through filter.
+ */
+public class DelegateServletFilter implements Filter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DelegateServletFilter.class);
+
+  private CopyOnWriteArraySet<String> keysOfInitializedFilters;
+
+  private FilterConfig filterConfig;
+
+  public DelegateServletFilter() {
+    keysOfInitializedFilters = new CopyOnWriteArraySet<>();
+  }
+
+  BundleContext getContext() {
+    final Bundle bundle = FrameworkUtil.getBundle(DelegateServletFilter.class);
+    if (bundle != null) {
+      return bundle.getBundleContext();
+    }
+    return null;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+    this.filterConfig = filterConfig;
+    // need to (re)initialize every Filter after the DelegateServletFilter is initialized
+    keysOfInitializedFilters.clear();
+  }
+
+  @Override
+  public void destroy() {
+    // do nothing
+  }
+
+  @Override
+  public void doFilter(
+      ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+      throws IOException, ServletException {
+    TreeSet<ServiceReference<Filter>> sortedFilterServiceReferences = null;
+    final BundleContext bundleContext = getContext();
+
+    if (bundleContext == null) {
+      throw new ServletException(
+          "Unable to get BundleContext. No servlet Filters can be applied. Blocking the request processing.");
+    }
+
+    try {
+      sortedFilterServiceReferences =
+          new TreeSet<>(bundleContext.getServiceReferences(Filter.class, null));
+    } catch (InvalidSyntaxException ise) {
+      LOGGER.debug("Should never get this exception as there is no filter being passed.");
+    }
+
+    if (!CollectionUtils.isEmpty(sortedFilterServiceReferences)) {
+      LOGGER.debug("Found {} filter(s), now filtering...", sortedFilterServiceReferences.size());
+      final ProxyFilterChain chain = new ProxyFilterChain(filterChain);
+
+      // Insert the Filters into the chain one at a time (from lowest service ranking
+      // to highest service ranking). The Filter with the highest service-ranking will
+      // end up at index 0 in the FilterChain, which means that the Filters will be
+      // run in order of highest to lowest service ranking.
+      for (ServiceReference<Filter> filterServiceReference : sortedFilterServiceReferences) {
+        final Filter filter = bundleContext.getService(filterServiceReference);
+
+        if (!hasBeenInitialized(filterServiceReference, bundleContext)) {
+          initializeFilter(bundleContext, filterServiceReference, filter);
+        }
+
+        chain.addFilter(filter);
+      }
+
+      chain.doFilter(servletRequest, servletResponse);
+    } else {
+      LOGGER.debug("Did not find any Filters. Acting as a pass-through filter...");
+      filterChain.doFilter(servletRequest, servletResponse);
+    }
+  }
+
+  private boolean hasBeenInitialized(
+      final ServiceReference<Filter> filterServiceReference, final BundleContext bundleContext) {
+    return keysOfInitializedFilters.contains(getFilterKey(filterServiceReference, bundleContext));
+  }
+
+  private void initializeFilter(
+      BundleContext bundleContext, ServiceReference<Filter> filterServiceReference, Filter filter)
+      throws ServletException {
+    final ServletContext servletContext;
+    final String filterName = getFilterName(filterServiceReference, bundleContext);
+
+    if (filterConfig == null) {
+      LOGGER.warn(
+          "DelegateServletFilter was initialized with a null filterConfig. Initializing Filter {} with null ServletContext",
+          filterName);
+      servletContext = null;
+    } else {
+      servletContext = filterConfig.getServletContext();
+    }
+
+    filter.init(new InitFilterConfig(filterServiceReference, servletContext, bundleContext));
+    keysOfInitializedFilters.add(getFilterKey(filterServiceReference, bundleContext));
+    LOGGER.debug("Initialized Filter {}", filterName);
+  }
+
+  public void removeFilter(final ServiceReference<Filter> filterServiceReference) {
+    if (filterServiceReference != null) {
+      final BundleContext bundleContext = getContext();
+
+      if (bundleContext != null) {
+        // unmark the filter as initialized so that it can be re-initialized if the
+        // filter is registered again
+        keysOfInitializedFilters.remove(getFilterKey(filterServiceReference, bundleContext));
+        bundleContext.getService(filterServiceReference).destroy();
+      } else {
+        LOGGER.warn(
+            "Unable to remove Filter. Try restarting the system or turning up logging to monitor current Filters.");
+      }
+    }
+  }
+
+  @Nonnull
+  private static String getFilterKey(
+      final ServiceReference<Filter> filterServiceReference, final BundleContext bundleContext) {
+    return getFilterName(filterServiceReference, bundleContext);
+  }
+
+  /**
+   * This logic to get the filter name from a {@link ServiceReference<Filter>} is copied from {@link
+   * org.ops4j.pax.web.extender.whiteboard.internal.tracker.ServletTracker#createWebElement(ServiceReference,
+   * javax.servlet.Servlet)}. See the pax-web Whiteboard documentation and {@link
+   * org.osgi.service.http.whiteboard.HttpWhiteboardConstants#HTTP_WHITEBOARD_FILTER_NAME} for how
+   * to configure {@link Filter} services with a filter name.
+   */
+  @Nonnull
+  private static String getFilterName(
+      ServiceReference<Filter> filterServiceReference, BundleContext bundleContext) {
+    final String HTTP_WHITEBOARD_FILTER_NAME = "osgi.http.whiteboard.filter.name";
+    final String filterNameFromTheServiceProperty =
+        getStringProperty(filterServiceReference, HTTP_WHITEBOARD_FILTER_NAME);
+    // If this service property is not specified, the fully qualified name of the service object's
+    // class is used as the servlet filter name.
+    if (StringUtils.isBlank(filterNameFromTheServiceProperty)) {
+      return bundleContext.getService(filterServiceReference).getClass().getCanonicalName();
+    } else {
+      return filterNameFromTheServiceProperty;
+    }
+  }
+
+  private static String getStringProperty(ServiceReference<?> serviceReference, String key) {
+    Object value = serviceReference.getProperty(key);
+    if (value != null && !(value instanceof String)) {
+      LOGGER.warn("Service property [key={}] value must be a String", key);
+      return null;
+    } else {
+      return (String) value;
+    }
+  }
+
+  /**
+   * This inner class is used to instantiate a {@link FilterConfig} from a {@link Filter}'s service
+   * properties containing init params and the same {@link ServletContext} as the {@link
+   * DelegateServletFilter}. The {@link FilterConfig} is used to initialize the {@link Filter}.
+   *
+   * <p>The logic of this inner class is copied from the {@link
+   * org.ops4j.pax.web.extender.whiteboard} feature.
+   */
+  private static class InitFilterConfig implements FilterConfig {
+
+    private final ServiceReference<Filter> filterServiceReference;
+
+    private final ServletContext servletContext;
+
+    private final Map<String, String> initParams;
+
+    private final BundleContext bundleContext;
+
+    InitFilterConfig(
+        ServiceReference<Filter> filterServiceReference,
+        ServletContext servletContext,
+        BundleContext bundleContext) {
+      this.filterServiceReference = filterServiceReference;
+      this.servletContext = servletContext;
+      this.bundleContext = bundleContext;
+      initParams = createInitParams();
+    }
+
+    @Override
+    public String getFilterName() {
+      return DelegateServletFilter.getFilterName(filterServiceReference, bundleContext);
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+      return servletContext;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+      return initParams.get(name);
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+      return Collections.enumeration(initParams.keySet());
+    }
+
+    /**
+     * This code to create the init params from a {@link ServiceReference<Filter>} is copied from
+     * {@link
+     * org.ops4j.pax.web.extender.whiteboard.internal.tracker.ServletTracker#createWebElement(ServiceReference,
+     * javax.servlet.Servlet)}. See the pax-web Whiteboard documentation and {@link
+     * org.ops4j.pax.web.extender.whiteboard.ExtenderConstants#PROPERTY_INIT_PREFIX} for how to
+     * configure {@link Filter} services with init params.
+     */
+    private Map<String, String> createInitParams() {
+      String[] initParamKeys = filterServiceReference.getPropertyKeys();
+      final String PROPERTY_INIT_PREFIX = "init-prefix";
+      String initPrefixProp = getStringProperty(filterServiceReference, PROPERTY_INIT_PREFIX);
+      if (initPrefixProp == null) {
+        final String DEFAULT_INIT_PREFIX_PROP = "init.";
+        initPrefixProp = DEFAULT_INIT_PREFIX_PROP;
+      }
+
+      // make all the service parameters available as initParams
+      Map<String, String> initParameters = new HashMap<>();
+      for (String key : initParamKeys) {
+        String value =
+            filterServiceReference.getProperty(key) == null
+                ? ""
+                : filterServiceReference.getProperty(key).toString();
+
+        final String HTTP_WHITEBOARD_SERVLET_INIT_PARAM_PREFIX = "servlet.init.";
+        if (key.startsWith(initPrefixProp)) {
+          initParameters.put(key.replaceFirst(initPrefixProp, ""), value);
+        } else if (key.startsWith(HTTP_WHITEBOARD_SERVLET_INIT_PARAM_PREFIX)) {
+          initParameters.put(
+              key.replaceFirst(HTTP_WHITEBOARD_SERVLET_INIT_PARAM_PREFIX, ""), value);
+        }
+      }
+
+      return initParameters;
+    }
+  }
+}

--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/DelegateServletFilter.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/DelegateServletFilter.java
@@ -14,62 +14,37 @@
 package org.codice.ddf.pax.web.jetty;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.List;
 import javax.annotation.Nullable;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link DelegateServletFilter} is meant to detect any {@link Filter}s and doFilter through those
- * before continuing on its {@link FilterChain}. If no {@link Filter}s are found, it becomes a
- * pass-through filter.
+ * {@link DelegateServletFilter} is meant to pick up any Filters that are exposed as services and
+ * hide their init and destroy methods. This allows us to configure {@link Filter}s in blueprint
+ * without that configuration being overwritten by future calls on the {@link Filter}s init method.
+ * Pax Web should handle the lifecycle of any {@link Filter} services so we don't need to worry
+ * about that here.
  */
 public class DelegateServletFilter implements Filter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DelegateServletFilter.class);
 
-  private final Set<String> keysOfInitializedFilters;
+  private List<Filter> filterList;
 
-  @Nullable
-  private FilterConfig filterConfig;
-
-  public DelegateServletFilter() {
-    keysOfInitializedFilters = new CopyOnWriteArraySet<>();
-  }
-
-  BundleContext getContext() {
-    final Bundle bundle = FrameworkUtil.getBundle(DelegateServletFilter.class);
-    if (bundle != null) {
-      return bundle.getBundleContext();
-    }
-    return null;
+  public DelegateServletFilter(List<Filter> filterList) {
+    this.filterList = filterList;
   }
 
   @Override
   public void init(@Nullable FilterConfig filterConfig) {
-    this.filterConfig = filterConfig;
-    // need to (re)initialize every Filter after the DelegateServletFilter is initialized
-    keysOfInitializedFilters.clear();
+    // do nothing
   }
 
   @Override
@@ -81,36 +56,10 @@ public class DelegateServletFilter implements Filter {
   public void doFilter(
       ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
       throws IOException, ServletException {
-    TreeSet<ServiceReference<Filter>> sortedFilterServiceReferences = null;
-    final BundleContext bundleContext = getContext();
+    if (!filterList.isEmpty()) {
+      ProxyFilterChain chain = new ProxyFilterChain(filterChain);
 
-    if (bundleContext == null) {
-      throw new ServletException(
-          "Unable to get BundleContext. No servlet Filters can be applied. Blocking the request processing.");
-    }
-
-    try {
-      sortedFilterServiceReferences =
-          new TreeSet<>(bundleContext.getServiceReferences(Filter.class, null));
-    } catch (InvalidSyntaxException ise) {
-      LOGGER.debug("Should never get this exception as there is no filter being passed.", ise);
-    }
-
-    if (!CollectionUtils.isEmpty(sortedFilterServiceReferences)) {
-      LOGGER.debug("Found {} filter(s), now filtering...", sortedFilterServiceReferences.size());
-      final ProxyFilterChain chain = new ProxyFilterChain(filterChain);
-
-      // Insert the Filters into the chain one at a time (from lowest service ranking
-      // to highest service ranking). The Filter with the highest service-ranking will
-      // end up at index 0 in the FilterChain, which means that the Filters will be
-      // run in order of highest to lowest service ranking.
-      for (ServiceReference<Filter> filterServiceReference : sortedFilterServiceReferences) {
-        final Filter filter = bundleContext.getService(filterServiceReference);
-
-        if (!hasBeenInitialized(filterServiceReference, bundleContext)) {
-          initializeFilter(bundleContext, filterServiceReference, filter);
-        }
-
+      for (Filter filter : filterList) {
         chain.addFilter(filter);
       }
 
@@ -118,172 +67,6 @@ public class DelegateServletFilter implements Filter {
     } else {
       LOGGER.debug("Did not find any Filters. Acting as a pass-through filter...");
       filterChain.doFilter(servletRequest, servletResponse);
-    }
-  }
-
-  private boolean hasBeenInitialized(
-      final ServiceReference<Filter> filterServiceReference, final BundleContext bundleContext) {
-    return keysOfInitializedFilters.contains(getFilterKey(filterServiceReference, bundleContext));
-  }
-
-  private void initializeFilter(
-      BundleContext bundleContext, ServiceReference<Filter> filterServiceReference, Filter filter)
-      throws ServletException {
-    final ServletContext servletContext;
-    final String filterName = getFilterName(filterServiceReference, bundleContext);
-
-    if (filterConfig == null) {
-      LOGGER.warn(
-          "DelegateServletFilter was initialized with a null filterConfig. Initializing Filter {} with null ServletContext",
-          filterName);
-      servletContext = null;
-    } else {
-      servletContext = filterConfig.getServletContext();
-    }
-
-    filter.init(new InitFilterConfig(filterServiceReference, servletContext, bundleContext));
-    keysOfInitializedFilters.add(getFilterKey(filterServiceReference, bundleContext));
-    LOGGER.debug("Initialized Filter {}", filterName);
-  }
-
-  public void removeFilter(@Nullable final ServiceReference<Filter> filterServiceReference) {
-    if (filterServiceReference != null) {
-      final BundleContext bundleContext = getContext();
-
-      if (bundleContext != null) {
-        // unmark the filter as initialized so that it can be re-initialized if the
-        // filter is registered again
-        keysOfInitializedFilters.remove(getFilterKey(filterServiceReference, bundleContext));
-        bundleContext.getService(filterServiceReference).destroy();
-      } else {
-        LOGGER.warn(
-            "Unable to remove Filter. Try restarting the system or turning up logging to monitor current Filters.");
-      }
-    }
-  }
-
-  private static String getFilterKey(
-      final ServiceReference<Filter> filterServiceReference, final BundleContext bundleContext) {
-    return getFilterName(filterServiceReference, bundleContext);
-  }
-
-  /**
-   * This logic to get the filter name from a {@link ServiceReference<Filter>} is copied from {@link
-   * org.ops4j.pax.web.extender.whiteboard.internal.tracker.ServletTracker#createWebElement(ServiceReference,
-   * javax.servlet.Servlet)}. See the pax-web Whiteboard documentation and {@link
-   * org.osgi.service.http.whiteboard.HttpWhiteboardConstants#HTTP_WHITEBOARD_FILTER_NAME} for how
-   * to configure {@link Filter} services with a filter name.
-   */
-  private static String getFilterName(
-      ServiceReference<Filter> filterServiceReference, BundleContext bundleContext) {
-    final String HTTP_WHITEBOARD_FILTER_NAME = "osgi.http.whiteboard.filter.name";
-    final String filterNameFromTheServiceProperty =
-        getStringProperty(filterServiceReference, HTTP_WHITEBOARD_FILTER_NAME);
-    // If this service property is not specified, the fully qualified name of the service object's
-    // class is used as the servlet filter name.
-    if (StringUtils.isBlank(filterNameFromTheServiceProperty)) {
-      return bundleContext.getService(filterServiceReference).getClass().getCanonicalName();
-    } else {
-      return filterNameFromTheServiceProperty;
-    }
-  }
-
-  @Nullable
-  private static String getStringProperty(ServiceReference<?> serviceReference, String key) {
-    Object value = serviceReference.getProperty(key);
-    if (value != null && !(value instanceof String)) {
-      LOGGER.warn("Service property [key={}] value must be a String", key);
-      return null;
-    } else {
-      return (String) value;
-    }
-  }
-
-  /**
-   * This inner class is used to instantiate a {@link FilterConfig} from a {@link Filter}'s service
-   * properties containing init params and the same {@link ServletContext} as the {@link
-   * DelegateServletFilter}. The {@link FilterConfig} is used to initialize the {@link Filter}.
-   *
-   * <p>The logic of this inner class is copied from the {@link
-   * org.ops4j.pax.web.extender.whiteboard} feature.
-   */
-  private static class InitFilterConfig implements FilterConfig {
-
-    private final String DEFAULT_INIT_PREFIX_PROP = "init.";
-
-    private final String HTTP_WHITEBOARD_SERVLET_INIT_PARAM_PREFIX = "servlet.init.";
-
-    private final String PROPERTY_INIT_PREFIX = "init-prefix";
-
-
-    private final ServiceReference<Filter> filterServiceReference;
-
-    private final ServletContext servletContext;
-
-    private final Map<String, String> initParams;
-
-    private final BundleContext bundleContext;
-
-    InitFilterConfig(
-        ServiceReference<Filter> filterServiceReference,
-        ServletContext servletContext,
-        BundleContext bundleContext) {
-      this.filterServiceReference = filterServiceReference;
-      this.servletContext = servletContext;
-      this.bundleContext = bundleContext;
-      initParams = createInitParams();
-    }
-
-    @Override
-    public String getFilterName() {
-      return DelegateServletFilter.getFilterName(filterServiceReference, bundleContext);
-    }
-
-    @Override
-    public ServletContext getServletContext() {
-      return servletContext;
-    }
-
-    @Override
-    public String getInitParameter(String name) {
-      return initParams.get(name);
-    }
-
-    @Override
-    public Enumeration<String> getInitParameterNames() {
-      return Collections.enumeration(initParams.keySet());
-    }
-
-    /**
-     * This code to create the init params from a {@link ServiceReference<Filter>} is copied from
-     * {@link
-     * org.ops4j.pax.web.extender.whiteboard.internal.tracker.ServletTracker#createWebElement(ServiceReference,
-     * javax.servlet.Servlet)}. See the pax-web Whiteboard documentation and {@link
-     * org.ops4j.pax.web.extender.whiteboard.ExtenderConstants#PROPERTY_INIT_PREFIX} for how to
-     * configure {@link Filter} services with init params.
-     */
-    private Map<String, String> createInitParams() {
-      String[] initParamKeys = filterServiceReference.getPropertyKeys();
-      String initPrefixProp = getStringProperty(filterServiceReference, PROPERTY_INIT_PREFIX);
-      if (initPrefixProp == null) {
-        initPrefixProp = DEFAULT_INIT_PREFIX_PROP;
-      }
-
-      // make all the service parameters available as initParams
-      Map<String, String> initParameters = new HashMap<>();
-      for (String key : initParamKeys) {
-        Object valueObject = filterServiceReference.getProperty(key);
-        String value = valueObject == null ? "" : valueObject.toString();
-
-        if (key.startsWith(initPrefixProp)) {
-          initParameters.put(key.replaceFirst(initPrefixProp, ""), value);
-        } else if (key.startsWith(HTTP_WHITEBOARD_SERVLET_INIT_PARAM_PREFIX)) {
-          initParameters.put(
-              key.replaceFirst(HTTP_WHITEBOARD_SERVLET_INIT_PARAM_PREFIX, ""), value);
-        }
-      }
-
-      return initParameters;
     }
   }
 }

--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/FilterInjector.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/FilterInjector.java
@@ -51,7 +51,7 @@ public class FilterInjector implements EventListenerHook {
 
   private final List<Filter> filterList;
 
-  private final List<Filter> referenceFilterList;
+  private final Filter serviceReferencedFiltersDelegate;
 
   private final ScheduledExecutorService executorService;
 
@@ -63,10 +63,10 @@ public class FilterInjector implements EventListenerHook {
    */
   public FilterInjector(
       List<Filter> filterList,
-      List<Filter> referenceFilterList,
+      Filter serviceReferencedFiltersDelegate,
       ScheduledExecutorService executorService) {
     this.filterList = filterList;
-    this.referenceFilterList = referenceFilterList;
+    this.serviceReferencedFiltersDelegate = serviceReferencedFiltersDelegate;
     this.executorService = executorService;
   }
 
@@ -108,9 +108,8 @@ public class FilterInjector implements EventListenerHook {
       Collection<ServiceReference<ServletContext>> references =
           context.getServiceReferences(ServletContext.class, null);
 
-      List<Filter> allFilterList = new ArrayList<>();
-      allFilterList.addAll(filterList);
-      allFilterList.addAll(referenceFilterList);
+      List<Filter> allFilterList = new ArrayList<>(filterList);
+      allFilterList.add(serviceReferencedFiltersDelegate);
 
       for (ServiceReference<ServletContext> reference : references) {
         Bundle refBundle = reference.getBundle();
@@ -157,9 +156,8 @@ public class FilterInjector implements EventListenerHook {
           "Failed trying to set the cookie config path to /. This can usually be ignored", e);
     }
 
-    List<Filter> allFilterList = new ArrayList<>();
-    allFilterList.addAll(filterList);
-    allFilterList.addAll(referenceFilterList);
+    List<Filter> allFilterList = new ArrayList<>(filterList);
+    allFilterList.add(serviceReferencedFiltersDelegate);
 
     for (Filter filter : allFilterList) {
       try {

--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/JettyAuthenticator.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/JettyAuthenticator.java
@@ -92,7 +92,7 @@ public class JettyAuthenticator extends LoginAuthenticator {
     if (!CollectionUtils.isEmpty(sortedSecurityFilterServiceReferences)) {
       LOGGER.debug(
           "Found {} filter(s), now filtering...", sortedSecurityFilterServiceReferences.size());
-      final ProxyFilterChain chain = new ProxyFilterChain();
+      final ProxySecurityFilterChain chain = new ProxySecurityFilterChain();
 
       // Insert the SecurityFilters into the chain one at a time (from lowest service ranking
       // to highest service ranking). The SecurityFilter with the highest service-ranking will

--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ProxyFilterChain.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ProxyFilterChain.java
@@ -16,6 +16,8 @@ package org.codice.ddf.pax.web.jetty;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.Nullable;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -35,8 +37,9 @@ public class ProxyFilterChain implements FilterChain {
 
   private final FilterChain filterChain;
 
-  private final LinkedList<Filter> filters;
+  private final List<Filter> filters;
 
+  @Nullable
   private Iterator<Filter> iterator;
 
   /**

--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ProxyFilterChain.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ProxyFilterChain.java
@@ -39,8 +39,7 @@ public class ProxyFilterChain implements FilterChain {
 
   private final List<Filter> filters;
 
-  @Nullable
-  private Iterator<Filter> iterator;
+  @Nullable private Iterator<Filter> iterator;
 
   /**
    * Creates a new ProxyFilterChain with the specified filter chain included.

--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ProxySecurityFilterChain.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ProxySecurityFilterChain.java
@@ -20,7 +20,6 @@ import java.util.List;
 import javax.annotation.Nullable;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.validation.constraints.Null;
 import org.codice.ddf.platform.filter.AuthenticationException;
 import org.codice.ddf.platform.filter.FilterChain;
 import org.codice.ddf.platform.filter.SecurityFilter;
@@ -39,8 +38,7 @@ public class ProxySecurityFilterChain implements FilterChain {
 
   private final List<SecurityFilter> filters;
 
-  @Nullable
-  private Iterator<SecurityFilter> iterator;
+  @Nullable private Iterator<SecurityFilter> iterator;
 
   /** Creates a new ProxySecurityFilterChain */
   public ProxySecurityFilterChain() {

--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ProxySecurityFilterChain.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ProxySecurityFilterChain.java
@@ -16,8 +16,11 @@ package org.codice.ddf.pax.web.jetty;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.Nullable;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.validation.constraints.Null;
 import org.codice.ddf.platform.filter.AuthenticationException;
 import org.codice.ddf.platform.filter.FilterChain;
 import org.codice.ddf.platform.filter.SecurityFilter;
@@ -34,8 +37,9 @@ public class ProxySecurityFilterChain implements FilterChain {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProxySecurityFilterChain.class);
 
-  private final LinkedList<SecurityFilter> filters;
+  private final List<SecurityFilter> filters;
 
+  @Nullable
   private Iterator<SecurityFilter> iterator;
 
   /** Creates a new ProxySecurityFilterChain */

--- a/platform/platform-paxweb-jettyconfig/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-paxweb-jettyconfig/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,6 +23,8 @@
         <argument ref="securityJavaSubjectThreadFactory"/>
     </bean>
 
+    <bean id="serviceReferencedFiltersDelegate" class="org.codice.ddf.pax.web.jetty.DelegateServletFilter" />
+
     <bean id="filterInjector" class="org.codice.ddf.pax.web.jetty.FilterInjector" init-method="init"
           destroy-method="destroy">
         <argument type="java.util.List">
@@ -63,7 +65,7 @@
                 <bean class="org.codice.ddf.pax.web.jetty.SecurityJavaSubjectFilter"/>
             </list>
         </argument>
-        <argument ref="filterList" />
+        <argument ref="serviceReferencedFiltersDelegate" />
         <argument ref="executor"/>
     </bean>
 
@@ -75,6 +77,16 @@
 
     <service interface="org.osgi.framework.hooks.service.EventListenerHook" ref="filterInjector"/>
 
-    <reference-list id="filterList" availability="optional" interface="javax.servlet.Filter" />
+    <service id="DoSFilter" interface="javax.servlet.Filter" ranking="100">
+        <service-properties>
+            <entry key="filter-name" value="DoSFilter"/>
+            <entry key="urlPatterns" value="/*"/>
+            <entry key="init.maxRequestsPerSec" value="1000"/>
+            <entry key="init.delayMs" value="-1" />
+            <entry key="init.enabled" value="true" />
+            <entry key="init.ipWhitelist" value="127.0.0.1,0:0:0:0:0:0:0:1" />
+        </service-properties>
+        <bean class="org.eclipse.jetty.servlets.DoSFilter"/>
+    </service>
 
 </blueprint>

--- a/platform/platform-paxweb-jettyconfig/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/platform-paxweb-jettyconfig/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,11 @@
         <argument ref="securityJavaSubjectThreadFactory"/>
     </bean>
 
-    <bean id="serviceReferencedFiltersDelegate" class="org.codice.ddf.pax.web.jetty.DelegateServletFilter" />
+    <bean id="delegateServletFilter" class="org.codice.ddf.pax.web.jetty.DelegateServletFilter" >
+        <argument ref="filterList" />
+    </bean>
+
+    <reference-list id="filterList" availability="optional" interface="javax.servlet.Filter" />
 
     <bean id="filterInjector" class="org.codice.ddf.pax.web.jetty.FilterInjector" init-method="init"
           destroy-method="destroy">
@@ -65,7 +69,7 @@
                 <bean class="org.codice.ddf.pax.web.jetty.SecurityJavaSubjectFilter"/>
             </list>
         </argument>
-        <argument ref="serviceReferencedFiltersDelegate" />
+        <argument ref="delegateServletFilter" />
         <argument ref="executor"/>
     </bean>
 
@@ -77,14 +81,14 @@
 
     <service interface="org.osgi.framework.hooks.service.EventListenerHook" ref="filterInjector"/>
 
-    <service id="DoSFilter" interface="javax.servlet.Filter" ranking="100">
+    <service id="doSFilter" interface="javax.servlet.Filter" ranking="100">
         <service-properties>
             <entry key="filter-name" value="DoSFilter"/>
             <entry key="urlPatterns" value="/*"/>
-            <entry key="init.maxRequestsPerSec" value="1000"/>
-            <entry key="init.delayMs" value="-1" />
-            <entry key="init.enabled" value="true" />
-            <entry key="init.ipWhitelist" value="127.0.0.1,0:0:0:0:0:0:0:1" />
+            <entry key="maxRequestsPerSec" value="1000"/>
+            <entry key="delayMs" value="-1" />
+            <entry key="enabled" value="true" />
+            <entry key="ipWhitelist" value="127.0.0.1,0:0:0:0:0:0:0:1" />
         </service-properties>
         <bean class="org.eclipse.jetty.servlets.DoSFilter"/>
     </service>

--- a/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/DelegateServletFilterTest.java
+++ b/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/DelegateServletFilterTest.java
@@ -1,0 +1,387 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.pax.web.jetty;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Set;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.springframework.osgi.mock.MockServiceReference;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DelegateServletFilterTest {
+
+  private DelegateServletFilter delegateServletFilter;
+
+  @Mock private BundleContext bundleContext;
+
+  private Set<ServiceReference<Filter>> registeredFilterServiceReferences;
+
+  @Before
+  public void setup() throws InvalidSyntaxException {
+    registeredFilterServiceReferences = new HashSet<>();
+    bundleContext = mock(BundleContext.class);
+    when(bundleContext.getServiceReferences(Filter.class, null))
+        .thenReturn(registeredFilterServiceReferences);
+
+    delegateServletFilter =
+        new DelegateServletFilter() {
+          @Override
+          protected BundleContext getContext() {
+            return bundleContext;
+          }
+        };
+  }
+
+  @Test
+  public void testInit() throws ServletException {
+    delegateServletFilter.init(mock(FilterConfig.class));
+  }
+
+  @Test
+  public void testDestroy() {
+    delegateServletFilter.destroy();
+  }
+
+  @Test
+  public void testDoFilterWithFilter() throws IOException, ServletException {
+    // given
+    final FilterConfig filterConfig = mock(FilterConfig.class);
+    final ServletContext servletContext = mock(ServletContext.class);
+    when(filterConfig.getServletContext()).thenReturn(servletContext);
+    delegateServletFilter.init(filterConfig);
+
+    final Filter filter = registerFilter(new Hashtable());
+
+    final ServletRequest servletRequest = mock(ServletRequest.class);
+    final ServletResponse servletResponse = mock(ServletResponse.class);
+    final FilterChain filterChain = mock(FilterChain.class);
+
+    // when
+    delegateServletFilter.doFilter(servletRequest, servletResponse, filterChain);
+
+    // then
+    final InOrder inOrder = Mockito.inOrder(filter, filterChain);
+
+    final ArgumentCaptor<FilterConfig> argument = ArgumentCaptor.forClass(FilterConfig.class);
+    inOrder.verify(filter).init(argument.capture());
+    final FilterConfig filterConfigInitArg = argument.getValue();
+    assertThat(filterConfigInitArg.getServletContext(), is(servletContext));
+
+    inOrder
+        .verify(filter)
+        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
+    inOrder.verify(filterChain).doFilter(servletRequest, servletResponse);
+  }
+
+  @Test
+  public void testDoFilterWithNoFilters() throws IOException, ServletException {
+    // given
+    delegateServletFilter.init(mock(FilterConfig.class));
+
+    final ServletRequest servletRequest = mock(ServletRequest.class);
+    final ServletResponse servletResponse = mock(ServletResponse.class);
+    final FilterChain filterChain = mock(FilterChain.class);
+
+    // when
+    delegateServletFilter.doFilter(servletRequest, servletResponse, filterChain);
+
+    // then
+    verify(filterChain).doFilter(servletRequest, servletResponse);
+  }
+
+  /**
+   * The {@link javax.servlet.Filter#init(FilterConfig)} javadoc does not specify that the {@link
+   * FilterConfig} argument may not be null. This test confirms that there are no errors when
+   * initializing the {@link Filter}s and filtering if this situation occurs.
+   */
+  @Test
+  public void testDoFilterAfterInitDelegateServletFilterWithNullFilterConfig()
+      throws ServletException, IOException {
+    // given
+    delegateServletFilter.init(null);
+
+    final Filter filter = registerFilter(new Hashtable());
+
+    final ServletRequest servletRequest = mock(ServletRequest.class);
+    final ServletResponse servletResponse = mock(ServletResponse.class);
+    final FilterChain filterChain = mock(FilterChain.class);
+
+    // when
+    delegateServletFilter.doFilter(servletRequest, servletResponse, filterChain);
+
+    // then
+    final InOrder inOrder = Mockito.inOrder(filter, filterChain);
+
+    final ArgumentCaptor<FilterConfig> argument = ArgumentCaptor.forClass(FilterConfig.class);
+    inOrder.verify(filter).init(argument.capture());
+    final FilterConfig filterConfigInitArg = argument.getValue();
+    assertThat(filterConfigInitArg.getServletContext(), is(nullValue(ServletContext.class)));
+
+    inOrder
+        .verify(filter)
+        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
+    inOrder.verify(filterChain).doFilter(servletRequest, servletResponse);
+  }
+
+  @Test
+  public void testFiltersOnlyInitializedOnce() throws IOException, ServletException {
+    // given
+    delegateServletFilter.init(mock(FilterConfig.class));
+
+    final Dictionary dictionary1 = new Hashtable();
+    dictionary1.put("osgi.http.whiteboard.filter.name", "filter1");
+    final Filter filter1 = registerFilter(dictionary1);
+
+    delegateServletFilter.doFilter(
+        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
+
+    final Dictionary dictionary2 = new Hashtable();
+    dictionary2.put("osgi.http.whiteboard.filter.name", "filter2");
+    final Filter filter2 = registerFilter(dictionary2);
+
+    delegateServletFilter.doFilter(
+        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
+    delegateServletFilter.doFilter(
+        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
+    delegateServletFilter.doFilter(
+        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
+
+    final Dictionary dictionary3 = new Hashtable();
+    dictionary3.put("osgi.http.whiteboard.filter.name", "filter3");
+    final Filter filter3 = registerFilter(dictionary3);
+
+    delegateServletFilter.doFilter(
+        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
+
+    // when
+    verify(filter1).init(any(FilterConfig.class));
+    verify(filter2).init(any(FilterConfig.class));
+    verify(filter3).init(any(FilterConfig.class));
+  }
+
+  @Test
+  public void testInitializeFilter() throws ServletException, IOException {
+    // given
+    final FilterConfig filterConfig = mock(FilterConfig.class);
+    final ServletContext servletContext = mock(ServletContext.class);
+    when(filterConfig.getServletContext()).thenReturn(servletContext);
+    delegateServletFilter.init(filterConfig);
+
+    final Dictionary dictionary = new Hashtable();
+    final String filterNameValue = "my-test-filter";
+    dictionary.put("osgi.http.whiteboard.filter.name", filterNameValue);
+    final String param1Key = "param1Key";
+    final String param1Value = "param1Value";
+    dictionary.put("init." + param1Key, param1Value);
+    final String param2Key = "param2Key";
+    final String param2Value = "param2Value";
+    dictionary.put("init." + param2Key, param2Value);
+    final Filter filter = registerFilter(dictionary);
+
+    // when
+    delegateServletFilter.doFilter(
+        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
+
+    // then
+    final ArgumentCaptor<FilterConfig> argument = ArgumentCaptor.forClass(FilterConfig.class);
+    verify(filter).init(argument.capture());
+    final FilterConfig filterConfigInitArg = argument.getValue();
+    assertThat(filterConfigInitArg.getFilterName(), is(filterNameValue));
+    assertThat(filterConfigInitArg.getServletContext(), is(servletContext));
+    assertThat(filterConfigInitArg.getInitParameter(param1Key), is(param1Value));
+    assertThat(filterConfigInitArg.getInitParameter(param2Key), is(param2Value));
+    assertThat(filterConfigInitArg.getInitParameter("notAnInitPropertyKey"), nullValue());
+    final List<String> initParamNames =
+        Collections.list(filterConfigInitArg.getInitParameterNames());
+    assertThat(initParamNames, hasSize(2));
+    assertThat(initParamNames, containsInAnyOrder(param1Key, param2Key));
+  }
+
+  /**
+   * This method tests some edge cases of adding {@link Filter}s through {@link ServiceReference}s.
+   * Filter names must have service-property key="{@link
+   * org.osgi.service.http.whiteboard.HttpWhiteboardConstants#HTTP_WHITEBOARD_FILTER_NAME}", so the
+   * service-property with key="filter-name" will not be used to init the {@link
+   * javax.servlet.Filter}. The init param service-property prefix may be defined using the {@link
+   * org.ops4j.pax.web.extender.whiteboard.ExtenderConstants#PROPERTY_INIT_PREFIX} service-property
+   * key.
+   */
+  @Test
+  public void testInitializeFilterWithComplicatedInitParams() throws ServletException, IOException {
+    // given
+    final FilterConfig filterConfig = mock(FilterConfig.class);
+    final ServletContext servletContext = mock(ServletContext.class);
+    when(filterConfig.getServletContext()).thenReturn(servletContext);
+    delegateServletFilter.init(filterConfig);
+
+    final Dictionary dictionary = new Hashtable();
+    dictionary.put("filter-name", "my-test-filter");
+    final String incorrectlyFormattedInitParamKey = "incorrectlyFormattedInitParamKey";
+    dictionary.put(
+        "init." + incorrectlyFormattedInitParamKey, "incorrectlyFormattedInitParamValue");
+    final String customInitPrefix = "myInitPrefix.";
+    dictionary.put("init-prefix", customInitPrefix);
+    final String initParamKey = "initParamKey";
+    final String initParamValue = "initParamValue";
+    dictionary.put(customInitPrefix + initParamKey, initParamValue);
+    final String servletInitParamKey = "servletInitParamKey";
+    final String servletInitParamValue = "servletInitParamValue";
+    dictionary.put("servlet.init." + servletInitParamKey, servletInitParamValue);
+    final String anotherServiceProperty = "anotherServiceProperty";
+    dictionary.put(anotherServiceProperty, "anotherServicePropertyValue");
+    final Filter filter = registerFilter(dictionary);
+
+    // when
+    delegateServletFilter.doFilter(
+        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
+
+    // then
+    final ArgumentCaptor<FilterConfig> argument = ArgumentCaptor.forClass(FilterConfig.class);
+    verify(filter).init(argument.capture());
+    final FilterConfig filterConfigInitArg = argument.getValue();
+    assertThat(filterConfigInitArg.getFilterName(), is(filter.getClass().getCanonicalName()));
+    assertThat(filterConfigInitArg.getServletContext(), is(servletContext));
+    assertThat(filterConfigInitArg.getInitParameter(incorrectlyFormattedInitParamKey), nullValue());
+    assertThat(filterConfigInitArg.getInitParameter(initParamKey), is(initParamValue));
+    assertThat(
+        filterConfigInitArg.getInitParameter(servletInitParamKey), is(servletInitParamValue));
+    assertThat(filterConfigInitArg.getInitParameter(anotherServiceProperty), nullValue());
+    final List<String> initParamNames =
+        Collections.list(filterConfigInitArg.getInitParameterNames());
+    assertThat(initParamNames, hasSize(2));
+    assertThat(initParamNames, containsInAnyOrder(initParamKey, servletInitParamKey));
+  }
+
+  @Test
+  public void testRemoveFilter() {
+    // given
+    final Filter filter = mock(Filter.class);
+    final MockServiceReference filterServiceReference = new MockServiceReference();
+    filterServiceReference.setProperties(new Hashtable());
+    when(bundleContext.getService(filterServiceReference)).thenReturn(filter);
+    registeredFilterServiceReferences.add(filterServiceReference);
+
+    // when
+    delegateServletFilter.removeFilter(filterServiceReference);
+
+    // then
+    verify(filter).destroy();
+  }
+
+  @Test
+  public void testRemoveNullFilter() {
+    delegateServletFilter.removeFilter(null);
+  }
+
+  @Test
+  public void testDoFilterWithFiltersInCorrectOrder() throws IOException, ServletException {
+    // given
+    delegateServletFilter.init(mock(FilterConfig.class));
+
+    final Dictionary dictionary0 = new Hashtable();
+    dictionary0.put(Constants.SERVICE_RANKING, 0);
+    final Filter filter0 = registerFilter(dictionary0);
+
+    final Dictionary dictionary100 = new Hashtable();
+    dictionary100.put(Constants.SERVICE_RANKING, 100);
+    final Filter filter100 = registerFilter(dictionary100);
+
+    final Dictionary dictionary1 = new Hashtable();
+    dictionary1.put(Constants.SERVICE_RANKING, 1);
+    final Filter filter1 = registerFilter(dictionary1);
+
+    final Filter filter = registerFilter(new Hashtable());
+
+    final Dictionary dictionary99 = new Hashtable();
+    dictionary99.put(Constants.SERVICE_RANKING, 99);
+    final Filter filter99 = registerFilter(dictionary99);
+
+    final ServletRequest servletRequest = mock(ServletRequest.class);
+    final ServletResponse servletResponse = mock(ServletResponse.class);
+
+    // when
+    delegateServletFilter.doFilter(servletRequest, servletResponse, mock(FilterChain.class));
+
+    // then
+    final InOrder inOrder = Mockito.inOrder(filter0, filter100, filter1, filter, filter99);
+    inOrder
+        .verify(filter100)
+        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
+    inOrder
+        .verify(filter99)
+        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
+    inOrder
+        .verify(filter1)
+        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
+    inOrder
+        .verify(filter0)
+        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
+    inOrder
+        .verify(filter)
+        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
+  }
+
+  private Filter registerFilter(Dictionary serviceProperties) throws IOException, ServletException {
+    final Filter filter = mock(Filter.class);
+    Mockito.doAnswer(
+            invocation -> {
+              Object[] args = invocation.getArguments();
+              ((FilterChain) args[2])
+                  .doFilter(((ServletRequest) args[0]), ((ServletResponse) args[1]));
+              return null;
+            })
+        .when(filter)
+        .doFilter(any(ServletRequest.class), any(ServletResponse.class), any(FilterChain.class));
+
+    final MockServiceReference filterServiceReference = new MockServiceReference();
+    filterServiceReference.setProperties(serviceProperties);
+    when(bundleContext.getService(filterServiceReference)).thenReturn(filter);
+    registeredFilterServiceReferences.add(filterServiceReference);
+    return filter;
+  }
+}

--- a/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/DelegateServletFilterTest.java
+++ b/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/DelegateServletFilterTest.java
@@ -13,72 +13,39 @@
  */
 package org.codice.ddf.pax.web.jetty;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Dictionary;
-import java.util.HashSet;
-import java.util.Hashtable;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
-import org.springframework.osgi.mock.MockServiceReference;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DelegateServletFilterTest {
 
   private DelegateServletFilter delegateServletFilter;
 
-  @Mock private BundleContext bundleContext;
-
-  private Set<ServiceReference<Filter>> registeredFilterServiceReferences;
-
   @Before
-  public void setup() throws InvalidSyntaxException {
-    registeredFilterServiceReferences = new HashSet<>();
-    bundleContext = mock(BundleContext.class);
-    when(bundleContext.getServiceReferences(Filter.class, null))
-        .thenReturn(registeredFilterServiceReferences);
-
-    delegateServletFilter =
-        new DelegateServletFilter() {
-          @Override
-          protected BundleContext getContext() {
-            return bundleContext;
-          }
-        };
+  public void setup() {
+    delegateServletFilter = new DelegateServletFilter(new ArrayList<>());
   }
 
   @Test
-  public void testInit() throws ServletException {
+  public void testInit() {
     delegateServletFilter.init(mock(FilterConfig.class));
   }
 
@@ -89,13 +56,10 @@ public class DelegateServletFilterTest {
 
   @Test
   public void testDoFilterWithFilter() throws IOException, ServletException {
-    // given
-    final FilterConfig filterConfig = mock(FilterConfig.class);
-    final ServletContext servletContext = mock(ServletContext.class);
-    when(filterConfig.getServletContext()).thenReturn(servletContext);
-    delegateServletFilter.init(filterConfig);
-
-    final Filter filter = registerFilter(new Hashtable());
+    List<Filter> filterList = new ArrayList<>();
+    Filter filter = makeFilter();
+    filterList.add(filter);
+    delegateServletFilter = new DelegateServletFilter(filterList);
 
     final ServletRequest servletRequest = mock(ServletRequest.class);
     final ServletResponse servletResponse = mock(ServletResponse.class);
@@ -107,11 +71,6 @@ public class DelegateServletFilterTest {
     // then
     final InOrder inOrder = Mockito.inOrder(filter, filterChain);
 
-    final ArgumentCaptor<FilterConfig> argument = ArgumentCaptor.forClass(FilterConfig.class);
-    inOrder.verify(filter).init(argument.capture());
-    final FilterConfig filterConfigInitArg = argument.getValue();
-    assertThat(filterConfigInitArg.getServletContext(), is(servletContext));
-
     inOrder
         .verify(filter)
         .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
@@ -120,8 +79,6 @@ public class DelegateServletFilterTest {
 
   @Test
   public void testDoFilterWithNoFilters() throws IOException, ServletException {
-    // given
-    delegateServletFilter.init(mock(FilterConfig.class));
 
     final ServletRequest servletRequest = mock(ServletRequest.class);
     final ServletResponse servletResponse = mock(ServletResponse.class);
@@ -134,239 +91,7 @@ public class DelegateServletFilterTest {
     verify(filterChain).doFilter(servletRequest, servletResponse);
   }
 
-  /**
-   * The {@link javax.servlet.Filter#init(FilterConfig)} javadoc does not specify that the {@link
-   * FilterConfig} argument may not be null. This test confirms that there are no errors when
-   * initializing the {@link Filter}s and filtering if this situation occurs.
-   */
-  @Test
-  public void testDoFilterAfterInitDelegateServletFilterWithNullFilterConfig()
-      throws ServletException, IOException {
-    // given
-    delegateServletFilter.init(null);
-
-    final Filter filter = registerFilter(new Hashtable());
-
-    final ServletRequest servletRequest = mock(ServletRequest.class);
-    final ServletResponse servletResponse = mock(ServletResponse.class);
-    final FilterChain filterChain = mock(FilterChain.class);
-
-    // when
-    delegateServletFilter.doFilter(servletRequest, servletResponse, filterChain);
-
-    // then
-    final InOrder inOrder = Mockito.inOrder(filter, filterChain);
-
-    final ArgumentCaptor<FilterConfig> argument = ArgumentCaptor.forClass(FilterConfig.class);
-    inOrder.verify(filter).init(argument.capture());
-    final FilterConfig filterConfigInitArg = argument.getValue();
-    assertThat(filterConfigInitArg.getServletContext(), is(nullValue(ServletContext.class)));
-
-    inOrder
-        .verify(filter)
-        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
-    inOrder.verify(filterChain).doFilter(servletRequest, servletResponse);
-  }
-
-  @Test
-  public void testFiltersOnlyInitializedOnce() throws IOException, ServletException {
-    // given
-    delegateServletFilter.init(mock(FilterConfig.class));
-
-    final Dictionary dictionary1 = new Hashtable();
-    dictionary1.put("osgi.http.whiteboard.filter.name", "filter1");
-    final Filter filter1 = registerFilter(dictionary1);
-
-    delegateServletFilter.doFilter(
-        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
-
-    final Dictionary dictionary2 = new Hashtable();
-    dictionary2.put("osgi.http.whiteboard.filter.name", "filter2");
-    final Filter filter2 = registerFilter(dictionary2);
-
-    delegateServletFilter.doFilter(
-        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
-    delegateServletFilter.doFilter(
-        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
-    delegateServletFilter.doFilter(
-        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
-
-    final Dictionary dictionary3 = new Hashtable();
-    dictionary3.put("osgi.http.whiteboard.filter.name", "filter3");
-    final Filter filter3 = registerFilter(dictionary3);
-
-    delegateServletFilter.doFilter(
-        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
-
-    // when
-    verify(filter1).init(any(FilterConfig.class));
-    verify(filter2).init(any(FilterConfig.class));
-    verify(filter3).init(any(FilterConfig.class));
-  }
-
-  @Test
-  public void testInitializeFilter() throws ServletException, IOException {
-    // given
-    final FilterConfig filterConfig = mock(FilterConfig.class);
-    final ServletContext servletContext = mock(ServletContext.class);
-    when(filterConfig.getServletContext()).thenReturn(servletContext);
-    delegateServletFilter.init(filterConfig);
-
-    final Dictionary dictionary = new Hashtable();
-    final String filterNameValue = "my-test-filter";
-    dictionary.put("osgi.http.whiteboard.filter.name", filterNameValue);
-    final String param1Key = "param1Key";
-    final String param1Value = "param1Value";
-    dictionary.put("init." + param1Key, param1Value);
-    final String param2Key = "param2Key";
-    final String param2Value = "param2Value";
-    dictionary.put("init." + param2Key, param2Value);
-    final Filter filter = registerFilter(dictionary);
-
-    // when
-    delegateServletFilter.doFilter(
-        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
-
-    // then
-    final ArgumentCaptor<FilterConfig> argument = ArgumentCaptor.forClass(FilterConfig.class);
-    verify(filter).init(argument.capture());
-    final FilterConfig filterConfigInitArg = argument.getValue();
-    assertThat(filterConfigInitArg.getFilterName(), is(filterNameValue));
-    assertThat(filterConfigInitArg.getServletContext(), is(servletContext));
-    assertThat(filterConfigInitArg.getInitParameter(param1Key), is(param1Value));
-    assertThat(filterConfigInitArg.getInitParameter(param2Key), is(param2Value));
-    assertThat(filterConfigInitArg.getInitParameter("notAnInitPropertyKey"), nullValue());
-    final List<String> initParamNames =
-        Collections.list(filterConfigInitArg.getInitParameterNames());
-    assertThat(initParamNames, hasSize(2));
-    assertThat(initParamNames, containsInAnyOrder(param1Key, param2Key));
-  }
-
-  /**
-   * This method tests some edge cases of adding {@link Filter}s through {@link ServiceReference}s.
-   * Filter names must have service-property key="{@link
-   * org.osgi.service.http.whiteboard.HttpWhiteboardConstants#HTTP_WHITEBOARD_FILTER_NAME}", so the
-   * service-property with key="filter-name" will not be used to init the {@link
-   * javax.servlet.Filter}. The init param service-property prefix may be defined using the {@link
-   * org.ops4j.pax.web.extender.whiteboard.ExtenderConstants#PROPERTY_INIT_PREFIX} service-property
-   * key.
-   */
-  @Test
-  public void testInitializeFilterWithComplicatedInitParams() throws ServletException, IOException {
-    // given
-    final FilterConfig filterConfig = mock(FilterConfig.class);
-    final ServletContext servletContext = mock(ServletContext.class);
-    when(filterConfig.getServletContext()).thenReturn(servletContext);
-    delegateServletFilter.init(filterConfig);
-
-    final Dictionary dictionary = new Hashtable();
-    dictionary.put("filter-name", "my-test-filter");
-    final String incorrectlyFormattedInitParamKey = "incorrectlyFormattedInitParamKey";
-    dictionary.put(
-        "init." + incorrectlyFormattedInitParamKey, "incorrectlyFormattedInitParamValue");
-    final String customInitPrefix = "myInitPrefix.";
-    dictionary.put("init-prefix", customInitPrefix);
-    final String initParamKey = "initParamKey";
-    final String initParamValue = "initParamValue";
-    dictionary.put(customInitPrefix + initParamKey, initParamValue);
-    final String servletInitParamKey = "servletInitParamKey";
-    final String servletInitParamValue = "servletInitParamValue";
-    dictionary.put("servlet.init." + servletInitParamKey, servletInitParamValue);
-    final String anotherServiceProperty = "anotherServiceProperty";
-    dictionary.put(anotherServiceProperty, "anotherServicePropertyValue");
-    final Filter filter = registerFilter(dictionary);
-
-    // when
-    delegateServletFilter.doFilter(
-        mock(ServletRequest.class), mock(ServletResponse.class), mock(FilterChain.class));
-
-    // then
-    final ArgumentCaptor<FilterConfig> argument = ArgumentCaptor.forClass(FilterConfig.class);
-    verify(filter).init(argument.capture());
-    final FilterConfig filterConfigInitArg = argument.getValue();
-    assertThat(filterConfigInitArg.getFilterName(), is(filter.getClass().getCanonicalName()));
-    assertThat(filterConfigInitArg.getServletContext(), is(servletContext));
-    assertThat(filterConfigInitArg.getInitParameter(incorrectlyFormattedInitParamKey), nullValue());
-    assertThat(filterConfigInitArg.getInitParameter(initParamKey), is(initParamValue));
-    assertThat(
-        filterConfigInitArg.getInitParameter(servletInitParamKey), is(servletInitParamValue));
-    assertThat(filterConfigInitArg.getInitParameter(anotherServiceProperty), nullValue());
-    final List<String> initParamNames =
-        Collections.list(filterConfigInitArg.getInitParameterNames());
-    assertThat(initParamNames, hasSize(2));
-    assertThat(initParamNames, containsInAnyOrder(initParamKey, servletInitParamKey));
-  }
-
-  @Test
-  public void testRemoveFilter() {
-    // given
-    final Filter filter = mock(Filter.class);
-    final MockServiceReference filterServiceReference = new MockServiceReference();
-    filterServiceReference.setProperties(new Hashtable());
-    when(bundleContext.getService(filterServiceReference)).thenReturn(filter);
-    registeredFilterServiceReferences.add(filterServiceReference);
-
-    // when
-    delegateServletFilter.removeFilter(filterServiceReference);
-
-    // then
-    verify(filter).destroy();
-  }
-
-  @Test
-  public void testRemoveNullFilter() {
-    delegateServletFilter.removeFilter(null);
-  }
-
-  @Test
-  public void testDoFilterWithFiltersInCorrectOrder() throws IOException, ServletException {
-    // given
-    delegateServletFilter.init(mock(FilterConfig.class));
-
-    final Dictionary dictionary0 = new Hashtable();
-    dictionary0.put(Constants.SERVICE_RANKING, 0);
-    final Filter filter0 = registerFilter(dictionary0);
-
-    final Dictionary dictionary100 = new Hashtable();
-    dictionary100.put(Constants.SERVICE_RANKING, 100);
-    final Filter filter100 = registerFilter(dictionary100);
-
-    final Dictionary dictionary1 = new Hashtable();
-    dictionary1.put(Constants.SERVICE_RANKING, 1);
-    final Filter filter1 = registerFilter(dictionary1);
-
-    final Filter filter = registerFilter(new Hashtable());
-
-    final Dictionary dictionary99 = new Hashtable();
-    dictionary99.put(Constants.SERVICE_RANKING, 99);
-    final Filter filter99 = registerFilter(dictionary99);
-
-    final ServletRequest servletRequest = mock(ServletRequest.class);
-    final ServletResponse servletResponse = mock(ServletResponse.class);
-
-    // when
-    delegateServletFilter.doFilter(servletRequest, servletResponse, mock(FilterChain.class));
-
-    // then
-    final InOrder inOrder = Mockito.inOrder(filter0, filter100, filter1, filter, filter99);
-    inOrder
-        .verify(filter100)
-        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
-    inOrder
-        .verify(filter99)
-        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
-    inOrder
-        .verify(filter1)
-        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
-    inOrder
-        .verify(filter0)
-        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
-    inOrder
-        .verify(filter)
-        .doFilter(eq(servletRequest), eq(servletResponse), any(FilterChain.class));
-  }
-
-  private Filter registerFilter(Dictionary serviceProperties) throws IOException, ServletException {
+  private Filter makeFilter() throws IOException, ServletException {
     final Filter filter = mock(Filter.class);
     Mockito.doAnswer(
             invocation -> {
@@ -378,10 +103,6 @@ public class DelegateServletFilterTest {
         .when(filter)
         .doFilter(any(ServletRequest.class), any(ServletResponse.class), any(FilterChain.class));
 
-    final MockServiceReference filterServiceReference = new MockServiceReference();
-    filterServiceReference.setProperties(serviceProperties);
-    when(bundleContext.getService(filterServiceReference)).thenReturn(filter);
-    registeredFilterServiceReferences.add(filterServiceReference);
     return filter;
   }
 }

--- a/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/FilterInjectorTest.java
+++ b/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/FilterInjectorTest.java
@@ -59,7 +59,7 @@ public class FilterInjectorTest {
     ResponseFilter responseFilter = mock(ResponseFilter.class);
     executorService = mock(ScheduledExecutorService.class);
     FilterInjector injector =
-        new FilterInjector(Arrays.asList(filter), Arrays.asList(responseFilter), executorService);
+        new FilterInjector(Arrays.asList(filter), responseFilter, executorService);
     updateMockReference();
 
     injector.event(curEvent, null);
@@ -70,8 +70,7 @@ public class FilterInjectorTest {
   @Test
   public void testInjectFilterHandlesOnlyServletContext() {
     SecurityJavaSubjectFilter filter = mock(SecurityJavaSubjectFilter.class);
-    FilterInjector injector =
-        new FilterInjector(Arrays.asList(filter), Arrays.asList(filter), executorService);
+    FilterInjector injector = new FilterInjector(Arrays.asList(filter), filter, executorService);
     curEvent = mock(ServiceEvent.class);
     curReference = mock(ServiceReference.class);
     curContext = mock(ServletContext.class);
@@ -93,8 +92,7 @@ public class FilterInjectorTest {
   @Test
   public void testInjectFilterIgnoresUnregisteringEvents() {
     SecurityJavaSubjectFilter filter = mock(SecurityJavaSubjectFilter.class);
-    FilterInjector injector =
-        new FilterInjector(Arrays.asList(filter), Arrays.asList(filter), executorService);
+    FilterInjector injector = new FilterInjector(Arrays.asList(filter), filter, executorService);
     curEvent = mock(ServiceEvent.class);
     when(curEvent.getType()).thenReturn(ServiceEvent.UNREGISTERING);
 
@@ -106,8 +104,7 @@ public class FilterInjectorTest {
   @Test
   public void testInjectFilterIgnoresModifiedEvents() {
     SecurityJavaSubjectFilter filter = mock(SecurityJavaSubjectFilter.class);
-    FilterInjector injector =
-        new FilterInjector(Arrays.asList(filter), Arrays.asList(filter), executorService);
+    FilterInjector injector = new FilterInjector(Arrays.asList(filter), filter, executorService);
     curEvent = mock(ServiceEvent.class);
     when(curEvent.getType()).thenReturn(ServiceEvent.MODIFIED);
 
@@ -119,8 +116,7 @@ public class FilterInjectorTest {
   @Test
   public void testInjectFilterIgnoresModifiedEndMatchEvents() {
     SecurityJavaSubjectFilter filter = mock(SecurityJavaSubjectFilter.class);
-    FilterInjector injector =
-        new FilterInjector(Arrays.asList(filter), Arrays.asList(filter), executorService);
+    FilterInjector injector = new FilterInjector(Arrays.asList(filter), filter, executorService);
     curEvent = mock(ServiceEvent.class);
     when(curEvent.getType()).thenReturn(ServiceEvent.MODIFIED_ENDMATCH);
 

--- a/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/ProxySecurityFilterChainTest.java
+++ b/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/ProxySecurityFilterChainTest.java
@@ -18,20 +18,21 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import org.codice.ddf.platform.filter.AuthenticationException;
+import org.codice.ddf.platform.filter.FilterChain;
+import org.codice.ddf.platform.filter.SecurityFilter;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Tests the proxy filter chain class. */
-public class ProxyFilterChainTest {
+public class ProxySecurityFilterChainTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ProxyFilterChainTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProxySecurityFilterChainTest.class);
 
   /**
    * Tests that all of the filters are properly called.
@@ -40,19 +41,18 @@ public class ProxyFilterChainTest {
    * @throws IOException
    */
   @Test
-  public void testDoFilter() throws IOException, ServletException {
-    FilterChain mockFilterChain = mock(FilterChain.class);
-    ProxyFilterChain proxyChain = new ProxyFilterChain(mockFilterChain);
-    Filter filter1 = createMockFilter("filter1");
-    Filter filter2 = createMockFilter("filter2");
-    Filter filter3 = createMockFilter("filter3");
+  public void testDoFilter() throws IOException, AuthenticationException {
+    ProxySecurityFilterChain proxyChain = new ProxySecurityFilterChain();
+    SecurityFilter filter1 = createMockSecurityFilter("filter1");
+    SecurityFilter filter2 = createMockSecurityFilter("filter2");
+    SecurityFilter filter3 = createMockSecurityFilter("filter3");
 
     ServletRequest request = mock(ServletRequest.class);
     ServletResponse response = mock(ServletResponse.class);
 
-    proxyChain.addFilter(filter1);
-    proxyChain.addFilter(filter2);
-    proxyChain.addFilter(filter3);
+    proxyChain.addSecurityFilter(filter1);
+    proxyChain.addSecurityFilter(filter2);
+    proxyChain.addSecurityFilter(filter3);
 
     proxyChain.doFilter(request, response);
 
@@ -60,7 +60,6 @@ public class ProxyFilterChainTest {
     verify(filter1).doFilter(request, response, proxyChain);
     verify(filter2).doFilter(request, response, proxyChain);
     verify(filter3).doFilter(request, response, proxyChain);
-    verify(mockFilterChain).doFilter(request, response);
   }
 
   /**
@@ -71,12 +70,11 @@ public class ProxyFilterChainTest {
    * @throws ServletException
    */
   @Test(expected = IllegalStateException.class)
-  public void testAddFilterAfterDo() throws IOException, ServletException {
-    FilterChain mockFilterChain = mock(FilterChain.class);
-    ProxyFilterChain proxyChain = new ProxyFilterChain(mockFilterChain);
-    Filter filter1 = mock(Filter.class);
+  public void testAddFilterAfterDo() throws IOException, AuthenticationException {
+    ProxySecurityFilterChain proxyChain = new ProxySecurityFilterChain();
+    SecurityFilter filter1 = mock(SecurityFilter.class);
     proxyChain.doFilter(mock(ServletRequest.class), mock(ServletResponse.class));
-    proxyChain.addFilter(filter1);
+    proxyChain.addSecurityFilter(filter1);
   }
 
   /**
@@ -87,18 +85,18 @@ public class ProxyFilterChainTest {
    * @throws ServletException
    */
   @Test(expected = IllegalStateException.class)
-  public void testAddFiltersAfterDo() throws IOException, ServletException {
-    FilterChain mockFilterChain = mock(FilterChain.class);
-    ProxyFilterChain proxyChain = new ProxyFilterChain(mockFilterChain);
-    Filter filter2 = mock(Filter.class);
-    Filter filter3 = mock(Filter.class);
+  public void testAddFiltersAfterDo() throws IOException, AuthenticationException {
+    ProxySecurityFilterChain proxyChain = new ProxySecurityFilterChain();
+    SecurityFilter filter2 = mock(SecurityFilter.class);
+    SecurityFilter filter3 = mock(SecurityFilter.class);
     proxyChain.doFilter(mock(ServletRequest.class), mock(ServletResponse.class));
-    proxyChain.addFilter(filter2);
-    proxyChain.addFilter(filter3);
+    proxyChain.addSecurityFilter(filter2);
+    proxyChain.addSecurityFilter(filter3);
   }
 
-  private Filter createMockFilter(final String name) throws IOException, ServletException {
-    Filter mockFilter = mock(Filter.class);
+  private SecurityFilter createMockSecurityFilter(final String name)
+      throws IOException, AuthenticationException {
+    SecurityFilter mockFilter = mock(SecurityFilter.class);
     Mockito.when(mockFilter.toString()).thenReturn(name);
     Mockito.doAnswer(
             invocation -> {


### PR DESCRIPTION
#### What does this PR do?

Adds the DelegateServletFilter back into DDF which will hold a DoSFilter
    so that we can configure it. This will prevent jetty from overwriting our
    configuration when it calls init on each of the filters injected in
    a servlet since the DelegateServletFilters init method only takes the
    servlet context from FilterConfig given to it. Also adds a
    ProxyFilterChain that allows us to add Filters to a
    javax.servlet.FilterChain, similar to how the ProxySecurityFilterChain
    allows us to add SecurityFilters to a ddf.platform.filter.FilterChain.

#### Who is reviewing it? 

@peterhuffer @paouelle 

#### Select relevant component teams: 

@codice/io 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.

@ryeats
@stustison
@tbatie

#### How should this be tested?

Start DDF and verify you have no issue viewing any UIs.


#### What are the relevant tickets?

For GH Issues:
Fixes: #4273 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
