### PR TITLE
DDF-4638 fixed bulk actions not getting enabled in upload view

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/alert/content.alert.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/alert/content.alert.view.js
@@ -34,6 +34,7 @@ const VisualizationView = require('../../golden-layout/golden-layout.view.js')
 
 module.exports = ContentView.extend({
   className: 'is-alert',
+  selectionInterface: alertInstance,
   initialize: function() {
     this._mapView = new VisualizationView({
       selectionInterface: alertInstance,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.view.js
@@ -83,7 +83,7 @@ var ContentView = Marionette.LayoutView.extend({
       <Root>
         <ContentLeft className="content-left" />
         <ContentRight>
-          <MultiSelectActions selectionInterface={store.get('content')} />
+          <MultiSelectActions selectionInterface={this.selectionInterface} />
           <Visualizations className="content-right" />
         </ContentRight>
       </Root>
@@ -94,6 +94,7 @@ var ContentView = Marionette.LayoutView.extend({
     contentLeft: '.content-left',
     contentRight: '.content-right',
   },
+  selectionInterface: store,
   initialize: function() {
     this._mapView = new GoldenLayoutView({
       selectionInterface: store.get('content'),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/upload/content.upload.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/upload/content.upload.view.js
@@ -34,6 +34,7 @@ const VisualizationView = require('../../golden-layout/golden-layout.view.js')
 
 module.exports = ContentView.extend({
   className: 'is-upload',
+  selectionInterface: uploadInstance,
   initialize: function() {
     this._mapView = new VisualizationView({
       selectionInterface: uploadInstance,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/multi-select-actions/multi-select-actions.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/multi-select-actions/multi-select-actions.tsx
@@ -15,7 +15,6 @@ import MultiSelectActionsPresentation from '../../presentation/multi-select-acti
 import withListenTo, { WithBackboneProps } from '../backbone-container'
 import ResultsExport from '../results-export'
 
-const store = require('../../../js/store.js')
 const lightboxInstance = require('../../../component/lightbox/lightbox.view.instance.js')
 
 type Props = {
@@ -44,7 +43,9 @@ class MultiSelectActions extends React.Component<Props, State> {
   handleExport = () => {
     lightboxInstance.model.updateTitle('Export Results')
     lightboxInstance.model.open()
-    lightboxInstance.showContent(<ResultsExport store={store} />)
+    lightboxInstance.showContent(
+      <ResultsExport store={this.props.selectionInterface} />
+    )
   }
 
   componentDidMount = () => {


### PR DESCRIPTION
#### What does this PR do?
Each view that instantiates the content view now overrides a `selectionInterface` variable with their specific selection interfaces
#### Who is reviewing it? 
@Bdthomson @andrewzimmer @nsuvarna 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@djblue
#### How should this be tested?
- Upload some items
- View the upload
- Select some items 
- Verify that the export is button is enabled and exports the selected results when clicked
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #4638
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
