### PR TITLE
DDF-04284 Poll interval configuration for OpensearchSource

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -245,11 +245,12 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   private void updateScheduler() {
     LOGGER.debug(
-        "Setting Availability poll task for {} minute(s) on Source {}", pollInterval, getId());
+        "Setting availability poll task for {} minute(s) on Source {}", pollInterval, getId());
 
     isAvailable = false;
 
     if (scheduler != null) {
+      LOGGER.debug("Cancelling availability poll task on Source {}", getId());
       scheduler.shutdownNow();
     }
 
@@ -278,12 +279,13 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
           }
         },
         1,
-        pollInterval.longValue()*60L,
+        pollInterval.longValue() * 60L,
         TimeUnit.SECONDS);
   }
 
   public void destroy(int code) {
     if (scheduler != null) {
+      LOGGER.debug("Cancelling availability poll task on Source {}", getId());
       scheduler.shutdownNow();
     }
   }

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -861,7 +861,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
   }
 
   public void setPollInterval(Integer interval) {
-    this.pollInterval = interval;
+    this.pollInterval = Math.max(1, interval);
     updateScheduler();
   }
 

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -279,8 +279,8 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
           }
         },
         1,
-        pollInterval.longValue() * 60L,
-        TimeUnit.SECONDS);
+        pollInterval,
+        TimeUnit.MINUTES);
   }
 
   public void destroy(int code) {

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -278,8 +278,8 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
           }
         },
         1,
-        pollInterval,
-        TimeUnit.MINUTES);
+        pollInterval.longValue()*60L,
+        TimeUnit.SECONDS);
   }
 
   public void destroy(int code) {

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -277,7 +277,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
             isAvailable = availabilityCheck();
           }
         },
-        0,
+        1,
         pollInterval,
         TimeUnit.MINUTES);
   }

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -278,9 +278,9 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
             isAvailable = availabilityCheck();
           }
         },
