### PR TITLE
DDF-4683 Remove 'Anyway' from warning module in UI Lite

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/low-bandwidth-map/low-bandwidth-map.hbs
@@ -16,7 +16,7 @@
     Low-bandwidth mode is enabled. Please confirm that you want this component to load despite potential bandwidth implications. Choosing to continue may cause available connection resources to be exhausted, and you or other users on your network may experience slowdowns or extended periods of waiting while necessary resources are fetched. 
     </h3>
     <button class="low-bandwidth-button is-positive" align="center">
-        <span>Continue to Map Anyway</span>
+        <span>Continue to Map</span>
     </button>
     <button class="low-bandwidth-button-close is-negative" align="center">
         <span>Close Map</span>


### PR DESCRIPTION
<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
This commit removes the word 'Anyway' from the text 'Continue to Map Anyway' that appears in the top button of the component that loads in place of a map when in UI Lite.
#### Who is reviewing it?
@samuelechu 
@brianfelix 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@andrewkfiedler
@djblue
#### How should this be tested?
1. Build and start DDF (if necessary, see the readme for more specific directions)
2. Run `profile:install standard` from the resulting Karaf console (at least on my shell, the text of runnable commands is colored blue, nonrunnable red. `profile:install` tends to take a minute to load as runnable).
2. Open DDF in your browser (https://localhost:8993/search/catalog/) and click the button labeled 'Sign in as Guest', which should redirect you a page whose base URL is in fact https://localhost:8993/search/catalog/.
3.  Open a map. If you do not see a tab containing the word 'Map', click the `Add Visual` button in the bottom right of the window and select either `2D Map` or `3D Map` from the options presented. The map should load automatically.
3. Enter Lite mode by navigating to https://localhost:8993/search/catalog/?lowBandwidth.
4. Open a map. This time, a component should load, warning you that you are in low-bandwidth mode and that maps use a lot of bandwidth. This component should have two buttons, one labeled `Continue to Map`, the other labeled `Close Map`.
5. Click `Continue to Map`. The map should load as normal.
6. Open another map. The map should not load automatically. You should see the same component as in step 5.
7. Click `Close Map`. The would-be map's tab should close.
8. Return to the normal UI by navigating to https://localhost:8993/search/catalog/.
9. Open a map. The map should load automatically.
#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: [#4683](https://github.com/codice/ddf/issues/4683)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
