### PR TITLE
DDF-04518 Cleared query attribute value when switching between attributes of different types

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -222,16 +222,14 @@ module.exports = Marionette.LayoutView.extend({
     this.filterAttribute.currentView.model.set('value', [attribute])
   },
   handleAttributeUpdate: function() {
+    const previousAttributeType =
+      metacardDefinitions.metacardTypes[this.model.get('type')].type
     this.model.set(
       'type',
       this.filterAttribute.currentView.model.get('value')[0]
     )
     const currentAttributeType =
       metacardDefinitions.metacardTypes[this.model.get('type')].type
-    const previousAttribute = this.filterAttribute.currentView.model
-      ._previousAttributes.value[0]
-    const previousAttributeType =
-      metacardDefinitions.metacardTypes[previousAttribute].type
     if (currentAttributeType !== previousAttributeType) {
       this.model.set('value', [''])
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -226,6 +226,15 @@ module.exports = Marionette.LayoutView.extend({
       'type',
       this.filterAttribute.currentView.model.get('value')[0]
     )
+    const currentAttributeType =
+      metacardDefinitions.metacardTypes[this.model.get('type')].type
+    const previousAttribute = this.filterAttribute.currentView.model
+      ._previousAttributes.value[0]
+    const previousAttributeType =
+      metacardDefinitions.metacardTypes[previousAttribute].type
+    if (currentAttributeType !== previousAttributeType) {
+      this.model.set('value', [''])
+    }
   },
   delete: function() {
     this.model.destroy()


### PR DESCRIPTION
#### What does this PR do?
When updating the filter, the type of the previously selected attribute is compared to the type of the currently selected attribute. If they're not the same type, the value is cleared to avoid unexpected/undesired values. 
#### Who is reviewing it? 
@andrewzimmer @Bdthomson 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining 
@djblue 
@millerw8 
#### How should this be tested?
- Switch to `anyGeo` and draw a shape
- Switch to `anyText` and verify that the value is empty
- Fill in a value and switch to a Boolean attribute
- Verify that the value is empty
- Switch to any other String attribute and enter a number
- Switch to a Date attribute and verify that the value is empty
- Choose a date and switch to another Date attribute
- Verify that the same date remains
- Switch between other attributes of the same type and make sure that the values remain (with the exception of different shapes: polygon to bounding box, bounding box to point radius, etc)
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #4518 
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