-        0,
-        pollInterval,
-        TimeUnit.MINUTES);
+        1,
+        pollInterval.longValue() * 60L,
+        TimeUnit.SECONDS);
   }
 
   public void destroy(int code) {

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -67,6 +67,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
@@ -87,6 +90,7 @@ import org.codice.ddf.cxf.client.SecureCxfClientFactory;
 import org.codice.ddf.libs.geo.util.GeospatialUtil;
 import org.codice.ddf.opensearch.OpenSearch;
 import org.codice.ddf.opensearch.OpenSearchConstants;
+import org.codice.ddf.platform.util.StandardThreadFactoryBuilder;
 import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.geotools.filter.FilterTransformer;
 import org.jdom2.Element;
@@ -133,7 +137,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   private final ClientFactoryFactory clientFactoryFactory;
 
-  @Nullable private SecureCxfClientFactory<OpenSearch> factory;
+  private SecureCxfClientFactory<OpenSearch> factory;
 
   // service properties
   protected String shortname;
@@ -146,7 +150,9 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   protected int distanceTolerance;
 
-  protected PropertyResolver endpointUrl;
+  protected PropertyResolver endpointUrl =
+      new PropertyResolver(
+          "${org.codice.ddf.external.protocol}${org.codice.ddf.external.hostname}:${org.codice.ddf.external.port}${org.codice.ddf.external.context}${org.codice.ddf.system.rootContext}/catalog/query");
 
   protected final FilterAdapter filterAdapter;
 
@@ -156,9 +162,9 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   protected Set<String> markUpSet;
 
-  protected String username;
+  protected String username = "";
 
-  protected String password;
+  protected String password = "";
 
   private XMLInputFactory xmlInputFactory;
 
@@ -168,15 +174,22 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   protected final OpenSearchFilterVisitor openSearchFilterVisitor;
 
-  protected Integer connectionTimeout;
+  protected Integer connectionTimeout = 30000;
 
-  protected Integer receiveTimeout;
+  protected Integer receiveTimeout = 60000;
 
   protected boolean disableCnCheck = false;
 
   protected boolean allowRedirects = false;
 
   protected BiConsumer<List<Element>, SourceResponse> foreignMarkupBiConsumer;
+
+  /** flag indicating whether the source could be contacted */
+  private volatile boolean isAvailable;
+
+  private ScheduledExecutorService scheduler;
+
+  protected Integer pollInterval = 5;
 
   /**
    * Creates an OpenSearch Site instance. Sets an initial default endpointUrl that can be
@@ -222,14 +235,57 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
    */
   public void init() {
     configureXmlInputFactory();
+    updateFactory();
   }
 
-  // lazy init
-  private SecureCxfClientFactory<OpenSearch> getClientFactory() {
-    if (factory == null) {
-      factory = createClientFactory(endpointUrl.getResolvedString(), username, password);
+  private void updateFactory() {
+    factory = createClientFactory(endpointUrl.getResolvedString(), username, password);
+    updateScheduler();
+  }
+
+  private void updateScheduler() {
+    LOGGER.debug(
+        "Setting Availability poll task for {} minute(s) on Source {}", pollInterval, getId());
+
+    isAvailable = false;
+
+    if (scheduler != null) {
+      scheduler.shutdownNow();
     }
-    return factory;
+
+    scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            StandardThreadFactoryBuilder.newThreadFactory("openSearchSourceThread"));
+
+    scheduler.scheduleWithFixedDelay(
+        new Runnable() {
+          private boolean availabilityCheck() {
+            LOGGER.debug("Checking availability for source {} ", getId());
+            try {
+              final WebClient client = factory.getWebClient();
+              final Response response = client.head();
+              return response != null
+                  && !(response.getStatus() >= 404 || response.getStatus() == 402);
+            } catch (Exception e) {
+              LOGGER.debug("Web Client was unable to connect to endpoint.", e);
+              return false;
+            }
+          }
+
+          @Override
+          public void run() {
+            isAvailable = availabilityCheck();
+          }
+        },
+        0,
+        pollInterval,
+        TimeUnit.MINUTES);
+  }
+
+  public void destroy(int code) {
+    if (scheduler != null) {
+      scheduler.shutdownNow();
+    }
   }
 
   protected SecureCxfClientFactory<OpenSearch> createClientFactory(
@@ -270,14 +326,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   @Override
   public boolean isAvailable() {
-    try {
-      final WebClient client = getClientFactory().getWebClient();
-      final Response response = client.head();
-      return response != null && !(response.getStatus() >= 404 || response.getStatus() == 402);
-    } catch (Exception e) {
-      LOGGER.debug("Web Client was unable to connect to endpoint.", e);
-      return false;
-    }
+    return isAvailable;
   }
 
   @Override
@@ -346,7 +395,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
             idSearch);
       }
 
-      final WebClient restWebClient = getClientFactory().getWebClientForSubject(subject);
+      final WebClient restWebClient = factory.getWebClientForSubject(subject);
       if (restWebClient == null) {
         throw new UnsupportedQueryException("Unable to create restWebClient");
       }
@@ -631,7 +680,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
    */
   public void setEndpointUrl(String endpointUrl) {
     this.endpointUrl = new PropertyResolver(endpointUrl);
-    factory = null;
+    updateFactory();
   }
 
   @Override
@@ -811,6 +860,11 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
     }
   }
 
