### PR TITLE
DDF-4769 Fix WFS 1.1.0 Source Page Calculation

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -696,7 +696,7 @@ public class WfsSource extends AbstractWfsSource {
 
       int stopIndex =
           Math.min(
-              (origPageSize * pageNumber) + query.getStartIndex(),
+              origPageSize + query.getStartIndex(),
               featureCollection.getFeatureMembers().size() + 1);
 
       LOGGER.debug(

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -1327,7 +1327,7 @@ public class WfsSourceTest {
   private void assertCorrectMetacardsReturned(
       List<Result> results, int startIndex, int expectedNumberOfMetacards) {
 
-    assertThat(results.size(), is(expectedNumberOfMetacards));
+    assertThat(results, hasSize(expectedNumberOfMetacards));
     for (int i = 0; i < expectedNumberOfMetacards; i++) {
       int id = startIndex + i;
       assertThat(results.get(i).getMetacard().getId(), equalTo("ID_" + String.valueOf(id)));

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -700,7 +700,6 @@ public class WfsSourceTest {
     SourceResponse response = executeQuery(startIndex, pageSize);
     List<Result> results = response.getResults();
 
-    assertThat(results.size(), is(pageSize));
     assertThat(response.getHits(), equalTo(new Long(MAX_FEATURES)));
 
     // Verify that metacards 1 thru 4 were returned since pageSize=4
@@ -772,6 +771,26 @@ public class WfsSourceTest {
 
     assertThat(results.size(), is(1));
     assertThat(response.getHits(), is((long) numFeatures));
+  }
+
+  /** Since page size=4 and startIndex=5, should get 4 results back and total hits of 10. */
+  @Test
+  public void testPagingToSecondPage()
+      throws WfsException, SecurityServiceException, TransformerConfigurationException,
+          UnsupportedQueryException {
+
+    int pageSize = 4;
+    int startIndex = 5;
+
+    setUp(ONE_TEXT_PROPERTY_SCHEMA, null, null, MAX_FEATURES, null);
+
+    SourceResponse response = executeQuery(startIndex, pageSize);
+    List<Result> results = response.getResults();
+
+    assertThat(response.getHits(), equalTo(new Long(MAX_FEATURES)));
+
+    // Verify that metacards 5 thru 8 were returned
+    assertCorrectMetacardsReturned(results, startIndex, 4);
   }
 
   /**
@@ -1308,6 +1327,7 @@ public class WfsSourceTest {
   private void assertCorrectMetacardsReturned(
       List<Result> results, int startIndex, int expectedNumberOfMetacards) {
 
+    assertThat(results.size(), is(expectedNumberOfMetacards));
     for (int i = 0; i < expectedNumberOfMetacards; i++) {
       int id = startIndex + i;
       assertThat(results.get(i).getMetacard().getId(), equalTo("ID_" + String.valueOf(id)));


### PR DESCRIPTION
#### What does this PR do?
Fixes `WfsSource` paging stop index calculation.

#### Who is reviewing it? 
@hayleynorton 
@glenhein 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@jrnorth 

#### How should this be tested?
1. Query the WFS Source and attempt to page past the first page.

#### What are the relevant tickets?
For GH Issues:
Fixes: #4769 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
