### PR TITLE
DDF-04367 Add documentation on shell command whitelist

### DIFF
--- a/distribution/docs/src/main/resources/content/_managing/_configuring/environment-hardening.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/environment-hardening.adoc
@@ -102,4 +102,29 @@ a|Update the Session configuration to have no greater than a 10 minute Session T
  * Select the *Configuration* tab. +
  * Select `Session`. +
  * Set `Session Timeout (in minutes)` to `10` (or less). +
+
+|Shell Command Access
+|command injection
+a|By default, some shell commands are disabled in order to secure the system.
+${branding} includes a whitelist of allowed shell commands in
+`${home_directory}/etc/org.apache.karaf.command.acl.shell.cfg`.
+
+By default, this list includes commands that are whitelisted only to administrators:
+
+* `complete`
+* `echo`
+* `format`
+* `grep`
+* `if`
+* `keymap`
+* `less`
+* `set`
+* `setopt`
+* `sleep`
+* `tac`
+* `wc`
+* `while`
+* `.invoke`
+* `unsetopt`
+
 |===


### PR DESCRIPTION
#### What does this PR do?
Adds documentation mentioning that shell commands are disabled by default due to security concerns. Also documents the existence of a whitelist for shell commands.

#### Who is reviewing it? 
@tyler30clemens 
@glenhein 
@rzwiefel 

#### Select relevant component teams: 
@codice/docs
@codice/security

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@garrettfreibott
@ricklarsen 

#### How should this be tested?
Build and view documentation section.

#### What are the relevant tickets?
Fixes: #4367 

#### Screenshots
![image](https://user-images.githubusercontent.com/12501737/52723923-a3587400-2f6b-11e9-9772-5298a1564b03.png)

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
