### PR TITLE
DDF-4625 Search From Location to Persist Filters

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/location-interaction.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/location-interaction.tsx
@@ -14,15 +14,46 @@ const CqlUtils = require('../../../js/CQLUtils')
 const wreqr = require('wreqr')
 const Query = require('../../../js/model/Query')
 
+const addFilter = (filterTree: any, filter: any) => {
+  filter.value = filter.value.value
+  filterTree.filters.push(filter)
+}
+
+const addMultipleFilters = (filterTree: any, filters: any) => {
+  filters.forEach((filter: any) => {
+    addFilter(filterTree, filter)
+  })
+}
+
+const createFilterTree = (locations: string[]) => {
+  const filterTree = {
+    type: 'OR',
+    filters: [] as any[],
+  }
+
+  locations.forEach((location: string) => {
+    const filterObject = CqlUtils.transformCQLToFilter(location)
+    if (filterObject.filters !== undefined) {
+      addMultipleFilters(filterTree, filterObject.filters)
+    } else {
+      addFilter(filterTree, filterObject)
+    }
+  })
+
+  return filterTree
+}
+
 const handleCreateSearch = (props: Props) => {
   const locations = getGeoLocations(props.model)
 
   if (locations.length === 0) return
 
   const locationString = `(${locations.join(` OR `)})`
+  const filterTree = createFilterTree(locations)
   const newQuery = new Query.Model({
-    type: locations.length > 1 ? 'advanced' : 'basic',
+    type: filterTree.filters.length > 1 ? 'advanced' : 'basic',
   })
+  newQuery.set('filterTree', filterTree)
   newQuery.set('cql', locationString)
 
   const existingQuery = store.getCurrentQueries()


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where searches created from location don't persist the filters to search forms.
The query was setting the cql correctly, but wasn't setting the filterTree which is how search forms deconstruct the query.
#### Who is reviewing it? 
@gjvera 
@mojogitoverhere 
@rymach 
@Lambeaux 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@djblue

#### How should this be tested?
1. Ingest at least one document with a single location
2. Ingest at least one document with multiple locations
3. For each of those documents:
  a. Create a search from location (a metacard interaction in the ellipsis menu of a result metacard)
  b. Edit the search and verify that the geo data is present in the search form
  c. Save the workspace and reload
  d. Verify that the geo data is still present
#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4625 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
