### PR TITLE
DDF-04321 Fix downstream CDM itest performance/timeout issues

### DIFF
--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -122,11 +122,8 @@
     <feature name="catalog-core-directorymonitor" version="${project.version}"
              description="Monitors directories to process content files.">
         <feature>apache-commons</feature>
-        <feature>bootflag-api</feature>
         <feature>catalog-transformer-bootflag</feature>
         <bundle>mvn:com.hazelcast/hazelcast/${hazelcast.version}</bundle>
-        <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient.version}</bundle>
-        <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-camelcontext/${project.version}</bundle>
         <bundle>mvn:net.jodah/failsafe/${jodah-failsafe.version}</bundle>
         <bundle>mvn:com.google.code.gson/gson/${gson.version}</bundle>

--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -125,13 +125,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-osgi</artifactId>
-            <version>${httpclient.version}</version>
+            <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore-osgi</artifactId>
-            <version>${httpcore.version}</version>
+            <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -404,7 +402,11 @@
                             ddf-security-common,
                             platform-util,
                             platform-util-unavailableurls,
-                            sardine
+                            sardine,
+                            <!-- Embedding httpclient and httpcore instead of using the bundles -->
+                            <!-- due to a downstream performance issue in itests -->
+                            httpclient,
+                            httpcore
                         </Embed-Dependency>
                         <Import-Package>
                             !org.eclipse.jetty.server.bio,

--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -396,7 +396,8 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <!-- Override this module's blueprint timeout to be 30 minutes instead of 5 (default) -->
+                        <Bundle-SymbolicName>${project.artifactId};blueprint.timeout:=1800000</Bundle-SymbolicName>
                         <Embed-Dependency>
                             catalog-core-api-impl,
                             ddf-security-common,

--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -396,8 +396,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <!-- Override this module's blueprint timeout to be 30 minutes instead of 5 (default) -->
-                        <Bundle-SymbolicName>${project.artifactId};blueprint.timeout:=1800000</Bundle-SymbolicName>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
                             catalog-core-api-impl,
                             ddf-security-common,

--- a/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,10 +21,12 @@
            http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
            http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
 
-    <reference id="camelContext" interface="org.apache.camel.CamelContext"
+    <!-- Over blueprint timeout is changed from 5 minutes to 30 minutes (see pom.xml) -->
+    <!-- Set these 2 references back to the default 5 minutes  -->
+    <reference timeout="300000" id="camelContext" interface="org.apache.camel.CamelContext"
                filter="(camel.context.name=catalogCamelContext)"/>
 
-    <reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
+    <reference timeout="300000" id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
 
     <!-- Waits for all input transformers before registering CDM services -->
     <reference id="inputTransformerServiceFlag" interface="org.codice.ddf.platform.bootflag.BootServiceFlag"

--- a/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-directorymonitor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,12 +21,10 @@
            http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
            http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
 
-    <!-- Over blueprint timeout is changed from 5 minutes to 30 minutes (see pom.xml) -->
-    <!-- Set these 2 references back to the default 5 minutes  -->
-    <reference timeout="300000" id="camelContext" interface="org.apache.camel.CamelContext"
+    <reference id="camelContext" interface="org.apache.camel.CamelContext"
                filter="(camel.context.name=catalogCamelContext)"/>
 
-    <reference timeout="300000" id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
+    <reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
 
     <!-- Waits for all input transformers before registering CDM services -->
     <reference id="inputTransformerServiceFlag" interface="org.codice.ddf.platform.bootflag.BootServiceFlag"

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorIT.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorIT.java
@@ -345,8 +345,6 @@ public class ContentDirectoryMonitorIT extends AbstractComponentTest {
         new BundleInfo("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.xalan"),
         new BundleInfo("com.google.code.gson", "gson"),
         new BundleInfo("com.hazelcast", "hazelcast"),
-        new BundleInfo("org.apache.httpcomponents", "httpcore-osgi"),
-        new BundleInfo("org.apache.httpcomponents", "httpclient-osgi"),
         new BundleInfo("net.jodah", "failsafe"),
         new BundleInfo("ddf.platform", "bootflag-api"),
         new BundleInfo("ddf.catalog.transformer", "catalog-transformer-bootflag"));

