### PR TITLE
DDF-4430 Changing docs to show JDK is not required for installation 

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddf
+++ b/distribution/ddf-common/src/main/resources/bin/ddf
@@ -51,10 +51,10 @@ managing_solr() {
     return $RC
 }
 
-shutdown_no_java_home() {
-    # Shutdown if JAVA_HOME is not set
-    if [ -z $JAVA_HOME ]; then
-        echo "JAVA_HOME not set. Set JAVA_HOME to proceed - exiting."
+shutdown_no_java_home_or_jre_home() {
+    # Shutdown if JAVA_HOME and JRE_HOME is not set
+    if [ -z $JAVA_HOME ] && [ -z $JRE_HOME ]; then
+        echo "JAVA_HOME nor JRE_HOME is set. Set JAVA_HOME or JRE_HOME to proceed - exiting."
         exit 1
     fi
 }
@@ -86,7 +86,7 @@ attempt_shutdown() {
 while true; do
     clear_restart_flag
     refresh_properties
-    shutdown_no_java_home
+    shutdown_no_java_home_or_jre_home
     attempt_startup
     attempt_shutdown
 done

--- a/distribution/ddf-common/src/main/resources/bin/ddf.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddf.bat
@@ -10,9 +10,9 @@ POPD
 SET GET_PROPERTY=%DIRNAME%get_property.bat
 SET SOLR_EXEC=%DDF_HOME%\bin\ddfsolr.bat
 
-REM Exit if JAVA_HOME not set
-IF "%JAVA_HOME%" == "" (
-    ECHO JAVA_HOME not set. Set JAVA_HOME to proceed - exiting.
+REM Exit if JAVA_HOME or JRE_HOME is not set
+IF "%JAVA_HOME%" == "" IF "%JRE_HOME%" == ""  (
+    ECHO JAVA_HOME nor JRE_HOME is set. Set JAVA_HOME or JRE_HOME to proceed - exiting.
     EXIT /B
 )
 

--- a/distribution/docs/src/main/resources/content/_installing/java-reqs.adoc
+++ b/distribution/docs/src/main/resources/content/_installing/java-reqs.adoc
@@ -1,0 +1,152 @@
+:title: Java Requirements
+:type: subInstalling
+:status: published
+:parent: Installation Prerequisites
+:order: 01
+
+== Java Requirements
+For a runtime system:
+
+* https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html[JRE 8 x64] {external-link} or https://openjdk.java.net/install[OpenJDK 8 JRE] {external-link} must be installed.
+* The `JRE_HOME` environment variable must be set to the locations where the JRE is installed
+
+For a development system:
+
+* http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] must be installed.
+* The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.
+
+. Install/Upgrade to Java 8 x64 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK] {external-link}
+.. The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] or later.
+.. Java version must contain only number values.
+. Install/Upgrade to http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8] {external-link}.
+. Set the `JAVA_HOME` environment variable to the location where the JDK is installed.
+
+
+.*NIX Unlinking JAVA_HOME if Previously Set
+[WARNING]
+====
+Unlink `JAVA_HOME` if it is already linked to a previous version of the JRE:
+
+`unlink JAVA_HOME`
+====
+
+If JDK was installed:
+====
+.Setting JAVA_HOME variable
+Replace `<JAVA_VERSION>` with the version and build number installed.
+
+. Open a terminal window(*NIX) or command prompt (Windows) with administrator privileges.
+. Determine Java Installation Directory (This varies between operating system versions).
++
+.Find Java Path in *NIX
+----
+which java
+----
++
+.Find Java Path in Windows
+The path to the JDK can vary between versions of Windows, so manually verify the path under:
++
+----
+C:\Program Files\Java\jdk<M.m.p_build>
+----
++
+. Copy path of Java installation to clipboard. (example: `/usr/java/<JAVA_VERSION`>)
+. Set `JAVA_HOME` by replacing <PATH_TO_JAVA> with the copied path in this command:
++
+.Setting `JAVA_HOME` on *NIX
+----
+JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+export JAVA_HOME
+----
++
+.Setting `JAVA_HOME` on Windows
+----
+set JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+setx JAVA_HOME "<PATH_TO_JAVA><JAVA_VERSION>"
+----
++
+.Adding `JAVA_HOME` to `PATH` Environment Variable on Windows
+----
+setx PATH "%PATH%;%JAVA_HOME%\bin"
+----
++
+. Restart Terminal (shell) or Command Prompt.
+
+* Verify that the `JAVA_HOME` was set correctly.
+====
+
+====
+
+.*NIX
+----
+echo $JAVA_HOME
+----
+
+.Windows
+----
+echo %JAVA_HOME%
+----
+====
+
+If JRE was installed:
+====
+.Setting JRE_HOME variable
+Replace `<JAVA_VERSION>` with the version and build number installed.
+
+. Open a terminal window(*NIX) or command prompt (Windows) with administrator privileges.
+. Determine Java Installation Directory (This varies between operating system versions).
++
+.Find Java Path in *NIX
+----
+which java
+----
++
+.Find Java Path in Windows
+The path to the JRE can vary between versions of Windows, so manually verify the path under:
++
+----
+C:\Program Files\Java\jre<M.m.p_build>
+----
++
+. Copy path of Java installation to clipboard. (example: `/usr/java/<JAVA_VERSION`>)
+. Set `JRE_HOME` by replacing <PATH_TO_JAVA> with the copied path in this command:
++
+.Setting `JRE_HOME` on *NIX
+----
+JRE_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+export JRE_HOME
+----
++
+.Setting `JRE_HOME` on Windows
+----
+set JRE_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+setx JRE_HOME "<PATH_TO_JAVA><JAVA_VERSION>"
+----
++
+.Adding `JRE_HOME` to `PATH` Environment Variable on Windows
+----
+setx PATH "%PATH%;%JRE_HOME%\bin"
+----
++
+. Restart Terminal (shell) or Command Prompt.
+
+* Verify that the `JRE_HOME` was set correctly.
+====
+
+.File Descriptor Limit on Linux
+[NOTE]
+====
+* For Linux systems, increase the file descriptor limit by editing `/etc/sysctl.conf` to include:
+
+----
+fs.file-max = 6815744
+----
+
+* For the change to take effect, a restart is required.
+
+.*Nix Restart Command
+----
+init 6
+----
+
+====

