### PR TITLE
DDF-04295 Reorder documentation for URL Resource Reader to match CDMs layout

### DIFF
--- a/distribution/docs/src/main/resources/content/_architectures/_resources/url-resource-reader.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_resources/url-resource-reader.adoc
@@ -20,17 +20,6 @@ For example, if path `/my/valid/path` is configured in the `URLResourceReader`&#
 
 The `URLResourceReader` is installed by default with a standard installation in the ${ddf-catalog} application.
 
-===== Configuring the URL Resource Reader
-
-Configure the URL Resource Reader from the ${admin-console}.
-
-. Navigate to the *${admin-console}*.
-. Select the *${ddf-catalog}* application.
-. Select the *Configuration* tab.
-. Select the *URL Resource Reader*.
-
-See <<{reference-prefix}ddf.catalog.resource.impl.URLResourceReader,URL Resource Reader configurations>> for all possible configurations.
-
 ===== Configuring Permissions for the URL Resource Reader
 
 Configuring the URL Resource Reader to retrieve files requires adding Security Manager read permission entries for the directory containing the resources. To add the correct permission entries, edit the file ${home_directory}/security/configurations.policy. In the URL Resource Reader section of the file, add two new permission for each top-level directory that the Resource Reader needs to access. The Resource Reader needs one permission to read the directory and another to read its contents.
@@ -48,6 +37,17 @@ permission java.io.FilePermission "<OTHER_DIRECTORY_PATH>", "read";
 }
 
 Trailing slashes after <DIRECTORY_PATH> have no effect on the permissions granted. For example, adding a permission for "${/}test${/}path" and "${/}test${/}path${/}" are equivalent. The recursive forms "${/}test${/}path${/}-", and "${/}test${/}path${/}${/}-" are also equivalent.
+
+===== Configuring the URL Resource Reader
+
+Configure the URL Resource Reader from the ${admin-console}.
+
+. Navigate to the *${admin-console}*.
+. Select the *${ddf-catalog}* application.
+. Select the *Configuration* tab.
+. Select the *URL Resource Reader*.
+
+See <<{reference-prefix}ddf.catalog.resource.impl.URLResourceReader,URL Resource Reader configurations>> for all possible configurations.
 
 ==== Using the URL Resource Reader
 


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #4296

#### What does this PR do?
The order for the docs of the URL Resource Reader is a little bit confusing. This PR changes the order to have the permissions mentioned first and then configuring, to match the CDM's documentation.

#### Who is reviewing it? 
@ahoffer
@austinsteffes

#### Select relevant component teams: 
@codice/docs 

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@ricklarsen

#### How should this be tested?
Build docs and verify configuring the permissions is mentioned before configuring the URL Resource Reader is mentioned

For GH Issues:
Fixes: #4295

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
