### PR TITLE
DDF-4688 setting the correct facet sort value

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -182,7 +182,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
           .filter(attr -> attr.contains(String.valueOf(FIRST_CHAR_OF_SUFFIX)))
           .forEach(query::addFacetField);
 
-      query.setFacetSort(textFacetProp.getSortKey().name());
+      query.setFacetSort(textFacetProp.getSortKey().name().toLowerCase());
       query.setFacetLimit(textFacetProp.getFacetLimit());
       query.setFacetMinCount(textFacetProp.getMinFacetCount());
     }


### PR DESCRIPTION
#### What does this PR do?
when setting the solr sort parameter, incorrect UPPER case value from Enum are set for the query. Resulting in the default alphanumeric facet name sort instead of facet count sort
#### Who is reviewing it? 
@bdeining 
@millerw8 
@Bdthomson 

#### How should this be tested?
Since DDF does not have any facet endpoint. This issue is not reproducible just in DDF
Using a `<Redacted>`OpenSearchEndpoint to reproduce

- Run and Install development profile
- Ingest some records
- Whitelist the facet field of interest
- Query query?q=*&facetFieldNames=<facetFieldOfInterest>&facetSort=recordCount&facetLimit=100
- Verify all facet value coming back and it is sorted by recordCount, not by facetName alphanumeric before this fix
- Query query?q=*&facetFieldNames=<facetFieldOfInterest>&facetSort=recordCount&facetLimit=1
- Verify the single facet name is the highest facet count from the previous query

#### Any background context you want to provide?
https://lucene.apache.org/solr/guide/6_6/faceting.html#Faceting-Thefacet.sortParameter

#### What are the relevant tickets?
For Jira:
[](https://codice.atlassian.net/browse/)

For GH Issues:
Fixes: https://github.com/codice/ddf/issues/4688

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
