### PR TITLE
DDF-4661 Add security permission for 3D globe to load correctly

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -131,7 +131,7 @@ grant codeBase "file:/spatial-csw-source/spatial-csw-endpoint/org.apache.camel.c
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}issuer${/}-", "read";
 }
 
-grant codeBase "file:/org.apache.servicemix.bundles.commons-httpclient/org.apache.camel.camel-http/spatial-wfs-v1_0_0-source/spatial-wfs-v2_0_0-source/spatial-wfs-v1_1_0-source/org.apache.ws.xmlschema.core/security-rest-cxfwrapper/catalog-core-urlresourcereader" {
+grant codeBase "file:/org.apache.servicemix.bundles.commons-httpclient/org.apache.camel.camel-http/spatial-wfs-v1_0_0-source/spatial-wfs-v2_0_0-source/spatial-wfs-v1_1_0-source/org.apache.ws.xmlschema.core/security-rest-cxfwrapper/catalog-core-urlresourcereader/org.codice.thirdparty.commons-httpclient" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";
 }
 

--- a/distribution/docs/src/main/resources/content/_managing/_running/ddf-service.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/ddf-service.adoc
@@ -39,7 +39,7 @@ ${branding-lowercase}${at-symbol}local> wrapper:install -i setenv-wrapper.conf -
 +
 .Windows
 ----
-${branding-lowercase}${at-symbol}local> wrapper:install -i setenv-windows-wrapper.conf -n${branding-lowercase} -d ${branding-lowercase} -D "${branding} Service"
+${branding-lowercase}${at-symbol}local> wrapper:install -i setenv-windows-wrapper.conf -n ${branding-lowercase} -d ${branding-lowercase} -D "${branding} Service"
 ----
 . (Windows users skip this step) (All *NIX) If ${branding} was installed to run as a non-root
 user (as-recommended,) edit `${home_directory}/bin/${branding-lowercase}-service` and change


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #4662 

#### What does this PR do?
The 3D globe would not load for some downstream products. There was a security manager exception that was blocking `org.codice.thirdparty.commons-httpclient`. This PR fixes this issue, as well as fixes a small typo.

#### Who is reviewing it? 
@austinsteffes 
@ahoffer 

#### Select relevant component teams: 
@codice/docs 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@ricklarsen - Documentation
@stustison

#### How should this be tested?
CI build 

#### What are the relevant tickets?
For GH Issues:
Fixes: #4661 

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
