### PR TITLE
[2.13.x] DDF-04370 Fixed quartz2 feature dependency for DefaultUsersDeletionScheduler

### DIFF
--- a/features/admin/src/main/feature/feature.xml
+++ b/features/admin/src/main/feature/feature.xml
@@ -112,6 +112,7 @@
         <bundle>mvn:io.fastjson/boon/${boon.version}</bundle>
 
         <feature>camel-blueprint</feature>
+        <feature>camel-quartz2</feature>
         <bundle>mvn:ddf.admin.core/admin-core-insecuredefaults/${project.version}</bundle>
     </feature>
 

--- a/features/camel/src/main/feature/feature.xml
+++ b/features/camel/src/main/feature/feature.xml
@@ -237,7 +237,7 @@
   <feature name="camel-quartz2" version="${camel.version}" start-level="50">
       <!-- Bundle wrap & deploy mchange's version of c3p0 0.9.5.3 to force quartz2's transitive
     dependency on 0.9.5.2 to use the newer version instead -->
-        <bundle dependency="true">wrap:mvn:com.mchange/c3p0/${c3p0-bundle-version}</bundle>
+        <bundle dependency="true">wrap:mvn:com.mchange/c3p0/${c3p0-bundle-version}$Bundle-Name=c3p0&amp;Bundle-SymbolicName=c3p0&amp;Bundle-Version=${c3p0-bundle-version}</bundle>
         <bundle dependency="true">mvn:com.zaxxer/HikariCP-java6/${hikaricp-version}</bundle>
         <bundle dependency="true">wrap:mvn:org.quartz-scheduler/quartz/${quartz2-version}$overwrite=merge&amp;DynamicImport-Package=org.apache.camel.component.quartz2</bundle>
         <feature version="${camel.version}">camel-core</feature>


### PR DESCRIPTION
#### What does this PR do?
The default users deletion was not working or showing notifications to the AdminUI after removing the camel-quartz2 dependency when updating c3p0. This PR is a quick fix to add the camel-quartz2 feature and fix the wrap for the c3p0 artifact. 

#### Who is reviewing it? 
@austinsteffes 
@ahoffer
@Lambeaux

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@bjeter
@emmberk
@stustison

#### How should this be tested?
See #4370

#### Any background context you want to provide?

#### What are the relevant tickets?
Work for: #4370 

#### Screenshots
Example of AdminUI notification 
![image](https://user-images.githubusercontent.com/31221295/52753460-f3f3bf80-2fb3-11e9-9a42-1492ffa7d128.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
