### PR TITLE
DDF-04389 Fix search options saving

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/paging/paging.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/paging/paging.view.js
@@ -14,8 +14,6 @@
  **/
 /*global define, alert*/
 const Marionette = require('marionette')
-const _ = require('underscore')
-const $ = require('jquery')
 const CustomElements = require('../../js/CustomElements.js')
 const template = require('./paging.hbs')
 const _debounce = require('lodash/debounce')
@@ -25,6 +23,7 @@ module.exports = Marionette.ItemView.extend({
   template: template,
   initialize: function(options) {
     this.listenTo(this.model, 'reset', this.render)
+    this.listenTo(this.getQuery().get('result'), 'change', this.render)
     this.listenTo(
       this.model.fullCollection,
       'add remove update',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
@@ -14,11 +14,8 @@
  **/
 /*global define*/
 const Marionette = require('marionette')
-const _ = require('underscore')
-const $ = require('jquery')
 const resultSelectorTemplate = require('./result-selector.hbs')
 const CustomElements = require('../../js/CustomElements.js')
-const properties = require('../../js/properties.js')
 const Common = require('../../js/Common.js')
 const ResultItemCollectionView = require('../result-item/result-item.collection.view.js')
 const PagingView = require('../paging/paging.view.js')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-settings/search-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-settings/search-settings.view.js
@@ -64,19 +64,18 @@ module.exports = Marionette.LayoutView.extend({
       .get('preferences')
       .get('resultCount')
 
-    this.propertyResultCount.show(
-      new PropertyView({
-        model: new Property({
-          label: 'Number of Search Results',
-          value: [userResultCount],
-          min: 1,
-          max: properties.resultCount,
-          type: 'RANGE',
-        }),
-      })
-    )
+    const model = new Property({
+      label: 'Number of Search Results',
+      value: [userResultCount],
+      min: 1,
+      max: properties.resultCount,
+      type: 'RANGE',
+    })
+
+    this.propertyResultCount.show(new PropertyView({ model }))
 
     this.propertyResultCount.currentView.turnOnEditing()
+    this.listenTo(model, 'change:value', this.updateResultCountSettings)
   },
   updateSearchSettings: function() {
     user


### PR DESCRIPTION
#### What does this PR do?
- Fix search options saving when clicking out of the settings pane.
- Also fixes a new issue found where paging would switch between `x results` or `x of y results` depending on a race condition.

#### Who is reviewing it? 
@andrewzimmer 
@hayleynorton 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@djblue

#### How should this be tested?
1. Download [fifty-numbers.zip](https://github.com/connexta/ddf-yorktown/files/2866300/fifty-numbers.zip) and unzip, then throw the folder into the upload editor to ingest 50 results.
2. Query and verify that the default is 25 results
3. Open the Search Options pane
<image src="https://user-images.githubusercontent.com/7236299/52807862-e25cf700-3049-11e9-8946-7f4f51070feb.png" width="300px"/>
4. Change the number to 5, then click OUT of the side pane (do not click "Back to Results") and verify that clicking Play on the search now limits it to 5.


#### What are the relevant tickets?
For GH Issues:
Fixes: #4389 

#### Checklist:
- [x] Documentation Updated (N/A)
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests (N/A)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
