### PR TITLE
DDF-4644 Add support for temporal queries to WFS 1.1.0 source

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -199,6 +199,12 @@
             <version>${tika.thirdparty.bundle.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>xml-path</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
@@ -1260,6 +1260,28 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
     throw new IllegalArgumentException("Unable to create Geometry from WKT String");
   }
 
+  @Override
+  public FilterType during(String propertyName, Date startDate, Date endDate) {
+    return propertyIsBetween(propertyName, startDate, endDate);
+  }
+
+  @Override
+  public FilterType before(String propertyName, Date date) {
+    return propertyIsLessThan(propertyName, date);
+  }
+
+  @Override
+  public FilterType after(String propertyName, Date date) {
+    return propertyIsGreaterThan(propertyName, date);
+  }
+
+  @Override
+  public FilterType relative(String propertyName, long duration) {
+    final DateTime now = new DateTime();
+    final DateTime start = now.minus(duration);
+    return during(propertyName, start.toDate(), now.toDate());
+  }
+
   @SuppressWarnings("squid:S00115")
   private enum PROPERTY_IS_OPS {
     PropertyIsEqualTo,

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -1103,7 +1103,7 @@ public class WfsFilterDelegateTest {
     final WfsFilterDelegate delegate = createDelegate();
     final FilterType filter = delegate.relative(MOCK_PROPERTY, 100_000L);
     final String xml = marshal(filter);
-    System.out.println(xml);
+
     final XmlPathConfig config =
         new XmlPathConfig().declaredNamespace("ogc", "http://www.opengis.net/ogc");
 


### PR DESCRIPTION
#### What does this PR do?
Implements `after`, `before`, `during`, and `relative` in the WFS 1.1.0 filter delegate.

#### Who is reviewing it? 
@leo-sakh 
@Corey-Collins 
@samuelechu 
@kentmorrissey 
@brianfelix 

#### Select relevant component teams: 
@codice/io 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@troymohl

#### How should this be tested?
1. Create a WFS 1.1.0 source with the URL http://services.azgs.az.gov/ArcGIS/services/aasggeothermal/CAWellLogs/MapServer/WFSServer
a. Disable the CN check and allow redirects. Leave everything else as-is.
2. In the Karaf console, run `log:set info org.apache.cxf` and `log:set warn org.apache.camel`.
3. Open Intrigue.
4. Run `AFTER`, `BEFORE`, `BETWEEN`, and `RELATIVE` temporal queries on the `ext.WellLog.StatusDate` field against the WFS source you configured. To verify correctness for each:
a. Check DDF's logs for an `Outbound Message` to http://services.azgs.az.gov/ArcGIS/services/aasggeothermal/CAWellLogs/MapServer/WFSServer. The request body should be a `GetFeature` XML request.
b. `AFTER` should map to a `PropertyIsGreaterThan` query with the date you specified.
c. `BEFORE` should map to a `PropertyIsLessThan` query with the date you specified.
d. `BETWEEN` should map to a `PropertyIsBetween` query with the two dates you specified.
e. `RELATIVE` should map to a `PropertyIsBetween` query with two dates that correspond to the period you specified.
f. Note that you will not receive any results for these queries. Most likely, this source does not support temporal queries like this. For this PR we only care that the outgoing queries are correct.

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #4644 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
