### PR TITLE
[2.13.x] DDF-04486 Enforce the WFS sources' configured connect and receive timeouts

### DIFF
--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/pom.xml
@@ -195,19 +195,18 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.36</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.34</minimum>
+                                            <minimum>0.63</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.25</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsSourceTest.java
@@ -23,10 +23,15 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
@@ -49,6 +54,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.xml.namespace.QName;
 import javax.xml.transform.TransformerConfigurationException;
@@ -74,6 +80,7 @@ import org.codice.ddf.cxf.client.SecureCxfClientFactory;
 import org.codice.ddf.spatial.ogc.catalog.common.AvailabilityTask;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsException;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsFeatureCollection;
+import org.codice.ddf.spatial.ogc.wfs.catalog.source.MarkableStreamInterceptor;
 import org.codice.ddf.spatial.ogc.wfs.catalog.source.WfsUriResolver;
 import org.codice.ddf.spatial.ogc.wfs.v1_0_0.catalog.common.DescribeFeatureTypeRequest;
 import org.codice.ddf.spatial.ogc.wfs.v1_0_0.catalog.common.GetCapabilitiesRequest;
@@ -1156,6 +1163,171 @@ public class WfsSourceTest {
     // Perform test
     assertEquals(source.getConnectionTimeout().intValue(), 10000);
     assertEquals(source.getReceiveTimeout().intValue(), 10000);
+  }
+
+  @Test
+  public void testClientFactoryIsCreatedCorrectlyWhenUsernameAndPasswordAreConfigured()
+      throws SecurityServiceException, WfsException {
+    setUp(ONE_TEXT_PROPERTY_SCHEMA, null, null, ONE_FEATURE, null);
+
+    final String wfsUrl = "http://localhost/wfs";
+    final String username = "test_user";
+    final String password = "encrypted_password";
+    final Boolean disableCnCheck = false;
+    final Integer connectionTimeout = 10000;
+    final Integer receiveTimeout = 20000;
+
+    source.setPollInterval(1);
+
+    doReturn("unencrypted_password").when(encryptionService).decryptValue(password);
+
+    final Map<String, Object> configuration =
+        ImmutableMap.<String, Object>builder()
+            .put("wfsUrl", wfsUrl)
+            .put("username", username)
+            .put("password", password)
+            .put("disableCnCheck", disableCnCheck)
+            .put("connectionTimeout", connectionTimeout)
+            .put("receiveTimeout", receiveTimeout)
+            .put("pollInterval", 1)
+            .build();
+    source.refresh(configuration);
+
+    verify(mockClientFactory)
+        .getSecureCxfClientFactory(
+            eq(wfsUrl),
+            eq(Wfs.class),
+            any(List.class),
+            isA(MarkableStreamInterceptor.class),
+            eq(disableCnCheck),
+            eq(false),
+            eq(connectionTimeout),
+            eq(receiveTimeout),
+            eq(username),
+            eq("unencrypted_password"));
+  }
+
+  @Test
+  public void testClientFactoryIsCreatedCorrectlyWhenCertAliasAndKeystorePathAreConfigured()
+      throws SecurityServiceException, WfsException {
+    setUp(ONE_TEXT_PROPERTY_SCHEMA, null, null, ONE_FEATURE, null);
+
+    final String wfsUrl = "http://localhost/wfs";
+    final Boolean disableCnCheck = false;
+    final Integer connectionTimeout = 10000;
+    final Integer receiveTimeout = 20000;
+    final String certAlias = "mycert";
+    final String keystorePath = "/path/to/keystore";
+    final String sslProtocol = "TLSv1.2";
+
+    source.setCertAlias(certAlias);
+    source.setKeystorePath(keystorePath);
+    source.setSslProtocol(sslProtocol);
+    source.setPollInterval(1);
+
+    final Map<String, Object> configuration =
+        ImmutableMap.<String, Object>builder()
+            .put("wfsUrl", wfsUrl)
+            .put("disableCnCheck", disableCnCheck)
+            .put("connectionTimeout", connectionTimeout)
+            .put("receiveTimeout", receiveTimeout)
+            .put("pollInterval", 1)
+            .build();
+    source.refresh(configuration);
+
+    verify(mockClientFactory)
+        .getSecureCxfClientFactory(
+            eq(wfsUrl),
+            eq(Wfs.class),
+            any(List.class),
+            isA(MarkableStreamInterceptor.class),
+            eq(disableCnCheck),
+            eq(false),
+            eq(connectionTimeout),
+            eq(receiveTimeout),
+            eq(certAlias),
+            eq(keystorePath),
+            eq(sslProtocol));
+  }
+
+  @Test
+  public void testClientFactoryIsCreatedCorrectlyWhenNoAuthIsConfigured()
+      throws SecurityServiceException, WfsException {
+    setUp(ONE_TEXT_PROPERTY_SCHEMA, null, null, ONE_FEATURE, null);
+
+    final String wfsUrl = "http://localhost/wfs";
+    final Boolean disableCnCheck = false;
+    final Integer connectionTimeout = 10000;
+    final Integer receiveTimeout = 20000;
+
+    source.setPollInterval(1);
+
+    final Map<String, Object> configuration =
+        ImmutableMap.<String, Object>builder()
+            .put("wfsUrl", wfsUrl)
+            .put("disableCnCheck", disableCnCheck)
+            .put("connectionTimeout", connectionTimeout)
+            .put("receiveTimeout", receiveTimeout)
+            .put("pollInterval", 1)
+            .build();
+    source.refresh(configuration);
+
+    verify(mockClientFactory)
+        .getSecureCxfClientFactory(
+            eq(wfsUrl),
+            eq(Wfs.class),
+            any(List.class),
+            isA(MarkableStreamInterceptor.class),
+            eq(disableCnCheck),
+            eq(false),
+            eq(connectionTimeout),
+            eq(receiveTimeout));
+  }
+
+  @Test
+  public void testNoWfsClientRefreshWhenConfigurationDoesNotChange()
+      throws SecurityServiceException, WfsException {
+    setUp(ONE_TEXT_PROPERTY_SCHEMA, null, null, ONE_FEATURE, null);
+
+    verify(mockClientFactory)
+        .getSecureCxfClientFactory(
+            anyString(),
+            eq(Wfs.class),
+            any(List.class),
+            isA(MarkableStreamInterceptor.class),
+            anyBoolean(),
+            anyBoolean(),
+            anyInt(),
+            anyInt());
+
+    verify(mockWfs).getCapabilities(any(GetCapabilitiesRequest.class));
+    verify(mockWfs).describeFeatureType(any(DescribeFeatureTypeRequest.class));
+
+    final String wfsUrl = "http://localhost/wfs";
+    final Boolean disableCnCheck = false;
+    final Integer initialConnectionTimeout = 10000;
+    final Integer initialReceiveTimeout = 20000;
+
+    source.setWfsUrl(wfsUrl);
+    source.setDisableCnCheck(disableCnCheck);
+    source.setConnectionTimeout(initialConnectionTimeout);
+    source.setReceiveTimeout(initialReceiveTimeout);
+    source.setPollInterval(1);
+
+    final Map<String, Object> configuration =
+        ImmutableMap.<String, Object>builder()
+            .put("wfsUrl", wfsUrl)
+            .put("disableCnCheck", disableCnCheck)
+            .put("connectionTimeout", initialConnectionTimeout)
+            .put("receiveTimeout", initialReceiveTimeout)
+            .put("pollInterval", 1)
+            .build();
+    source.refresh(configuration);
+
+    verifyNoMoreInteractions(mockClientFactory);
+
+    verify(mockWfs).getCapabilities(any(GetCapabilitiesRequest.class));
+    verify(mockWfs).describeFeatureType(any(DescribeFeatureTypeRequest.class));
   }
 
   private SourceResponse executeQuery(int startIndex, int pageSize)

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -258,19 +258,18 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.64</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.63</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.51</minimum>
+                                            <minimum>0.57</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/pom.xml
@@ -228,19 +228,18 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.53</minimum>
+                                            <minimum>0.64</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.39</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsSource.java
@@ -369,8 +369,8 @@ public class WfsSource extends AbstractWfsSource {
               new MarkableStreamInterceptor(),
               this.disableCnCheck,
               false,
-              null,
-              null,
+              connectionTimeout,
+              receiveTimeout,
               username,
               password);
     } else if (StringUtils.isNotBlank(getCertAlias())
@@ -383,8 +383,8 @@ public class WfsSource extends AbstractWfsSource {
               new MarkableStreamInterceptor(),
               this.disableCnCheck,
               false,
-              null,
-              null,
+              connectionTimeout,
+              receiveTimeout,
               getCertAlias(),
               getKeystorePath(),
               getSslProtocol());
@@ -396,7 +396,9 @@ public class WfsSource extends AbstractWfsSource {
               initProviders(),
               new MarkableStreamInterceptor(),
               this.disableCnCheck,
-              false);
+              false,
+              connectionTimeout,
+              receiveTimeout);
     }
   }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes the WFS 1.0.0, 1.1.0, and 2.0.0 sources so their configured connect and receive timeouts will actually be used for connections to the external WFS server.

