### PR TITLE
DDF-04426 [2.13.x] Expands external host/port properties

### DIFF
--- a/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
+++ b/platform/admin/core/admin-core-impl/src/test/java/org/codice/ddf/admin/core/impl/SystemPropertiesAdminTest.java
@@ -25,11 +25,13 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.management.NotCompliantMBeanException;
+import org.apache.commons.io.FileUtils;
 import org.codice.ddf.admin.core.api.SystemPropertyDetails;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
@@ -53,32 +55,8 @@ public class SystemPropertiesAdminTest {
 
   File userAttrsFile = null;
 
-  int expectedSystemPropertiesCount = 0;
-
   @Before
   public void setUp() throws IOException {
-    System.setProperty(SystemBaseUrl.EXTERNAL_PORT, "1234");
-    System.setProperty(SystemBaseUrl.EXTERNAL_HOST, "host");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemBaseUrl.EXTERNAL_HTTP_PORT, "4567");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemBaseUrl.EXTERNAL_HTTPS_PORT, "8901");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemBaseUrl.INTERNAL_HOST, "internal_host");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemBaseUrl.INTERNAL_HTTP_PORT, "5567");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemBaseUrl.INTERNAL_HTTPS_PORT, "9901");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemInfo.ORGANIZATION, "org");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemInfo.SITE_CONTACT, "contact");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemInfo.SITE_NAME, "site");
-    expectedSystemPropertiesCount++;
-    System.setProperty(SystemInfo.VERSION, "version");
-    expectedSystemPropertiesCount++;
-
     TemporaryFolder temporaryFolder = new TemporaryFolder();
     temporaryFolder.create();
     etcFolder = temporaryFolder.newFolder("etc");
@@ -87,51 +65,55 @@ public class SystemPropertiesAdminTest {
     systemPropsFile = new File(etcFolder, "custom.system.properties");
     userPropsFile = new File(etcFolder, "users.properties");
     userAttrsFile = new File(etcFolder, "users.attributes");
+
+    try (InputStream is =
+        SystemPropertiesAdminTest.class.getResourceAsStream("/custom.system.properties")) {
+      FileUtils.copyToFile(is, systemPropsFile);
+    }
   }
 
   @Test
   public void testReadSystemProperties() throws NotCompliantMBeanException {
     SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
     List<SystemPropertyDetails> details = spa.readSystemProperties();
-    assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HOST), equalTo("host"));
-    assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HTTP_PORT), equalTo("4567"));
-    assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HTTPS_PORT), equalTo("8901"));
-    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HOST), equalTo("internal_host"));
-    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HTTP_PORT), equalTo("5567"));
-    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HTTPS_PORT), equalTo("9901"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HOST), equalTo("localhost"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HTTP_PORT), equalTo("5678"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.EXTERNAL_HTTPS_PORT), equalTo("1234"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HOST), equalTo("localhost"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HTTP_PORT), equalTo("5678"));
+    assertThat(getDetailsValue(details, SystemBaseUrl.INTERNAL_HTTPS_PORT), equalTo("1234"));
     assertThat(getDetailsValue(details, SystemInfo.ORGANIZATION), equalTo("org"));
     assertThat(getDetailsValue(details, SystemInfo.SITE_CONTACT), equalTo("contact"));
     assertThat(getDetailsValue(details, SystemInfo.SITE_NAME), equalTo("site"));
     assertThat(getDetailsValue(details, SystemInfo.VERSION), equalTo("version"));
-    assertThat(details.size(), is(expectedSystemPropertiesCount));
   }
 
   @Test
