### PR TITLE
DDF-4321 adding new role with hostname to control validation filtering

### DIFF
--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -19,15 +19,15 @@
     <OCD name="Metacard Validation Filter Plugin"
          id="ddf.catalog.metacard.validation.MetacardValidityFilterPlugin">
         <AD
-                description="Comma-delimited mapping of Metacard SECURITY attribute to user attribute. Users with this role will always receive metacards with errors and/or warnings."
+                description="Comma-delimited mapping of Metacard SECURITY attribute to user attributes. Users with one of these attributes will always receive metacards with errors and/or warnings."
                 name="Attribute map" id="attributeMap" required="false" type="String"
-                default="invalid-state=data-manager\,system-user" cardinality="100"/>
+                default="invalid-state=localhost-data-manager\,system-user" cardinality="100"/>
         <AD
-                description="Sets whether metacards with validation errors are filtered for users without the configured user attribute."
+                description="Sets whether metacards with validation errors are filtered for users without one of the configured user attribute."
                 name="Filter errors" id="filterErrors" type="Boolean"
                 default="true"/>
         <AD
-                description="Sets whether metacards with validation warnings are filtered for users without the configured user attribute."
+                description="Sets whether metacards with validation warnings are filtered for users without one of the configured user attribute."
                 name="Filter warnings" id="filterWarnings" type="Boolean"
                 default="false"/>
     </OCD>
@@ -40,11 +40,11 @@
                 type="String"
                 default="" cardinality="100"/>
         <AD
-                description="Sets whether validation errors are enforced"
+                description="Sets whether validation errors are enforced."
                 name="Enforce errors" id="enforceErrors" required="true" type="Boolean"
                 default="true"/>
         <AD
-                description="Sets whether validation warnings are enforced"
+                description="Sets whether validation warnings are enforced."
                 name="Enforce warnings" id="enforceWarnings" required="true" type="Boolean"
                 default="true"/>
     </OCD>

--- a/distribution/ddf-common/src/main/resources/etc/ddf.catalog.metacard.validation.MetacardValidityFilterPlugin.config
+++ b/distribution/ddf-common/src/main/resources/etc/ddf.catalog.metacard.validation.MetacardValidityFilterPlugin.config
@@ -1,0 +1,5 @@
+attributeMap=[ \
+  "invalid-state\=${org.codice.ddf.system.hostname}-data-manager,system-user", \
+  ]
+filterErrors=B"true"
+filterWarnings=B"false"

--- a/distribution/ddf-common/src/main/resources/etc/users.properties
+++ b/distribution/ddf-common/src/main/resources/etc/users.properties
@@ -32,4 +32,4 @@
 
 # DDF Changes: changed username/pw to admin/admin, added localhost certificate user
 admin=admin,group,admin,manager,viewer,system-admin,systembundles,ssh
-localhost=localhost,group,admin,manager,viewer,system-user,system-admin,system-history,data-manager,systembundles,ssh
+localhost=localhost,group,admin,manager,viewer,system-user,system-admin,system-history,localhost-data-manager,systembundles,ssh

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/hiding-errors-by-role.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/hiding-errors-by-role.adoc
@@ -7,6 +7,8 @@
 
 == {title}
 
+* *{hardening-step}*
+
 Prevent certain users from seeing data with certain types of errors or warnings.
 Typically, this is used for security markings.
 If the *Metacard Validation Filter Plugin* is configured to *Filter errors* and/or *Filter warnings*, metacards with errors/warnings will be hidden from users without the specified user attributes.
@@ -20,7 +22,7 @@ If the *Metacard Validation Filter Plugin* is configured to *Filter errors* and/
 ... `invalid-state=<USER ROLE>`.
 ... Replace `<USER ROLE>` with the roles that should be allowed to view invalid metacards.
 [NOTE]
-To prevent other ${branding} systems from querying invalid data in the local catalog, it is
+To harden the system and prevent other ${branding} systems from querying invalid data in the local catalog, it is
 recommended to create and set user roles that are unique to the local system (ie. a user role
 that includes a UUID).
 . Select *Filter errors* to filter errors. Users without the `invalid-state` attribute will not see metacards with errors.

