### PR TITLE
[2.13.x] DDF-4590 Add retry logic

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/shell.init.script
+++ b/distribution/ddf-common/src/main/resources/etc/shell.init.script
@@ -67,8 +67,11 @@ if { %(jlineReader != null) } {
 
 // DDF additions
 lna = { bundle:list -t 0 | grep -v Active };
-waitForReady = { system:wait-for-ready $args } ;
-wfr = { system:wait-for-ready $args } ;
+waitForReady = {
+  while { (bundle:list | grep "DDF :: Platform :: Sync Installer :: Impl" | grep "Active") isEmpty } { echo -n ". "; sleep 1 }
+  system:wait-for-ready $args
+}
+wfr = { waitForReady $args } ;
 
 // Fixes hitting `tab` on an empty console to list available commands.
 // See https://issues.apache.org/jira/browse/KARAF-5224.


### PR DESCRIPTION
### Backport of [PR 4591](https://github.com/codice/ddf/pull/4591)

#### What does this PR do?
Adds retry logic to wfr command

#### Who is reviewing it? 

@Bdthomson 
@Kjames5269 
@rzwiefel
@tbatie

#### How should this be tested?
Start up DDF and run `wfr` right away to ensure that `wfr` works before the `system:wait-for-ready` bundle comes up.

#### Any background context you want to provide?
#### What are the relevant tickets?

For GH Issues:
Fixes: #4590 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

