### PR TITLE
[2.13.x]DDF-04318 Fix the error handling in Intrigue WebSockets

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
@@ -122,13 +122,22 @@ module.exports = Backbone.AssociatedModel.extend({
                         handled = true;
                         res.options = options;
                         switch (res.code) {
+                            case 400:
+                            case 404:
+                            case 500:
+                                options.error({
+                                    responseJSON: res
+                                });
+                                break;
                             case -32000:
                                 if (rpc !== null) {
                                     rpc.close();
                                     rpc = null;
                                 }
                                 options.error({
-                                    message: 'User not logged in.'
+                                    responseJSON: {
+                                        message: 'User not logged in.'
+                                    }
                                 });
                                 break;
                             default:


### PR DESCRIPTION
#### What does this PR do?
This is equivalent to the second commit from #4540. The first commit from #4540 is not necessary since the original change that caused this bug was never reverted on `2.13.x`
#### Who is reviewing it? 
@tyler30clemens @austinsteffes 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler 
@tbatie

#### How should this be tested?
- Build DDF (include ui in the build)
- Install DDF

Verify the first commit's functionality works:
- Ingest some records and run some queries to make sure Intrigue is working normally.
- With one of the executed queries still up, open a new tab for the AdminUI and logout.
- Go back to Intrigue and edit the open query and/or execute it.
- The query should now return no results with an error icon next to the query.

Verify the second commit's bug fix:
- Create two Opensearch sources, 1 with a madeup hostname and 1 with the default loopback value.
- Try and execute the default wildcard search
- It should return records but show a red triangle indicating one of the sources is unavailable

#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4318 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
