### PR TITLE
[2.13.x] DDF-04487 Generate Solr stop key for *nix

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # Capture start|stop|restart command
-# Set a default value in the event no arguments are provided
 COMMAND=$1
 shift
 
@@ -52,8 +51,8 @@ set_security_properties() {
 }
 
 generate_stopkey() {
-    export STOP_KEY=`head /dev/random | tr -c -d "a-z0-9" | cut -c1-8`
-	echo $STOP_KEY > STOPKEY
+    export STOP_KEY=`head /dev/urandom | tr -c -d "a-z0-9" | cut -c1-8`
+	echo $STOP_KEY >& STOPKEY
 }
 
 
@@ -61,7 +60,6 @@ start_solr() {
     if [ "$SOLR_UNSECURE" != "true" ]; then
         set_security_properties
     fi
-
     generate_stopkey
     $SOLR_EXEC $1 -force -p $SOLR_PORT -m $SOLR_MEM
     local rc=$?
@@ -72,7 +70,7 @@ start_solr() {
 stop_solr() {
     export STOP_KEY=`cat STOPKEY`
     $SOLR_EXEC stop -p $SOLR_PORT
-    rm STOPKEY
+    [ -f STOPKEY ] && rm STOPKEY
 }
 
 print_messages() {

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -51,15 +51,28 @@ set_security_properties() {
       export SOLR_SSL_TRUST_STORE_TYPE=$($GET javax.net.ssl.trustStoreType)
 }
 
+generate_stopkey() {
+    export STOP_KEY=`head /dev/random | tr -c -d "a-z0-9" | cut -c1-8`
+	echo $STOP_KEY > STOPKEY
+}
+
+
 start_solr() {
     if [ "$SOLR_UNSECURE" != "true" ]; then
         set_security_properties
     fi
 
+    generate_stopkey
     $SOLR_EXEC $1 -force -p $SOLR_PORT -m $SOLR_MEM
     local rc=$?
     print_messages $rc
     return $rc
+}
+
+stop_solr() {
+    export STOP_KEY=`cat STOPKEY`
+    $SOLR_EXEC stop -p $SOLR_PORT
+    rm STOPKEY
 }
 
 print_messages() {
@@ -72,9 +85,8 @@ print_messages() {
     fi
 }
 
-
 if [ "$COMMAND" = "stop" ]; then
-    $SOLR_EXEC stop -p $SOLR_PORT
+	stop_solr
 else
     # Read protocol from properties file
     SOLR_PROTOCOL=$($GET "solr.http.protocol")


### PR DESCRIPTION
#### What does this PR do?
Generates a stop key every time Solr is started by the `ddfsolr` script.

#### Who is reviewing it? 
@garrettfreibott  @mcalcote @brjeter @tyler30clemens @austinsteffes 

#### Select relevant component teams: 
@codice/security 
@codice/solr 
#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter 
@garrettfreibott 

For GH Issues:
Fixes: #4415 

####Testing
* Testing is limited to Windows
* Test `ddfsolr.bat start`,  `ddfsolr.bat restart`,  and `ddfsolr.bat stop`
* Test that `ddfsolr.bat stop` removes the file named STOPKEY
                  
#### Checklist:
- [No] Documentation Updated
- [No] Update / Add Threat Dragon models
- [No] Update / Add Unit Tests
- [No] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
