### PR TITLE
DDF-04411 Fixes this.region undefined issue in MRC

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/marionette-region-container/marionette-region-container.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/marionette-region-container/marionette-region-container.spec.js
@@ -26,4 +26,27 @@ describe('<MarionetteRegionContainer />', () => {
       attachTo: div,
     })
   })
+
+  it('handles switching views quickly', done => {
+    const div = document.createElement('div')
+    document.body.appendChild(div)
+    const TestView = Marionette.ItemView.extend({
+      template: '<h1></h1>',
+      onRender() {
+        done()
+        div.remove()
+      },
+    })
+    const TestView2 = Marionette.ItemView.extend({
+      template: '<h1></h1>',
+      onRender() {
+        done()
+        div.remove()
+      },
+    })
+    const wrapper = mount(<MarionetteRegionContainer view={TestView} />, {
+      attachTo: div,
+    })
+    wrapper.setProps({ view: TestView2 })
+  })
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/marionette-region-container/marionette-region-container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/marionette-region-container/marionette-region-container.tsx
@@ -64,7 +64,7 @@ export default hot(module)(
     }
     // we might need to update this to account for more scenarios later
     componentDidUpdate(prevProps: Props) {
-      if (this.props.view !== prevProps.view) {
+      if (this.region && this.props.view !== prevProps.view) {
         this.handleViewChange()
       }
     }


### PR DESCRIPTION
#### What does this PR do?
 - Fixes this.region undefined in Marionette Region Container
 - The issue would happen if the view prop to the component changed
 before the component was able to be initially mounted to the DOM.
 Since we only use props (no local state), updating componentDidUpdate
 to return until this.region exists is sufficient.
 - Added a test for this scenario.

#### Who is reviewing it? 
@djblue 
@tbatie 
@samuelechu 
@adimka 

#### How should this be tested?
Ensure the build passes, specifically the new test.  If you want to try out the failure, update the component to not have my changes and run the test.  It'll fail without them.

#### Any background context you want to provide?
So far nothing in the codebase updates the props in this manner, but once https://github.com/codice/ddf/pull/4310 is in that will no longer be the case.  Basically, this is to prevent future issues.

#### What are the relevant tickets?
For GH Issues:
Fixes: #4411 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