+  public void setPollInterval(Integer interval) {
+    this.pollInterval = interval;
+    updateScheduler();
+  }
+
   @Override
   public ResourceResponse retrieveResource(URI uri, Map<String, Serializable> requestProperties)
       throws ResourceNotFoundException, ResourceNotSupportedException, IOException {
@@ -887,7 +941,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   public void setUsername(String username) {
     this.username = username;
-    factory = null;
+    updateFactory();
   }
 
   public String getPassword() {
@@ -896,7 +950,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   public void setPassword(String password) {
     this.password = encryptionService.decryptValue(password);
-    factory = null;
+    updateFactory();
   }
 
   public Boolean getDisableCnCheck() {
@@ -905,7 +959,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   public void setDisableCnCheck(Boolean disableCnCheck) {
     this.disableCnCheck = disableCnCheck;
-    factory = null;
+    updateFactory();
   }
 
   public Boolean getAllowRedirects() {
@@ -914,7 +968,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   public void setAllowRedirects(Boolean allowRedirects) {
     this.allowRedirects = allowRedirects;
-    factory = null;
+    updateFactory();
   }
 
   public Integer getConnectionTimeout() {
@@ -923,7 +977,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   public void setConnectionTimeout(Integer connectionTimeout) {
     this.connectionTimeout = connectionTimeout;
-    factory = null;
+    updateFactory();
   }
 
   public Integer getReceiveTimeout() {
@@ -932,7 +986,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
 
   public void setReceiveTimeout(Integer receiveTimeout) {
     this.receiveTimeout = receiveTimeout;
-    factory = null;
+    updateFactory();
   }
 
   private WebClient newRestClient(
@@ -1022,6 +1076,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
   }
 
   protected static class SpatialSearch {
+
     private final Geometry geometry;
     private final BoundingBox boundingBox;
     private final Polygon polygon;

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -278,7 +278,7 @@ public class OpenSearchSource implements FederatedSource, ConfiguredService {
             isAvailable = availabilityCheck();
           }
         },
-        1,
+        0,
         pollInterval,
         TimeUnit.MINUTES);
   }

--- a/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -42,7 +42,7 @@
                                 interface="ddf.catalog.source.FederatedSource">
 
         <cm:managed-component class="org.codice.ddf.opensearch.source.OpenSearchSource"
-                              init-method="init">
+                              init-method="init" destroy-method="destroy">
             <!-- Defines the methods to be invoked when the OpenSearch Source 
                 instance is created and when it is deleted. The init method is called after 
                 all of the setter methods have been called. -->
@@ -65,6 +65,7 @@
             <property name="disableCnCheck" value="false"/>
             <property name="connectionTimeout" value="30000"/>
             <property name="receiveTimeout" value="60000"/>
+            <property name="pollInterval" value="5"/>
             <property name="parameters">
                 <list>
                     <value>q</value>

--- a/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -71,6 +71,10 @@
             name="Receive Timeout" id="receiveTimeout"
             required="true" type="Integer" default="60000"/>
 
+        <AD description="Poll Interval to Check if the Source is available (in minutes - minimum 1)."
+            name="Poll Interval" id="pollInterval"
+            required="true" type="Integer" default="5"/>
+
         <AD name="Entry XML Element" id="markUpSet" required="false"
             type="String"
             default=""

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
@@ -745,10 +745,11 @@ public class TestSecurity extends AbstractIntegrationTest {
         .assertThat()
         .statusCode(equalTo(500));
 
-    String unavailableOpenSourceId = "Unavailable OpenSearchSource";
+    String unavailableOpenSourceId = "unavailableOpenSearchSource";
 
     OpenSearchFeature.createManagedService(
         getServiceManager(), unavailableOpenSourceId, "bad", "auth");
+    getCatalogBundle().waitForFederatedSource(unavailableOpenSourceId);
 
     String unavailableOpenSearchQuery =
         SERVICE_ROOT.getUrl() + "/catalog/query?q=*&src=" + unavailableOpenSourceId;


### PR DESCRIPTION
#### What does this PR do?
Fixes #4284 
The OpenSearchSource doesn't have a configurable poll interval. We have a server admin that would like us to stop polling him every minute. Other sources allow you to change the poll interval, but not this one. This change adds Poll interval configuration for OpensearchSource.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@leo-sakh 
@glenhein 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@bdeining
@troymohl
@lamhuy 
#### How should this be tested?
Add a loopback source
Turn up cxf logging to watch poll
etc.
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
