### PR TITLE
DDF-4779 Extension point for redux providers

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/extension-points/extension-points.tsx
@@ -14,17 +14,20 @@ import routes from './routes'
 import Navigator, { Props } from './navigator'
 import filterActions from './filter-actions'
 import { SFC } from '../react-component/hoc/utils'
+import { providers, Props as ProviderProps } from './providers'
 
 export type ExtensionPointsType = {
   routes: {}
   navigator: SFC<Props>
   filterActions: React.ReactNode
+  providers: SFC<ProviderProps>
 }
 
 const ExtensionPoints: ExtensionPointsType = {
   routes: routes,
   navigator: Navigator,
   filterActions: filterActions,
+  providers: providers,
 }
 
 export default ExtensionPoints

--- a/ui/packages/catalog-ui-search/src/main/webapp/extension-points/providers/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/extension-points/providers/index.tsx
@@ -1,0 +1,1 @@
+export { default as providers, Props } from './providers.container'

--- a/ui/packages/catalog-ui-search/src/main/webapp/extension-points/providers/providers.container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/extension-points/providers/providers.container.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { hot } from 'react-hot-loader'
+
+import ThemeContainer from '../../react-component/container/theme-container'
+import { IntlProvider } from 'react-intl'
+
+const properties = require('properties')
+
+export type Props = {
+  children: React.ReactNode
+}
+
+const ProviderContainer = (props: Props) => {
+  return (
+    <React.Fragment>
+      <ThemeContainer>
+        <IntlProvider locale={navigator.language} messages={properties.i18n}>
+          <>{props.children}</>
+        </IntlProvider>
+      </ThemeContainer>
+    </React.Fragment>
+  )
+}
+
+export default hot(module)(ProviderContainer)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/Entry.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/Entry.tsx
@@ -31,10 +31,11 @@ export type EntryParameters = {
   routes?: ExtensionPointsType['routes']
   navigator?: ExtensionPointsType['navigator']
   filterActions?: ExtensionPointsType['filterActions']
+  providers?: ExtensionPointsType['providers']
 }
 
 const entry = (extensionPoints: EntryParameters = {}) => {
-  const { routes, navigator, filterActions } = extensionPoints
+  const { routes, navigator, filterActions, providers } = extensionPoints
   if (routes) {
     ExtensionPoints.routes = routes
   }
@@ -43,6 +44,9 @@ const entry = (extensionPoints: EntryParameters = {}) => {
   }
   if (filterActions) {
     ExtensionPoints.filterActions = filterActions
+  }
+  if (providers) {
+    ExtensionPoints.providers = providers
   }
   require('../js/ApplicationStart')
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/extensions/marionette.ItemView.attachElContent.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/extensions/marionette.ItemView.attachElContent.js
@@ -14,21 +14,16 @@ import { render } from 'react-dom'
 import React from 'react'
 const Parser = require('html-react-parser')
 const properties = require('properties')
-import ThemeContainer from '../../react-component/container/theme-container'
-import { IntlProvider } from 'react-intl'
+import ExtensionPoints from '../../extension-points'
+
+const Providers = ExtensionPoints.providers
 
 Marionette.ItemView.prototype.attachElContent = function(rendering) {
   this.triggerMethod('before:react:attach', rendering)
   render(
-    <ThemeContainer>
-      <React.Fragment>
-        <IntlProvider locale={navigator.language} messages={properties.i18n}>
-          <React.Fragment>
-            {React.isValidElement(rendering) ? rendering : Parser(rendering)}
-          </React.Fragment>
-        </IntlProvider>
-      </React.Fragment>
-    </ThemeContainer>,
+    <Providers>
+      {React.isValidElement(rendering) ? rendering : Parser(rendering)}
+    </Providers>,
     this.el
   )
   this.triggerMethod('after:react:attach', rendering)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/router-container/router-container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/router-container/router-container.tsx
@@ -13,16 +13,14 @@ import * as React from 'react'
 import Router from '../../presentation/router'
 
 import Navigation from '../navigation-container'
-import ThemeContainer from '../theme-container'
-
-import { IntlProvider } from 'react-intl'
-
-const properties = require('properties')
+import ExtensionPoints from '../../../extension-points'
 
 type Props = {
   navigation: React.ReactNode
   routeDefinitions: object
 }
+
+const Providers = ExtensionPoints.providers
 
 class RouterContainer extends React.Component<Props, {}> {
   constructor(props: Props) {
@@ -31,19 +29,13 @@ class RouterContainer extends React.Component<Props, {}> {
   render() {
     const navigation = <Navigation {...this.props} />
     return (
-      <ThemeContainer>
-        <React.Fragment>
-          <IntlProvider locale={navigator.language} messages={properties.i18n}>
-            <React.Fragment>
-              <Router
-                nav={navigation}
-                routeDefinitions={this.props.routeDefinitions}
-                {...this.props}
-              />
-            </React.Fragment>
-          </IntlProvider>
-        </React.Fragment>
-      </ThemeContainer>
+      <Providers>
+        <Router
+          nav={navigation}
+          routeDefinitions={this.props.routeDefinitions}
+          {...this.props}
+        />
+      </Providers>
     )
   }
 }


### PR DESCRIPTION
#### What does this PR do?
- Provides an extension point in DDF for specify redux providers at the top level of the dom tree. 

#### Who is reviewing it? 
@GabrielFabian 
@cantstoptheunk 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@tbatie

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Verify that DDF works as expected in terms of internationalization. This is unfortunately the only way to test this inside of DDF. 
- Verify downstream that internationalization works as expected. 

#### Any background context you want to provide?
- None

#### What are the relevant tickets?
For GH Issues:
Fixes: #4779 

#### Screenshots
- None

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
