### PR TITLE
DDF-4648 Update WFS 1.1 bounding box to be GML 3.1.1 compliant

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
 
+import static com.google.common.primitives.Doubles.asList;
+
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
@@ -57,6 +59,7 @@ import net.opengis.filter.v_1_1_0.UpperBoundaryType;
 import net.opengis.gml.v_3_1_1.AbstractGeometryType;
 import net.opengis.gml.v_3_1_1.AbstractRingPropertyType;
 import net.opengis.gml.v_3_1_1.CoordinatesType;
+import net.opengis.gml.v_3_1_1.DirectPositionType;
 import net.opengis.gml.v_3_1_1.EnvelopeType;
 import net.opengis.gml.v_3_1_1.LineStringType;
 import net.opengis.gml.v_3_1_1.LinearRingType;
@@ -1050,7 +1053,17 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
     bboxType.setPropertyName(createPropertyNameType(propertyName).getValue());
 
     EnvelopeType envelopeType = gmlObjectFactory.createEnvelopeType();
-    envelopeType.setCoordinates(createCoordinatesTypeFromWkt(wkt).getValue());
+
+    Envelope envelope = createEnvelopeFromWkt(wkt);
+
+    DirectPositionType lowerCorner = new DirectPositionType();
+    lowerCorner.setValue(asList(envelope.getMinX(), envelope.getMinY()));
+    envelopeType.setLowerCorner(lowerCorner);
+
+    DirectPositionType upperCorner = new DirectPositionType();
+    upperCorner.setValue(asList(envelope.getMaxX(), envelope.getMaxY()));
+    envelopeType.setUpperCorner(upperCorner);
+
     bboxType.setEnvelope(gmlObjectFactory.createEnvelope(envelopeType));
 
     return filterObjectFactory.createBBOX(bboxType);
@@ -1103,28 +1116,6 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
     } else {
       throw new IllegalArgumentException("Unable to parse Point coordinates from WKT String");
     }
