### PR TITLE
[2.13.x] DDF-04487 Solr stop key for *nix

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddf
+++ b/distribution/ddf-common/src/main/resources/bin/ddf
@@ -61,7 +61,9 @@ shutdown_no_java_home_or_jre_home() {
 
 attempt_startup() {
     if managing_solr; then
-        $SOLR_EXEC restart
+        echo "Checking for running Solr instance..."
+        $SOLR_EXEC stop
+        $SOLR_EXEC start
     fi
 
     if [ "$START_KARAF" = "true" ]; then

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -74,7 +74,7 @@ start_solr() {
 stop_solr() {
     export STOP_KEY=`cat STOPKEY`
     $SOLR_EXEC stop -p $SOLR_PORT
-    [ -f STOPKEY ] && rm STOPKEY
+    [ -f STOPKEY ] && rm -f STOPKEY
 }
 
 print_messages() {

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # Capture start|stop|restart command
-# Set a default value in the event no arguments are provided
 COMMAND=$1
 shift
 
@@ -52,8 +51,8 @@ set_security_properties() {
 }
 
 generate_stopkey() {
-    export STOP_KEY=`head /dev/random | tr -c -d "a-z0-9" | cut -c1-8`
-	echo $STOP_KEY > STOPKEY
+    export STOP_KEY=`head /dev/urandom | tr -c -d "a-z0-9" | cut -c1-8`
+	echo $STOP_KEY >& STOPKEY
 }
 
 
@@ -61,7 +60,6 @@ start_solr() {
     if [ "$SOLR_UNSECURE" != "true" ]; then
         set_security_properties
     fi
-
     generate_stopkey
     $SOLR_EXEC $1 -force -p $SOLR_PORT -m $SOLR_MEM
     local rc=$?
@@ -72,7 +70,7 @@ start_solr() {
 stop_solr() {
     export STOP_KEY=`cat STOPKEY`
     $SOLR_EXEC stop -p $SOLR_PORT
-    rm STOPKEY
+    [ -f STOPKEY ] && rm STOPKEY
 }
 
 print_messages() {

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -51,7 +51,11 @@ set_security_properties() {
 }
 
 generate_stopkey() {
-    export STOP_KEY=`head /dev/urandom | tr -c -d "a-z0-9" | cut -c1-8`
+    # Generate a random string of 8 lowercase letters and digits.
+    # NOTE: Mac OS interprets bytes as belonging to the UTF-8 character set.
+    # The urandom stream does not spit out valid UTF-8 characters.
+    # Tell Mac OS to not interpret the bytes as charcters with LC_ALL=C
+    export STOP_KEY=`LC_ALL=C head /dev/urandom | tr -c -d "a-z0-9" | cut -c1-8`
 	echo $STOP_KEY >& STOPKEY
 }
 

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -51,15 +51,28 @@ set_security_properties() {
       export SOLR_SSL_TRUST_STORE_TYPE=$($GET javax.net.ssl.trustStoreType)
 }
 
+generate_stopkey() {
+    export STOP_KEY=`head /dev/random | tr -c -d "a-z0-9" | cut -c1-8`
+	echo $STOP_KEY > STOPKEY
+}
+
+
 start_solr() {
     if [ "$SOLR_UNSECURE" != "true" ]; then
         set_security_properties
     fi
 
+    generate_stopkey
     $SOLR_EXEC $1 -force -p $SOLR_PORT -m $SOLR_MEM
     local rc=$?
     print_messages $rc
     return $rc
+}
+
+stop_solr() {
+    export STOP_KEY=`cat STOPKEY`
+    $SOLR_EXEC stop -p $SOLR_PORT
+    rm STOPKEY
 }
 
 print_messages() {
@@ -72,9 +85,8 @@ print_messages() {
     fi
 }
 
-
 if [ "$COMMAND" = "stop" ]; then
-    $SOLR_EXEC stop -p $SOLR_PORT
+	stop_solr
 else
     # Read protocol from properties file
     SOLR_PROTOCOL=$($GET "solr.http.protocol")

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -28,7 +28,6 @@ SCRIPTDIR=$(dirname $0)
 HOME_DIR=$(cd "${SCRIPTDIR}/.."; pwd -P)
 GET=${SCRIPTDIR}/get_property
 SOLR_EXEC=${HOME_DIR}/solr/bin/solr
-STOPKEY_FILE=${HOME_DOR}/STOPKEY
 
 # Read port from custom.system.properties file
 SOLR_PORT=$($GET "solr.http.port")

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -55,8 +55,8 @@ generate_stopkey() {
     # NOTE: Mac OS interprets bytes as belonging to the UTF-8 character set.
     # The urandom stream does not spit out valid UTF-8 characters.
     # Tell Mac OS to not interpret the bytes as charcters with LC_ALL=C
-    export STOP_KEY=`LC_ALL=C && head /dev/urandom | tr -c -d "a-z0-9" | cut -c1-8`
-	echo $STOP_KEY >& STOPKEY
+    export STOP_KEY=`cat /dev/urandom | env LC_CTYPE=C tr -dc a-z0-9 | head -c 8`
+    echo $STOP_KEY >& STOPKEY
 }
 
 

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -99,7 +99,7 @@ else
 
     # Do not proceed if required properties are missing
     if [ -z "$SOLR_PROTOCOL" ]; then
-        echo "Cannot determine Solr protocol (http or https) from custom.system.properties file. Exiing."
+        echo "Cannot determine Solr protocol (http or https) from custom.system.properties file. Exiting."
         exit 3
     fi
 

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# Capture start|stop|restart command
+# Capture start|stop command
 COMMAND=$1
 shift
 
 # -----------------------------------------------------------------------------
 usage() {
-    echo "Usage: $0 {start|stop|restart} " >&2; exit 1;
+    echo "Usage: $0 {start|stop} " >&2; exit 1;
 }
 
 # -----------------------------------------------------------------------------
@@ -15,7 +15,7 @@ if [ -z  "$COMMAND" ]; then
     usage
 fi
 
-if  ! ( [ "$COMMAND" == "start" ] || [ "$COMMAND" == "stop" ] || [ "$COMMAND" == "restart" ] ); then
+if  ! ( [ "$COMMAND" == "start" ] || [ "$COMMAND" == "stop" ] ); then
     echo "Unknown command: $COMMAND" >&2
     usage
 fi
@@ -28,6 +28,7 @@ SCRIPTDIR=$(dirname $0)
 HOME_DIR=$(cd "${SCRIPTDIR}/.."; pwd -P)
 GET=${SCRIPTDIR}/get_property
 SOLR_EXEC=${HOME_DIR}/solr/bin/solr
+STOPKEY_FILE=${HOME_DOR}/STOPKEY
 
 # Read port from custom.system.properties file
 SOLR_PORT=$($GET "solr.http.port")
@@ -72,9 +73,13 @@ start_solr() {
 }
 
 stop_solr() {
-    export STOP_KEY=`cat STOPKEY`
-    $SOLR_EXEC stop -p $SOLR_PORT
-    [ -f STOPKEY ] && rm -f STOPKEY
+
+	if [ -f STOPKEY ]; then
+	    export STOP_KEY=`cat STOPKEY`;
+	    rm STOPKEY;
+	fi
+    $SOLR_EXEC stop -p $SOLR_PORT;
+
 }
 
 print_messages() {
@@ -87,7 +92,7 @@ print_messages() {
     fi
 }
 
-if [ "$COMMAND" = "stop" ]; then
+if [ "$COMMAND" == "stop" ]; then
 	stop_solr
 else
     # Read protocol from properties file
@@ -95,7 +100,7 @@ else
 
     # Do not proceed if required properties are missing
     if [ -z "$SOLR_PROTOCOL" ]; then
-        echo "Cannot determine Solr protocol (http or https) from custom.system.properties file. Exiting."
+        echo "Cannot determine Solr protocol (http or https) from custom.system.properties file. Exiing."
         exit 3
     fi
 

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -55,7 +55,7 @@ generate_stopkey() {
     # NOTE: Mac OS interprets bytes as belonging to the UTF-8 character set.
     # The urandom stream does not spit out valid UTF-8 characters.
     # Tell Mac OS to not interpret the bytes as charcters with LC_ALL=C
-    export STOP_KEY=`LC_ALL=C head /dev/urandom | tr -c -d "a-z0-9" | cut -c1-8`
+    export STOP_KEY=`LC_ALL=C && head /dev/urandom | tr -c -d "a-z0-9" | cut -c1-8`
 	echo $STOP_KEY >& STOPKEY
 }
 


### PR DESCRIPTION
#### What does this PR do?
The Solr start script generates a stop key every time Solr is started

#### Who is reviewing it? 
@garrettfreibott  @mcalcote @brjeter @tyler30clemens @austinsteffes 

#### Select relevant component teams: 
@codice/security 
@codice/solr 
#### Ask 2 committers to review/merge the PR and tag them here.
@clockard 
@brjeter 
@garrettfreibott 

For GH Issues:
Fixes: #4487 

####Testing
* Should be tested on both **Mac and Linux**
* Test `ddfsolr start`,  `ddfsolr restart`,  and `ddfsolr stop`
* Test that `ddfsolr stop` removes the file named STOPKEY
* Test that the Solr process is eventually killed even if the STOPKEY file is missing (usually 180 seconds) 
                  
#### Checklist:
- [No] Documentation Updated
- [No] Update / Add Threat Dragon models
- [No] Update / Add Unit Tests
- [No] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an inline code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
