### PR TITLE
DDF-4676 Adding ID to sources endpoint for actions and updated source action provider

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -93,10 +93,10 @@
     <cm:managed-service-factory id="ddf.catalog.impl.action.SourceActionProviderImpl"
                                 factory-pid="ddf.catalog.impl.action.SourceActionProviderImpl" interface="ddf.action.ActionProvider">
         <service-properties>
-            <entry key="id" value="catalog.data.source.simple"/>
+            <entry key="id" value="catalog.data.source.iframe.simple"/>
         </service-properties>
         <cm:managed-component class="ddf.catalog.impl.action.SourceActionProviderImpl">
-            <argument value="catalog.data.source.simple"/>
+            <argument value="catalog.data.source.iframe.simple"/>
             <cm:managed-properties persistent-id=""
                                    update-strategy="container-managed" />
         </cm:managed-component>

--- a/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/CatalogServiceImpl.java
+++ b/catalog/rest/catalog-rest-impl/src/main/java/org/codice/ddf/rest/impl/CatalogServiceImpl.java
@@ -280,6 +280,7 @@ public class CatalogServiceImpl implements CatalogService {
     jsonObject.put("title", action.getTitle());
     jsonObject.put("url", action.getUrl().toString());
     jsonObject.put("description", action.getDescription());
+    jsonObject.put("id", action.getId());
     return jsonObject;
   }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/source-item/source-item.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/source-item/source-item.tsx
@@ -84,6 +84,7 @@ type SourceAction = {
   title: string
   description: string
   url: string
+  id: string
 }
 
 type Props = {
@@ -116,11 +117,16 @@ export default hot(module)(({ id, sourceActions, available }: Props) => {
                       sourceAction.description
                     }`}
                     onClick={() => {
-                      lightboxInstance.model.updateTitle(sourceAction.title)
-                      lightboxInstance.model.open()
-                      lightboxInstance.showContent(
-                        new SourceAppView({ url: sourceAction.url })
-                      )
+                      if (sourceAction.id.startsWith('catalog.data.source.window')) {
+                        const windowFeatures = "location=yes,height=570,width=520,scrollbars=yes,status=yes"
+                        window.open(sourceAction.url, "_blank", windowFeatures)
+                     } else {
+                        lightboxInstance.model.updateTitle(sourceAction.title)
+                        lightboxInstance.model.open()
+                        lightboxInstance.showContent(
+                          new SourceAppView({ url: sourceAction.url })
+                        )
+                      }
                     }}
                   />
                 </div>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/source-item/source-item.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/source-item/source-item.tsx
@@ -117,10 +117,13 @@ export default hot(module)(({ id, sourceActions, available }: Props) => {
                       sourceAction.description
                     }`}
                     onClick={() => {
-                      if (sourceAction.id.startsWith('catalog.data.source.window')) {
-                        const windowFeatures = "location=yes,height=570,width=520,scrollbars=yes,status=yes"
-                        window.open(sourceAction.url, "_blank", windowFeatures)
-                     } else {
+                      if (
+                        sourceAction.id.startsWith('catalog.data.source.window')
+                      ) {
+                        const windowFeatures =
+                          'location=yes,height=570,width=520,scrollbars=yes,status=yes'
+                        window.open(sourceAction.url, '_blank', windowFeatures)
+                      } else {
                         lightboxInstance.model.updateTitle(sourceAction.title)
                         lightboxInstance.model.open()
                         lightboxInstance.showContent(

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/source-item/source-item.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/source-item/source-item.tsx
@@ -92,6 +92,9 @@ type Props = {
   id: string
 } & RootProps
 
+const windowWidth = '520'
+const windowHeight = '570'
+
 export default hot(module)(({ id, sourceActions, available }: Props) => {
   return (
     <Root available={available}>
@@ -120,10 +123,11 @@ export default hot(module)(({ id, sourceActions, available }: Props) => {
                       if (
                         sourceAction.id.startsWith('catalog.data.source.window')
                       ) {
-                        const windowFeatures =
-                          'location=yes,height=570,width=520,scrollbars=yes,status=yes'
+                        const windowFeatures = `location=yes,height=${windowHeight},width=${windowWidth},scrollbars=yes,status=yes`
                         window.open(sourceAction.url, '_blank', windowFeatures)
-                      } else {
+                      } else if (
+                        sourceAction.id.startsWith('catalog.data.source.iframe')
+                      ) {
                         lightboxInstance.model.updateTitle(sourceAction.title)
                         lightboxInstance.model.open()
                         lightboxInstance.showContent(


### PR DESCRIPTION
#### What does this PR do?
Within the SourceItem.tsx, we support plugging in the option to add links in the sources page to open up modals (ideally for authentication mechanisms). Unfortunately, due to various cross origin restrictions and oddities with iframes and associated security, a lot of these external domains are getting blocked in the iframe.

It would be nice if we make a slight modification to allow things other than strictly iframes, such as a new window. This replicates a similar flow to a lot of big names (github, facebook, google, etc) that physically launch a new window, not an iframe.

#### Who is reviewing it? 
@bdeining 
@djblue 
@Bdthomson 
@middlets719 
@adimka 
@gordocanchola 
@zta6 

#### How should this be tested?
View sources page and ensure functionality has not regressed. 

#### What are the relevant tickets?
For GH Issues:
Fixes: #4676