### PR TITLE
DDF-04318 Temporarily undo recent websockets change which breaks search when there is an unavailable source

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketServlet.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/ws/SecureWebSocketServlet.java
@@ -15,7 +15,6 @@ package org.codice.ddf.catalog.ui.ws;
 
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
-import ddf.security.common.SecurityTokenHolder;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import org.eclipse.jetty.websocket.api.Session;
@@ -45,20 +44,9 @@ public class SecureWebSocketServlet extends WebSocketServlet {
     executor.shutdown();
   }
 
-  /*
-   Pass the TokenHolder into the WebSocket, in order to know when the user has logged out. Can't
-   pass the Session because Jetty won't let anything check session attributes unless there's a
-   request (excluding WebSocket requests) being actively fulfilled for that session.
-  */
   @Override
   public void configure(WebSocketServletFactory factory) {
-    factory.setCreator(
-        (req, resp) ->
-            new SocketWrapper(
-                executor,
-                ws,
-                (SecurityTokenHolder)
-                    req.getSession().getAttribute(SecurityConstants.SAML_ASSERTION)));
+    factory.setCreator((req, resp) -> new SocketWrapper(executor, ws));
   }
 
   @org.eclipse.jetty.websocket.api.annotations.WebSocket
@@ -66,12 +54,10 @@ public class SecureWebSocketServlet extends WebSocketServlet {
 
     private final WebSocket ws;
     private final ExecutorService executor;
-    private final SecurityTokenHolder securityTokenHolder;
 
-    SocketWrapper(ExecutorService executor, WebSocket ws, SecurityTokenHolder securityTokenHolder) {
+    SocketWrapper(ExecutorService executor, WebSocket ws) {
       this.ws = ws;
       this.executor = executor;
-      this.securityTokenHolder = securityTokenHolder;
     }
 
     private void runWithUser(Session session, Runnable runnable) {
@@ -89,11 +75,7 @@ public class SecureWebSocketServlet extends WebSocketServlet {
 
     @OnWebSocketConnect
     public void onOpen(Session session) {
-      if (isUserLoggedIn()) {
-        runWithUser(session, () -> ws.onOpen(session));
-      } else {
-        onError(session, new WebSocketAuthenticationException("User not logged in."));
-      }
+      runWithUser(session, () -> ws.onOpen(session));
     }
 
     @OnWebSocketClose
@@ -108,23 +90,15 @@ public class SecureWebSocketServlet extends WebSocketServlet {
 
     @OnWebSocketMessage
     public void onMessage(Session session, String message) {
-      if (isUserLoggedIn()) {
-        runWithUser(
-            session,
-            () -> {
-              try {
-                ws.onMessage(session, message);
-              } catch (IOException e) {
-                LOGGER.error("Failed to receive ws message.", e);
-              }
-            });
-      } else {
-        onError(session, new WebSocketAuthenticationException("User not logged in.", message));
-      }
-    }
-
-    private boolean isUserLoggedIn() {
-      return securityTokenHolder.getRealmTokenMap().size() > 0;
+      runWithUser(
+          session,
+          () -> {
+            try {
+              ws.onMessage(session, message);
+            } catch (IOException e) {
+              LOGGER.error("Failed to receive ws message.", e);
+            }
+          });
     }
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
@@ -139,21 +139,16 @@ module.exports = Backbone.AssociatedModel.extend({
             handled = true
             res.options = options
             switch (res.code) {
-              case -32000:
-                if (rpc !== null) {
-                  rpc.close()
-                  rpc = null
-                }
+              case 400:
+              case 404:
+              case 500:
                 options.error({
-                  message: 'User not logged in.',
+                  responseJSON: res,
                 })
                 break
               default:
                 // notify user and fallback to http
-                if (rpc !== null) {
-                  rpc.close()
-                  rpc = null
-                }
+                rpc = null
                 options.error({
                   responseJSON: {
                     message:


### PR DESCRIPTION
#### What does this PR do?
My recent websockets bug fix broke some error cases, such as having an unavailable source: https://github.com/codice/ddf/pull/4368
This reverts that change temporarily to unblock others, and I will put in a permanent fix later.
#### Who is reviewing it? 
@andrewkfiedler @tbatie @tyler30clemens @austinsteffes 

#### How should this be tested?
- Build DDF (include ui in the build)
- Install DDF
- Create two Opensearch sources, 1 with a madeup hostname and 1 with the default loopback value.
- Go to Intrigue and ingest a couple of records
- Try and execute the default wildcard search
- It should return records but show a red triangle indicating one of the sources is unavailable
#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4318

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