--- a/distribution/docs/src/main/resources/content/_managing/_securing/hardening-checklist.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_securing/hardening-checklist.adoc
@@ -19,6 +19,7 @@ To harden a new system, perform configuration as <<{managing-prefix}configuring,
 ** [ ] <<{managing-prefix}allowing_guest_user_access,Allow Guest User Access>> (if allowing Guest users)
 * [ ] <<{managing-prefix}configuring_guest_claim_attributes,Configure Guest Claim Attributes>> (if allowing Guest users)
 * [ ] <<{managing-prefix}configuring_guest_access,Configure Guest User Authentication>>
+* [ ] <<{managing-prefix}hiding_errors_and_warnings_from_users_based_on_role, Create unique user role>>
 * [ ] <<{managing-prefix}limiting_access_to_the_sts, Limit Access to the STS>>
 * [ ] <<{managing-prefix}restricting_access_to_admin_console, Restricting Access to ${admin-console}>>
 * [ ] <<{managing-prefix}restricting_feature_app_service_and_configuration_access, Restrict Feature, App, Service, and Configuration Access>>

--- a/distribution/docs/src/main/resources/content/_reference/_tables/MetacardValidityFilterPlugin.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/MetacardValidityFilterPlugin.adoc
@@ -20,7 +20,7 @@
 |attributeMap
 |String
 |Mapping of Metacard SECURITY attribute to user attribute. Users with this role will always receive metacards with errors and/or warnings.
-|invalid-state=data-manager
+|invalid-state=localhost-data-manager
 |false
 
 |Filter errors

--- a/distribution/test/itests/test-itests-common/src/main/resources/etc/test-users.properties
+++ b/distribution/test/itests/test-itests-common/src/main/resources/etc/test-users.properties
@@ -1,5 +1,5 @@
 admin=admin,group,admin,manager,viewer,system-admin,systembundles
-localhost=localhost,group,admin,manager,viewer,system-user,system-admin,system-history,data-manager,systembundles
+localhost=localhost,group,admin,manager,viewer,system-user,system-admin,system-history,localhost-data-manager,systembundles
 slang=password1,A
 tchalla=password1,B
 nromanova=password1,C

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdmin.java
@@ -84,6 +84,8 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
       "The unique name of this instance. This name will be provided via web services that ask for the name.";
   private static final String VERSION_TITLE = "Version";
   private static final String VERSION_DESCRIPTION = "The version of this instance.";
+  private static final String LOCALHOST_DATA_MANAGER = "localhost-data-manager";
+  private static final String DATA_MANAGER = "data-manager";
 
   private static final Gson GSON =
       new GsonBuilder()
@@ -222,10 +224,12 @@ public class SystemPropertiesAdmin extends StandardMBean implements SystemProper
         String oldHostValue = usersDotProperties.getProperty(oldHostName);
 
         if (oldHostValue != null) {
+          String newInternalHost = System.getProperty(SystemBaseUrl.INTERNAL_HOST);
+          String newHostValue =
+              oldHostValue.replaceAll(
+                  LOCALHOST_DATA_MANAGER, String.format("%s-%s", newInternalHost, DATA_MANAGER));
           usersDotProperties.remove(oldHostName);
-          usersDotProperties.setProperty(
-              System.getProperty(SystemBaseUrl.INTERNAL_HOST), oldHostValue);
-
+          usersDotProperties.setProperty(newInternalHost, newHostValue);
           usersDotProperties.save();
         }
       }

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/resources/users.properties
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/resources/users.properties
@@ -32,4 +32,4 @@
 
 # DDF Changes: changed username/pw to admin/admin, added localhost certificate user
 admin=admin,group,admin,manager,viewer
-localhost=localhost,group,admin,manager,viewer,codice-history,data-manager
+localhost=localhost,group,admin,manager,viewer,codice-history,localhost-data-manager


### PR DESCRIPTION


##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #4388 

#### What does this PR do?
At installation, a role including the hostname is added and used in the MetacardValidityFilterPlugin

#### Who is reviewing it?
@ahoffer @tyler30clemens

#### Select relevant component teams:
#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@lessarderic
@mcalcote

#### How should this be tested?
* Install with dev=true
* Navigate to admin ui -> catalog -> configuration -> Metacard Validation Filter Plugin
* Make sure Attribute Map's value contains ${your host name}-data-manager
* Upload invalid metacard in catalog. Ensure you can see the result in the search
* Sign out and sign in as admin. Ensure you can NOT see the result in the search

#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4321 

#### Checklist:
- [X ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