#### Who is reviewing it? 
@leo-sakh 
@Corey-Collins 

#### Select relevant component teams: 
@codice/io 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@troymohl

#### How should this be tested?
Repeat the following steps for a WFS 1.0.0, 1.1.0, and 2.0.0 source:
**Note:** run `log:set debug org.codice.ddf.spatial.ogc.wfs.v110.catalog.source` before testing the 1.1.0 source.
1. Create a new WFS source.
2. Set the WFS URL to point to a valid WFS server.
a. http://giswebservices.massgis.state.ma.us/geoserver/wfs is a public WFS server that will work for testing this.
b. **Important:** If you use this server, you must set `Forced Feature Type` to GISDATA.MINLL1_ARC
3. Click `Save`.
4. Enable the source via the `Active Binding` dropdown.
5. Verify the source shows up as available.
a. You may have to click `Refresh Sources` for this to happen.
b. If you used the WFS source I mentioned in step 2, it will take several seconds for the source to show up as available.
6. Open the source configuration and set the connection timeout to `1` (that is, 1 millisecond).
a. This will cause all the source's connection attempts to time out after 1 millisecond which should break it completely.
7. Click `Save`.
8. Disable the source via the `Active Binding` dropdown.
9. Re-enable the source via the `Active Binding` dropdown.
10. Verify the source shows up as unavailable, even if you click `Refresh Sources`.
11. Check the logs for a `SocketTimeoutException` with the message `connect timed out`. 
12. Open the source configuration and set the connection timeout back to `30000`.
13. Set the receive timeout to `1`.
a. This will cause all the source's requests to timeout after 1 millisecond which should break it completely.
14. Click `Save`.
15. Verify the source shows up as unavailable, even if you click `Refresh Sources`.
16. Check the logs for a `SocketTimeoutException` with the message `read timed out`.

#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4486  

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
