### PR TITLE
DDF-04519 Changed PropertyClaimsHandler to use karaf.jaas.modules to read the users.properties file

### DIFF
--- a/platform/security/sts/security-sts-propertyclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-propertyclaimshandler/pom.xml
@@ -24,6 +24,11 @@
     <packaging>bundle</packaging>
     <dependencies>
         <dependency>
+            <groupId>org.apache.karaf.jaas</groupId>
+            <artifactId>org.apache.karaf.jaas.modules</artifactId>
+            <version>${karaf.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.cxf.services.sts</groupId>
             <artifactId>cxf-services-sts-core</artifactId>
             <scope>compile</scope>

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/main/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandler.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/main/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandler.java
@@ -44,7 +44,7 @@ public class PropertyFileClaimsHandler implements ClaimsHandler, RealmSupport {
 
   private String propertyFileLocation;
 
-  private HashMap<String, String> userMapping;
+  private Map<String, String> userMapping;
 
   private List<String> supportedRealms;
 
@@ -170,23 +170,23 @@ public class PropertyFileClaimsHandler implements ClaimsHandler, RealmSupport {
         && !propertyFileLocation.isEmpty()
         && !propertyFileLocation.equals(this.propertyFileLocation)) {
 
-      Properties p = new Properties();
+      Properties props = new Properties();
       try {
-        p.load(getClass().getResourceAsStream(propertyFileLocation));
+        props.load(getClass().getResourceAsStream(propertyFileLocation));
       } catch (FileNotFoundException e) {
         LOGGER.debug("File not found when attempting to load user properties file.", e);
       } catch (IOException e) {
         LOGGER.debug("Exception when trying to load the user properties file.", e);
       }
 
-      propBackingEngine = new PropertiesBackingEngine(p);
+      propBackingEngine = new PropertiesBackingEngine(props);
 
       List<UserPrincipal> userList = propBackingEngine.listUsers();
-      userMapping = new HashMap();
+      userMapping = new HashMap<>();
       for (UserPrincipal eachUser : userList) {
 
         List<RolePrincipal> userRoles = propBackingEngine.listRoles(eachUser);
-        List<String> roleList = new ArrayList();
+        List<String> roleList = new ArrayList<>();
         for (RolePrincipal userRole : userRoles) {
           roleList.add(userRole.getName());
         }

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/main/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandler.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/main/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandler.java
@@ -54,7 +54,7 @@ public class PropertyFileClaimsHandler implements ClaimsHandler, RealmSupport {
 
   private String idClaimType;
 
-  private PropertiesBackingEngine pbe;
+  private PropertiesBackingEngine propBackingEngine;
 
   @Override
   public List<URI> getSupportedClaimTypes() {
@@ -179,13 +179,13 @@ public class PropertyFileClaimsHandler implements ClaimsHandler, RealmSupport {
         LOGGER.debug("Exception when trying to load the user properties file.", e);
       }
 
-      pbe = new PropertiesBackingEngine(p);
+      propBackingEngine = new PropertiesBackingEngine(p);
 
-      List<UserPrincipal> userList = pbe.listUsers();
+      List<UserPrincipal> userList = propBackingEngine.listUsers();
       userMapping = new HashMap();
       for (UserPrincipal eachUser : userList) {
 
-        List<RolePrincipal> userRoles = pbe.listRoles(eachUser);
+        List<RolePrincipal> userRoles = propBackingEngine.listRoles(eachUser);
         List<String> roleList = new ArrayList();
         for (RolePrincipal userRole : userRoles) {
           roleList.add(userRole.getName());

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/main/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandler.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/main/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandler.java
@@ -16,10 +16,13 @@ package org.codice.ddf.security.sts.claims.property;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
 import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.x500.X500Principal;
@@ -35,6 +38,7 @@ import org.apache.felix.utils.properties.Properties;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.apache.karaf.jaas.modules.properties.PropertiesBackingEngine;
+import org.codice.ddf.configuration.AbsolutePathResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +46,10 @@ public class PropertyFileClaimsHandler implements ClaimsHandler, RealmSupport {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PropertyFileClaimsHandler.class);
 
-  private String propertyFileLocation;
+  private static Path propertyFileLocation =
+      Paths.get(new AbsolutePathResolver("etc/users.properties").getPath());
+
+  private boolean propertiesLoaded = false;
 
   private Map<String, String> userMapping;
 
@@ -67,6 +74,11 @@ public class PropertyFileClaimsHandler implements ClaimsHandler, RealmSupport {
   @Override
   public ProcessedClaimCollection retrieveClaimValues(
       ClaimCollection claims, ClaimsParameters parameters) {
+
+    if (!this.propertiesLoaded) {
+      loadClaimsFromPropertiesFile();
+    }
+
     ProcessedClaimCollection claimsColl = new ProcessedClaimCollection();
     Principal principal = parameters.getPrincipal();
     boolean needsRoleClaim = false;
@@ -162,39 +174,69 @@ public class PropertyFileClaimsHandler implements ClaimsHandler, RealmSupport {
   }
 
   public String getPropertyFileLocation() {
-    return propertyFileLocation;
+    return propertyFileLocation.toString();
   }
 
+  /**
+   * Sets the path to where the user properties file can be found
+   *
+   * @param propertyFileLocation The absolute path to the file
+   * @return void
+   */
   public void setPropertyFileLocation(String propertyFileLocation) {
     if (propertyFileLocation != null
         && !propertyFileLocation.isEmpty()
-        && !propertyFileLocation.equals(this.propertyFileLocation)) {
+        && !propertyFileLocation.equals(this.propertyFileLocation.toString())) {
 
-      Properties props = new Properties();
-      try {
-        props.load(getClass().getResourceAsStream(propertyFileLocation));
-      } catch (FileNotFoundException e) {
-        LOGGER.debug("File not found when attempting to load user properties file.", e);
-      } catch (IOException e) {
-        LOGGER.debug("Exception when trying to load the user properties file.", e);
-      }
-
-      propBackingEngine = new PropertiesBackingEngine(props);
-
-      List<UserPrincipal> userList = propBackingEngine.listUsers();
-      userMapping = new HashMap<>();
-      for (UserPrincipal eachUser : userList) {
-
-        List<RolePrincipal> userRoles = propBackingEngine.listRoles(eachUser);
-        List<String> roleList = new ArrayList<>();
-        for (RolePrincipal userRole : userRoles) {
-          roleList.add(userRole.getName());
-        }
-
-        userMapping.put(eachUser.getName(), StringUtils.join(roleList, ","));
-      }
+      setPropertyFileLocation(Paths.get(propertyFileLocation));
     }
-    this.propertyFileLocation = propertyFileLocation;
+  }
+
+  /**
+   * Sets the path to where the user properties file can be found
+   *
+   * @param propertyFilePath The path to the file
+   * @return void
+   */
+  public void setPropertyFileLocation(Path propertyFilePath) {
+    if (propertyFilePath != null) {
+      this.propertyFileLocation = propertyFilePath;
+
+      this.userMapping = null;
+      this.propertiesLoaded = false;
+
+      loadClaimsFromPropertiesFile();
+    }
+  }
+
+  private void loadClaimsFromPropertiesFile() {
+
+    Properties props = new Properties();
+
+    try {
+      props.load(this.propertyFileLocation.toFile());
+    } catch (FileNotFoundException e) {
+      LOGGER.debug("File not found when attempting to load user properties file.", e);
+    } catch (IOException e) {
+      LOGGER.debug("Exception when trying to load the user properties file.", e);
+    }
+
+    propBackingEngine = new PropertiesBackingEngine(props);
+
+    List<UserPrincipal> userList = propBackingEngine.listUsers();
+    userMapping = new HashMap();
+    for (UserPrincipal eachUser : userList) {
+
+      List<RolePrincipal> userRoles = propBackingEngine.listRoles(eachUser);
+      List<String> roleList = new ArrayList<>();
+      for (RolePrincipal userRole : userRoles) {
+        roleList.add(userRole.getName());
+      }
+
+      userMapping.put(eachUser.getName(), StringUtils.join(roleList, ","));
+    }
+
+    this.propertiesLoaded = true;
   }
 
   public String getRoleClaimType() {

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,7 +32,6 @@
                   value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role"/>
         <property name="idClaimType"
                   value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"/>
-        <property name="propertyFileLocation" value="${ddf.etc}/users.properties"/>
     </bean>
 
     <bean id="attributeClaimsHandler" class="org.codice.ddf.security.sts.claims.property.UsersAttributesFileClaimsHandler" init-method="init">

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandlerTest.java
@@ -63,18 +63,18 @@ public class PropertyFileClaimsHandlerTest {
     assertEquals("editor", processedClaimCollection.get(0).getValues().get(3));
     assertEquals("writer", processedClaimCollection.get(0).getValues().get(4));
 
-    ClaimsParameters claimsParametersAdam = mock(ClaimsParameters.class);
-    Principal principalAdam = mock(Principal.class);
-    when(principalAdam.getName()).thenReturn("adam");
-    when(claimsParametersAdam.getPrincipal()).thenReturn(principalAdam);
-    ProcessedClaimCollection processedClaimCollectionAdam =
-        propertyFileClaimsHandler.retrieveClaimValues(claimCollection, claimsParametersAdam);
+    ClaimsParameters claimsParametersUser1 = mock(ClaimsParameters.class);
+    Principal principalUser1 = mock(Principal.class);
+    when(principalUser1.getName()).thenReturn("User1");
+    when(claimsParametersUser1.getPrincipal()).thenReturn(principalUser1);
+    ProcessedClaimCollection processedClaimCollectionUser1 =
+        propertyFileClaimsHandler.retrieveClaimValues(claimCollection, claimsParametersUser1);
 
-    assertEquals(2, processedClaimCollectionAdam.size());
-    assertEquals(2, processedClaimCollectionAdam.get(0).getValues().size());
-    assertEquals("adam", processedClaimCollectionAdam.get(1).getValues().get(0));
-    assertEquals("editor", processedClaimCollectionAdam.get(0).getValues().get(0));
-    assertEquals("writer", processedClaimCollectionAdam.get(0).getValues().get(1));
+    assertEquals(2, processedClaimCollectionUser1.size());
+    assertEquals(2, processedClaimCollectionUser1.get(0).getValues().size());
+    assertEquals("User1", processedClaimCollectionUser1.get(1).getValues().get(0));
+    assertEquals("editor", processedClaimCollectionUser1.get(0).getValues().get(0));
+    assertEquals("writer", processedClaimCollectionUser1.get(0).getValues().get(1));
   }
 
   @Test

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/java/org/codice/ddf/security/sts/claims/property/PropertyFileClaimsHandlerTest.java
@@ -39,23 +39,42 @@ public class PropertyFileClaimsHandlerTest {
     propertyFileClaimsHandler.setRoleClaimType("http://myroletype");
     propertyFileClaimsHandler.setIdClaimType("http://myidtype");
 
+    Claim claimRole = new Claim();
+    claimRole.setClaimType(URI.create("http://myroletype"));
+    Claim claimId = new Claim();
+    claimId.setClaimType(URI.create("http://myidtype"));
     ClaimCollection claimCollection = new ClaimCollection();
-    Claim claim1 = new Claim();
-    claim1.setClaimType(URI.create("http://myroletype"));
-    Claim claim2 = new Claim();
-    claim2.setClaimType(URI.create("http://myidtype"));
-    claimCollection.add(claim1);
-    claimCollection.add(claim2);
-    ClaimsParameters claimsParameters = mock(ClaimsParameters.class);
-    Principal principal = mock(Principal.class);
-    when(principal.getName()).thenReturn("admin");
-    when(claimsParameters.getPrincipal()).thenReturn(principal);
+    claimCollection.add(claimRole);
+    claimCollection.add(claimId);
+
+    ClaimsParameters claimsParametersAdmin = mock(ClaimsParameters.class);
+    Principal principalAdmin = mock(Principal.class);
+    when(principalAdmin.getName()).thenReturn("admin");
+    when(claimsParametersAdmin.getPrincipal()).thenReturn(principalAdmin);
     ProcessedClaimCollection processedClaimCollection =
-        propertyFileClaimsHandler.retrieveClaimValues(claimCollection, claimsParameters);
+        propertyFileClaimsHandler.retrieveClaimValues(claimCollection, claimsParametersAdmin);
 
     assertEquals(2, processedClaimCollection.size());
-    assertEquals(4, processedClaimCollection.get(0).getValues().size());
+    assertEquals(5, processedClaimCollection.get(0).getValues().size());
     assertEquals("admin", processedClaimCollection.get(1).getValues().get(0));
+    assertEquals("admin", processedClaimCollection.get(0).getValues().get(0));
+    assertEquals("manager", processedClaimCollection.get(0).getValues().get(1));
+    assertEquals("viewer", processedClaimCollection.get(0).getValues().get(2));
+    assertEquals("editor", processedClaimCollection.get(0).getValues().get(3));
+    assertEquals("writer", processedClaimCollection.get(0).getValues().get(4));
+
+    ClaimsParameters claimsParametersAdam = mock(ClaimsParameters.class);
+    Principal principalAdam = mock(Principal.class);
+    when(principalAdam.getName()).thenReturn("adam");
+    when(claimsParametersAdam.getPrincipal()).thenReturn(principalAdam);
+    ProcessedClaimCollection processedClaimCollectionAdam =
+        propertyFileClaimsHandler.retrieveClaimValues(claimCollection, claimsParametersAdam);
+
+    assertEquals(2, processedClaimCollectionAdam.size());
+    assertEquals(2, processedClaimCollectionAdam.get(0).getValues().size());
+    assertEquals("adam", processedClaimCollectionAdam.get(1).getValues().get(0));
+    assertEquals("editor", processedClaimCollectionAdam.get(0).getValues().get(0));
+    assertEquals("writer", processedClaimCollectionAdam.get(0).getValues().get(1));
   }
 
   @Test

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/resources/users.properties
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/resources/users.properties
@@ -33,5 +33,5 @@
 # DDF Changes: changed username/pw to admin/admin, added localhost certificate user
 admin=admin,group,admin,manager,viewer,_g_:mygroup
 localhost=localhost,group,admin,manager,viewer,codice-history,localhost-data-manager
-adam=changeit,group,_g_:mygroup
+user1=changeit,group,_g_:mygroup
 _g_\:mygroup = group,editor,writer

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/resources/users.properties
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/resources/users.properties
@@ -31,5 +31,7 @@
 #
 
 # DDF Changes: changed username/pw to admin/admin, added localhost certificate user
-admin=admin,group,admin,manager,viewer
+admin=admin,group,admin,manager,viewer,_g_:mygroup
 localhost=localhost,group,admin,manager,viewer,codice-history,localhost-data-manager
+adam=changeit,group,_g_:mygroup
+_g_\:mygroup = group,editor,writer

--- a/platform/security/sts/security-sts-propertyclaimshandler/src/test/resources/users.properties
+++ b/platform/security/sts/security-sts-propertyclaimshandler/src/test/resources/users.properties
@@ -33,5 +33,5 @@
 # DDF Changes: changed username/pw to admin/admin, added localhost certificate user
 admin=admin,group,admin,manager,viewer,_g_:mygroup
 localhost=localhost,group,admin,manager,viewer,codice-history,localhost-data-manager
-user1=changeit,group,_g_:mygroup
+User1=changeit,group,_g_:mygroup
 _g_\:mygroup = group,editor,writer


### PR DESCRIPTION
…read the users.properties file

<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->


Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #DDF-04519
____


#### What does this PR do?
Changes the STS PropertyClaimsHandler to use the org.apache.karaf.jaas.modules.properties.PropertiesBackingEngine to read the users.properties file so that groups are interpreted as intended. Also modifies the test to add in a further check for group usage
#### Who is reviewing it? 
@bakejeyner
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/data 
@codice/security 
 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@blen-desta
@brjeter 
@stustison 

#### How should this be tested?
1. Create a users.properties file contains a group definition and a user that is in that group
e.g.
admin=admin,group,admin,manager,viewer,system-admin,systembundles,_g_:mygroup
localhost=localhost,group,admin,manager,viewer,system-admin,system-history,systembundles
_g_:mygroup = group,editor,writer
2. Turn on logging in karaf using log:set TRACE ddf.security.pdp
3. Start DDF and log in as the user that you added to the group
3. View the ddf.log file and look at the xacml request that was generated. The roles that were assigned to the group should be in the request (editor and writer) in the example above

#### Any background context you want to provide?
#### What are the relevant tickets?
For Jira:
[](https://codice.atlassian.net/browse/)

For GH Issues:
Fixes: #DDF-04519

#### Screenshots
Not applicable
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
