### PR TITLE
[2.13.x] DDF-4424 Increasing sustainability of the CDM codebase

### DIFF
--- a/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/framework/FrameworkProducer.java
+++ b/catalog/core/catalog-core-camelcomponent/src/main/java/ddf/camel/component/catalog/framework/FrameworkProducer.java
@@ -147,6 +147,7 @@ public class FrameworkProducer extends DefaultProducer {
     } catch (ClassCastException cce) {
       exchange.getIn().setBody(new ArrayList<Metacard>());
       LOGGER.debug("Received a non-String as the operation type");
+      throw new FrameworkProducerException(cce);
     } catch (SourceUnavailableException | IngestException e) {
       LOGGER.debug("Exception cataloging metacards", e);
       throw new FrameworkProducerException(e);

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/AsyncFileEntry.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/AsyncFileEntry.java
@@ -44,6 +44,7 @@ public class AsyncFileEntry implements Comparable<AsyncFileEntry> {
   private boolean directory;
   private long length;
 
+  //  Due to how GSON deserializes this, this variable cannot be a Set.
   private final ConcurrentSkipListSet<AsyncFileEntry> children = new ConcurrentSkipListSet<>();
   //  Leaving transient to avoid loops
   @Nullable private transient AsyncFileEntry parent;
@@ -60,7 +61,7 @@ public class AsyncFileEntry implements Comparable<AsyncFileEntry> {
     refresh();
   }
 
-  //  For GSON serialization
+  //  For GSON deserialization
   private AsyncFileEntry() {
     contentFile = null;
   }

--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/AsyncFileAlterationObserverTest.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/AsyncFileAlterationObserverTest.java
@@ -1184,14 +1184,20 @@ public class AsyncFileAlterationObserverTest {
   @Test
   public void testJsonSerial() throws Exception {
 
-    initNestedDirectory(1, 1, 0, 0);
+    initNestedDirectory(10, 1, 0, 0);
     observer.initialize();
+
+    initFiles(1, monitoredDirectory, "zz00");
+    initFiles(1, monitoredDirectory, "za0");
+    initFiles(1, monitoredDirectory, "z5a0");
 
     AsyncFileAlterationObserver two = AsyncFileAlterationObserver.load(new File("File01"), store);
 
+    two.setListener(fileListener);
     two.checkAndNotify();
 
     assertThat(two.getRootFile().getChildren().get(0).getParent().isPresent(), is(true));
+    verify(fileListener, times(3)).onFileCreate(any(File.class), any(Synchronization.class));
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR:
____
-->

#### What does this PR do?
Addresses @lessarderic 's comments from #4617 
Due to the severity of the bug, these comments were not able to be addressed in that PR. These changes are not 100% necessary but are very useful to have. 

#### Who is reviewing it? 
@lessarderic 
@peterhuffer @kcover @clockard @jhunzik @brjeter 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/io 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->

#### How should this be tested?
CI.

<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
@lessarderic In reference to camel route unit testing: https://github.com/codice/ddf/pull/4617#discussion_r271114633
> Since we're actually expecting a different exception than the one thrown (`IngestException`) in these tests, would it be worth using JUnit's https://junit.org/junit4/javadoc/latest/org/junit/rules/ExpectedException.html and validate that the cause is what we expect?

I tried implementing thrown.expect but was running into strange errors because the exception includes a bunch of other exceptions. I think this should be fine.

#### What are the relevant tickets?
For Jira:
[DDF-4424](https://codice.atlassian.net/browse/DDF-4424)

For GH Issues:
Fixes: #____

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
