### PR TITLE
DDF-04320 Force Camel's quartz component to use newer version of c3p0

### DIFF
--- a/features/camel/src/main/feature/feature.xml
+++ b/features/camel/src/main/feature/feature.xml
@@ -235,7 +235,9 @@
     </feature>
 
   <feature name="camel-quartz2" version="${camel.version}" start-level="50">
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.c3p0/${c3p0-bundle-version}</bundle>
+      <!-- Bundle wrap & deploy mchange's version of c3p0 0.9.5.3 to force quartz2's transitive
+    dependency on 0.9.5.2 to use the newer version instead -->
+        <bundle dependency="true">wrap:mvn:com.mchange/c3p0/${c3p0-bundle-version}</bundle>
         <bundle dependency="true">mvn:com.zaxxer/HikariCP-java6/${hikaricp-version}</bundle>
         <bundle dependency="true">wrap:mvn:org.quartz-scheduler/quartz/${quartz2-version}$overwrite=merge&amp;DynamicImport-Package=org.apache.camel.component.quartz2</bundle>
         <feature version="${camel.version}">camel-core</feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -58,7 +58,7 @@
         <commons-pool-version>${commons-pool.version}</commons-pool-version>
         <commons-io-version>${commons-io.version}</commons-io-version>
         <cxf-version-range>[3.1,4.0)</cxf-version-range>
-        <c3p0-bundle-version>0.9.5.2_2</c3p0-bundle-version>
+        <c3p0-bundle-version>0.9.5.3</c3p0-bundle-version>
         <freemarker-version>2.3.28</freemarker-version>
         <geronimo-jms-spec-version>1.1.1</geronimo-jms-spec-version>
         <geronimo-jms2-spec-version>${geronimo-jms_2_spec.version}</geronimo-jms2-spec-version>

--- a/platform/admin/core/admin-core-insecuredefaults/pom.xml
+++ b/platform/admin/core/admin-core-insecuredefaults/pom.xml
@@ -71,11 +71,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-quartz2</artifactId>
-            <version>${camel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
             <version>${camel.version}</version>
         </dependency>


### PR DESCRIPTION
#### What does this PR do?
Upgrades Camel's transitive `c3p0` version `0.9.5.2` dependency from the Quartz component(s) to `0.9.5.3`. Embedded versions used by pure quartz have not been touched. 

#### Who is reviewing it? 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@stustison

#### How should this be tested?
Full build followed by thorough testing of features that use scheduling over Camel. Re-test the following PR's testing steps: https://github.com/codice/ddf/pull/2551

#### What are the relevant tickets?
Fixes: #4320 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
