### PR TITLE
DDF-04566 The local query issued as part of a list search always fails

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -220,7 +220,7 @@ Query.Model = PartialAssociatedModel.extend({
   startTieredSearch: function(ids) {
     this.set('federation', 'local')
     this.startSearch(undefined, searches => {
-      $.when(searches).then(() => {
+      $.when(...searches).then(() => {
         const queryResponse = this.get('result')
         if (queryResponse && queryResponse.isUnmerged()) {
           this.listenToOnce(


### PR DESCRIPTION
<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
The `$.when` API does not support passing in an array of Promise-like objects. This was causing the `then()` callback to be executed immediately, cancelling the first local list query, and always sending out the federated queries. This PR spreads the array of Promises to conform with the `when` API
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@willwill96 @gjvera @rymach @Lambeaux 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@bdeining
@djblue

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Ingest some data
2. Create a new list and add the local data to it
3. Open the network tab
4. Run a search based on the list and verify only one cql request is sent out to the local catalog
5. Add a federated source with some data
6. Add a federated result to the list
7. Run a search based on the list and verify a cql request is sent out to the local catalog and another is sent out to the federated source

#### Any background context you want to provide?
#### What are the relevant tickets?
For Jira:
[](https://codice.atlassian.net/browse/)

For GH Issues:
Fixes: #4566 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