-  }
-
-  private String buildCoordinateString(Envelope envelope) {
-    return String.valueOf(envelope.getMinX())
-        + ","
-        + envelope.getMinY()
-        + " "
-        + envelope.getMaxX()
-        + ","
-        + envelope.getMaxY();
-  }
-
-  private JAXBElement<CoordinatesType> createCoordinatesTypeFromWkt(String wkt) {
-
-    Envelope envelope = createEnvelopeFromWkt(wkt);
-
-    String coords = buildCoordinateString(envelope);
-    CoordinatesType coordinatesType = new CoordinatesType();
-
-    coordinatesType.setValue(coords);
-
-    return gmlObjectFactory.createCoordinates(coordinatesType);
   }
 
   private JAXBElement<LiteralType> createLiteralType(Object literalValue) {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
 
+import static java.util.Arrays.asList;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -31,7 +32,6 @@ import java.io.Writer;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -45,6 +45,8 @@ import net.opengis.filter.v_1_1_0.BinarySpatialOpType;
 import net.opengis.filter.v_1_1_0.DistanceBufferType;
 import net.opengis.filter.v_1_1_0.FilterType;
 import net.opengis.filter.v_1_1_0.UnaryLogicOpType;
+import net.opengis.gml.v_3_1_1.DirectPositionType;
+import net.opengis.gml.v_3_1_1.EnvelopeType;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.FeatureAttributeDescriptor;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.FeatureMetacardType;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs11Constants.SPATIAL_OPERATORS;
@@ -75,9 +77,7 @@ public class WfsFilterDelegateTest {
 
   private static final String UNLITERAL = "Unliteral";
 
-  private static final List<String> SUPPORTED_GEO = Arrays.asList("Intersects", "BBox", "Within");
-
-  private static final String SRS_NAME = "EPSG:4326";
+  private static final List<String> SUPPORTED_GEO = asList("Intersects", "BBox", "Within");
 
   private static final String POLYGON = "POLYGON ((30 -10, 30 30, 10 30, 10 -10, 30 -10))";
 
@@ -336,7 +336,7 @@ public class WfsFilterDelegateTest {
   public void testAnd() {
     WfsFilterDelegate delegate = createTextualDelegate();
     FilterType filter = delegate.propertyIsEqualTo(Metacard.ANY_TEXT, LITERAL, true);
-    FilterType filterToCheck = delegate.and(Arrays.asList(filter, filter));
+    FilterType filterToCheck = delegate.and(asList(filter, filter));
     assertThat(filterToCheck, notNullValue());
     assertThat(filterToCheck.isSetLogicOps(), is(true));
   }
@@ -358,7 +358,7 @@ public class WfsFilterDelegateTest {
   public void testOr() {
     WfsFilterDelegate delegate = createTextualDelegate();
     FilterType filter = delegate.propertyIsEqualTo(Metacard.ANY_TEXT, LITERAL, true);
-    FilterType filterToCheck = delegate.or(Arrays.asList(filter, filter));
+    FilterType filterToCheck = delegate.or(asList(filter, filter));
     assertThat(filterToCheck, notNullValue());
     assertThat(filterToCheck.isSetLogicOps(), is(true));
   }
@@ -1155,6 +1155,17 @@ public class WfsFilterDelegateTest {
     assertThat(filter.getLogicOps().getValue(), is(instanceOf(UnaryLogicOpType.class)));
     UnaryLogicOpType type = (UnaryLogicOpType) filter.getLogicOps().getValue();
     assertThat(type.getSpatialOps().getValue(), is(instanceOf(BBOXType.class)));
+
+    BBOXType bboxType = (BBOXType) type.getSpatialOps().getValue();
+    EnvelopeType envelope = bboxType.getEnvelope().getValue();
+
+    DirectPositionType lowerCorner = envelope.getLowerCorner();
+    assertThat("The bounding box's lower corner was null.", lowerCorner, is(notNullValue()));
+    assertThat(lowerCorner.getValue(), is(asList(10.0, -10.0)));
+
+    DirectPositionType upperCorner = envelope.getUpperCorner();
+    assertThat("The bounding box's upper corner was null.", upperCorner, is(notNullValue()));
+    assertThat(upperCorner.getValue(), is(asList(30.0, 30.0)));
   }
 
   @Test
@@ -1226,6 +1237,17 @@ public class WfsFilterDelegateTest {
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BBOXType.class)));
     assertThat(filter.isSetLogicOps(), is(false));
+
+    BBOXType bboxType = (BBOXType) filter.getSpatialOps().getValue();
+    EnvelopeType envelope = bboxType.getEnvelope().getValue();
+
+    DirectPositionType lowerCorner = envelope.getLowerCorner();
+    assertThat("The bounding box's lower corner was null.", lowerCorner, is(notNullValue()));
+    assertThat(lowerCorner.getValue(), is(asList(10.0, -10.0)));
+
+    DirectPositionType upperCorner = envelope.getUpperCorner();
+    assertThat("The bounding box's upper corner was null.", upperCorner, is(notNullValue()));
+    assertThat(upperCorner.getValue(), is(asList(30.0, 30.0)));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
The envelope now specifies the bounding box's corners using the lowerCorner and upperCorner properties instead of the coordinates property which was deprecated with GML version 3.1.0.

#### Who is reviewing it? 
@leo-sakh 
@brianfelix 
@Corey-Collins 
@samuelechu 
@kentmorrissey 

#### Select relevant component teams: 
@codice/io 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@troymohl

#### How should this be tested?
1. Create a WFS 1.1.0 source with the URL http://services.azgs.az.gov/ArcGIS/services/OneGeology/AZGS_Arizona_Geology_WFS/MapServer/WFSServer
a. Disable the CN check and allow redirects. Set the `Forced Spatial Filter Type` to `BBOX`. Leave everything else as-is.
2. In the Karaf console, run `log:set info org.apache.cxf` and `log:set warn org.apache.camel`.
3. Open Intrigue.
4. Run an `anyGeo` bounding box query against the source you just configured.
a. Note that you will not receive any results for this query. For this PR we only care that the outgoing queries are correct.
5. Check DDF's logs for an `Outbound Message` to http://services.azgs.az.gov/ArcGIS/services/OneGeology/AZGS_Arizona_Geology_WFS/MapServer/WFSServer. The request body should be a `GetFeature` XML request.
6. Verify the `GetFeature` request contains a `BBOX` element containing an `Envelope` element that contains one `lowerCorner` and one `upperCorner` element.
7. Verify the lower and upper coordinates match the lower and upper corners of your bounding box.

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #4648 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
