### PR TITLE
DDF-04338 Adds space around the map actions / buttons

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.less
@@ -37,9 +37,10 @@
   }
 
   .cesium-viewer-toolbar {
-    top: 0px;
-    right: 0px;
-    padding-right: @minimumSpacing;
+    top: @minimumSpacing;
+    right: @minimumSpacing;
+    padding: @minimumSpacing;
+    max-width: ~'calc(100% - 2*@{minimumSpacing})';
     .is-medium-font;
     background: inherit;
     line-height: @minimumButtonSize;


### PR DESCRIPTION
#### What does this PR do?
 - Adds space around the map actions / buttons so that the user is more
 easily able to associate them with the map, and so that overall it's
 more aesthetically pleasing.

#### Who is reviewing it? 
@TeresaHudson 
@tbatie 
@jhunzik 
@samuelechu 
@mcalcote 

#### How should this be tested?
Open the 2d and 3d maps and verify there is space around them.  Verify it works on smaller screens as well.

#### What are the relevant tickets?
For GH Issues:
Fixes: #4338 

#### Screenshots
![image](https://user-images.githubusercontent.com/11984853/52378303-8f20ee00-2a24-11e9-8eff-908cd97d9920.png)

