### PR TITLE
DDF-04657 Improve search form selection UX

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
@@ -23,6 +23,16 @@ import React from 'react'
 import { lighten, readableColor, transparentize } from 'polished'
 import styled from '../../react-component/styles/styled-components'
 
+const ListContainer = styled.div`
+  max-height: 60vh;
+  overflow: hidden;
+`
+
+const ScrollableContainer = styled.div`
+  max-height: calc(60vh - 67px);
+  overflow-y: auto;
+`
+
 const ListItem = styled.div`
   cursor: pointer;
   display: block;
@@ -68,7 +78,7 @@ class SearchForms extends React.Component {
       .filter(form => form.title.toLowerCase().match(filter.toLowerCase()));
 
     return (
-      <React.Fragment>
+      <ListContainer>
         <FilterPadding>
           <input
             style={{ width: '100%' }}
@@ -77,17 +87,19 @@ class SearchForms extends React.Component {
             placeholder="Type to filter"
           />
         </FilterPadding>
-        {forms.length === 0 ? <NoSearchForms /> : null}
-        {filteredForms
-          .map(form => (
-            <SearchFormItem
-              title={form.title}
-              key={form.id}
-              onClick={() => onClick(form)}
-            />
-          ))}
-          {forms.length !== 0 && filteredForms.length === 0 ? <NothingFound/> : null}
-      </React.Fragment>
+        <ScrollableContainer>
+          {forms.length === 0 ? <NoSearchForms /> : null}
+          {filteredForms
+            .map(form => (
+              <SearchFormItem
+                title={form.title}
+                key={form.id}
+                onClick={() => onClick(form)}
+              />
+            ))}
+            {forms.length !== 0 && filteredForms.length === 0 ? <NothingFound/> : null}
+        </ScrollableContainer>
+      </ListContainer>
     )
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
@@ -24,12 +24,13 @@ import { lighten, readableColor, transparentize } from 'polished'
 import styled from '../../react-component/styles/styled-components'
 
 const ListContainer = styled.div`
-  max-height: 60vh;
+  max-height: 50vh;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 `
 
 const ScrollableContainer = styled.div`
-  max-height: calc(60vh - 67px);
   overflow-y: auto;
 `
 
@@ -38,6 +39,7 @@ const ListItem = styled.div`
   display: block;
   line-height: ${props => props.theme.minimumButtonSize};
   padding: 0px ${props => props.theme.largeSpacing};
+  box-sizing: border-box;
 `
 
 const HoverableListItem = styled(ListItem)`
