### PR TITLE
[2.14.X] DDF-4722 removed 'experimental' tag from docs

### DIFF
--- a/catalog/spatial/registry/registry-api/src/main/java/org/codice/ddf/registry/api/internal/RegistryStore.java
+++ b/catalog/spatial/registry/registry-api/src/main/java/org/codice/ddf/registry/api/internal/RegistryStore.java
@@ -16,10 +16,6 @@ package org.codice.ddf.registry.api.internal;
 import ddf.catalog.service.ConfiguredService;
 import ddf.catalog.source.CatalogStore;
 
-/**
- * <b> This code is experimental. While this interface is functional and tested, it may change or be
- * removed in a future version of the library. </b>
- */
 public interface RegistryStore extends CatalogStore, ConfiguredService {
 
   /**

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/json-definition-files.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/json-definition-files.adoc
@@ -4,11 +4,6 @@
 :summary: Introduction to JSON definition files.
 :order: 32
 
-[WARNING]
-====
-This section concerns capabilities that are considered experimental. The features described in this section may change or be removed in a future version of the application.
-====
-
 ${branding} supports adding new attribute types, metacard types, validators, and more using json-formatted definition files.
 
 The following may be defined in a JSON definition file:

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/_sources/registry-store.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/_sources/registry-store.adoc
@@ -11,11 +11,6 @@
 
 == {title}
 
-[NOTE]
-====
-The Registry Store is currently marked *Experimental*. While functional and tested, it is subject to change or removal during the incubation period.
-====
-
 The Registry Store is the interface that allows CSW messages to be turned into usable Registry metacards and for those metacards to be turned back into CSW messages.
 
 .Installing Registry Store


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.13.X AND 2.14.x IS IN EFFECT
Link to 2.13.x PR: #4723 

#### What does this PR do?

Removes the "experimental" tag from components that are not experimental.

#### Who is reviewing it? 

@ahoffer @austinsteffes @Kjames5269 

#### Select relevant component teams: 

@codice/docs 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.

@brendan-hofmann
@brjeter
@clockard
@lessarderic
@mcalcote
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?

verify content
#### What are the relevant tickets?
For GH Issues:
Fixes: #4722 

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