--- a/distribution/docs/src/main/resources/content/_managing/_installing/hardware-reqs.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_installing/hardware-reqs.adoc
@@ -36,7 +36,7 @@
 |WebGL capable GPU
 
 |Additional Software
-|JDK 8 x64
+|JRE 8 x64
 |JDK 8 x64
 
 |===

--- a/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc
+++ b/distribution/docs/src/main/resources/content/_quickstart/quickstart-installing.adoc
@@ -24,12 +24,16 @@ For security reasons, ${branding} cannot be started from a user's home directory
 .Java Requirements (Quick Install)
 Set up Java to run ${branding}.
 
-* Install/Upgrade to Java 8 x64 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK] {external-link}
-** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] {external-link} or later.
-** Java Version and Build numbers must contain only number values.
+* For a runtime system:
+** Install https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html[Oracle JRE 8 x64] {external-link} or https://openjdk.java.net/install[OpenJDK 8 JRE] {external-link}
+* For a development system:
+** Install/Upgrade to Java 8 x64 http://www.oracle.com/technetwork/java/javase/downloads/index.html[J2SE 8 SDK] {external-link}
+*** The recommended version is http://www.oracle.com/technetwork/java/javase/8u60-relnotes-2620227.html[8u60] {external-link} or later.
+*** Java Version and Build numbers must contain only number values.
 * Microsoft Windows and Linux are supported. For more information about supported versions, see <<{managing-prefix}installation_prerequisites,Installation Prerequisites>>
-* http://www.oracle.com/technetwork/java/javase/downloads/index.html[JDK8x64] {external-link} must be installed.
-* The `JAVA_HOME` environment variable must be set to the location where the JDK is installed.
+* https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html[JRE 8 x64] {external-link} or https://openjdk.java.net/install[OpenJDK 8 JRE] {external-link} must be installed.
+* If the JRE was installed, the `JRE_HOME` environment variable must be set to the location where the JRE is installed.
+* If the JDK was installed, the `JAVA_HOME` environment variable must be set to the location where the JDK is installed.
 
 .Setting JAVA_HOME variable (Replace `<JAVA_VERSION>` with the version and build number installed.)
 ====
@@ -47,8 +51,12 @@ which java
 ----
 
 . Copy path to Java installation. (example: `/usr/java/<JAVA_VERSION>`)
-. Set `JAVA_HOME` by replacing <PATH_TO_JAVA> with the copied path in this command:
+. Set `JAVA_HOME` or `JRE_HOME` by replacing <PATH_TO_JAVA> with the copied path in this command:
+====
 
+If JDK was installed:
+
+====
 .Setting `JAVA_HOME` on Windows
 ----
 set JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
@@ -61,8 +69,36 @@ setx PATH "%PATH%;%JAVA_HOME%\bin"
 
 .Setting `JAVA_HOME` on *nix
 ----
-JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
-export JAVA_HOME
+export JAVA_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+----
+
+.Adding `JAVA_HOME` to `PATH` Environment Variable on *nix
+----
+export PATH=$JAVA_HOME/bin\:$PATH
+----
+====
+
+IF JRE was installed:
+
+====
+.Setting `JRE_HOME` on Windows
+----
+set JRE_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+----
+
+.Adding `JRE_HOME` to `PATH` Environment Variable on Windows
+----
+setx PATH "%PATH%;%JRE_HOME%\bin"
+----
+
+.Setting `JRE_HOME` on *nix
+----
+export JRE_HOME=<PATH_TO_JAVA><JAVA_VERSION>
+----
+
+.Adding `JRE_HOME` to `PATH` Environment Variable on *nix
+----
+export PATH=$JRE_HOME/bin\:$PATH
 ----
 ====
 
@@ -123,6 +159,8 @@ Prior to installing ${branding}, ensure the system time is accurate to prevent f
 The Windows Zip implementation, which is invoked when a user double-clicks on a zip file in the Windows Explorer, creates a corrupted installation.
 This is a consequence of its inability to process long file paths.
 Instead, use the java jar command line utility to unzip the distribution (see example below) or use a third party utility such as 7-Zip.
+
+Note: If and only if a JDK is installed, the jar command may be used; otherwise, another archiving utility that does not have issue with long paths should be installed
 
 .Use Java to Unzip in Windows(Replace `<PATH_TO_JAVA>` with correct path `and <JAVA_VERSION>` with current version.)
 ----


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #4443


#### What does this PR do?
Changes documentation to denote that JDK is not a required installation step and instead JRE can be used if it is not a development system.

#### Who is reviewing it? 
@ahoffer @tyler30clemens 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@ethantmanns
@ricklarsen - Documentation
@vinamartin

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Build and check out docs locally for correctness
Unset JAVA_HOME
Start up DDF
DDF should not start and should output message saying to set JAVA_HOME to start
(Set JRE_HOME and DDF should start up)

#### What are the relevant tickets?

For GH Issues:
Fixes: #4430 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
