### PR TITLE
DDF-4736 Perform a fuzzy search against a few query metacard attributes

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/QueryMetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/QueryMetacardApplication.java
@@ -88,7 +88,8 @@ public class QueryMetacardApplication implements SparkApplication {
   private final SubjectIdentity subjectIdentity;
 
   private static final Set<String> SEARCHABLE_ATTRIBUTES =
-      ImmutableSet.of(Core.TITLE, Core.METACARD_OWNER, QueryAttributes.QUERY_SOURCES);
+      ImmutableSet.of(
+          Core.TITLE, Core.METACARD_OWNER, Core.DESCRIPTION, QueryAttributes.QUERY_SOURCES);
 
   public QueryMetacardApplication(
       CatalogFramework catalogFramework,

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/QueryMetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/QueryMetacardApplication.java
@@ -20,6 +20,7 @@ import static spark.Spark.post;
 import static spark.Spark.put;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import ddf.catalog.CatalogFramework;
@@ -40,13 +41,17 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.util.impl.ResultIterable;
 import ddf.security.SubjectIdentity;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.SecurityUtils;
 import org.codice.ddf.catalog.ui.metacard.query.data.metacard.QueryMetacardTypeImpl;
 import org.codice.ddf.catalog.ui.metacard.query.data.model.QueryBasic;
+import org.codice.ddf.catalog.ui.metacard.query.util.QueryAttributes;
 import org.codice.ddf.catalog.ui.util.EndpointUtil;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortOrder;
@@ -72,6 +77,8 @@ public class QueryMetacardApplication implements SparkApplication {
 
   private static final String ASCENDING = "asc";
 
+  private static final String TEXT = "text";
+
   private final CatalogFramework catalogFramework;
 
   private final EndpointUtil endpointUtil;
@@ -79,6 +86,9 @@ public class QueryMetacardApplication implements SparkApplication {
   private final FilterBuilder filterBuilder;
 
   private final SubjectIdentity subjectIdentity;
+
+  private static final Set<String> SEARCHABLE_ATTRIBUTES =
+      ImmutableSet.of(Core.TITLE, Core.METACARD_OWNER, QueryAttributes.QUERY_SOURCES);
 
   public QueryMetacardApplication(
       CatalogFramework catalogFramework,
@@ -106,15 +116,19 @@ public class QueryMetacardApplication implements SparkApplication {
           int start = getOrDefaultParam(req, START, MIN_START);
           int count = getOrDefaultParam(req, COUNT, MAX_PAGE_SIZE);
 
-          String attr = req.queryParams(ATTR);
-
-          if (StringUtils.isBlank(attr) || !isValidAttribute(attr.toLowerCase())) {
-            attr = Core.MODIFIED;
-          }
-
           SortOrder sort = getSortOrder(req);
+          String attr =
+              getOrDefaultParam(
+                  req, ATTR, Core.MODIFIED, QueryMetacardTypeImpl.getQueryAttributeNames());
+          String text = getOrDefaultParam(req, TEXT, null, Collections.emptySet());
 
-          Filter filter = filterBuilder.attribute(Core.METACARD_TAGS).is().like().text(QUERY_TAG);
+          Filter filter;
+
+          if (StringUtils.isNotBlank(text)) {
+            filter = getFuzzyQueryMetacardAttributeFilter(text);
+          } else {
+            filter = getQueryMetacardFilter();
+          }
 
           QueryRequest queryRequest =
               new QueryRequestImpl(
@@ -194,13 +208,37 @@ public class QueryMetacardApplication implements SparkApplication {
         GSON::toJson);
   }
 
+  private Filter getFuzzyQueryMetacardAttributeFilter(String value) {
+    List<Filter> attributeFilters =
+        SEARCHABLE_ATTRIBUTES
+            .stream()
+            .map(name -> getFuzzyAttributeFilter(name, value))
+            .collect(Collectors.toList());
+    return filterBuilder.allOf(getQueryMetacardFilter(), filterBuilder.anyOf(attributeFilters));
+  }
+
+  private Filter getQueryMetacardFilter() {
+    return filterBuilder.attribute(Core.METACARD_TAGS).is().like().text(QUERY_TAG);
+  }
+
+  private Filter getFuzzyAttributeFilter(String attribute, String value) {
+    return filterBuilder.attribute(attribute).is().like().fuzzyText(value);
+  }
+
   @VisibleForTesting
   String getSubjectIdentifier() {
     return subjectIdentity.getUniqueIdentifier(SecurityUtils.getSubject());
   }
 
-  private static boolean isValidAttribute(String name) {
-    return QueryMetacardTypeImpl.getQueryAttributeNames().contains(name);
+  private static String getOrDefaultParam(
+      Request request, String key, String defaultValue, Set<String> validValues) {
+    String value = request.queryParams(key);
+
+    if (value != null && (validValues.isEmpty() || validValues.contains(value.toLowerCase()))) {
+      return value;
+    }
+
+    return defaultValue;
   }
 
   private static int getOrDefaultParam(Request request, String key, int defaultValue) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/metacard/QueryMetacardTypeImpl.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/metacard/QueryMetacardTypeImpl.java
@@ -54,6 +54,8 @@ public class QueryMetacardTypeImpl extends MetacardTypeImpl {
 
     QUERY_DESCRIPTORS.add(MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Core.METACARD_OWNER));
 
+    QUERY_DESCRIPTORS.add(MetacardImpl.BASIC_METACARD.getAttributeDescriptor(Core.DESCRIPTION));
+
     QUERY_DESCRIPTORS.add(
         new AttributeDescriptorImpl(
             QUERY_CQL,

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
@@ -56,6 +56,9 @@ public class QueryBasic {
   @SerializedName("owner")
   private String owner;
 
+  @SerializedName("description")
+  private String description;
+
   @SerializedName("cql")
   private String cql;
 
@@ -93,6 +96,7 @@ public class QueryBasic {
     this.metacardId = getAttributeValue(metacard, Core.ID, String.class);
     this.title = getAttributeValue(metacard, Core.TITLE, String.class);
     this.owner = getAttributeValue(metacard, Core.METACARD_OWNER, String.class);
+    this.description = getAttributeValue(metacard, Core.DESCRIPTION, String.class);
     this.created = getAttributeValue(metacard, Core.CREATED, Date.class);
     this.modified = getAttributeValue(metacard, Core.MODIFIED, Date.class);
     this.cql = getAttributeValue(metacard, QUERY_CQL, String.class);
@@ -117,6 +121,7 @@ public class QueryBasic {
     metacard.setAttribute(new AttributeImpl(Core.ID, this.metacardId));
     metacard.setAttribute(new AttributeImpl(Core.TITLE, this.title));
     metacard.setAttribute(new AttributeImpl(Core.METACARD_OWNER, this.owner));
+    metacard.setAttribute(new AttributeImpl(Core.DESCRIPTION, this.description));
     metacard.setAttribute(new AttributeImpl(Core.CREATED, this.created));
     metacard.setAttribute(new AttributeImpl(Core.MODIFIED, this.modified));
     metacard.setAttribute(new AttributeImpl(QUERY_CQL, this.cql));

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/util/QueryAttributes.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/util/QueryAttributes.java
@@ -40,4 +40,6 @@ public class QueryAttributes {
   public static final String SCHEDULES = "schedules";
 
   public static final String FACETS = "facets";
+
+  private QueryAttributes() {}
 }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/QueryMetacardApplicationTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/QueryMetacardApplicationTest.java
@@ -17,9 +17,9 @@ import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static spark.Spark.stop;
 
 import com.jayway.restassured.RestAssured;
@@ -27,9 +27,6 @@ import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
-import ddf.catalog.filter.AttributeBuilder;
-import ddf.catalog.filter.ContextualExpressionBuilder;
-import ddf.catalog.filter.ExpressionBuilder;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.DeleteRequest;
@@ -53,12 +50,10 @@ import javax.annotation.Nullable;
 import org.apache.commons.io.IOUtils;
 import org.codice.ddf.catalog.ui.util.EndpointUtil;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.opengis.filter.Filter;
 import spark.Request;
 import spark.Spark;
 
@@ -69,7 +64,7 @@ public class QueryMetacardApplicationTest {
 
   private static final EndpointUtil ENDPOINT_UTIL = mock(EndpointUtil.class);
 
-  private static final FilterBuilder FILTER_BUILDER = mock(FilterBuilder.class);
+  private static final FilterBuilder FILTER_BUILDER = mock(FilterBuilder.class, RETURNS_DEEP_STUBS);
 
   private static final SubjectIdentity SUBJECT_IDENTITY = mock(SubjectIdentity.class);
 
@@ -90,22 +85,6 @@ public class QueryMetacardApplicationTest {
   @AfterClass
   public static void tearDownClass() {
     stop();
-  }
-
-  @Before
-  public void setup() {
-    AttributeBuilder attributeBuilder = mock(AttributeBuilder.class);
-    when(FILTER_BUILDER.attribute(any(String.class))).thenReturn(attributeBuilder);
-
-    ExpressionBuilder expressionBuilder = mock(ExpressionBuilder.class);
-    when(attributeBuilder.is()).thenReturn(expressionBuilder);
-
-    ContextualExpressionBuilder contextualExpressionBuilder =
-        mock(ContextualExpressionBuilder.class);
-    when(expressionBuilder.like()).thenReturn(contextualExpressionBuilder);
-
-    Filter filter = mock(Filter.class);
-    when(contextualExpressionBuilder.text(any(String.class))).thenReturn(filter);
   }
 
   @Test
@@ -145,6 +124,19 @@ public class QueryMetacardApplicationTest {
     doReturn(queryResponse).when(CATALOG_FRAMEWORK).query(any(QueryRequest.class));
 
     int statusCode = RestAssured.given().get(localhostUrl).statusCode();
+
+    assertThat(statusCode, is(200));
+  }
+
+  @Test
+  public void testRetrieveAllQueryMetacardsFuzzySearch() throws Exception {
+    Result result = new ResultImpl(new MetacardImpl());
+    QueryResponse queryResponse = mock(QueryResponse.class);
+
+    doReturn(Collections.singletonList(result)).when(queryResponse).getResults();
+    doReturn(queryResponse).when(CATALOG_FRAMEWORK).query(any(QueryRequest.class));
+
+    int statusCode = RestAssured.given().get(localhostUrl + "?text=foobar").statusCode();
 
     assertThat(statusCode, is(200));
   }

--- a/distribution/docs/src/main/resources/content/_integrating/_endpoints/query-endpoints.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_endpoints/query-endpoints.adoc
@@ -125,9 +125,27 @@ To retrieve a query metacard through the queries endpoint, send a `GET` request 
 |asc, desc
 |String
 
+|text
+|A text field to search against a few attributes.
+|None
+|All strings
+|String
+
 |===
 
 A successful retrieval request will return a status of `200 OK`.
+
+=== Queries Endpoint Retrieve All Fuzzy Examples
+
+To retrieve all query metacards based on some text based value through the queries endpoint, send a `GET` request to the queries endpoint specifying a value for `text` as a query parameters.
+
+.Retrieve All Queries Fuzzy Search Endpoint URL
+[source,https]
+----
+https://<HOSTNAME>:<PORT>/search/catalog/internal/queries?text=<VALUE>
+----
+
+A fuzzy search will only be performed against the `title`, `modified`, `owner`, and `description` attributes.
 
 === Queries Endpoint Retrieve Examples
 


### PR DESCRIPTION
#### What does this PR do?
- Adds the ability to perform a fuzzy search against `title`, `owner`, `sources`, and `description`. 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@GabrielFabian 
@glenhein 

#### Ask 2 committers to review/merge the PR and tag them here.
@ethantmanns
@ricklarsen - Documentation

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Ingest a couple of query metacards with similar and different titles
- Perform a fuzzy search against the query metacards and determine if the results are close to your `text` parameter. 

#### Any background context you want to provide?
- None

#### What are the relevant tickets?
For GH Issues:
Fixes: #4736 

#### Screenshots
- None

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
