### PR TITLE
DDF-04346 - Preserving Original Query Structure For Advanced Queries

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -81,11 +81,6 @@ const determineView = comparator => {
   return necessaryView
 }
 
-// strip extra quotes
-const stripQuotes = property => {
-  return property.replace(/^"(.+(?="$))"$/, '$1')
-}
-
 module.exports = Marionette.LayoutView.extend({
   template: template,
   tagName: CustomElements.register('filter'),
@@ -198,7 +193,7 @@ module.exports = Marionette.LayoutView.extend({
   // With the relative date comparator being the same as =, we need to try and differentiate them this way
   getComparatorForFilter(filter) {
     const propertyDefinition =
-      metacardDefinitions.metacardTypes[stripQuotes(filter.property)]
+      metacardDefinitions.metacardTypes[filter.property]
     if (
       propertyDefinition &&
       propertyDefinition.type === 'DATE' &&
@@ -368,7 +363,7 @@ module.exports = Marionette.LayoutView.extend({
           }
           this.model.set({
             value,
-            type: filter.property.split('"').join(''),
+            type: filter.property,
             comparator: this.getComparatorForFilter(filter),
           })
         }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -58,8 +58,10 @@ const minimumDifference = 0.0001
 const minimumBuffer = 0.000001
 
 const filterToLocationOldModel = filter => {
+  if (filter === '') return filter
+
   const filterValue =
-    typeof filter.value === 'object' ? filter.value.value : filter.value
+    typeof filter.geojson === 'object' ? filter.geojson : filter.value.value
 
   // for backwards compatability with wkt
   if (typeof filterValue === 'string') {
@@ -127,7 +129,6 @@ module.exports = Marionette.LayoutView.extend({
     const filter = this.propertyModel.get('value')
     this.model.set(filterToLocationOldModel(filter))
 
-    debugger
     switch (filter.type) {
       // these cases are for when the model matches the filter model
       case 'DWITHIN':

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -60,16 +60,18 @@ const minimumBuffer = 0.000001
 const filterToLocationOldModel = filter => {
   if (filter === '') return filter
 
+  if (typeof filter.geojson === 'object') {
+    return deserialize(filter.geojson)
+  }
+
   const filterValue =
-    typeof filter.geojson === 'object' ? filter.geojson : filter.value.value
+    typeof filter.value === 'object' ? filter.value.value : filter.value
 
   // for backwards compatability with wkt
   if (typeof filterValue === 'string') {
     const json = wkx.Geometry.parse(filterValue).toGeoJSON()
     return deserialize(json)
   }
-
-  return deserialize(filter.geojson)
 }
 
 module.exports = Marionette.LayoutView.extend({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -51,9 +51,24 @@ const LocationOldModel = require('./location-old')
 const CQLUtils = require('../../js/CQLUtils.js')
 const ShapeUtils = require('../../js/ShapeUtils.js')
 const { Direction } = require('../location-new/utils/dms-utils.js')
+import { deserialize } from './location-serialization'
+const wkx = require('wkx')
 
 const minimumDifference = 0.0001
 const minimumBuffer = 0.000001
+
+const filterToLocationOldModel = filter => {
+  const filterValue =
+    typeof filter.value === 'object' ? filter.value.value : filter.value
+
+  // for backwards compatability with wkt
+  if (typeof filterValue === 'string') {
+    const json = wkx.Geometry.parse(filterValue).toGeoJSON()
+    return deserialize(json)
+  }
+
+  return deserialize(filter.geojson)
+}
 
 module.exports = Marionette.LayoutView.extend({
   template: function() {
@@ -107,101 +122,41 @@ module.exports = Marionette.LayoutView.extend({
     this.model.setLatLon()
   },
   deserialize: function() {
-    if (this.propertyModel) {
-      var filter = this.propertyModel.get('value')
-      var filterValue =
-        typeof filter.value === 'object' ? filter.value.value : filter.value
-      switch (filter.type) {
-        // these cases are for when the model matches the filter model
-        case 'DWITHIN':
-          if (CQLUtils.isPointRadiusFilter(filter)) {
-            let pointText = filterValue.substring(6)
-            pointText = pointText.substring(0, pointText.length - 1)
-            var latLon = pointText.split(' ')
-            this.model.set({
-              mode: 'circle',
-              locationType: 'latlon',
-              lat: latLon[1],
-              lon: latLon[0],
-              radius: filter.distance,
-            })
-            wreqr.vent.trigger('search:circledisplay', this.model)
-          } else if (CQLUtils.isPolygonFilter(filter)) {
-            this.handlePolygonDeserialization(filter)
-          } else {
-            let pointText = filterValue.substring(11)
-            pointText = pointText.substring(0, pointText.length - 1)
-            this.model.set({
-              mode: 'line',
-              lineWidth: filter.distance,
-              line: pointText.split(',').map(function(coordinate) {
-                return coordinate.split(' ').map(function(value) {
-                  return Number(value)
-                })
-              }),
-            })
-            wreqr.vent.trigger('search:linedisplay', this.model)
-          }
-          break
-        case 'INTERSECTS':
-          if (!filterValue || typeof filterValue !== 'string') {
-            break
-          }
-          this.handlePolygonDeserialization({
-            polygon: CQLUtils.arrayFromPolygonWkt(filterValue),
-          })
-          break
-        // these cases are for when the model matches the location model
-        case 'BBOX':
-          this.model.set({
-            mode: 'bbox',
-            locationType: 'latlon',
-            north: filter.north,
-            south: filter.south,
-            east: filter.east,
-            west: filter.west,
-          })
-          wreqr.vent.trigger('search:bboxdisplay', this.model)
-          break
-        case 'MULTIPOLYGON':
-        case 'POLYGON':
-          this.handlePolygonDeserialization(filter)
-          break
-        case 'POINTRADIUS':
-          this.model.set({
-            mode: 'circle',
-            locationType: 'latlon',
-            lat: filter.lat,
-            lon: filter.lon,
-            radius: filter.radius,
-          })
-          wreqr.vent.trigger('search:circledisplay', this.model)
-          break
-        case 'LINE':
-          this.model.set({
-            mode: 'line',
-            line: filter.line,
-            lineWidth: filter.lineWidth,
-          })
-          wreqr.vent.trigger('search:linedisplay', this.model)
-          break
-      }
-    }
-  },
-  handlePolygonDeserialization(filter) {
-    const polygonArray =
-      (filter.value &&
-        filter.value.value &&
-        CQLUtils.arrayFromPolygonWkt(filter.value.value)) ||
-      []
-    const bufferWidth = filter.polygonBufferWidth || filter.distance
+    if (!this.propertyModel) return
 
-    this.model.set({
-      mode: 'poly',
-      polygon: filter.polygon || polygonArray,
-      ...(bufferWidth && { polygonBufferWidth: bufferWidth }),
-    })
-    wreqr.vent.trigger('search:polydisplay', this.model)
+    const filter = this.propertyModel.get('value')
+    this.model.set(filterToLocationOldModel(filter))
+
+    debugger
+    switch (filter.type) {
+      // these cases are for when the model matches the filter model
+      case 'DWITHIN':
+        if (CQLUtils.isPointRadiusFilter(filter)) {
+          wreqr.vent.trigger('search:circledisplay', this.model)
+        } else if (CQLUtils.isPolygonFilter(filter)) {
+          wreqr.vent.trigger('search:polydisplay', this.model)
+        } else {
+          wreqr.vent.trigger('search:linedisplay', this.model)
+        }
+        break
+      case 'INTERSECTS':
+        wreqr.vent.trigger('search:polydisplay', this.model)
+        break
+      // these cases are for when the model matches the location model
+      case 'BBOX':
+        wreqr.vent.trigger('search:bboxdisplay', this.model)
+        break
+      case 'MULTIPOLYGON':
+      case 'POLYGON':
+        wreqr.vent.trigger('search:polydisplay', this.model)
+        break
+      case 'POINTRADIUS':
+        wreqr.vent.trigger('search:circledisplay', this.model)
+        break
+      case 'LINE':
+        wreqr.vent.trigger('search:linedisplay', this.model)
+        break
+    }
   },
   clearLocation: function() {
     this.model.set({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -1,0 +1,216 @@
+const wkx = require('wkx')
+const DistanceUtils = require('../../js/DistanceUtils')
+const Turf = require('@turf/turf')
+
+const is3DArray = array =>
+  Array.isArray(array) && Array.isArray(array[0]) && Array.isArray(array[0][0])
+const is4DArray = array => is3DArray(array) && Array.isArray(array[0][0][0])
+
+const LineString = {
+  'json->location': ({ coordinates, buffer = {} }) => ({
+    mode: 'line',
+    line: coordinates,
+    lineWidth: buffer.width,
+    lineUnits: buffer.unit,
+  }),
+  'location->json': ({ line = [], lineWidth = 1, lineUnits = 'meters' }) => ({
+    type: 'LineString',
+    coordinates: line,
+    buffer: {
+      width: lineWidth,
+      unit: lineUnits,
+    },
+  }),
+}
+
+const MultiLineString = {
+  'json->location': ({ coordinates, buffer = {} }) => ({
+    mode: 'multiline',
+    multiline: coordinates,
+    lineWidth: buffer.width,
+    lineUnits: buffer.unit,
+  }),
+  'location->json': ({
+    multiline = [],
+    lineWidth = 1,
+    lineUnits = 'meters',
+  }) => ({
+    type: 'MultiLineString',
+    coordinates: multiline,
+    buffer: {
+      width: lineWidth,
+      unit: lineUnits,
+    },
+  }),
+}
+
+const Point = {
+  'json->location': ({ coordinates: [lon, lat], buffer = {} }) => ({
+    mode: 'circle',
+    locationType: 'latlon',
+    lat,
+    lon,
+    radius: buffer.width,
+    radiusUnits: buffer.unit,
+  }),
+  'location->json': ({
+    lat = 0,
+    lon = 0,
+    radius = 1,
+    radiusUnits = 'meters',
+  }) => ({
+    type: 'Point',
+    coordinates: [lon, lat],
+    buffer: {
+      width: radius,
+      unit: radiusUnits,
+    },
+  }),
+}
+
+const Polygon = {
+  'json->location': ({ coordinates, buffer = {} }) => ({
+    mode: 'poly',
+    polygon: coordinates,
+    polygonBufferWidth: buffer.width,
+    polygonBufferUnits: buffer.unit,
+    polyType: 'polygon',
+  }),
+  'location->json': ({
+    polygon = [],
+    polygonBufferWidth = 0,
+    polygonBufferUnits = 'meters',
+  }) => ({
+    type: 'Polygon',
+    coordinates: is3DArray(polygon) ? polygon : [polygon],
+    buffer: {
+      width: polygonBufferWidth,
+      unit: polygonBufferUnits,
+    },
+  }),
+}
+
+const BoundingBox = {
+  'json->location': ({ north, east, south, west }) => {
+    const coordinates = [
+      [
+        [west, north],
+        [east, north],
+        [east, south],
+        [west, south],
+        [west, north],
+      ],
+    ]
+
+    return {
+      mode: 'bbox',
+      polygon: coordinates,
+      north,
+      east,
+      south,
+      west,
+    }
+  },
+  'location->json': ({ north, east, south, west }) => {
+    return {
+      type: 'BoundingBox',
+      north,
+      east,
+      south,
+      west,
+    }
+  },
+}
+
+const MultiPolygon = {
+  'json->location': ({ coordinates, buffer = {} }) => ({
+    mode: 'multipolygon',
+    polygon: coordinates,
+    polygonBufferWidth,
+    polygonBufferUnits,
+    polyType: 'multipolygon',
+  }),
+  'location->json': ({
+    polygon = [],
+    polygonBufferWidth,
+    polygonBufferUnits,
+  }) => ({
+    type: 'MultiPolygon',
+    coordinates: is3DArray(polygon) ? [polygon] : polygon,
+    buffer: {
+      width: polygonBufferWidth,
+      unit: polygonBufferUnits,
+    },
+  }),
+}
+
+const Keyword = {
+  'json->location': ({ keywordValue, value = {} }) => {
+    const { type, coordinates, buffer = {} } = value
+    return {
+      mode: 'keyword',
+      keywordValue,
+      polygon: coordinates,
+      polygonBufferWidth: buffer.width,
+      polygonBufferUnits: buffer.unit,
+      polyType: type === 'MultiPolygon' ? 'multipolygon' : 'polygon',
+    }
+  },
+  'location->json': ({
+    polygon = [],
+    polyType,
+    keywordValue,
+    polygonBufferWidth,
+    polygonBufferUnits,
+  }) => ({
+    type: 'Keyword',
+    keywordValue,
+    value: {
+      type: polyType === 'polygon' ? 'Polygon' : 'MultiPolygon',
+      coordinates: polygon,
+      buffer: {
+        width: polygonBufferWidth,
+        unit: polygonBufferUnits,
+      },
+    },
+  }),
+}
+
+const Serializers = {
+  line: LineString,
+  multiline: MultiLineString,
+  circle: Point,
+  poly: Polygon,
+  multipolygon: MultiPolygon,
+  keyword: Keyword,
+  bbox: BoundingBox,
+}
+
+const Deserializers = {
+  Point,
+  Polygon,
+  MultiPolygon,
+  LineString,
+  MultiLineString,
+  BoundingBox,
+  Keyword,
+}
+
+export const serialize = location => {
+  const mode = location.mode
+  if (mode) {
+    const serializer = Serializers[mode]['location->json']
+    if (typeof serializer === 'function') {
+      return serializer(location)
+    }
+  }
+}
+
+export const deserialize = json => {
+  if (json) {
+    const deserializer = Deserializers[json.type]['json->location']
+    if (typeof deserializer === 'function') {
+      return deserializer(json)
+    }
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
@@ -97,11 +97,6 @@ describe('serialize/deserialize point', () => {
   it('properly tranlates filter tree JSON into location model representation', () => {
     expect(deserialize(serializedPoint)).to.deep.include(deserializedPoint)
   })
-
-  it('properly tranlates filter location model into filter tree json', () => {
-    console.log(serialize(deserializedPoint))
-    // assert(serialize(deserializedPoint) === serializedPoint, "serialization of point is successful")
-  })
 })
 
 describe('serialize/deserialize polygon', () => {
@@ -145,9 +140,13 @@ describe('serialize/deserialize polygon', () => {
   it('properly tranlates filter tree JSON into location model representation', () => {
     expect(deserialize(serializedPolygon)).to.deep.include(deserializedPolygon)
   })
+
+  it('properly tranlates filter location model into filter tree json', () => {
+    expect(serialize(deserializedPolygon)).to.deep.include(serializedPolygon)
+  })
 })
 
-describe('deserialize bbox', () => {
+describe('serialize/deserialize bbox', () => {
   const serializedBbox = {
     type: 'Feature',
     bbox: [-44.449923, -27.849887, -112.533338, -92.952499],
@@ -196,10 +195,16 @@ describe('deserialize bbox', () => {
     west: -112.533338,
   }
 
-  expect(deserialize(serializedBbox)).to.deep.include(deserializedBbox)
+  it('properly tranlates filter tree JSON into location model representation', () => {
+    expect(deserialize(serializedBbox)).to.deep.include(deserializedBbox)
+  })
+
+  it('properly tranlates filter location model into filter tree json', () => {
+    expect(serialize(deserializedBbox)).to.deep.include(serializedBbox)
+  })
 })
 
-describe('deserialize multipolygon', () => {
+describe('serialize/deserialize multipolygon', () => {
   const serializedPolygon = {
     type: 'Feature',
     geometry: {
@@ -237,7 +242,58 @@ describe('deserialize multipolygon', () => {
     polyType: 'polygon',
   }
 
-  expect(deserialize(serializedPolygon)).to.deep.include(deserializedPolygon)
+  it('properly tranlates filter tree JSON into location model representation', () => {
+    expect(deserialize(serializedPolygon)).to.deep.include(deserializedPolygon)
+  })
+
+  it('properly tranlates filter location model into filter tree json', () => {
+    expect(serialize(deserializedPolygon)).to.deep.include(serializedPolygon)
+  })
 })
 
-describe('deserialize keyword', () => {})
+describe('serialize/deserialize keyword', () => {
+  const serializedKeyword = {
+    mode: 'keyword',
+    keywordValue: 'Egra, IND',
+    polygon: [
+      [87.3879, 21.7495],
+      [87.6879, 21.7495],
+      [87.6879, 22.0495],
+      [87.3879, 22.0495],
+      [87.3879, 21.7495],
+    ],
+    polygonBufferWidth: 0,
+    polygonBufferUnits: 'meters',
+    polyType: 'polygon',
+  }
+
+  const deserializedKeyword = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [87.3879, 21.7495],
+        [87.6879, 21.7495],
+        [87.6879, 22.0495],
+        [87.3879, 22.0495],
+        [87.3879, 21.7495],
+      ],
+    },
+    properties: {
+      type: 'Keyword',
+      keywordValue: 'Egra, IND',
+      buffer: {
+        width: 0,
+        unit: 'meters',
+      },
+    },
+  }
+
+  it('properly tranlates filter tree JSON into location model representation', () => {
+    expect(deserialize(deserializedKeyword)).to.deep.include(serializedKeyword)
+  })
+
+  it('properly tranlates filter location model into filter tree json', () => {
+    expect(serialize(serializedKeyword)).to.deep.include(deserializedKeyword)
+  })
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
@@ -1,0 +1,243 @@
+import { expect, assert } from 'chai'
+import { serialize, deserialize } from './location-serialization'
+
+describe('serialize/deserialize line', () => {
+  const serializedLine = {
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      coordinates: [[-134.388122, 53.795318], [-125.668486, 43.012693]],
+    },
+    properties: {
+      type: 'LineString',
+      buffer: {
+        width: 1,
+        unit: 'meters',
+      },
+    },
+  }
+
+  const deserializedLine = {
+    mode: 'line',
+    line: [[-134.388122, 53.795318], [-125.668486, 43.012693]],
+    lineWidth: 1,
+    lineUnits: 'meters',
+  }
+
+  it('properly tranlates filter tree JSON into location model representation', () => {
+    expect(deserialize(serializedLine)).to.deep.include(deserializedLine)
+  })
+
+  it('properly tranlates filter location model into filter tree json', () => {
+    expect(serialize(deserializedLine)).to.deep.include(serializedLine)
+  })
+})
+
+describe('serialize/deserialize multiline', () => {
+  const serializedMultiLine = {
+    type: 'Feature',
+    geometry: {
+      type: 'MultiLineString',
+      coordinates: [[-134.388122, 53.795318], [-125.668486, 43.012693]],
+    },
+    properties: {
+      type: 'MultiLineString',
+      buffer: {
+        width: 1,
+        unit: 'meters',
+      },
+    },
+  }
+
+  const deserializedMultiLine = {
+    mode: 'multiline',
+    multiline: [[-134.388122, 53.795318], [-125.668486, 43.012693]],
+    lineWidth: 1,
+    lineUnits: 'meters',
+  }
+
+  it('properly tranlates filter tree JSON into location model representation', () => {
+    expect(deserialize(serializedMultiLine)).to.deep.include(
+      deserializedMultiLine
+    )
+  })
+
+  it('properly tranlates filter location model into filter tree json', () => {
+    expect(serialize(deserializedMultiLine)).to.deep.include(
+      serializedMultiLine
+    )
+  })
+})
+
+describe('serialize/deserialize point', () => {
+  const serializedPoint = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [-111.131821, 31.964569],
+    },
+    properties: {
+      type: 'Point',
+      buffer: {
+        width: 140603.222706,
+        unit: 'meters',
+      },
+    },
+  }
+
+  const deserializedPoint = {
+    mode: 'circle',
+    locationType: 'latlon',
+    lat: -111.131821,
+    lon: 31.964569,
+    radius: 140603.222706,
+    radiusUnits: 'meters',
+  }
+
+  it('properly tranlates filter tree JSON into location model representation', () => {
+    expect(deserialize(serializedPoint)).to.deep.include(deserializedPoint)
+  })
+
+  it('properly tranlates filter location model into filter tree json', () => {
+    console.log(serialize(deserializedPoint))
+    // assert(serialize(deserializedPoint) === serializedPoint, "serialization of point is successful")
+  })
+})
+
+describe('serialize/deserialize polygon', () => {
+  const serializedPolygon = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-125.180588, 48.603515],
+          [-130.42847, 38.872222],
+          [-117.556532, 41.896131],
+          [-125.180588, 48.603515],
+        ],
+      ],
+    },
+    properties: {
+      type: 'Polygon',
+      buffer: {
+        width: 0,
+        unit: 'meters',
+      },
+    },
+  }
+
+  const deserializedPolygon = {
+    mode: 'poly',
+    polygon: [
+      [
+        [-125.180588, 48.603515],
+        [-130.42847, 38.872222],
+        [-117.556532, 41.896131],
+        [-125.180588, 48.603515],
+      ],
+    ],
+    polygonBufferWidth: 0,
+    polygonBufferUnits: 'meters',
+    polyType: 'polygon',
+  }
+
+  it('properly tranlates filter tree JSON into location model representation', () => {
+    expect(deserialize(serializedPolygon)).to.deep.include(deserializedPolygon)
+  })
+})
+
+describe('deserialize bbox', () => {
+  const serializedBbox = {
+    type: 'Feature',
+    bbox: [-44.449923, -27.849887, -112.533338, -92.952499],
+    geometry: {
+      type: 'Polygon',
+      coordinates: {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-44.449923, -27.849887],
+              [-112.533338, -27.849887],
+              [-112.533338, -92.952499],
+              [-44.449923, -92.952499],
+              [-44.449923, -27.849887],
+            ],
+          ],
+        },
+      },
+    },
+    properties: {
+      type: 'BoundingBox',
+      north: -27.849887,
+      east: -92.952499,
+      south: -44.449923,
+      west: -112.533338,
+    },
+  }
+
+  const deserializedBbox = {
+    mode: 'bbox',
+    polygon: [
+      [
+        [-112.533338, -27.849887],
+        [-92.952499, -27.849887],
+        [-92.952499, -44.449923],
+        [-112.533338, -44.449923],
+        [-112.533338, -27.849887],
+      ],
+    ],
+    north: -27.849887,
+    east: -92.952499,
+    south: -44.449923,
+    west: -112.533338,
+  }
+
+  expect(deserialize(serializedBbox)).to.deep.include(deserializedBbox)
+})
+
+describe('deserialize multipolygon', () => {
+  const serializedPolygon = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-125.180588, 48.603515],
+          [-130.42847, 38.872222],
+          [-117.556532, 41.896131],
+          [-125.180588, 48.603515],
+        ],
+      ],
+    },
+    properties: {
+      type: 'Polygon',
+      buffer: {
+        width: 0,
+        unit: 'meters',
+      },
+    },
+  }
+
+  const deserializedPolygon = {
+    mode: 'poly',
+    polygon: [
+      [
+        [-125.180588, 48.603515],
+        [-130.42847, 38.872222],
+        [-117.556532, 41.896131],
+        [-125.180588, 48.603515],
+      ],
+    ],
+    polygonBufferWidth: 0,
+    polygonBufferUnits: 'meters',
+    polyType: 'polygon',
+  }
+
+  expect(deserialize(serializedPolygon)).to.deep.include(deserializedPolygon)
+})
+
+describe('deserialize keyword', () => {})

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -108,10 +108,7 @@ module.exports = Marionette.LayoutView.extend({
       })
     )
 
-    if (
-      this.options.isForm === true &&
-      this.model.get('filterTree') !== undefined
-    ) {
+    if (this.model.get('filterTree') !== undefined) {
       this.queryAdvanced.currentView.deserialize(this.model.get('filterTree'))
     } else if (this.options.isAdd) {
       this.queryAdvanced.currentView.deserialize(cql.read("anyText ILIKE '%'"))

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -170,6 +170,13 @@ function translateFilterToBasicMap(filter) {
   }
 }
 
+function getFilterTree(model) {
+  if (typeof model.get('filterTree') === 'object') {
+    return model.get('filterTree')
+  }
+  return cql.simplify(cql.read(model.get('cql')))
+}
+
 module.exports = Marionette.LayoutView.extend({
   template: template,
   tagName: CustomElements.register('query-basic'),
@@ -195,9 +202,8 @@ module.exports = Marionette.LayoutView.extend({
     this.model = this.model._cloneOf
       ? store.getQueryById(this.model._cloneOf)
       : this.model
-    var translationToBasicMap = translateFilterToBasicMap(
-      cql.simplify(cql.read(this.model.get('cql')))
-    )
+    const filter = getFilterTree(this.model)
+    var translationToBasicMap = translateFilterToBasicMap(filter)
     this.filter = translationToBasicMap.propertyValueMap
     this.handleDownConversion(translationToBasicMap.downConversion)
     this.setupSettings()
@@ -440,6 +446,7 @@ module.exports = Marionette.LayoutView.extend({
     var filter = this.constructFilter()
     var generatedCQL = CQLUtils.transformFilterToCQL(filter)
     this.model.set({
+      filterTree: filter,
       cql: generatedCQL,
     })
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -13,6 +13,7 @@
 const $ = require('jquery')
 const cql = require('./cql.js')
 const DistanceUtils = require('./DistanceUtils.js')
+import { serialize } from '../component/location-old/location-serialization'
 
 function sanitizeForCql(text) {
   return text
@@ -223,7 +224,9 @@ function generateFilter(type, property, value, metacardDefinitions) {
   switch (metacardDefinitions.metacardTypes[property].type) {
     case 'LOCATION':
     case 'GEOMETRY':
-      return generateAnyGeoFilter(property, value)
+      const geo = generateAnyGeoFilter(property, value)
+      geo.geojson = serialize(value)
+      return geo
     default:
       const filter = {
         type,

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -85,6 +85,28 @@ Query.Model = PartialAssociatedModel.extend({
       isTransient: true,
     },
   ],
+  set: function(data, ...args) {
+    if (
+      typeof data === 'object' &&
+      data.filterTree !== undefined &&
+      typeof data.filterTree === 'string'
+    ) {
+      // for backwards compatability 
+      try {
+        data.filterTree = JSON.parse(data.filterTree)
+      } catch (e) {
+        data.filterTree = CQLUtils.transformCQLToFilter(data.cql)
+      }
+    }
+    return PartialAssociatedModel.prototype.set.call(this, data, ...args)
+  },
+  toJSON: function(...args) {
+    const json = PartialAssociatedModel.prototype.toJSON.call(this, ...args)
+    if (typeof json.filterTree === 'object') {
+      json.filterTree = JSON.stringify(json.filterTree)
+    }
+    return json
+  },
   //in the search we are checking for whether or not the model
   //only contains 5 items to know if we can search or not
   //as soon as the model contains more than 5 items, we assume

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -91,7 +91,7 @@ Query.Model = PartialAssociatedModel.extend({
       data.filterTree !== undefined &&
       typeof data.filterTree === 'string'
     ) {
-      // for backwards compatability 
+      // for backwards compatability
       try {
         data.filterTree = JSON.parse(data.filterTree)
       } catch (e) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/index.tsx
@@ -19,7 +19,7 @@ import {
 
 import withListenTo, { WithBackboneProps } from '../backbone-container'
 
-const CqlUtils = require('../../../js/CQLUtils')
+import * as CqlUtils from '../../../js/CQLUtils'
 
 import * as CustomElements from '../../../js/CustomElements'
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/index.tsx
@@ -19,7 +19,8 @@ import {
 
 import withListenTo, { WithBackboneProps } from '../backbone-container'
 
-import * as CqlUtils from '../../../js/CQLUtils'
+// import * as CqlUtils from '../../../js/CQLUtils'
+const CqlUtils = require('../../../js/CQLUtils')
 
 import * as CustomElements from '../../../js/CustomElements'
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/index.tsx
@@ -19,7 +19,7 @@ import {
 
 import withListenTo, { WithBackboneProps } from '../backbone-container'
 
-import * as CqlUtils from '../../../js/CQLUtils'
+const CqlUtils = require('../../../js/CQLUtils')
 
 import * as CustomElements from '../../../js/CustomElements'
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
@@ -11,7 +11,8 @@ class Keyword extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      value: typeof props.value === 'string' ? props.value : '',
+      keywordValue:
+        typeof props.keywordValue === 'string' ? props.keywordValue : '',
       loading: false,
       error: null,
       polyType: null,
@@ -31,7 +32,7 @@ class Keyword extends React.Component {
   async onChange(suggestion) {
     const geofeature =
       this.props.geofeature || (suggestItem => this.geofeature(suggestItem))
-    this.setState({ value: suggestion.name, loading: true })
+    this.setState({ keywordValue: suggestion.name, loading: true })
     try {
       const { type, geometry = {} } = await geofeature(suggestion)
       this.setState({ loading: false })
@@ -44,7 +45,7 @@ class Keyword extends React.Component {
             locationType: 'latlon',
             polygon: polygon,
             polyType: 'polygon',
-            keywordValue: this.state.value,
+            keywordValue: this.state.keywordValue,
           })
           break
         }
@@ -57,7 +58,7 @@ class Keyword extends React.Component {
             locationType: 'latlon',
             polygon: polygon,
             polyType: 'multipolygon',
-            keywordValue: this.state.value,
+            keywordValue: this.state.keywordValue,
           })
           break
         }
@@ -89,11 +90,11 @@ class Keyword extends React.Component {
       polygonBufferUnits,
       polyType,
     } = this.props
-    const { value, loading, error } = this.state
+    const { keywordValue, loading, error } = this.state
     return (
       <div>
         <AutoComplete
-          value={value}
+          value={keywordValue}
           onChange={option => this.onChange(option)}
           minimumInputLength={2}
           placeholder="Enter a region, country, or city"

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
@@ -11,8 +11,7 @@ class Keyword extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      keywordValue:
-        typeof props.keywordValue === 'string' ? props.keywordValue : '',
+      value: typeof props.value === 'string' ? props.value : '',
       loading: false,
       error: null,
       polyType: null,
@@ -32,7 +31,7 @@ class Keyword extends React.Component {
   async onChange(suggestion) {
     const geofeature =
       this.props.geofeature || (suggestItem => this.geofeature(suggestItem))
-    this.setState({ keywordValue: suggestion.name, loading: true })
+    this.setState({ value: suggestion.name, loading: true })
     try {
       const { type, geometry = {} } = await geofeature(suggestion)
       this.setState({ loading: false })
@@ -45,7 +44,7 @@ class Keyword extends React.Component {
             locationType: 'latlon',
             polygon: polygon,
             polyType: 'polygon',
-            keywordValue: this.state.keywordValue,
+            value: this.state.value,
           })
           break
         }
@@ -58,7 +57,7 @@ class Keyword extends React.Component {
             locationType: 'latlon',
             polygon: polygon,
             polyType: 'multipolygon',
-            keywordValue: this.state.keywordValue,
+            value: this.state.value,
           })
           break
         }
@@ -90,11 +89,11 @@ class Keyword extends React.Component {
       polygonBufferUnits,
       polyType,
     } = this.props
-    const { keywordValue, loading, error } = this.state
+    const { value, loading, error } = this.state
     return (
       <div>
         <AutoComplete
-          value={keywordValue}
+          value={value}
           onChange={option => this.onChange(option)}
           minimumInputLength={2}
           placeholder="Enter a region, country, or city"

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
@@ -34,7 +34,17 @@ const inputs = plugin({
   },
   keyword: {
     label: 'Keyword',
-    Component: Keyword,
+    Component: ({ props, setState, keywordValue }) => {
+      return (
+        <Keyword
+          {...props}
+          value={keywordValue}
+          setState={({ value, ...data }) => {
+            setState({ keywordValue: value, ...data })
+          }}
+        />
+      )
+    },
   },
 })
 


### PR DESCRIPTION
#### What does this PR do?
One common complaint we have received is the lack of preservation pertinent to queries being saved from Intrigue.

**Two Main Issues:**

    * Queries saved from a keyword re-render as a polygon or multipolygon (keyword metadata is lost and not preserved)

    * Queries saved from bounding box re-render as polygon (bbox corner points are not preserved and fail to reconstruct the correct bbox mode)


This user experience is strange and causes a lot of confusion due to lack of preserved information related to the original query.
#### Who is reviewing it? 
@Bdthomson 
@bdeining 
@middlets719 
@adimka 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@troymohl 
@millerw8 
@djblue 
@andrewkfiedler 

#### How should this be tested?
Create queries for all the location types using the advanced query builder, persist them, refresh, ensure that bbox and keywords persisted and reloaded correctly. 
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #4346 

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