-  public void testWriteSystemPropertiesNullProps() throws NotCompliantMBeanException {
+  public void testWriteSystemPropertiesNullProps() throws NotCompliantMBeanException, IOException {
     SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
     spa.writeSystemProperties(null);
-    List<SystemPropertyDetails> details = spa.readSystemProperties();
-    assertThat(SystemBaseUrl.EXTERNAL.getHost(), equalTo("host"));
-    assertThat(SystemBaseUrl.EXTERNAL.getPort(), equalTo("1234"));
-    assertThat(SystemBaseUrl.EXTERNAL.getHttpPort(), equalTo("4567"));
-    assertThat(SystemBaseUrl.EXTERNAL.getHttpsPort(), equalTo("8901"));
-    assertThat(SystemBaseUrl.INTERNAL.getHost(), equalTo("internal_host"));
-    assertThat(SystemBaseUrl.INTERNAL.getHttpPort(), equalTo("5567"));
-    assertThat(SystemBaseUrl.INTERNAL.getHttpsPort(), equalTo("9901"));
-    assertThat(SystemBaseUrl.EXTERNAL.getProtocol(), equalTo("https://"));
-    assertThat(SystemInfo.getOrganization(), equalTo("org"));
-    assertThat(SystemInfo.getSiteContatct(), equalTo("contact"));
-    assertThat(SystemInfo.getSiteName(), equalTo("site"));
-    assertThat(SystemInfo.getVersion(), equalTo("version"));
-    assertThat(details.size(), is(expectedSystemPropertiesCount));
+
+    // Read the system dot properties file and make sure that the new values evaluate to what we
+    // expect
+    org.apache.felix.utils.properties.Properties systemProps =
+        new org.apache.felix.utils.properties.Properties(systemPropsFile);
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HOST), equalTo("localhost"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HTTP_PORT), equalTo("5678"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HTTPS_PORT), equalTo("1234"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HOST), equalTo("localhost"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HTTP_PORT), equalTo("5678"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HTTPS_PORT), equalTo("1234"));
+    assertThat(systemProps.getProperty(SystemInfo.ORGANIZATION), equalTo("org"));
+    assertThat(systemProps.getProperty(SystemInfo.SITE_CONTACT), equalTo("contact"));
+    assertThat(systemProps.getProperty(SystemInfo.SITE_NAME), equalTo("site"));
+    assertThat(systemProps.getProperty(SystemInfo.VERSION), equalTo("version"));
   }
 
   @Test
   public void testWriteSystemProperties() throws Exception {
-
     Properties userProps = new Properties();
     userProps.put("admin", "admin,group,somethingelse");
-    userProps.put("internal_host", "host,group,somethingelse");
+    userProps.put("localhost", "host,group,somethingelse");
     try (FileOutputStream outProps = new FileOutputStream(userPropsFile)) {
       userProps.store(outProps, null);
     }
@@ -142,7 +124,7 @@ public class SystemPropertiesAdminTest {
               + "    \"admin\" : {\n"
               + "\n"
               + "    },\n"
-              + "    \"internal_host\" : {\n"
+              + "    \"localhost\" : {\n"
               + "\n"
               + "    }\n"
               + "}";
@@ -152,28 +134,29 @@ public class SystemPropertiesAdminTest {
     SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
     Map<String, String> map = new HashMap<>();
     map.put(SystemBaseUrl.INTERNAL_HOST, "newhost");
+    map.put(SystemBaseUrl.EXTERNAL_HOST, "newhost");
     spa.writeSystemProperties(map);
-    List<SystemPropertyDetails> details = spa.readSystemProperties();
-    assertThat(SystemBaseUrl.EXTERNAL.getHost(), equalTo("host"));
-    assertThat(SystemBaseUrl.EXTERNAL.getPort(), equalTo("8901"));
-    assertThat(SystemBaseUrl.EXTERNAL.getHttpPort(), equalTo("4567"));
-    assertThat(SystemBaseUrl.EXTERNAL.getHttpsPort(), equalTo("8901"));
-    assertThat(SystemBaseUrl.INTERNAL.getHost(), equalTo("newhost"));
-    assertThat(SystemBaseUrl.INTERNAL.getHttpPort(), equalTo("5567"));
-    assertThat(SystemBaseUrl.INTERNAL.getHttpsPort(), equalTo("9901"));
-    assertThat(SystemBaseUrl.EXTERNAL.getProtocol(), equalTo("https://"));
-    assertThat(SystemInfo.getOrganization(), equalTo("org"));
-    assertThat(SystemInfo.getSiteContatct(), equalTo("contact"));
-    assertThat(SystemInfo.getSiteName(), equalTo("site"));
-    assertThat(SystemInfo.getVersion(), equalTo("version"));
-    assertThat(details.size(), is(expectedSystemPropertiesCount));
+
+    // Read the system dot properties file and make sure that the new values evaluate to what we
+    // expect
+    org.apache.felix.utils.properties.Properties systemProps =
+        new org.apache.felix.utils.properties.Properties(systemPropsFile);
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HOST), equalTo("newhost"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HTTP_PORT), equalTo("5678"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HTTPS_PORT), equalTo("1234"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HOST), equalTo("newhost"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HTTP_PORT), equalTo("5678"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HTTPS_PORT), equalTo("1234"));
+    assertThat(systemProps.getProperty(SystemInfo.ORGANIZATION), equalTo("org"));
+    assertThat(systemProps.getProperty(SystemInfo.SITE_CONTACT), equalTo("contact"));
+    assertThat(systemProps.getProperty(SystemInfo.SITE_NAME), equalTo("site"));
+    assertThat(systemProps.getProperty(SystemInfo.VERSION), equalTo("version"));
 
     // only writes out the changed props
     assertTrue(systemPropsFile.exists());
     Properties sysProps = new Properties();
     try (FileReader sysPropsReader = new FileReader(systemPropsFile)) {
       sysProps.load(sysPropsReader);
-      assertThat(sysProps.size(), is(2));
       assertThat(sysProps.getProperty(SystemBaseUrl.INTERNAL_HOST), equalTo("newhost"));
     }
 
@@ -206,6 +189,37 @@ public class SystemPropertiesAdminTest {
         fail("User attribute file did not get updated.");
       }
     }
