### PR TITLE
DDF-04479 Fix Set Map Home Deferred Announcements

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -37,7 +37,6 @@ var MapInfoView = require('../../map-info/map-info.view.js')
 var properties = require('../../../js/properties.js')
 var Common = require('../../../js/Common.js')
 const announcement = require('../../announcement')
-const _ = require('underscore')
 
 const Gazetteer = require('../../../react-component/location/gazetteer.js')
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -261,17 +261,12 @@ module.exports = Marionette.LayoutView.extend({
   saveAsHome: function() {
     const boundingBox = this.map.getBoundingBox()
     const userPreferences = user.get('user').get('preferences')
-    if (!_.isEqual(boundingBox, userPreferences.get('mapHome'))) {
-      userPreferences.once('sync', () =>
-        announcement.announce({
-          title: 'Success!',
-          message: 'New map home location set.',
-          type: 'success',
-        })
-      )
-
-      userPreferences.set('mapHome', boundingBox)
-    }
+    userPreferences.set('mapHome', boundingBox)
+    announcement.announce({
+      title: 'Success!',
+      message: 'New map home location set.',
+      type: 'success',
+    })
   },
   addPanZoom: function() {
     const PanZoomView = Marionette.ItemView.extend({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -37,6 +37,7 @@ var MapInfoView = require('../../map-info/map-info.view.js')
 var properties = require('../../../js/properties.js')
 var Common = require('../../../js/Common.js')
 const announcement = require('../../announcement')
+const _ = require('underscore')
 
 const Gazetteer = require('../../../react-component/location/gazetteer.js')
 
@@ -260,15 +261,17 @@ module.exports = Marionette.LayoutView.extend({
   saveAsHome: function() {
     const boundingBox = this.map.getBoundingBox()
     const userPreferences = user.get('user').get('preferences')
-    userPreferences.once('sync', () =>
-      announcement.announce({
-        title: 'Success!',
-        message: 'New map home location set.',
-        type: 'success',
-      })
-    )
+    if (!_.isEqual(boundingBox, userPreferences.get('mapHome'))) {
+      userPreferences.once('sync', () =>
+        announcement.announce({
+          title: 'Success!',
+          message: 'New map home location set.',
+          type: 'success',
+        })
+      )
 
-    userPreferences.set('mapHome', boundingBox)
+      userPreferences.set('mapHome', boundingBox)
+    }
   },
   addPanZoom: function() {
     const PanZoomView = Marionette.ItemView.extend({


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where announcements were being deferred to the next saving of user preferences when saving the same location twice.

#### Who is reviewing it? 
@gjvera 
@mojogitoverhere 
@rymach 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@djblue 

#### How should this be tested?
1. Pan to some location
2. Click `Set Home` Twice from the Home dropdown
  - One announcement should show up for each time you click `Set Home`
4. Click on the cog in the top right and go to `Theme Settings`
5. Click and drag the zoom bar to set a new zoom level.
  - Verify no announcements regarding map home location come up

#### Any background context you want to provide?
When you click `Set Home` a listener is created for the response on a network request for updating user preferences regardless of whether the location has changed. If the location hasn't changed, then the network request never goes out and the listener gets deferred to the next time the user saves their preferences.

#### What are the relevant tickets?
For Jira:
[](https://codice.atlassian.net/browse/)

For GH Issues:
Fixes: #4479 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
