### PR TITLE
[2.13.x] DDF-04316 Add better logging for failed automatic logout

### DIFF
--- a/ui/packages/security-servlet-logout/src/main/resources/logout-response.html
+++ b/ui/packages/security-servlet-logout/src/main/resources/logout-response.html
@@ -27,9 +27,8 @@
 <body class="full-width logout-response-body">
 <div class="full-width logout-response-container">
     <div class="logout-msg">
-        <h2>You are now signed out.</h2>
+        <h2 id="extramessage"></h2>
         <h4>You can <a id="landinglink" href="#">return to the landing page.</a></h4>
-        <h4 id="extramessage"></h4>
     </div>
 </div>
 <script src="./js/logout-response.js?bust=${timestamp}"></script>


### PR DESCRIPTION
#### What does this PR do?
This PR adds better logging to inform the user that they are not actually logged out after a failed automatic logout attempt. This occurs about 5% of the time, and the other times, it returns a successful logout. 

#### Who is reviewing it? 
@austinsteffes 
@ahoffer 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter 
@stustison 

#### How should this be tested?
1. Install and login through the UI
2. Wait and be idle on the UI until session expiring countdown executes
3. Have chance of being redirected to a successful logout, or `Unable to logout. Please try again.`

#### Any background context you want to provide?
It was discovered that there was a null pointer exception from a race condition. Due to being extremely rare to reproduce, it was decided to just better log that the user is not logged out. 

#### What are the relevant tickets?
For GH Issues:
Work for: #4316 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