@@ -61,6 +63,7 @@ const SearchFormItem = ({ title, onClick }) => {
 }
 
 const FilterPadding = styled.div`
+  box-sizing: border-box;
   padding: 0px ${props => props.theme.minimumSpacing} ${props => props.theme.minimumSpacing} ${props => props.theme.minimumSpacing};
 `
 class SearchForms extends React.Component {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
@@ -66,9 +66,9 @@ const SearchFormItem = ({ title, onClick }) => {
 
 const FilterPadding = styled.div`
   box-sizing: border-box;
-  padding: 0px ${props => props.theme.minimumSpacing}
-    ${props => props.theme.minimumSpacing}
-    ${props => props.theme.minimumSpacing};
+  padding-right: ${props => props.theme.minimumSpacing};
+  padding-bottom: ${props => props.theme.minimumSpacing};
+  padding-left: ${props => props.theme.minimumSpacing};
 `
 class SearchForms extends React.Component {
   constructor(props) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
@@ -20,6 +20,7 @@ const Router = require('../router/router.js')
 const user = require('../singletons/user-instance')
 const SearchForm = require('../search-form/search-form')
 import React from 'react'
+import { lighten, readableColor, transparentize } from 'polished'
 import styled from '../../react-component/styles/styled-components'
 
 const ListItem = styled.div`
@@ -29,15 +30,28 @@ const ListItem = styled.div`
   padding: 0px ${props => props.theme.largeSpacing};
 `
 
+const HoverableListItem = styled(ListItem)`
+  &:hover {
+    background: ${props => transparentize(0.9, readableColor(props.theme.backgroundDropdown))};
+    box-shadow: inset 0px 0px 0px 1px ${props => props.theme.primaryColor}
+  }
+`
+
+const WarningItem = styled(ListItem)`
+  text-align: center;
+  color: ${props => lighten(0.2, props.theme.warningColor)};
+`
+
+const NothingFound = () => <WarningItem>Nothing Found</WarningItem>
+
 const NoSearchForms = () => <ListItem>No search forms are available</ListItem>
 
 const SearchFormItem = ({ title, onClick }) => {
-  return <ListItem onClick={onClick}>{title}</ListItem>
+  return <HoverableListItem onClick={onClick}>{title}</HoverableListItem>
 }
 
 const FilterPadding = styled.div`
-  padding-left: ${props => props.theme.minimumSpacing};
-  padding-right: ${props => props.theme.minimumSpacing};
+  padding: 0px ${props => props.theme.minimumSpacing} ${props => props.theme.minimumSpacing} ${props => props.theme.minimumSpacing};
 `
 class SearchForms extends React.Component {
   constructor(props) {
@@ -50,6 +64,9 @@ class SearchForms extends React.Component {
     const { filter } = this.state
     const { forms, onClick } = this.props
 
+    const filteredForms = forms
+      .filter(form => form.title.toLowerCase().match(filter.toLowerCase()));
+
     return (
       <React.Fragment>
         <FilterPadding>
@@ -61,8 +78,7 @@ class SearchForms extends React.Component {
           />
         </FilterPadding>
         {forms.length === 0 ? <NoSearchForms /> : null}
-        {forms
-          .filter(form => form.title.toLowerCase().match(filter.toLowerCase()))
+        {filteredForms
           .map(form => (
             <SearchFormItem
               title={form.title}
@@ -70,6 +86,7 @@ class SearchForms extends React.Component {
               onClick={() => onClick(form)}
             />
           ))}
+          {forms.length !== 0 && filteredForms.length === 0 ? <NothingFound/> : null}
       </React.Fragment>
     )
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
@@ -19,6 +19,7 @@ const Marionette = require('marionette')
 const Router = require('../router/router.js')
 const user = require('../singletons/user-instance')
 const SearchForm = require('../search-form/search-form')
+import { matchesFilter } from '../select/filterHelper'
 import React from 'react'
 import { lighten, readableColor, transparentize } from 'polished'
 import styled from '../../react-component/styles/styled-components'
@@ -81,7 +82,7 @@ class SearchForms extends React.Component {
     const { forms, onClick } = this.props
 
     const filteredForms = forms.filter(form =>
-      form.title.toLowerCase().match(filter.toLowerCase())
+      matchesFilter(filter, form.title, false)
     )
 
     return (

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-list/search-form-list.view.js
@@ -44,8 +44,9 @@ const ListItem = styled.div`
 
 const HoverableListItem = styled(ListItem)`
   &:hover {
-    background: ${props => transparentize(0.9, readableColor(props.theme.backgroundDropdown))};
-    box-shadow: inset 0px 0px 0px 1px ${props => props.theme.primaryColor}
+    background: ${props =>
+      transparentize(0.9, readableColor(props.theme.backgroundDropdown))};
+    box-shadow: inset 0px 0px 0px 1px ${props => props.theme.primaryColor};
   }
 `
 
@@ -64,7 +65,9 @@ const SearchFormItem = ({ title, onClick }) => {
 
 const FilterPadding = styled.div`
   box-sizing: border-box;
-  padding: 0px ${props => props.theme.minimumSpacing} ${props => props.theme.minimumSpacing} ${props => props.theme.minimumSpacing};
+  padding: 0px ${props => props.theme.minimumSpacing}
+    ${props => props.theme.minimumSpacing}
+    ${props => props.theme.minimumSpacing};
 `
 class SearchForms extends React.Component {
   constructor(props) {
@@ -77,8 +80,9 @@ class SearchForms extends React.Component {
     const { filter } = this.state
     const { forms, onClick } = this.props
 
-    const filteredForms = forms
-      .filter(form => form.title.toLowerCase().match(filter.toLowerCase()));
+    const filteredForms = forms.filter(form =>
+      form.title.toLowerCase().match(filter.toLowerCase())
+    )
 
     return (
       <ListContainer>
@@ -92,15 +96,16 @@ class SearchForms extends React.Component {
         </FilterPadding>
         <ScrollableContainer>
           {forms.length === 0 ? <NoSearchForms /> : null}
-          {filteredForms
-            .map(form => (
-              <SearchFormItem
-                title={form.title}
-                key={form.id}
-                onClick={() => onClick(form)}
-              />
-            ))}
-            {forms.length !== 0 && filteredForms.length === 0 ? <NothingFound/> : null}
+          {filteredForms.map(form => (
+            <SearchFormItem
+              title={form.title}
+              key={form.id}
+              onClick={() => onClick(form)}
+            />
+          ))}
+          {forms.length !== 0 && filteredForms.length === 0 ? (
+            <NothingFound />
+          ) : null}
         </ScrollableContainer>
       </ListContainer>
     )

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.hbs
@@ -29,7 +29,9 @@
         Advanced Search
     </div>
 </div>
+<div class="is-divider composed-menu"></div>
 <div class="interaction interaction-type" title="Change the form used to construct the search." data-help="Change the form used to construct the search."></div>
+<div class="is-divider composed-menu"></div>
 <div class="interaction interaction-reset" title="Resets the search form." data-help="Resets the search form.">
     <div class="interaction-icon fa fa-undo"></div>
     <div class="interaction-text">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-interactions/search-interactions.less
@@ -2,7 +2,6 @@
   > * {
     white-space: nowrap;
     padding: 0px 10px;
-    cursor: pointer;
     overflow: hidden;
     line-height: @minimumButtonSize;
     height: @minimumButtonSize;
@@ -11,6 +10,10 @@
     &.is-active {
       background: fade(contrast(@backgroundDropdown), 10%);
     }
+  }
+
+  .interaction {
+    cursor: pointer;
   }
 
   .interaction-icon,


### PR DESCRIPTION
Depends on https://github.com/codice/ddf/pull/4653 for search form selection to work
<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
- Highlights elements on hover
- Keeps the filter box on top of the list so it is always reachable
- Adds a "Nothing Found" message if the filter doesn't match anything (like the attribute dropdown for queries)
- Adds divider lines between the search interactions

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/ui @willwill96 @gjvera @Lambeaux @rymach 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@bdeining
@djblue

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Verify the dividers in the text/basic/advanced dropdown look good
- Click "Use Another Search Form" and verify the "no search forms" message is shown when the user has no search forms
- Create a few forms (~3)
- Verify the forms appear in the list, are functional, and there is no scrollbar
- Verify filtering works
- Create even more forms until the list overflows (need about 10-15)
- Verify the list reaches the max height allowed and becomes scrollable
- Repeat the process for different zoom levels, spacing, and themes (dark, sea, etc
#### Any background context you want to provide?
#### What are the relevant tickets?
For Jira:
[](https://codice.atlassian.net/browse/)

For GH Issues:
Fixes: #4657 

#### Screenshots
<!--(if appropriate)-->
##### Text/Basic/Advanced Dropdown #####
BEFORE
<img width="346" alt="Screen Shot 2019-04-09 at 1 02 25 PM" src="https://user-images.githubusercontent.com/8922441/55831375-cb75d680-5ac7-11e9-9150-6aa174af27fe.png">

AFTER
<img width="347" alt="Screen Shot 2019-04-09 at 12 44 16 PM" src="https://user-images.githubusercontent.com/8922441/55831397-da5c8900-5ac7-11e9-8238-09ae62433ad0.png">

##### Search Form Selection Dropdown #####
BEFORE
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/8922441/55831448-f2340d00-5ac7-11e9-8a48-30b5d5c145ee.gif)

AFTER
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/8922441/55835051-0d0a7f80-5ad0-11e9-8a2c-e415b0dc08af.gif)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
