### PR TITLE
DDF-04524 Enabling Warning Message on Export Results (All) 

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/number/number.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/input-wrappers/number/number.tsx
@@ -16,15 +16,17 @@ import Base, { Type, BaseProps, destructureBaseProps } from '../base'
 type Props = {
   value: string
   onChange?: (value: boolean) => void
+  placeholder: string
 } & BaseProps
 
 export default hot(module)((props: Props) => {
-  const { value, onChange, ...otherProps } = props
+  const { value, onChange, placeholder, ...otherProps } = props
   return (
     <Base
       value={[value]}
       type={Type.number}
       onChange={onChange}
+      placeholder={placeholder || 'Enter a numerical input'}
       {...destructureBaseProps(otherProps) as any}
     />
   )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/table-export/table-export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/table-export/table-export.tsx
@@ -85,7 +85,7 @@ function getWarning(exportCountInfo: ExportCountInfo): string {
     .getCurrentQuery()
     .get('result')
   const totalHits = getHits(result.get('status').toJSON())
-  let limitWarning = `You cannot export more than the administrator configured limit of ${
+  const limitWarning = `You cannot export more than the administrator configured limit of ${
     properties.exportResultLimit
   }.`
   let warningMessage = ''

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/table-export/table-export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/table-export/table-export.tsx
@@ -25,53 +25,44 @@ const properties = require('../../../js/properties.js')
 const announcement = require('../../../component/announcement/index.jsx')
 const Sources = require('../../../component/singletons/sources-instance.js')
 const contentDisposition = require('content-disposition')
-
 function buildCqlQueryFromMetacards(metacards: any) {
   const queryParts = metacards.map((metacard: any) => {
     return `(("id" ILIKE '${metacard.metacard.id}'))`
   })
   return `(${queryParts.join(' OR ')})`
 }
-
 const visibleData = (selectionInterface: any) =>
   buildCqlQueryFromMetacards(
     selectionInterface.getActiveSearchResults().toJSON()
   )
-
 const allData = (selectionInterface: any) =>
   selectionInterface.getCurrentQuery().get('cql')
-
 function getCqlForSize(exportSize: string, selectionInterface: any) {
   return exportSize === 'visible'
     ? visibleData(selectionInterface)
     : allData(selectionInterface)
 }
-
 function getSrcs(selectionInterface: any) {
   const srcs = selectionInterface.getCurrentQuery().get('src')
   return srcs === undefined ? _.pluck(Sources.toJSON(), 'id') : srcs
 }
-
 function getColumnOrder(): string[] {
   return user
     .get('user')
     .get('preferences')
     .get('columnOrder')
 }
-
 function getHiddenFields(): string[] {
   return user
     .get('user')
     .get('preferences')
     .get('columnHide')
 }
-
 function getHits(sources: Source[]): number {
   return sources
     .filter(source => source.id !== 'cache')
     .reduce((hits, source) => (source.hits ? hits + source.hits : hits), 0)
 }
-
 function getExportCount({
   exportSize,
   selectionInterface,
@@ -80,56 +71,59 @@ function getExportCount({
   if (exportSize === 'custom') {
     return customExportCount
   }
-
   const result = selectionInterface.getCurrentQuery().get('result')
   return exportSize === 'all'
     ? getHits(result.get('status').toJSON())
     : result.get('results').length
 }
-
 function getSorts(selectionInterface: any) {
   return selectionInterface.getCurrentQuery().get('sorts')
 }
-
 function getWarning(exportCountInfo: ExportCountInfo): string {
   const exportCount = getExportCount(exportCountInfo)
-  if (
-    exportCountInfo.exportSize === 'custom' &&
-    exportCount > properties.exportResultLimit
-  ) {
-    return `You cannot export more than the administrator configured limit of ${
-      properties.exportResultLimit
-    }`
-  }
-
   const result = exportCountInfo.selectionInterface
     .getCurrentQuery()
     .get('result')
   const totalHits = getHits(result.get('status').toJSON())
-
+  let limitWarning = `You cannot export more than the administrator configured limit of ${
+    properties.exportResultLimit
+  }.`
   let warningMessage = ''
-  if (exportCount > totalHits) {
-    warningMessage = `You are trying to export ${exportCount} results but there ${
-      totalHits === 1 ? `is` : `are`
-    } only ${totalHits}.  Only ${totalHits} ${
-      totalHits === 1 ? `result` : `results`
-    } will be exported.`
+  if (exportCount > properties.exportResultLimit) {
+    if (exportCountInfo.exportSize === 'custom') {
+      return limitWarning
+    }
+    warningMessage =
+      limitWarning +
+      `  Only ${properties.exportResultLimit} ${
+        properties.exportResultLimit === 1 ? `result` : `results`
+      } will be exported.`
   }
-  if (totalHits > 100 && exportCount > 100) {
-    warningMessage += ` This may take a long time.`
+  if (exportCountInfo.exportSize === 'custom') {
+    if (exportCount > totalHits) {
+      warningMessage = `You are trying to export ${exportCount} results but there ${
+        totalHits === 1 ? `is` : `are`
+      } only ${totalHits}.  Only ${totalHits} ${
+        totalHits === 1 ? `result` : `results`
+      } will be exported.`
+    }
+  }
+  if (
+    totalHits > 100 &&
+    exportCount > 100 &&
+    properties.exportResultLimit > 100
+  ) {
+    warningMessage += `  This may take a long time.`
   }
   return warningMessage
 }
-
 type Props = {
   selectionInterface: () => void
 }
-
 type Option = {
   label: string
   value: string
 }
-
 type State = {
   exportFormats: Option[]
   exportSizes: Option[]
@@ -137,23 +131,19 @@ type State = {
   exportSize: string
   customExportCount: number
 }
-
 type Source = {
   id: string
   hits: number
 }
-
 type ExportResponse = {
   displayName: string
   id: string
 }
-
 interface ExportCountInfo {
   exportSize: string
   selectionInterface: any
   customExportCount: number
 }
-
 export default hot(module)(
   class TableExport extends React.Component<Props, State> {
     constructor(props: Props) {
@@ -188,11 +178,9 @@ export default hot(module)(
           if (format1.displayName > format2.displayName) {
             return 1
           }
-
           if (format1.displayName < format2.displayName) {
             return -1
           }
-
           return 0
         }
       )
@@ -225,7 +213,6 @@ export default hot(module)(
       try {
         const hiddenFields = getHiddenFields()
         const columnOrder = getColumnOrder()
-
         const cql = getCqlForSize(exportSize, selectionInterface)
         const sources = getSrcs(selectionInterface)
         const sorts = getSorts(selectionInterface)
@@ -238,7 +225,6 @@ export default hot(module)(
           columnOrder: columnOrder.length > 0 ? columnOrder : {},
           columnAliasMap: properties.attributeAliases,
         }
-
         const body = {
           cql,
           srcs: sources,
@@ -246,7 +232,6 @@ export default hot(module)(
           sorts,
           args,
         }
-
         const response = await exportResultSet(exportFormat, body)
         this.onDownloadSuccess(response)
       } catch (error) {
@@ -260,7 +245,6 @@ export default hot(module)(
         const filename = contentDisposition.parse(
           response.headers.get('content-disposition')
         ).parameters.filename
-
         saveFile(filename, 'data:' + contentType, data)
       } else {
         announcement.announce({

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/table-export/table-export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/table-export/table-export.tsx
@@ -77,6 +77,7 @@ export default hot(module)((props: Props) => {
           <Number
             label=""
             showLabel={false}
+            placeholder="Enter number of results you would like to export"
             name="customExport"
             value={customExportCount.toString()}
             onChange={handleCustomExportCountChange}


### PR DESCRIPTION
#### Reviewers
@bdeining 
@adimka 
@middlets719 
@gordocanchola 
@zta6 
@andrewkfiedler 
@djblue 

#### What does this PR do?
- Adds message on admin export limit when `Exporting All`
- Adds placeholder update for numerical field `Enter number of results you would like to export`
- Refactor baseline input to allow for placeholder from props

#### How should this be tested?

## Testing Export Message

1. Ingest data into DDF
2. Open table view
3. Select the `Export` button
4. When choosing `All` from the dropdown, it should display a message if it exceeds the admin configurable limit (see note below to modify the limit)

```
To modify the admin configurable limit to a lower number to make it easier to test this, open up the catalog-ui-search settings from the admin page. Set this number to something small like 5, then retest
```

## Testing Placeholder

1. When following the above steps for exporting, swap the dropdown to `custom number`
2. When the number is removed, there should be a placeholder that is present.
3. Previously, the placeholder said `Enter a city or region` but now it should say something along the lines of `Enter number of results you would like to export`

#### What are the relevant tickets?
Github Issues: #4524 

#### Screenshots
<img width="1341" alt="Screen Shot 2019-03-11 at 12 26 56 PM" src="https://user-images.githubusercontent.com/7055226/54153681-6ca43b00-43fd-11e9-884e-c16644ceafde.png">
<img width="560" alt="Screen Shot 2019-03-11 at 12 26 51 PM" src="https://user-images.githubusercontent.com/7055226/54153682-6ca43b00-43fd-11e9-9652-d651d6fdbdd7.png">


