### PR TITLE
DDF-04474 Fixing Location Serialization Failures With Query Preservation & Clientside Filtering

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -69,8 +69,18 @@ const filterToLocationOldModel = filter => {
 
   // for backwards compatability with wkt
   if (filterValue && typeof filterValue === 'string') {
-    const json = wkx.Geometry.parse(filterValue).toGeoJSON()
-    return deserialize(json)
+    const geometry = wkx.Geometry.parse(filterValue).toGeoJSON()
+    return deserialize({
+      type: 'Feature',
+      geometry,
+      properties: {
+        type: geometry.type,
+        buffer: {
+          width: filter.distance,
+          unit: 'meters',
+        },
+      },
+    })
   }
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -8,155 +8,192 @@ const is3DArray = array =>
 const is4DArray = array => is3DArray(array) && Array.isArray(array[0][0][0])
 
 const LineString = {
-  'json->location': ({
-    geometry: { coordinates },
-    properties: { buffer } = {},
-  }) => ({
-    mode: 'line',
-    line: coordinates,
-    lineWidth: buffer.width,
-    lineUnits: buffer.unit,
-  }),
-  'location->json': ({ line = [], lineWidth = 1, lineUnits = 'meters' }) => ({
-    type: 'Feature',
-    geometry: {
-      type: 'LineString',
-      coordinates: line,
-    },
-    properties: {
-      type: 'LineString',
-      buffer: {
-        width: lineWidth,
-        unit: lineUnits,
+  'json->location': json => {
+    const {
+      geometry: { coordinates },
+      properties: { buffer } = {},
+    } = json
+
+    const { width = 1, unit = 'meters' } = buffer
+
+    return {
+      mode: 'line',
+      line: coordinates,
+      lineWidth: width,
+      lineUnits: unit,
+    }
+  },
+  'location->json': location => {
+    const { line = [], lineWidth = 1, lineUnits = 'meters' } = location
+
+    return {
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: line,
       },
-    },
-  }),
+      properties: {
+        type: 'LineString',
+        buffer: {
+          width: lineWidth,
+          unit: lineUnits,
+        },
+      },
+    }
+  },
 }
 
 const MultiLineString = {
-  'json->location': ({
-    geometry: { coordinates },
-    properties: { buffer } = {},
-  }) => ({
-    mode: 'multiline',
-    multiline: coordinates,
-    lineWidth: buffer.width,
-    lineUnits: buffer.unit,
-  }),
-  'location->json': ({
-    multiline = [],
-    lineWidth = 1,
-    lineUnits = 'meters',
-  }) => ({
-    type: 'Feature',
-    geometry: {
-      type: 'MultiLineString',
-      coordinates: multiline,
-    },
-    properties: {
-      type: 'MultiLineString',
-      buffer: {
-        width: lineWidth,
-        unit: lineUnits,
+  'json->location': json => {
+    const {
+      geometry: { coordinates },
+      properties: { buffer } = {},
+    } = json
+
+    const { width = 1, unit = 'meters' } = buffer
+
+    return {
+      mode: 'multiline',
+      multiline: coordinates,
+      lineWidth: width,
+      lineUnits: unit,
+    }
+  },
+  'location->json': location => {
+    const { multiline = [], lineWidth = 1, lineUnits = 'meters' } = location
+
+    return {
+      type: 'Feature',
+      geometry: {
+        type: 'MultiLineString',
+        coordinates: multiline,
       },
-    },
-  }),
+      properties: {
+        type: 'MultiLineString',
+        buffer: {
+          width: lineWidth,
+          unit: lineUnits,
+        },
+      },
+    }
+  },
 }
 
 const Point = {
-  'json->location': ({
-    geometry: {
-      coordinates: [lon, lat],
-    },
-    properties: { buffer } = {},
-  }) => ({
-    mode: 'circle',
-    locationType: 'latlon',
-    lat,
-    lon,
-    radius: buffer.width,
-    radiusUnits: buffer.unit,
-  }),
-  'location->json': ({
-    lat = 0,
-    lon = 0,
-    radius = 1,
-    radiusUnits = 'meters',
-  }) => ({
-    type: 'Feature',
-    geometry: {
-      type: 'Point',
-      coordinates: [lon, lat],
-    },
-    properties: {
-      type: 'Point',
-      buffer: {
-        width: radius,
-        unit: radiusUnits,
+  'json->location': json => {
+    const {
+      geometry: { coordinates },
+      properties: { buffer } = {},
+    } = json
+
+    const [lon = 0, lat = 0] = coordinates
+    const { width = 1, unit = 'meters' } = buffer
+
+    return {
+      mode: 'circle',
+      locationType: 'latlon',
+      lat,
+      lon,
+      radius: width,
+      radiusUnits: unit,
+    }
+  },
+  'location->json': location => {
+    const { lat = 0, lon = 0, radius = 1, radiusUnits = 'meters' } = location
+
+    return {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [lon, lat],
       },
-    },
-  }),
+      properties: {
+        type: 'Point',
+        buffer: {
+          width: radius,
+          unit: radiusUnits,
+        },
+      },
+    }
+  },
 }
 
 const Polygon = {
-  'json->location': ({
-    geometry: { coordinates },
-    properties: { buffer } = {},
-  }) => ({
-    mode: 'poly',
-    polygon: coordinates,
-    polygonBufferWidth: buffer.width,
-    polygonBufferUnits: buffer.unit,
-    polyType: 'polygon',
-  }),
-  'location->json': ({
-    polygon = [],
-    polygonBufferWidth = 0,
-    polygonBufferUnits = 'meters',
-  }) => ({
-    type: 'Feature',
-    geometry: {
-      type: 'Polygon',
-      coordinates: is3DArray(polygon) ? polygon : [polygon],
-    },
-    properties: {
-      type: 'Polygon',
-      buffer: {
-        width: polygonBufferWidth,
-        unit: polygonBufferUnits,
+  'json->location': json => {
+    const {
+      geometry: { coordinates },
+      properties: { buffer } = {},
+    } = json
+
+    const [polygon] = coordinates
+    const { width = 0, unit = 'meters' } = buffer
+
+    return {
+      mode: 'poly',
+      polygon,
+      polygonBufferWidth: width,
+      polygonBufferUnits: unit,
+      polyType: 'polygon',
+    }
+  },
+  'location->json': location => {
+    const {
+      polygon = [],
+      polygonBufferWidth = 0,
+      polygonBufferUnits = 'meters',
+    } = location
+
+    return {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [polygon],
       },
-    },
-  }),
+      properties: {
+        type: 'Polygon',
+        buffer: {
+          width: polygonBufferWidth,
+          unit: polygonBufferUnits,
+        },
+      },
+    }
+  },
 }
 
 const BoundingBox = {
-  'json->location': ({ properties: { north, east, south, west } }) => {
-    const coordinates = [
-      [
-        [west, north],
-        [east, north],
-        [east, south],
-        [west, south],
-        [west, north],
-      ],
-    ]
+  'json->location': json => {
+    const {
+      geometry: { coordinates },
+      properties: { north, east, south, west },
+    } = json
+
+    const [polygon] = coordinates
 
     return {
       mode: 'bbox',
-      polygon: coordinates,
+      polygon,
       north,
       east,
       south,
       west,
     }
   },
-  'location->json': ({ north, east, south, west }) => {
+  'location->json': location => {
+    const { north, east, south, west } = location
     return {
       type: 'Feature',
       bbox: [south, north, west, east],
       geometry: {
         type: 'Polygon',
-        coordinates: Turf.bboxPolygon([south, north, west, east]),
+        coordinates: [
+          [
+            [west, north],
+            [east, north],
+            [east, south],
+            [west, south],
+            [west, north],
+          ],
+        ],
       },
       properties: {
         type: 'BoundingBox',
@@ -170,72 +207,100 @@ const BoundingBox = {
 }
 
 const MultiPolygon = {
-  'json->location': ({
-    geometry: { coordinates },
-    properties: { buffer } = {},
-  }) => ({
-    mode: 'multipolygon',
-    polygon: coordinates,
-    polygonBufferWidth,
-    polygonBufferUnits,
-    polyType: 'multipolygon',
-  }),
-  'location->json': ({
-    polygon = [],
-    polygonBufferWidth,
-    polygonBufferUnits,
-  }) => ({
-    type: 'Feature',
-    geometry: {
-      type: 'MultiPolygon',
-      coordinates: is3DArray(polygon) ? [polygon] : polygon,
-    },
-    properties: {
-      type: 'MultiPolygon',
-      buffer: {
-        width: polygonBufferWidth,
-        unit: polygonBufferUnits,
+  'json->location': json => {
+    const {
+      geometry: { coordinates },
+      properties: { buffer } = {},
+    } = json
+
+    const { width = 0, unit = 'meters' } = buffer
+
+    const polygon = coordinates.map(([child]) => child)
+
+    return {
+      mode: 'poly',
+      polygon,
+      polygonBufferWidth: width,
+      polygonBufferUnits: unit,
+      polyType: 'multipolygon',
+    }
+  },
+  'location->json': location => {
+    const {
+      polygon = [],
+      polygonBufferWidth = 0,
+      polygonBufferUnits = 'meters',
+    } = location
+
+    const coordinates = polygon.map(child => [child])
+
+    return {
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates,
       },
-    },
-  }),
+      properties: {
+        type: 'MultiPolygon',
+        buffer: {
+          width: polygonBufferWidth,
+          unit: polygonBufferUnits,
+        },
+      },
+    }
+  },
 }
 
 const Keyword = {
-  'json->location': ({
-    properties: { keywordValue, buffer },
-    geometry = {},
-  }) => {
-    const { type, coordinates } = geometry
+  'json->location': json => {
+    const {
+      properties: { keywordValue, buffer },
+      geometry = {},
+    } = json
+
+    const { type, coordinates = [] } = geometry
+    const { width = 0, unit = 'meters' } = buffer
+
+    const [polygon] =
+      type === 'Polygon' ? coordinates : [coordinates.map(([child]) => child)]
+
     return {
       mode: 'keyword',
       keywordValue,
-      polygon: coordinates,
-      polygonBufferWidth: buffer.width,
-      polygonBufferUnits: buffer.unit,
-      polyType: type === 'MultiPolygon' ? 'multipolygon' : 'polygon',
+      polygon,
+      polygonBufferWidth: width,
+      polygonBufferUnits: unit,
+      polyType: type === 'Polygon' ? 'polygon' : 'multipolygon',
     }
   },
-  'location->json': ({
-    polygon = [],
-    polyType,
-    keywordValue,
-    polygonBufferWidth,
-    polygonBufferUnits,
-  }) => ({
-    type: 'Feature',
-    geometry: {
-      type: polyType === 'polygon' ? 'Polygon' : 'MultiPolygon',
-      coordinates: polygon,
-    },
-    properties: {
-      type: 'Keyword',
+  'location->json': location => {
+    const {
+      polygon = [],
+      polyType,
       keywordValue,
-      buffer: {
-        width: polygonBufferWidth,
-        unit: polygonBufferUnits,
+      polygonBufferWidth = 0,
+      polygonBufferUnits = 'meters',
+    } = location
+
+    const coordinates =
+      polyType === 'polygon' ? [polygon] : polygon.map(child => [child])
+
+    return {
+      type: 'Feature',
+      geometry: {
+        type: polyType === 'polygon' ? 'Polygon' : 'MultiPolygon',
+        coordinates,
       },
-    },
-  }),
+      properties: {
+        type: 'Keyword',
+        keywordValue,
+        buffer: {
+          width: polygonBufferWidth,
+          unit: polygonBufferUnits,
+        },
+      },
+    }
+  },
 }
 
 const Serializers = plugin.Serializers({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -2,9 +2,6 @@ const wkx = require('wkx')
 const DistanceUtils = require('../../js/DistanceUtils')
 const plugin = require('plugins/location-serialization')
 
-const is3DArray = array =>
-  Array.isArray(array) && Array.isArray(array[0]) && Array.isArray(array[0][0])
-
 const LineString = {
   'json->location': json => {
     const {
@@ -126,10 +123,6 @@ const Polygon = {
     const [polygon] = coordinates
     const { width = 0, unit = 'meters' } = buffer
 
-    if (is3DArray(polygon)) {
-      return MultiPolygon['json->location'](location)
-    }
-
     return {
       mode: 'poly',
       polygon,
@@ -143,9 +136,10 @@ const Polygon = {
       polygon = [],
       polygonBufferWidth = 0,
       polygonBufferUnits = 'meters',
+      polyType = 'polygon',
     } = location
 
-    if (is3DArray(polygon)) {
+    if (polyType === 'multipolygon') {
       return MultiPolygon['location->json'](location)
     }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -1,11 +1,9 @@
 const wkx = require('wkx')
 const DistanceUtils = require('../../js/DistanceUtils')
-const Turf = require('@turf/turf')
 const plugin = require('plugins/location-serialization')
 
 const is3DArray = array =>
   Array.isArray(array) && Array.isArray(array[0]) && Array.isArray(array[0][0])
-const is4DArray = array => is3DArray(array) && Array.isArray(array[0][0][0])
 
 const LineString = {
   'json->location': json => {
@@ -128,6 +126,10 @@ const Polygon = {
     const [polygon] = coordinates
     const { width = 0, unit = 'meters' } = buffer
 
+    if (is3DArray(polygon)) {
+      return MultiPolygon['json->location'](location)
+    }
+
     return {
       mode: 'poly',
       polygon,
@@ -142,6 +144,10 @@ const Polygon = {
       polygonBufferWidth = 0,
       polygonBufferUnits = 'meters',
     } = location
+
+    if (is3DArray(polygon)) {
+      return MultiPolygon['location->json'](location)
+    }
 
     return {
       type: 'Feature',
@@ -308,7 +314,6 @@ const Serializers = plugin.Serializers({
   multiline: MultiLineString,
   circle: Point,
   poly: Polygon,
-  multipolygon: MultiPolygon,
   keyword: Keyword,
   bbox: BoundingBox,
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
@@ -125,12 +125,10 @@ describe('serialize/deserialize polygon', () => {
   const deserializedPolygon = {
     mode: 'poly',
     polygon: [
-      [
-        [-125.180588, 48.603515],
-        [-130.42847, 38.872222],
-        [-117.556532, 41.896131],
-        [-125.180588, 48.603515],
-      ],
+      [-125.180588, 48.603515],
+      [-130.42847, 38.872222],
+      [-117.556532, 41.896131],
+      [-125.180588, 48.603515],
     ],
     polygonBufferWidth: 0,
     polygonBufferUnits: 'meters',
@@ -147,52 +145,43 @@ describe('serialize/deserialize polygon', () => {
 })
 
 describe('serialize/deserialize bbox', () => {
-  const serializedBbox = {
-    type: 'Feature',
-    bbox: [-44.449923, -27.849887, -112.533338, -92.952499],
-    geometry: {
-      type: 'Polygon',
-      coordinates: {
-        type: 'Feature',
-        properties: {},
-        geometry: {
-          type: 'Polygon',
-          coordinates: [
-            [
-              [-44.449923, -27.849887],
-              [-112.533338, -27.849887],
-              [-112.533338, -92.952499],
-              [-44.449923, -92.952499],
-              [-44.449923, -27.849887],
-            ],
-          ],
-        },
-      },
-    },
-    properties: {
-      type: 'BoundingBox',
-      north: -27.849887,
-      east: -92.952499,
-      south: -44.449923,
-      west: -112.533338,
-    },
-  }
-
   const deserializedBbox = {
     mode: 'bbox',
     polygon: [
-      [
-        [-112.533338, -27.849887],
-        [-92.952499, -27.849887],
-        [-92.952499, -44.449923],
-        [-112.533338, -44.449923],
-        [-112.533338, -27.849887],
-      ],
+      [-122.144963, 51.08591],
+      [-108.169324, 51.08591],
+      [-108.169324, 12.374553],
+      [-122.144963, 12.374553],
+      [-122.144963, 51.08591],
     ],
-    north: -27.849887,
-    east: -92.952499,
-    south: -44.449923,
-    west: -112.533338,
+    north: 51.08591,
+    east: -108.169324,
+    south: 12.374553,
+    west: -122.144963,
+  }
+
+  const serializedBbox = {
+    type: 'Feature',
+    bbox: [12.374553, 51.08591, -122.144963, -108.169324],
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-122.144963, 51.08591],
+          [-108.169324, 51.08591],
+          [-108.169324, 12.374553],
+          [-122.144963, 12.374553],
+          [-122.144963, 51.08591],
+        ],
+      ],
+    },
+    properties: {
+      type: 'BoundingBox',
+      north: 51.08591,
+      east: -108.169324,
+      south: 12.374553,
+      west: -122.144963,
+    },
   }
 
   it('properly tranlates filter tree JSON into location model representation', () => {
@@ -208,18 +197,20 @@ describe('serialize/deserialize multipolygon', () => {
   const serializedPolygon = {
     type: 'Feature',
     geometry: {
-      type: 'Polygon',
+      type: 'MultiPolygon',
       coordinates: [
         [
-          [-125.180588, 48.603515],
-          [-130.42847, 38.872222],
-          [-117.556532, 41.896131],
-          [-125.180588, 48.603515],
+          [
+            [-125.180588, 48.603515],
+            [-130.42847, 38.872222],
+            [-117.556532, 41.896131],
+            [-125.180588, 48.603515],
+          ],
         ],
       ],
     },
     properties: {
-      type: 'Polygon',
+      type: 'MultiPolygon',
       buffer: {
         width: 0,
         unit: 'meters',
@@ -239,7 +230,7 @@ describe('serialize/deserialize multipolygon', () => {
     ],
     polygonBufferWidth: 0,
     polygonBufferUnits: 'meters',
-    polyType: 'polygon',
+    polyType: 'multipolygon',
   }
 
   it('properly tranlates filter tree JSON into location model representation', () => {
@@ -272,11 +263,13 @@ describe('serialize/deserialize keyword', () => {
     geometry: {
       type: 'Polygon',
       coordinates: [
-        [87.3879, 21.7495],
-        [87.6879, 21.7495],
-        [87.6879, 22.0495],
-        [87.3879, 22.0495],
-        [87.3879, 21.7495],
+        [
+          [87.3879, 21.7495],
+          [87.6879, 21.7495],
+          [87.6879, 22.0495],
+          [87.3879, 22.0495],
+          [87.3879, 21.7495],
+        ],
       ],
     },
     properties: {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
@@ -34,7 +34,7 @@ const inputs = plugin({
   },
   keyword: {
     label: 'Keyword',
-    Component: ({ props, setState, keywordValue }) => {
+    Component: ({ setState, keywordValue, ...props }) => {
       return (
         <Keyword
           {...props}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/text-field/text-field.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/text-field/text-field.js
@@ -17,7 +17,7 @@ const TextField = props => {
           </span>
         ) : null}
         <input
-          value={value || ''}
+          value={value !== undefined ? value : ''}
           type={type}
           onChange={e => {
             onChange(e.target.value)


### PR DESCRIPTION
#### What does this PR do?

- Fixed backward compat. with CQL distance/units
- Fix clientside filtering
- Fixed keyword component not properly rendering the multipoly/poly components
- Fixed not properly representing geojson spec in location-serialization
- Fixed text-field 0 value to look for undefined values more explicitly

#### Who is reviewing it? 
@bdeining 
@middlets719 
@djblue 
@andrewkfiedler 
#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@djblue 
@andrewkfiedler 
@bdeining 

#### How should this be tested?
This PR should be tested in 2 parts:

## Part 1: 
1) Need to perform queries including all serialization types. BBox, Polygon, Line, etc. 
2) Save the queries individually or combined. 
3) Refresh the page
4) Ensure that the original structure of the query was fully preserved (bbox re-renders as bbox and keyword rerenders as keyword)

**Important Note**
> Within the preservation of a keyword, beneath the keyword component should also populate the respective polygon/multipolygon component as well. For example, if you persist a query involving a keyword of Russia, it should re-render a multipolygon component beneath keyword representing the geometry and buffer that was originally persisted. In addition, if you saved something like North Korea, it should re-render a singular polygon with the associated buffer that was originally persisted. 

## Part 2: 
1) Need to add filters including all serialization types. BBox, Polygon, Line, etc. 
2) Save the filter
3) Refresh the page
4) Ensure that the original structure of the filter was fully preserved.

**Important Note**
> In this case, the keyword will re-render as a polygon and bbox will also re-render as a polygon, this is expected

#### What are the relevant tickets?
For GH Issues:
Fixes: #4474 