### PR TITLE
[2.13.x] DDF-1366 Updated the CSW Registry Store to not be registered as a FederatedSource service

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -47,6 +47,7 @@ import ddf.catalog.plugin.PostQueryPlugin;
 import ddf.catalog.plugin.PreAuthorizationPlugin;
 import ddf.catalog.plugin.PreQueryPlugin;
 import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.source.CatalogStore;
 import ddf.catalog.source.ConnectedSource;
 import ddf.catalog.source.FederatedSource;
 import ddf.catalog.source.Source;
@@ -70,6 +71,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -796,19 +798,15 @@ public class QueryOperations extends DescribableImpl {
           for (String id : sourceIds) {
             LOGGER.debug("Looking up source ID = {}", id);
 
-            List<FederatedSource> sources = new ArrayList<>();
-            sources.addAll(
-                frameworkProperties
-                    .getFederatedSources()
-                    .stream()
-                    .filter(e -> e.getId().equals(id))
-                    .collect(Collectors.toList()));
-            sources.addAll(
-                frameworkProperties
-                    .getCatalogStores()
-                    .stream()
-                    .filter(e -> e.getId().equals(id))
-                    .collect(Collectors.toList()));
+            Stream<FederatedSource> federatedSources =
+                frameworkProperties.getFederatedSources().stream();
+            Stream<CatalogStore> catalogStores = frameworkProperties.getCatalogStores().stream();
+
+            List<FederatedSource> sources =
+                new ArrayList<>(
+                    Stream.concat(federatedSources, catalogStores)
+                        .filter(e -> e.getId().equals(id))
+                        .collect(Collectors.toList()));
 
             if (sources.isEmpty()) {
               exceptions.add(

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -796,22 +796,29 @@ public class QueryOperations extends DescribableImpl {
           for (String id : sourceIds) {
             LOGGER.debug("Looking up source ID = {}", id);
 
-            final List<FederatedSource> fedSources =
+            List<FederatedSource> sources = new ArrayList<>();
+            sources.addAll(
                 frameworkProperties
                     .getFederatedSources()
                     .stream()
                     .filter(e -> e.getId().equals(id))
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toList()));
+            sources.addAll(
+                frameworkProperties
+                    .getCatalogStores()
+                    .stream()
+                    .filter(e -> e.getId().equals(id))
+                    .collect(Collectors.toList()));
 
-            if (fedSources.isEmpty()) {
+            if (sources.isEmpty()) {
               exceptions.add(
                   new ProcessingDetailsImpl(
                       id, new SourceUnavailableException("Source id is not found")));
             } else {
-              if (fedSources.size() != 1) {
+              if (sources.size() != 1) {
                 LOGGER.debug("Multiple sources found for id: {}", id);
               }
-              FederatedSource source = fedSources.get(0);
+              FederatedSource source = sources.get(0);
 
               boolean canAccessSource = queryOps.canAccessSource(source, queryRequest);
               if (!canAccessSource) {

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -160,7 +160,6 @@
         <interfaces>
             <value>org.codice.ddf.registry.api.internal.RegistryStore</value>
             <value>ddf.catalog.source.CatalogStore</value>
-            <value>ddf.catalog.source.FederatedSource</value>
         </interfaces>
         <cm:managed-component class="org.codice.ddf.registry.api.impl.RegistryStoreImpl"
                               init-method="init" destroy-method="destroy">


### PR DESCRIPTION
#### What does this PR do?
This PR updates the CSW Registry Store to not be registered as a FederatedSource service. This PR is required by https://github.com/codice/ddf/pull/3858. Because RegistryStoreImpl was unnecessarily being registered as 2 different types of Sources, the SourcePoller was recognizing 2 different sources with the same key. See https://github.com/codice/ddf/pull/3858#discussion_r229886462.

#### Who is reviewing it? 
@jhunzik @peterhuffer 
#### Select relevant component teams: 
@codice/io

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@vinamartin

#### How should this be tested?
Confirm that the Csw Registry Store still works
- view connection status
- push/pull

You should no longer see the registry as a source in the Admin Console or Intrigue. Confirm that no documentation updates were missed.

#### What are the relevant tickets?
[DDF-1366](https://codice.atlassian.net/browse/DDF-1366)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.