### PR TITLE
[2.13.x]DDF-04318 Check that the user is logged in for every Intrigue WebSocket request

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
@@ -158,19 +158,19 @@ public class QueryApplication implements SparkApplication, Function {
   @Override
   public Object apply(Object req) {
     if (!(req instanceof List)) {
-      return JsonRpc.invalidParams("params not list", req);
+      return JsonRpc.invalidParams("parameters not a list", req);
     }
 
     List params = (List) req;
 
     if (params.size() != 1) {
-      return JsonRpc.invalidParams("must pass exactly 1 param", params);
+      return JsonRpc.invalidParams("must pass exactly 1 parameter", params);
     }
 
     Object param = params.get(0);
 
     if (!(param instanceof String)) {
-      return JsonRpc.invalidParams("param not string", param);
+      return JsonRpc.invalidParams("parameter not a string", param);
     }
 
     CqlRequest cqlRequest;
@@ -178,7 +178,7 @@ public class QueryApplication implements SparkApplication, Function {
     try {
       cqlRequest = mapper.readValue((String) param, CqlRequest.class);
     } catch (RuntimeException e) {
-      return JsonRpc.invalidParams("param not valid json", param);
+      return JsonRpc.invalidParams("parameter not valid json", param);
     }
 
     try {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/JsonRpc.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/JsonRpc.java
@@ -13,10 +13,12 @@
  */
 package org.codice.ddf.catalog.ui.ws;
 
+import ddf.security.common.audit.SecurityLogger;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.boon.json.JsonFactory;
 import org.boon.json.JsonParserFactory;
@@ -34,6 +36,7 @@ public class JsonRpc implements WebSocket {
   public static final int METHOD_NOT_FOUND = -32601;
   public static final int INVALID_PARAMS = 32602;
   public static final int INTERNAL_ERROR = -32603;
+  public static final int NOT_LOGGED_IN_ERROR = -32000;
 
   private static final String JSONRPC = "jsonrpc";
   private static final String METHOD = "method";
@@ -97,83 +100,126 @@ public class JsonRpc implements WebSocket {
 
   @Override
   public void onError(Session session, Throwable ex) {
-    // no action required on error
+    if (ex instanceof SecureWebSocketException) {
+      SecurityLogger.audit("Received WebSockets request for user that is not logged in.");
+      handleMessage(
+          session,
+          ((SecureWebSocketException) ex).getWsMessage(),
+          (message, id) -> error(NOT_LOGGED_IN_ERROR, ex.getMessage()));
+    } else {
+      // no action required
+    }
   }
 
   @Override
   public void onMessage(Session session, String message) throws IOException {
-    session.getRemote().sendStringByFuture(mapper.toJson(handleMessage(message)));
+    handleMessage(session, message, this::callMethod);
   }
 
-  private Object handleMessage(String message) {
+  private void handleMessage(
+      Session session, String message, BiFunction<Map, Object, Object> handleFunc) {
+    Object id;
+    Object result;
+
+    try {
+      Map messageMap = parseMessage(message);
+      id = parseId(messageMap);
+      validateJsonRpcVersion(messageMap, id);
+      result = handleFunc.apply(messageMap, id);
+    } catch (JsonRpcException exception) {
+      id = exception.messageId;
+      result = exception.error;
+    }
+
+    session.getRemote().sendStringByFuture(mapper.toJson(response(id, result)));
+  }
+
+  private Map parseMessage(String message) throws JsonRpcException {
     Object parsed;
 
     try {
       parsed = mapper.fromJson(message);
     } catch (RuntimeException ex) {
-      return response(null, error(PARSE_ERROR, "Parse error", message));
+      throw new JsonRpcException(null, error(PARSE_ERROR, "Parse error", message));
     }
 
-    return exec(parsed);
+    if (!(parsed instanceof Map)) {
+      throw new JsonRpcException(null, invalid("message must be a map", parsed));
+    }
+
+    return (Map) parsed;
   }
 
-  private Object exec(Object message) {
-
-    if (!(message instanceof Map)) {
-      return response(null, invalid("message must be a map", message));
+  private Object parseId(Map message) throws JsonRpcException {
+    if (!message.containsKey("id")) {
+      throw new JsonRpcException(null, invalid("required key `id` missing"));
     }
 
-    Map msg = (Map) message;
-
-    if (!msg.containsKey("id")) {
-      return response(null, invalid("required key `id` missing"));
-    }
-
-    Object id = msg.get("id");
+    Object id = message.get("id");
 
     if (!(id instanceof String || id instanceof Number || id == null)) {
-      return response(null, invalid("key `id` not string or number or null", id));
+      throw new JsonRpcException(null, invalid("key `id` not string or number or null", id));
+    } else {
+      return id;
+    }
+  }
+
+  private void validateJsonRpcVersion(Map message, Object id) throws JsonRpcException {
+    if (!message.containsKey(JSONRPC)) {
+      throw new JsonRpcException(id, invalid("required key `jsonrpc` missing"));
     }
 
-    if (!msg.containsKey(JSONRPC)) {
-      return response(id, invalid("required key `jsonrpc` missing"));
+    if (!VERSION.equals(message.get(JSONRPC))) {
+      throw new JsonRpcException(
+          id, invalid("key `jsonrpc` not equal to `2.0`", message.get(JSONRPC)));
+    }
+  }
+
+  private Object callMethod(Map message, Object id) throws JsonRpcException {
+    if (!message.containsKey(METHOD)) {
+      throw new JsonRpcException(id, invalid("required key `method` missing"));
     }
 
-    if (!VERSION.equals(msg.get(JSONRPC))) {
-      return response(id, invalid("key `jsonrpc` not equal to `2.0`", msg.get(JSONRPC)));
+    if (!(message.get(METHOD) instanceof String)) {
+      throw new JsonRpcException(id, invalid("key `method` not string", message.get(METHOD)));
     }
 
-    if (!msg.containsKey(METHOD)) {
-      return response(id, invalid("required key `method` missing"));
-    }
-
-    if (!(msg.get(METHOD) instanceof String)) {
-      return response(id, invalid("key `method` not string", msg.get(METHOD)));
-    }
-
-    String method = (String) msg.get(METHOD);
+    String method = (String) message.get(METHOD);
 
     if (!methods.containsKey(method)) {
-      return response(id, error(METHOD_NOT_FOUND, String.format("method `%s` not found", method)));
+      throw new JsonRpcException(
+          id, error(METHOD_NOT_FOUND, String.format("method `%s` not found", method)));
     }
 
-    Object params = msg.get("params");
+    Object params = message.get("params");
 
     if (params != null && !(params instanceof List || params instanceof Map)) {
-      return response(id, invalidParams("parameters must be a structured value", params));
+      throw new JsonRpcException(
+          id, invalidParams("parameters must be a structured value", params));
     }
 
     try {
-      return response(id, methods.get(method).apply(params));
+      return methods.get(method).apply(params);
     } catch (RuntimeException e) {
-      return response(id, JsonRpc.error(INTERNAL_ERROR, "Internal Error"));
+      throw new JsonRpcException(id, error(INTERNAL_ERROR, "Internal Error"));
+    }
+  }
+
+  private static class JsonRpcException extends RuntimeException {
+    private final Object messageId;
+    private final Error error;
+
+    private JsonRpcException(Object messageId, Error error) {
+      this.messageId = messageId;
+      this.error = error;
     }
   }
 
   private static class Error {
-    public final int code;
-    public final String message;
-    public final Object data;
+    private final int code;
+    private final String message;
+    private final Object data;
+    private Object id;
 
     private Error(int code, String message) {
       this(code, message, null);

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketException.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketException.java
@@ -1,6 +1,19 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.ddf.catalog.ui.ws;
 
-/** Exception to */
+/** An exception to represent a security-related error in the {@link SecureWebSocketServlet}. */
 public class SecureWebSocketException extends RuntimeException {
   private final String wsMessage;
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketException.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketException.java
@@ -1,0 +1,19 @@
+package org.codice.ddf.catalog.ui.ws;
+
+/** Exception to */
+public class SecureWebSocketException extends RuntimeException {
+  private final String wsMessage;
+
+  SecureWebSocketException(String message) {
+    this(message, null);
+  }
+
+  SecureWebSocketException(String message, String wsMessage) {
+    super(message);
+    this.wsMessage = wsMessage;
+  }
+
+  public String getWsMessage() {
+    return wsMessage;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketServlet.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketServlet.java
@@ -45,6 +45,11 @@ public class SecureWebSocketServlet extends WebSocketServlet {
     executor.shutdown();
   }
 
+  /*
+   Pass the TokenHolder into the WebSocket, in order to know when the user has logged out. Can't
+   pass the Session because Jetty won't let anything check session attributes unless there's a
+   request (excluding WebSocket requests) being actively fulfilled for that session.
+  */
   @Override
   public void configure(WebSocketServletFactory factory) {
     factory.setCreator(

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/WebSocketAuthenticationException.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/WebSocketAuthenticationException.java
@@ -14,14 +14,14 @@
 package org.codice.ddf.catalog.ui.ws;
 
 /** An exception to represent a security-related error in the {@link SecureWebSocketServlet}. */
-public class SecureWebSocketException extends RuntimeException {
+public class WebSocketAuthenticationException extends RuntimeException {
   private final String wsMessage;
 
-  SecureWebSocketException(String message) {
+  WebSocketAuthenticationException(String message) {
     this(message, null);
   }
 
-  SecureWebSocketException(String message, String wsMessage) {
+  WebSocketAuthenticationException(String message, String wsMessage) {
     super(message);
     this.wsMessage = wsMessage;
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
@@ -122,16 +122,21 @@ module.exports = Backbone.AssociatedModel.extend({
                         handled = true;
                         res.options = options;
                         switch (res.code) {
-                            case 400:
-                            case 404:
-                            case 500:
+                            case -32000:
+                                if (rpc !== null) {
+                                    rpc.close();
+                                    rpc = null;
+                                }
                                 options.error({
-                                    responseJSON: res
+                                    message: 'User not logged in.'
                                 });
                                 break;
                             default:
                                 // notify user and fallback to http
-                                rpc = null;
+                                if (rpc !== null) {
+                                    rpc.close();
+                                    rpc = null;
+                                }
                                 options.error({
                                     responseJSON: {
                                         message: 'Search failed due to unknown reasons, please try again.'


### PR DESCRIPTION
#### What does this PR do?
Updates the backend of Intrigue's WebSocket implementation to get the User's security token holder, when the WebSocket connection is initially opened. Then, at every request, the security token holder is checked. If it's empty, send an error because the user is no longer logged in under the same Http session.

**NOTE:** The third commit is the most complex change to review, but that commit should be easier to review if you review it in on its own.
#### Who is reviewing it? 
@ahoffer @tyler30clemens 
#### Select relevant component teams: 
@codice/security 
#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@djblue
@stustison
#### How should this be tested?
- Ingest some records and run some queries to make sure Intrigue is working normally.
- With one of the executed queries still up, open a new tab for the AdminUI and logout.
- Go back to Intrigue and edit the open query and/or execute it.
- The query should now return no results with an error icon next to the query.

#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4318 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