--- a/catalog/transformer/catalog-transformer-bootflag/pom.xml
+++ b/catalog/transformer/catalog-transformer-bootflag/pom.xml
@@ -117,7 +117,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.84</minimum>
+                                            <minimum>0.78</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
@@ -127,7 +127,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.73</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
+++ b/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
@@ -47,11 +47,7 @@ public class InputTransformerBootServiceFlag implements BootServiceFlag {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(InputTransformerBootServiceFlag.class);
 
-  private static final String TRANSFORMER_WAIT_TIMEOUT_PROPERTY =
-      "org.codice.ddf.platform.bootflag.transformerWaitTimeoutSeconds";
-
-  private static final long DEFAULT_TRANSFORMER_WAIT_TIMEOUT_SECONDS =
-      TimeUnit.MINUTES.toSeconds(20);
+  private static final long DEFAULT_TRANSFORMER_WAIT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(20);
 
   private static final long DEFAULT_TRANSFORMER_CHECK_PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(20);
 
@@ -81,7 +77,7 @@ public class InputTransformerBootServiceFlag implements BootServiceFlag {
     this.inputTransformers = inputTransformers;
     this.executorService = Executors.newSingleThreadExecutor();
     this.transformerCheckPeriodMillis = DEFAULT_TRANSFORMER_CHECK_PERIOD_MILLIS;
-    this.transformerWaitTimeoutMillis = getTransformerWaitTimeout();
+    this.transformerWaitTimeoutMillis = DEFAULT_TRANSFORMER_WAIT_TIMEOUT_MILLIS;
     executorService.submit(
         () -> waitForInputTransformers(FrameworkUtil.getBundle(this.getClass())));
   }
@@ -159,25 +155,6 @@ public class InputTransformerBootServiceFlag implements BootServiceFlag {
     }
 
     return false;
-  }
-
-  private static long getTransformerWaitTimeout() {
-    long timeoutSeconds;
-    try {
-      timeoutSeconds = Long.parseLong(System.getProperty(TRANSFORMER_WAIT_TIMEOUT_PROPERTY));
-    } catch (NumberFormatException e) {
-      timeoutSeconds = DEFAULT_TRANSFORMER_WAIT_TIMEOUT_SECONDS;
-      LOGGER.debug(
-          "Invalid or no {} property as long. Using default timeout of {} seconds",
-          TRANSFORMER_WAIT_TIMEOUT_PROPERTY,
-          DEFAULT_TRANSFORMER_WAIT_TIMEOUT_SECONDS);
-    }
-    return TimeUnit.SECONDS.toMillis(timeoutSeconds);
-  }
-
-  @VisibleForTesting
-  public long getTransformerWaitTimeoutMillis() {
-    return transformerWaitTimeoutMillis;
   }
 
   public void destroy() {

--- a/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
+++ b/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
@@ -51,7 +51,7 @@ public class InputTransformerBootServiceFlag implements BootServiceFlag {
       "org.codice.ddf.platform.bootflag.transformerWaitTimeoutSeconds";
 
   private static final long DEFAULT_TRANSFORMER_WAIT_TIMEOUT_SECONDS =
-      TimeUnit.MINUTES.toSeconds(5);
+      TimeUnit.MINUTES.toSeconds(20);
 
   private static final long DEFAULT_TRANSFORMER_CHECK_PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(20);
 

--- a/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
+++ b/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
@@ -47,7 +47,7 @@ public class InputTransformerBootServiceFlag implements BootServiceFlag {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(InputTransformerBootServiceFlag.class);
 
-  private static final long DEFAULT_TRANSFORMER_WAIT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(20);
+  private static final long DEFAULT_TRANSFORMER_WAIT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
   private static final long DEFAULT_TRANSFORMER_CHECK_PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(20);
 

--- a/catalog/transformer/catalog-transformer-bootflag/src/test/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlagTest.java
+++ b/catalog/transformer/catalog-transformer-bootflag/src/test/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlagTest.java
@@ -13,8 +13,6 @@
  */
 package org.codice.ddf.catalog.transformer.bootflag;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -37,9 +35,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
 public class InputTransformerBootServiceFlagTest {
-
-  private static final String TRANSFORMER_WAIT_TIMEOUT_PROPERTY =
-      "org.codice.ddf.platform.bootflag.transformerWaitTimeoutSeconds";
 
   private Bundle bundle;
 
@@ -95,15 +90,6 @@ public class InputTransformerBootServiceFlagTest {
 
     verify(bundleContext, times(0))
         .registerService(isA(Class.class), isA(Object.class), isA(Dictionary.class));
-  }
-
-  @Test
-  public void testTimeoutSystemPropertyIsRespected() {
-    System.setProperty(TRANSFORMER_WAIT_TIMEOUT_PROPERTY, "1");
-    InputTransformerBootServiceFlag waiter =
-        new InputTransformerBootServiceFlag(
-            mock(InputTransformerIds.class), Collections.emptyList());
-    assertThat(waiter.getTransformerWaitTimeoutMillis(), is(1000L));
   }
 
   private List<ServiceReference<InputTransformer>> mockServiceReferences(String... propertyValues) {

--- a/distribution/ddf-common/src/main/resources/etc/transformers/README.md
+++ b/distribution/ddf-common/src/main/resources/etc/transformers/README.md
@@ -6,12 +6,6 @@ those IDs. This prevents the CDM from ingesting resources too soon on system res
 
 To allow the CDM to wait for additional Input Transformers, drop a new JSON file in this directory with the IDs of the Input Transformers.
 
-To increase or decrease the amount of time required to wait for Input Transformers use the following system property. The timeout
-cannot be set to below 30 seconds. The default timeout is set to 5 minutes.
-```
-org.codice.ddf.platform.bootflag.transformerWaitTimeoutSeconds
-```
-
 ## File Format
 
 The file contains a single JSON array of string elements. For example:

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -141,9 +141,9 @@ public abstract class AbstractIntegrationTest {
 
   private static final File UNPACK_DIRECTORY = new File("target/exam");
 
-  public static final long GENERIC_TIMEOUT_SECONDS = TimeUnit.MINUTES.toSeconds(5);
+  public static final long GENERIC_TIMEOUT_SECONDS = TimeUnit.MINUTES.toSeconds(2);
 
-  public static final long GENERIC_TIMEOUT_MILLISECONDS = TimeUnit.MINUTES.toMillis(5);
+  public static final long GENERIC_TIMEOUT_MILLISECONDS = TimeUnit.MINUTES.toMillis(2);
 
   private static final String UNABLE_TO_DETERMINE_EXAM_DIR_ERROR =
       "Unable to determine current exam directory";

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerImpl.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/ServiceManagerImpl.java
@@ -82,8 +82,7 @@ public class ServiceManagerImpl implements ServiceManager {
   public static final long MANAGED_SERVICE_TIMEOUT =
       AbstractIntegrationTest.GENERIC_TIMEOUT_MILLISECONDS;
 
-  public static final long FEATURES_AND_BUNDLES_TIMEOUT =
-      AbstractIntegrationTest.GENERIC_TIMEOUT_MILLISECONDS;
+  public static final long FEATURES_AND_BUNDLES_TIMEOUT = TimeUnit.MINUTES.toMillis(20);
 
   public static final long HTTP_ENDPOINT_TIMEOUT =
       AbstractIntegrationTest.GENERIC_TIMEOUT_MILLISECONDS;


### PR DESCRIPTION
#### What does this PR do?
Set generic timeout back to 2 min and increase features and bundles timeout for better features and bundles startup for itests.

#### Who is reviewing it? 
@peterhuffer
@austinsteffes 
@bakejeyner

#### Select relevant component teams: 
@codice/test 

#### Ask 2 committers to review/merge the PR and tag them here.
@AzGoalie
@brjeter
@clockard

#### How should this be tested?
- **Run downstream itests and verify they pass**
- **Test the CDM**:

Set log:set TRACE org.codice.ddf.catalog.transformer.bootflag for detailed logs.
Verify the following scenarios.

Start a normal CDM (move/delete/inplace) and verify it begins ingesting
Start a normal CDM (move/delete/inplace). Restart the distribution and verify it does not start until all InputTransformers are available (view logs).
Before a fresh install, edit the ddf-default-input-transformers.json file to include an InputTransformer ID that doesn't exist. Verify install fails.

#### Any background context you want to provide?
Some downstream features and bundles can take longer to start.

#### What are the relevant tickets?
For GH Issues:
Fixes: #4321


#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
