### PR TITLE
DDF-04408 Adds faceting driven auto-complete to ui

### DIFF
--- a/catalog/ui/catalog-ui-search/pom.xml
+++ b/catalog/ui/catalog-ui-search/pom.xml
@@ -498,17 +498,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.43</minimum>
+                                            <minimum>0.44</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.40</minimum>
+                                            <minimum>0.43</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.38</minimum>
+                                            <minimum>0.40</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -47,6 +47,7 @@ import org.apache.commons.collections.Factory;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.branding.BrandingPlugin;
+import org.codice.ddf.catalog.ui.security.FacetWhitelistConfiguration;
 import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.gsonsupport.GsonTypeAdapters.LongDoubleTypeAdapter;
 import org.codice.proxy.http.HttpProxyService;
@@ -236,6 +237,8 @@ public class ConfigurationApplication implements SparkApplication {
   private Set<String> requiredAttributes = Collections.emptySet();
   private Map<String, Set<String>> attributeEnumMap = Collections.emptyMap();
 
+  private FacetWhitelistConfiguration facetWhitelistConfiguration;
+
   private static final String INTRIGUE_BASE_NAME = "IntrigueBundle";
 
   private volatile Map<String, String> i18n = Collections.emptyMap();
@@ -341,8 +344,10 @@ public class ConfigurationApplication implements SparkApplication {
     setAttributeEnumMap(mergedEntryMap);
   }
 
-  public ConfigurationApplication(UuidGenerator uuidGenerator) {
+  public ConfigurationApplication(
+      UuidGenerator uuidGenerator, FacetWhitelistConfiguration facetWhitelistConfiguration) {
     this.uuidGenerator = uuidGenerator;
+    this.facetWhitelistConfiguration = facetWhitelistConfiguration;
   }
 
   public List<Long> getScheduleFrequencyList() {
@@ -562,6 +567,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("basicSearchMatchType", basicSearchMatchType);
     config.put("useHyphensInUuid", uuidGenerator.useHyphens());
     config.put("i18n", i18n);
+    config.put("facetWhitelist", facetWhitelistConfiguration.getFacetAttributeWhitelist());
     return config;
   }
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/FacetAttributeAccessPlugin.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/FacetAttributeAccessPlugin.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.security;
+
+import static ddf.catalog.Constants.EXPERIMENTAL_FACET_PROPERTIES_KEY;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.TermFacetProperties;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.plugin.AccessPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Security-based plugin that checks to make sure that attributes attached to faceted query requests
+ * are valid as defined by the whitelist in the admin console.
+ */
+public class FacetAttributeAccessPlugin implements AccessPlugin {
+
+  private FacetWhitelistConfiguration config;
+
+  public FacetAttributeAccessPlugin(FacetWhitelistConfiguration config) {
+    this.config = config;
+  }
+
+  @Override
+  public CreateRequest processPreCreate(CreateRequest input) throws StopProcessingException {
+    return input;
+  }
+
+  @Override
+  public UpdateRequest processPreUpdate(
+      UpdateRequest input, Map<String, Metacard> existingMetacards) throws StopProcessingException {
+    return input;
+  }
+
+  @Override
+  public DeleteRequest processPreDelete(DeleteRequest input) throws StopProcessingException {
+    return input;
+  }
+
+  @Override
+  public DeleteResponse processPostDelete(DeleteResponse input) throws StopProcessingException {
+    return input;
+  }
+
+  @Override
+  public QueryRequest processPreQuery(QueryRequest input) throws StopProcessingException {
+    if (input.getProperties().get(EXPERIMENTAL_FACET_PROPERTIES_KEY)
+        instanceof TermFacetProperties) {
+      TermFacetProperties facetProperties =
+          (TermFacetProperties) input.getProperties().get(EXPERIMENTAL_FACET_PROPERTIES_KEY);
+      Set<String> facetAttributes = facetProperties.getFacetAttributes();
+
+      for (String attr : facetAttributes) {
+        if (!config.getFacetAttributeWhitelist().contains(attr)) {
+          throw new StopProcessingException("Invalid Facet Attribute Detected: " + attr);
+        }
+      }
+    }
+
+    return input;
+  }
+
+  @Override
+  public QueryResponse processPostQuery(QueryResponse input) throws StopProcessingException {
+    return input;
+  }
+
+  @Override
+  public ResourceRequest processPreResource(ResourceRequest input) throws StopProcessingException {
+    return input;
+  }
+
+  @Override
+  public ResourceResponse processPostResource(ResourceResponse input, Metacard metacard)
+      throws StopProcessingException {
+    return input;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/FacetWhitelistConfiguration.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/FacetWhitelistConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.security;
+
+import java.util.Collections;
+import java.util.List;
+
+public class FacetWhitelistConfiguration {
+  private List<String> facetAttributeWhitelist = Collections.emptyList();
+
+  public List<String> getFacetAttributeWhitelist() {
+    return facetAttributeWhitelist;
+  }
+
+  public void setFacetAttributeWhitelist(List<String> attrs) {
+    facetAttributeWhitelist = attrs;
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -83,6 +83,7 @@
           class="org.codice.ddf.catalog.ui.config.ConfigurationApplication"
           destroy-method="destroy">
         <argument ref="uuidGenerator"/>
+        <argument ref="facetWhitelistConfiguration" />
 
         <cm:managed-properties
                 persistent-id="org.codice.ddf.catalog.ui"
@@ -142,6 +143,17 @@
         <argument ref="subjectIdentity"/>
     </bean>
 
+
+    <bean id="facetAttributeAccessPlugin"
+          class="org.codice.ddf.catalog.ui.security.FacetAttributeAccessPlugin">
+        <argument ref="facetWhitelistConfiguration" />
+    </bean>
+
+    <service interface="ddf.catalog.plugin.AccessPlugin">
+        <ref component-id="facetAttributeAccessPlugin"/>
+    </service>
+
+
     <service interface="ddf.catalog.plugin.AccessPlugin">
         <ref component-id="accessControlAccessPlugin"/>
     </service>
@@ -164,6 +176,13 @@
           class="org.codice.ddf.catalog.ui.security.AccessControlSecurityConfiguration">
         <cm:managed-properties
                 persistent-id="org.codice.ddf.catalog.ui.security"
+                update-strategy="container-managed"/>
+    </bean>
+
+    <bean id="facetWhitelistConfiguration"
+          class="org.codice.ddf.catalog.ui.security.FacetWhitelistConfiguration">
+        <cm:managed-properties
+                persistent-id="org.codice.ddf.catalog.ui.facetwhitelist"
                 update-strategy="container-managed"/>
     </bean>
 

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.facetwhitelist.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.facetwhitelist.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Attribute Suggestion Whitelist"
+         id="org.codice.ddf.catalog.ui.facetwhitelist">
+
+        <AD id="facetAttributeWhitelist"
+            name="Attribute Suggestion Whitelist"
+            description="The list of attributes you want to be able to make suggestions for. CAUTION: these attributes are not run through security"
+            type="String"
+            cardinality="1000"/>
+
+    </OCD>
+
+    <Designate pid="org.codice.ddf.catalog.ui.facetwhitelist">
+        <Object ocdref="org.codice.ddf.catalog.ui.facetwhitelist"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/config/ConfigurationApplicationTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/config/ConfigurationApplicationTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
+import org.codice.ddf.catalog.ui.security.FacetWhitelistConfiguration;
 import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.proxy.http.HttpProxyService;
 import org.junit.Before;
@@ -55,7 +56,9 @@ public class ConfigurationApplicationTest {
 
   @Before
   public void setUp() {
-    configurationApplication = new ConfigurationApplication(mock(UuidGenerator.class));
+    configurationApplication =
+        new ConfigurationApplication(
+            mock(UuidGenerator.class), mock(FacetWhitelistConfiguration.class));
     resourceBundleLocator = mock(ResourceBundleLocator.class);
   }
 

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/SearchFormsLoaderTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/SearchFormsLoaderTest.java
@@ -22,7 +22,9 @@ import static org.mockito.Mockito.when;
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.AttributeRegistry;
 import ddf.catalog.data.Metacard;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import javax.xml.bind.JAXBException;
@@ -47,7 +49,17 @@ public class SearchFormsLoaderTest {
   private static final URL LOADER_RESOURCES_DIR =
       SearchFormsLoaderTest.class.getResource("/forms/loader");
 
-  private static final String ROOT = LOADER_RESOURCES_DIR.getPath();
+  private static final String ROOT;
+
+  static {
+    String filePath;
+    try {
+      filePath = Paths.get(LOADER_RESOURCES_DIR.toURI()).toFile().toString();
+    } catch (URISyntaxException e) {
+      filePath = "";
+    }
+    ROOT = filePath;
+  }
 
   private TemplateTransformer transformer;
 

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/commands/SearchFormsManageCommandTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/commands/SearchFormsManageCommandTest.java
@@ -120,8 +120,12 @@ public class SearchFormsManageCommandTest {
     List<String> idToDelete = ImmutableList.of("1", "2");
     DeleteRequest mockDeleteReq = new DeleteRequestImpl(idToDelete.toArray(new String[0]));
     verify(catalogFramework).delete(refEq(mockDeleteReq));
-    assertThat(this.getOutput(), containsString("\u001B[93mDeleted: \u001B[32m1\u001B[m\n"));
-    assertThat(this.getOutput(), containsString("\u001B[93mDeleted: \u001B[32m2\u001B[m\n"));
+    assertThat(
+        this.getOutput(),
+        containsString("\u001B[93mDeleted: \u001B[32m1\u001B[m" + System.lineSeparator()));
+    assertThat(
+        this.getOutput(),
+        containsString("\u001B[93mDeleted: \u001B[32m2\u001B[m" + System.lineSeparator()));
   }
 
   @Test
@@ -131,10 +135,14 @@ public class SearchFormsManageCommandTest {
     assertThat(
         this.getOutput(),
         containsString(
-            "\u001B[93mTitle: title1\n"
-                + "\u001B[32m\t- 1\u001B[m\n"
-                + "\u001B[93mTitle: title2\n"
-                + "\u001B[32m\t- 2\u001B[m\n"));
+            "\u001B[93mTitle: title1"
+                + System.lineSeparator()
+                + "\u001B[32m\t- 1\u001B[m"
+                + System.lineSeparator()
+                + "\u001B[93mTitle: title2"
+                + System.lineSeparator()
+                + "\u001B[32m\t- 2\u001B[m"
+                + System.lineSeparator()));
   }
 
   private static void interceptSystemOut() {

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/FacetAttributePluginTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/FacetAttributePluginTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.security;
+
+import static ddf.catalog.Constants.EXPERIMENTAL_FACET_PROPERTIES_KEY;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.TermFacetProperties;
+import ddf.catalog.plugin.AccessPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FacetAttributePluginTest {
+
+  private static final String ATTR_1 = "attr1";
+
+  private AccessPlugin accessPlugin;
+
+  private QueryRequest queryRequest;
+
+  private TermFacetProperties facetProperties;
+
+  private Set<String> facetAttributes;
+
+  private Map<String, Serializable> queryProperties;
+
+  @Before
+  public void setUp() {
+    FacetWhitelistConfiguration config = new FacetWhitelistConfiguration();
+    config.setFacetAttributeWhitelist(Arrays.asList(ATTR_1));
+    accessPlugin = new FacetAttributeAccessPlugin(config);
+
+    queryRequest = mock(QueryRequest.class);
+    queryProperties = new HashMap<>();
+    when(queryRequest.getProperties()).thenReturn(queryProperties);
+
+    facetProperties = mock(TermFacetProperties.class);
+    facetAttributes = new HashSet<>();
+    when(facetProperties.getFacetAttributes()).thenReturn(facetAttributes);
+  }
+
+  @Test
+  public void testValidFacetAttribute() throws StopProcessingException {
+    queryProperties.put(EXPERIMENTAL_FACET_PROPERTIES_KEY, facetProperties);
+    facetAttributes.add(ATTR_1);
+    assertThat(queryRequest, is(accessPlugin.processPreQuery(queryRequest)));
+  }
+
+  @Test(expected = StopProcessingException.class)
+  public void testInvalidFacetAttribute() throws StopProcessingException {
+    queryProperties.put(EXPERIMENTAL_FACET_PROPERTIES_KEY, facetProperties);
+    facetAttributes.add("invalidAttribute");
+    accessPlugin.processPreQuery(queryRequest);
+  }
+
+  @Test
+  public void testQueryWithNoFacets() throws StopProcessingException {
+    assertThat(queryRequest, is(accessPlugin.processPreQuery(queryRequest)));
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -94,6 +94,7 @@ module.exports = Marionette.LayoutView.extend({
         'filter-builder': this,
         isForm: this.options.isForm || false,
         isFormBuilder: this.options.isFormBuilder || false,
+        suggester: this.options.suggester,
       })
     )
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
@@ -58,6 +58,7 @@ module.exports = Marionette.CollectionView.extend({
       isForm: this.options.isForm || false,
       isFormBuilder: this.options.isFormBuilder || false,
       isSortable: !this.sortable.options.disabled,
+      suggester: this.options.suggester,
     }
   },
   initialize: function() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -290,6 +290,25 @@ module.exports = Marionette.LayoutView.extend({
       this.model.get('type'),
       currentComparator
     )
+    let type = this.model.get('type')
+
+    if (this.options.suggester && propertyJSON.enum === undefined) {
+      this.options.suggester(propertyJSON).then(suggestions => {
+        if (suggestions.length > 0) {
+          propertyJSON.enum = suggestions.map(label => ({
+            label,
+            value: label,
+          }))
+          const ViewToUse = determineView(currentComparator)
+          this.filterInput.show(
+            new ViewToUse({
+              model: new PropertyModel(propertyJSON),
+            })
+          )
+          this.turnOnEditing()
+        }
+      })
+    }
     const ViewToUse = determineView(currentComparator)
     this.filterInput.show(
       new ViewToUse({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/multivalue/multivalue.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/multivalue/multivalue.view.js
@@ -55,6 +55,9 @@ module.exports = Marionette.LayoutView.extend({
     this.values.currentView.addNewValue(this.model)
   },
   isValid: function() {
+    if (this.model.get('enumCustom')) {
+      return true
+    }
     return this.values.currentView.children.every(function(valueView) {
       const inputView = valueView.input.currentView
       return inputView.isValid()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -14,7 +14,7 @@
  **/
 /*global define, setTimeout*/
 const Marionette = require('marionette')
-const _ = require('underscore')
+const memoize = require('lodash/memoize')
 const $ = require('jquery')
 const template = require('./query-advanced.hbs')
 const CustomElements = require('../../js/CustomElements.js')
@@ -24,6 +24,40 @@ const cql = require('../../js/cql.js')
 const store = require('../../js/store.js')
 const QuerySettingsView = require('../query-settings/query-settings.view.js')
 const user = require('../singletons/user-instance.js')
+const properties = require('../../js/properties.js')
+
+import query from '../../react-component/utils/query'
+
+const fetchSuggestions = memoize(async attr => {
+  const json = await query({
+    count: 0,
+    cql: "anyText ILIKE ''",
+    facets: [attr],
+  })
+
+  const suggestions = json.facets[attr]
+
+  if (suggestions === undefined) {
+    return []
+  }
+
+  suggestions.sort((a, b) => b.count - a.count)
+
+  return suggestions.map(({ value }) => value)
+})
+
+const isValidFacetAttribute = (id, type) => {
+  if (!['STRING', 'INTEGER', 'FLOAT'].includes(type)) {
+    return false
+  }
+  if (id === 'anyText') {
+    return false
+  }
+  if (!properties.facetWhitelist.includes(id)) {
+    return false
+  }
+  return true
+}
 
 module.exports = Marionette.LayoutView.extend({
   template: template,
@@ -103,6 +137,13 @@ module.exports = Marionette.LayoutView.extend({
     this.queryAdvanced.show(
       new FilterBuilderView({
         model: new FilterBuilderModel(),
+        suggester: async ({ id, type }) => {
+          if (!isValidFacetAttribute(id, type)) {
+            return []
+          }
+
+          return fetchSuggestions(id)
+        },
         isForm: this.options.isForm || false,
         isFormBuilder: this.options.isFormBuilder || false,
       })
@@ -142,6 +183,7 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
   cancel: function() {
+    fetchSuggestions.cache.clear()
     this.$el.removeClass('is-editing')
     this.onBeforeShow()
     if (typeof this.options.onCancel === 'function') {
@@ -149,6 +191,7 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
   save: function() {
+    fetchSuggestions.cache.clear()
     if (!this.options.isSearchFormEditor) {
       this.$el.removeClass('is-editing')
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/query/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/query/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './query'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/query/query.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/query/query.tsx
@@ -1,0 +1,19 @@
+import fetch from '../fetch'
+
+type Query = {
+  srcs: string[]
+  count: number
+  cql: string
+  facets: string[]
+}
+
+const query = async (q: Query) => {
+  const res = await fetch('./internal/cql', {
+    method: 'POST',
+    body: JSON.stringify(q),
+  })
+
+  return res.json()
+}
+
+export default query


### PR DESCRIPTION
<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Adds Faceting driven dropdown to the advanced query form. An `AccessPlugin` uses an admin configurable list of attributes to determine which attributes are able to be faceted against. If you try to issue a faceted query on an attribute not included in that list, a `StopProcessingException` will be thrown. By default, this list is empty so systems must opt in to faceting driven autocomplete.

As of right now, only string, float, and integer attributes will support this dropdown. Future work will include investigation into how best to handle dates and locations.

Also fixes some unit tests that were broken on Windows due to platform dependent operations. These changes are in `SearchFormsLoaderTest` and `SearchFormsManageCommandTest`.


#### Who is reviewing it? 
@gjvera 
@mojogitoverhere 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@djblue 
#### How should this be tested?
1. Ingest a bunch of data
2. Add attributes to the `Attribute Suggestion Whitelist` in the admin console (ex. title, id, etc.)
3. In Intrigue, verify that only attributes specified in that list populate the dropdown with values.
4. Using Postman or some other similar application, create a faceted query against an attribute not included in that list and ensure through the Karaf log that an exception is thrown and results are not returned. Alternatively remove an attribute from that list after loading the UI and then, without refreshing the page, ensure that the dropdown is not populated with values.

<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?


For GH Issues:
Fixes: #4408 

#### Screenshots
![image](https://user-images.githubusercontent.com/10997562/53021011-739ae780-3415-11e9-9062-a6a1d4b6085b.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