+  }
+
+  @Test
+  public void testWritePlaceholderProperties() throws Exception {
+    SystemPropertiesAdmin spa = new SystemPropertiesAdmin(mockGuestClaimsHandlerExt);
+    Map<String, String> map = new HashMap<>();
+    map.put(SystemBaseUrl.INTERNAL_HOST, "localhost");
+    map.put(SystemBaseUrl.INTERNAL_HTTP_PORT, "9999");
+    map.put(SystemBaseUrl.INTERNAL_HTTPS_PORT, "1111");
+    map.put(SystemBaseUrl.EXTERNAL_HOST, "localhost");
+    map.put(SystemBaseUrl.EXTERNAL_HTTP_PORT, "5678");
+    map.put(SystemBaseUrl.EXTERNAL_HTTPS_PORT, "1234");
+
+    spa.writeSystemProperties(map);
+
+    // Read the system dot properties file and make sure that the new values evaluate to what we
+    // expect
+    org.apache.felix.utils.properties.Properties systemProps =
+        new org.apache.felix.utils.properties.Properties(systemPropsFile);
+
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HOST), equalTo("localhost"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HOST), equalTo("localhost"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HTTP_PORT), equalTo("5678"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.EXTERNAL_HTTPS_PORT), equalTo("1234"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HOST), equalTo("localhost"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HTTP_PORT), equalTo("9999"));
+    assertThat(systemProps.getProperty(SystemBaseUrl.INTERNAL_HTTPS_PORT), equalTo("1111"));
+    assertThat(systemProps.getProperty(SystemInfo.ORGANIZATION), equalTo("org"));
+    assertThat(systemProps.getProperty(SystemInfo.SITE_CONTACT), equalTo("contact"));
+    assertThat(systemProps.getProperty(SystemInfo.SITE_NAME), equalTo("site"));
+    assertThat(systemProps.getProperty(SystemInfo.VERSION), equalTo("version"));
   }
 
   private String getDetailsValue(List<SystemPropertyDetails> props, String key) {

--- a/platform/admin/core/admin-core-impl/src/test/resources/custom.system.properties
+++ b/platform/admin/core/admin-core-impl/src/test/resources/custom.system.properties
@@ -1,0 +1,22 @@
+#
+# Global URL Properties
+#
+# The httpsPort and httpPort are the ports that the system will run on
+org.codice.ddf.system.protocol=https://
+org.codice.ddf.system.hostname=localhost
+org.codice.ddf.system.httpsPort=1234
+org.codice.ddf.system.httpPort=5678
+org.codice.ddf.system.port=${org.codice.ddf.system.httpsPort}
+org.codice.ddf.system.rootContext=/services
+# external properties are useful when DDF is behind a proxy and
+# the URL a user sees is different than the local url DDF uses
+org.codice.ddf.external.protocol=${org.codice.ddf.system.protocol}
+org.codice.ddf.external.hostname=${org.codice.ddf.system.hostname}
+org.codice.ddf.external.httpsPort=${org.codice.ddf.system.httpsPort}
+org.codice.ddf.external.httpPort=${org.codice.ddf.system.httpPort}
+org.codice.ddf.external.port=${org.codice.ddf.external.httpsPort}
+org.codice.ddf.external.context=
+org.codice.ddf.system.siteName=site
+org.codice.ddf.system.siteContact=contact
+org.codice.ddf.system.version=version
+org.codice.ddf.system.organization=org


### PR DESCRIPTION
#### What does this PR do?
Expands the external host and port properties so that they align with what is displayed in the UI. This makes it so when a user updates the internal host/port in the installer the external ones are not touched.
Backport of https://github.com/codice/ddf/pull/4429

#### Who is reviewing it? 
@Kjames5269 @jhunzik 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@emmberk

#### How should this be tested?
Run through the installer and try

- Setting just the internal hostname and ports, verify that custom.system.properties reflects what was set in the UI
- Setting just the external hostname and ports, verify that custom.system.properties reflects what was set in the UI
- Setting both external and internal hostname and ports, verify that custom.system.properties reflects what was set in the UI
- Verify ?dev=true still works as expected when setting internal/external ports (functionality should be unchanged)
- Verify [remote headless server instructions](https://github.com/codice/ddf/blob/8e26bed97f7cffa8d3b02b03df63982a6bfab5cf/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc#quick-install-of-branding-on-a-remote-headless-server) still work (this should not be changed by this change because it is an admin's responsibility to expand/change these properties)

#### Any background context you want to provide?
Bug was likely introduced from this commit: https://github.com/codice/ddf/commit/c35076fbd73d3b7abee65dabba721c6004ffabbb

#### What are the relevant tickets?
For GH Issues:
Fixes: #4426 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
