### PR TITLE
DDF-4683 Remove 'Anyway' from warning module in UI Lite

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
@@ -1,27 +1,29 @@
 {{!--
 /**
- * Copyright (c) Codice Foundation
- *
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
- * <http://www.gnu.org/licenses/lgpl.html>.
- *
- **/
- --}}
-<div class="low-bandwidth-confirmation">
+* Copyright (c) Codice Foundation
+*
+* This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation, either
+* version 3 of the License, or any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is
+distributed along with this program and can be found at
+* <http://www.gnu.org/licenses/lgpl.html>. * **/ --}} <div class="low-bandwidth-confirmation">
     <h3 align="center">
-    Low-bandwidth mode is enabled. Please confirm that you want this component to load despite potential bandwidth implications. Choosing to continue may cause available connection resources to be exhausted, and you or other users on your network may experience slowdowns or extended periods of waiting while necessary resources are fetched. 
+        Low-bandwidth mode is enabled. Please confirm that you want this component to load despite potential bandwidth
+        implications. Choosing to continue may cause available connection resources to be exhausted, and you or other
+        users on your network may experience slowdowns or extended periods of waiting while necessary resources are
+        fetched.
     </h3>
     <button class="low-bandwidth-button is-positive" align="center">
-        <span>Continue to Map Anyway</span>
+        <span>Continue to Map</span>
     </button>
     <button class="low-bandwidth-button-close is-negative" align="center">
         <span>Close Map</span>
     </button>
-</div>
-<div class="map-container">
-    
-</div>
+    </div>
+    <div class="map-container">
+
+    </div>


### PR DESCRIPTION
<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
This commit removes the word 'Anyway' from the text 'Continue to
Map Anyway' that appears in the top button of the component that
loads in place of a map when in UI Lite.
#### Who is reviewing it?
@samuelechu 
@brianfelix 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@djblue
#### How should this be tested?
1. Build DDF, making sure that this commit is included in what you're building
2. Unzip the relevant zip file under /distribution/ddf/target
3. Open DDF in your browser (https://localhost:8993/search/catalog/) and open a map. The map should load automatically.
4. Enter Lite mode by inserting `?lowBandwidth` immediately after `https://localhost:8993/search/catalog/` in your URL.
5. Open a map. This time, opening the map should load a component warning you that you are in Lite mode and that maps use a lot of bandwidth. This component should have two buttons: one labeled `Continue to Map`, the other labeled `Close Map`.
6. Click `Continue to Map`. The map should now load as normal.
7. Open another map. The map should not load automatically. You should see the same component as in step 5.
8. Click `Close Map`. The would-be map's tab should close.
9. Return to the normal UI by navigating to `https://localhost:8993/search/catalog/`.
10. Open a map. The map should load automatically.
#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: [#4683](https://github.com/codice/ddf/issues/4683)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
