### PR TITLE
DDF-04456 Fixing point/rad and excess boolean ANDS

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -327,18 +327,7 @@ module.exports = Marionette.LayoutView.extend({
     }
 
     var type = this.comparatorToCQL()[comparator]
-    if (metacardDefinitions.metacardTypes[this.model.get('type')].multivalued) {
-      return {
-        type: 'AND',
-        filters: this.filterInput.currentView.model
-          .getValue()
-          .map(function(currentValue) {
-            return CQLUtils.generateFilter(type, property, currentValue)
-          }),
-      }
-    } else {
-      return CQLUtils.generateFilter(type, property, value)
-    }
+    return CQLUtils.generateFilter(type, property, value)
   },
   deleteInvalidFilters: function() {
     if (!this.filterInput.currentView.isValid()) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -64,13 +64,15 @@ const MultiLineString = {
 
 const Point = {
   'json->location': ({
-    geometry: { coordinates } = [lat, lon],
+    geometry: {
+      coordinates: [lon, lat],
+    },
     properties: { buffer } = {},
   }) => ({
     mode: 'circle',
     locationType: 'latlon',
-    lat: coordinates[0],
-    lon: coordinates[1],
+    lat,
+    lon,
     radius: buffer.width,
     radiusUnits: buffer.unit,
   }),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
@@ -74,7 +74,7 @@ describe('serialize/deserialize point', () => {
     type: 'Feature',
     geometry: {
       type: 'Point',
-      coordinates: [-111.131821, 31.964569],
+      coordinates: [31.964569, -111.131821],
     },
     properties: {
       type: 'Point',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -160,7 +160,7 @@ module.exports = Marionette.LayoutView.extend({
         this.options.isFormBuilder !== true
           ? this.queryAdvanced.currentView.transformToCql()
           : '',
-      filterTree: this.queryAdvanced.currentView.getFilters(),
+      filterTree: cql.simplify(this.queryAdvanced.currentView.getFilters()),
     })
     if (typeof this.options.onSave === 'function') {
       this.options.onSave()


### PR DESCRIPTION
#### What does this PR do?
1) Fixes incorrect deserialization of point-radius from geojson filtertree when rendering circles on map. 
2) Fixes issue where we would excessively render AND boolean clauses on queries in the advanced query editor. 
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@bdeining 
@djblue 

#### How should this be tested?
Create a point radius from advanced query window, ensure that it renders correctly when re-editing. 

For GH Issues:
Fixes: #4456

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
