### PR TITLE
DDF-04553 added functionality for multi-zipped exports

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
@@ -125,11 +125,11 @@ module.exports = Marionette.ItemView.extend({
           className={`query-interaction interaction-zipped-export ${exportClass} ${
             disabledExport ? 'is-disabled' : ''
           }`}
-          title="Export Selected (ZIP)"
-          data-help="Opens a form to export the selected search results in a compressed ZIP folder."
+          title="Export Selected (Compressed)"
+          data-help="Opens a form to export the selected search results in a compressed zip folder."
         >
           <div className={`interaction-text ${exportClass}`}>
-            Export Selected (ZIP)
+            Export Selected (Compressed)
           </div>
         </div>
       </React.Fragment>
@@ -269,7 +269,7 @@ module.exports = Marionette.ItemView.extend({
     lightboxInstance.showContent(<ResultsExport store={store} />)
   },
   handleZippedExport: function() {
-    lightboxInstance.model.updateTitle('Export Results as ZIP')
+    lightboxInstance.model.updateTitle('Export Results (Compressed)')
     lightboxInstance.model.open()
     lightboxInstance.showContent(
       <ResultsExport store={store} transformer={'zipCompression'} />

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
@@ -121,6 +121,17 @@ module.exports = Marionette.ItemView.extend({
             Export Selected
           </div>
         </div>
+        <div
+          className={`query-interaction interaction-zipped-export ${exportClass} ${
+            disabledExport ? 'is-disabled' : ''
+          }`}
+          title="Export Selected (ZIP)"
+          data-help="Opens a form to export the selected search results in a compressed ZIP folder."
+        >
+          <div className={`interaction-text ${exportClass}`}>
+            Export Selected (ZIP)
+          </div>
+        </div>
       </React.Fragment>
     )
   },
@@ -138,6 +149,7 @@ module.exports = Marionette.ItemView.extend({
     'click .interaction-feedback': 'handleFeedback',
     'click .interaction-annotations': 'handleAnnotations',
     'click .interaction-export': 'handleExport',
+    'click .interaction-zipped-export': 'handleZippedExport',
     click: 'handleClick',
   },
   ui: {},
@@ -255,6 +267,13 @@ module.exports = Marionette.ItemView.extend({
     lightboxInstance.model.updateTitle('Export Results')
     lightboxInstance.model.open()
     lightboxInstance.showContent(<ResultsExport store={store} />)
+  },
+  handleZippedExport: function() {
+    lightboxInstance.model.updateTitle('Export Results as ZIP')
+    lightboxInstance.model.open()
+    lightboxInstance.showContent(
+      <ResultsExport store={store} transformer={'zipCompression'} />
+    )
   },
   handleResult: function() {
     this.$el.toggleClass('has-results', this.model.get('result') !== undefined)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/results-export/results-export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/results-export/results-export.tsx
@@ -80,14 +80,7 @@ class ResultsExport extends React.Component<Props, State> {
       prevState.selectedResults !== this.state.selectedResults ||
       _prevProps.transformer !== this.props.transformer
     ) {
-      let type = this.getTransformerType()
-
-      if (this.props.transformer) {
-        type = 'metacard'
-      }
-
-      this.fetchExportOptions(type)
-
+      this.fetchExportOptions()
       this.setState({
         selectedFormat: 'Select an export option',
         downloadDisabled: true,
@@ -95,23 +88,15 @@ class ResultsExport extends React.Component<Props, State> {
     }
   }
   getTransformerType = () => {
-    let transformerType = 'metacard'
-
-    if (this.state.selectedResults.length > 1) {
-      transformerType = 'query'
-    }
-    return transformerType
+    return !this.props.transformer && this.state.selectedResults.length > 1
+      ? 'query'
+      : 'metacard'
   }
   componentDidMount() {
-    if (this.props.transformer) {
-      this.fetchExportOptions('metacard')
-    } else {
-      const type = this.getTransformerType()
-      this.fetchExportOptions(type)
-    }
+    this.fetchExportOptions()
   }
-  fetchExportOptions = (transformerType: string) => {
-    fetch(`./internal/transformers/${transformerType}`)
+  fetchExportOptions = () => {
+    fetch(`./internal/transformers/${this.getTransformerType()}`)
       .then(response => response.json())
       .then((exportFormats: ExportFormat[]) => {
         return exportFormats.sort(


### PR DESCRIPTION
#### What does this PR do?
Adds the ability for a user to export multiple results in a zip file.

#### Who is reviewing it? 
@bdeining @andrewkfiedler @bellcc @cantstoptheunk 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@andrewkfiedler


#### How should this be tested?
Perform a query.
Select one or more results.
Clicks Export Selected (zip).
Selects transformer to apply on result(s).
Hits download button.
Verify zipped file with contents of the export is downloaded to your machine.
Unzip the export and verify contents.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #4553

#### Screenshots
<img width="390" alt="Screen Shot 2019-03-15 at 10 41 43 AM" src="https://user-images.githubusercontent.com/12813760/54447440-0aa24900-470f-11e9-92d0-cb79a2794fe1.png">
<img width="1663" alt="Screen Shot 2019-03-15 at 10 41 36 AM" src="https://user-images.githubusercontent.com/12813760/54447439-0aa24900-470f-11e9-81d2-726dd7e16303.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
