### PR TITLE
DDF-04363 Fixed off-by-one error for negative decimal coordinates in tooltip

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/map-info/map-info.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/map-info/map-info.view.js
@@ -14,6 +14,7 @@
  **/
 /*global require*/
 import React from 'react'
+import leftPad from '../../react-component/utils/left-pad'
 
 const Marionette = require('marionette')
 const CustomElements = require('../../js/CustomElements.js')
@@ -34,15 +35,6 @@ function getCoordinateFormat() {
     .get('user')
     .get('preferences')
     .get('coordinateFormat')
-}
-
-function leftPad(numToPad, size) {
-  var sign = Math.sign(numToPad) === -1 ? '-' : ''
-  var numNoDecimal = Math.floor(Math.abs(numToPad))
-  return new Array(sign === '-' ? size - 1 : size)
-    .concat([Math.sign(numToPad) * numNoDecimal])
-    .join(' ')
-    .slice(-size)
 }
 
 function formatAttribute(attributeName, attributeValue) {
@@ -114,10 +106,10 @@ module.exports = Marionette.LayoutView.extend({
   decimalComponent(lat, lon) {
     return (
       <span>
-        {`${leftPad(lat, 3, ' ')}.${Math.abs(lat % 1)
+        {`${leftPad(lat, 3)}.${Math.abs(lat % 1)
           .toFixed(6)
           .toString()
-          .slice(2)} ${leftPad(lon, 4, ' ')}.${Math.abs(lon % 1)
+          .slice(2)} ${leftPad(lon, 4)}.${Math.abs(lon % 1)
           .toFixed(6)
           .toString()
           .slice(2)}`}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/map-info/map-info.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/map-info/map-info.view.js
@@ -38,8 +38,9 @@ function getCoordinateFormat() {
 
 function leftPad(numToPad, size) {
   var sign = Math.sign(numToPad) === -1 ? '-' : ''
+  var numNoDecimal = Math.floor(Math.abs(numToPad))
   return new Array(sign === '-' ? size - 1 : size)
-    .concat([numToPad])
+    .concat([Math.sign(numToPad) * numNoDecimal])
     .join(' ')
     .slice(-size)
 }
@@ -113,10 +114,10 @@ module.exports = Marionette.LayoutView.extend({
   decimalComponent(lat, lon) {
     return (
       <span>
-        {`${leftPad(Math.floor(lat), 3, ' ')}.${Math.abs(lat % 1)
+        {`${leftPad(lat, 3, ' ')}.${Math.abs(lat % 1)
           .toFixed(6)
           .toString()
-          .slice(2)} ${leftPad(Math.floor(lon), 4, ' ')}.${Math.abs(lon % 1)
+          .slice(2)} ${leftPad(lon, 4, ' ')}.${Math.abs(lon % 1)
           .toFixed(6)
           .toString()
           .slice(2)}`}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/left-pad/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/left-pad/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+export { default } from './left-pad'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/left-pad/left-pad.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/left-pad/left-pad.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+export default function leftPad(numToPad: number, size: number) {
+  var sign = Math.sign(numToPad) === -1 ? '-' : ''
+  var numNoDecimal = Math.floor(Math.abs(numToPad))
+  return new Array(sign === '-' ? size - 1 : size)
+    .concat([Math.sign(numToPad) * numNoDecimal])
+    .join(' ')
+    .slice(-size)
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/left-pad/leftpad.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/left-pad/leftpad.spec.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+import { expect } from 'chai'
+import leftPad from './left-pad'
+
+describe('left-pad', () => {
+  it('positive latitude, no decimal', () => {
+    expect(leftPad(88, 3)).to.equal(' 88')
+  })
+  it('positive longitude, no decimal', () => {
+    expect(leftPad(179, 4)).to.equal(' 179')
+  })
+  it('negative latitude, no decimal', () => {
+    expect(leftPad(-88, 3)).to.equal('-88')
+  })
+  it('negative longitude, no decimal', () => {
+    expect(leftPad(-179, 4)).to.equal('-179')
+  })
+  it('positive latitude, with decimal', () => {
+    expect(leftPad(88.209234, 3)).to.equal(' 88')
+  })
+  it('positive longitude, with decimal', () => {
+    expect(leftPad(179.209234, 4)).to.equal(' 179')
+  })
+  it('negative latitude, with decimal', () => {
+    expect(leftPad(-88.209234, 3)).to.equal('-88')
+  })
+  it('negative longitude, with decimal', () => {
+    expect(leftPad(-179.209234, 4)).to.equal('-179')
+  })
+})

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/wrap-num/wrap-num.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/wrap-num/wrap-num.spec.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+import { expect } from 'chai'
+import wrapNum from './wrap-num'
+
+describe('wrap-num', () => {
+  it('overflow +1/-1', () => {
+    expect(wrapNum(181, -180, 180)).to.equal(-179)
+    expect(wrapNum(-181, -180, 180)).to.equal(179)
+  })
+  it('overflow +/-a lot', () => {
+    expect(wrapNum(64.25 + 180 * 7, -180, 180)).to.equal(-180 + 64.25)
+    expect(wrapNum(-64.25 - 180 * 7, -180, 180)).to.equal(180 - 64.25)
+  })
+  it('no overflow mid', () => {
+    expect(wrapNum(-179, -180, 180)).to.equal(-179)
+    expect(wrapNum(179, -180, 180)).to.equal(179)
+    expect(wrapNum(0, -180, 180)).to.equal(0)
+    expect(wrapNum(5, -180, 180)).to.equal(5)
+    expect(wrapNum(-15, -180, 180)).to.equal(-15)
+  })
+  it('max should map to min', () => {
+    expect(wrapNum(180, -180, 180)).to.equal(-180)
+  })
+  it('min should remain min', () => {
+    expect(wrapNum(-180, -180, 180)).to.equal(-180)
+  })
+})


### PR DESCRIPTION
#### What does this PR do?
Before, the `leftPad` method in `map-info.view.js`, which is used in the tooltip's `<span>` to format the latitude and longitude, was being passed `Math.floor(lat)` and `Math.floor(lon)`. This caused the off-by-one error because when `Math.floor()` is evaluated on -179.152798 for example, it returns -180. This PR makes some adjustments to avoid the off-by-one behavior on negative decimal coordinates in both the 2D and 3D maps.
#### Who is reviewing it? 
@Bdthomson 
@andrewzimmer 
@nsuvarna 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler 
@bdeining
@djblue 
#### How should this be tested?
Follow the steps to reproduce in the issue and verify that you now see the expected behavior
#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4363 
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
