### PR TITLE
[2.13.x] DDF-4704 Added ldap configurations to Security App

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/security-services.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/security-services.json
@@ -20,6 +20,8 @@
     "mvn:ddf.security.sts/security-sts-guestvalidator/${project.version}",
     "mvn:ddf.security.sts/security-sts-pkivalidator/${project.version}",
     "mvn:ddf.security.sts/security-sts-propertyclaimshandler/${project.version}",
+    "mvn:ddf.security.sts/security-sts-ldaplogin/${project.version}",
+    "mvn:ddf.security.sts/security-sts-ldapclaimshandler/${project.version}",
     "mvn:ddf.security.sts/security-sts-realm/${project.version}",
     "mvn:ddf.security.sts/security-sts-server/${project.version}"
   ]


### PR DESCRIPTION
#### What does this PR do?
This PR adds back the ldap configurations to the Security application

#### Who is reviewing it? 
@austinsteffes
@ahoffer
@jhunzik

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@brjeter
@clockard

#### How should this be tested?
1. Standard install of DDF
2. Go to System features to install all the ldap features 
3. Close tab and open tab again to allow to refresh 
4. See the ldap configurations present under System -> Configurations 
5. See the ldap configurations present under Security -> Configurations 

#### What are the relevant tickets?
For GH Issues:
Work for: #4704

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
