### PR TITLE
DDF-4249 Add support for multiple access controlled tags per metacard type

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.security.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.security.xml
@@ -30,7 +30,7 @@
 
         <AD id="policyToFilterEnabled"
             name="Attempt to optimize queries by enhancing them with policy information"
-            description="Allows the system to introspect user queries and defer processing to Solr if appropriate"
+            description="Allows the system to introspect user queries and move some policy filtering to Solr as part of the query, if appropriate"
             type="Boolean"
             default="true"
             required="false"/>

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlTagsTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/security/accesscontrol/AccessControlTagsTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,7 +68,15 @@ public class AccessControlTagsTest {
 
   @Test
   public void testBindWithServicePropertyOfIncorrectTypeIsIgnored() {
-    when(mockTypeRef.getProperty("access-controlled-tag")).thenReturn(new Object());
+    when(mockTypeRef.getProperty(ACCESS_CONTROLLED_TAG)).thenReturn(new Object());
+    tagSet.bindTag(mockTypeRef);
+    assertThat(tagSet.getAccessControlledTags(), is(empty()));
+  }
+
+  @Test
+  public void testBindWithServicePropertyOfInvalidSetIsIgnored() {
+    when(mockTypeRef.getProperty(ACCESS_CONTROLLED_TAG))
+        .thenReturn(ImmutableSet.of("string", new Object()));
     tagSet.bindTag(mockTypeRef);
     assertThat(tagSet.getAccessControlledTags(), is(empty()));
   }
@@ -78,6 +87,15 @@ public class AccessControlTagsTest {
     tagSet.bindTag(mockTypeRef);
     assertThat(tagSet.getAccessControlledTags(), hasSize(1));
     assertThat(tagSet.getAccessControlledTags(), hasItems(EXPECTED_TAG_A));
+  }
+
+  @Test
+  public void testBindWithExpectedServicePropertySetSavesTheTags() {
+    when(mockTypeRef.getProperty(ACCESS_CONTROLLED_TAG))
+        .thenReturn(ImmutableSet.of(EXPECTED_TAG_A, EXPECTED_TAG_B));
+    tagSet.bindTag(mockTypeRef);
+    assertThat(tagSet.getAccessControlledTags(), hasSize(2));
+    assertThat(tagSet.getAccessControlledTags(), hasItems(EXPECTED_TAG_A, EXPECTED_TAG_B));
   }
 
   @Test
@@ -108,7 +126,20 @@ public class AccessControlTagsTest {
     assertThat(tagSet.getAccessControlledTags(), hasSize(1));
     assertThat(tagSet.getAccessControlledTags(), hasItems(EXPECTED_TAG_A));
 
-    when(mockTypeRef.getProperty("access-controlled-tag")).thenReturn(new Object());
+    when(mockTypeRef.getProperty(ACCESS_CONTROLLED_TAG)).thenReturn(new Object());
+    tagSet.unbindTag(mockTypeRef);
+    assertThat(tagSet.getAccessControlledTags(), hasSize(1));
+    assertThat(tagSet.getAccessControlledTags(), hasItems(EXPECTED_TAG_A));
+  }
+
+  @Test
+  public void testUnbindWithServicePropertyOfInvalidSetIsIgnored() {
+    bindTagForTest(EXPECTED_TAG_A);
+    assertThat(tagSet.getAccessControlledTags(), hasSize(1));
+    assertThat(tagSet.getAccessControlledTags(), hasItems(EXPECTED_TAG_A));
+
+    when(mockTypeRef.getProperty(ACCESS_CONTROLLED_TAG))
+        .thenReturn(ImmutableSet.of("string", new Object()));
     tagSet.unbindTag(mockTypeRef);
     assertThat(tagSet.getAccessControlledTags(), hasSize(1));
     assertThat(tagSet.getAccessControlledTags(), hasItems(EXPECTED_TAG_A));
@@ -121,6 +152,19 @@ public class AccessControlTagsTest {
     assertThat(tagSet.getAccessControlledTags(), hasItems(EXPECTED_TAG_A));
 
     when(mockTypeRef.getProperty(ACCESS_CONTROLLED_TAG)).thenReturn(EXPECTED_TAG_A);
+    tagSet.unbindTag(mockTypeRef);
+    assertThat(tagSet.getAccessControlledTags(), is(empty()));
+  }
+
+  @Test
+  public void testUnbindWithExpectedServicePropertySetRemovesTheTags() {
+    bindTagForTest(EXPECTED_TAG_A);
+    bindTagForTest(EXPECTED_TAG_B);
+    assertThat(tagSet.getAccessControlledTags(), hasSize(2));
+    assertThat(tagSet.getAccessControlledTags(), hasItems(EXPECTED_TAG_A, EXPECTED_TAG_B));
+
+    when(mockTypeRef.getProperty(ACCESS_CONTROLLED_TAG))
+        .thenReturn(ImmutableSet.of(EXPECTED_TAG_A, EXPECTED_TAG_B));
     tagSet.unbindTag(mockTypeRef);
     assertThat(tagSet.getAccessControlledTags(), is(empty()));
   }


### PR DESCRIPTION
#### What does this PR do?
Adds support for providing a set of values on the `access-controlled-tag` so that the relationship between metacard types and access controlled tags do not need to be 1-to-1, for example: 
```
<service ref="attributeGroupMetacardType" interface="ddf.catalog.data.MetacardType">
    <service-properties>
          <entry key="name" value="attribute-group"/>
          <!-- If the following entry changes, also change the metacard tag in AttributeGroupType -->
          <entry key="access-controlled-tag">
                <set>
                    <value>tag1</value>
                    <value>tag2</value>
                </set>
          </entry>
    </service-properties>
</service>
```

Also re-words a configuration's description for more clarity. 

#### Who is reviewing it? 
@gordocanchola 
@Schachte 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@jrnorth 

#### How should this be tested?
Complete the following:

1. Unzip and startup DDF
1. Run `log:set TRACE org.codice.ddf.catalog.ui.security.accesscontrol`
1. Run `profile:install standard`
1. Shutdown DDF by running `halt` then reboot; hit ENTER to access the shell during startup when the option is presented by Karaf
1. Look for the following logs:

##### Metacard types we do not care about
```
...

Registered metacard type metacard.version is not access-controlled
Registered metacard type fallback.doc is not access-controlled
Registered metacard type fallback.mp4 is not access-controlled

...
```

##### Metacard types we DO care about
```
...

Found single tag query-template
Found access-controlled metacard type 'query-template', caching tags '[query-template]'

...

Found single tag workspace
Found access-controlled metacard type 'workspace', caching tags '[workspace]'

...

Found single tag attribute-group
Found access-controlled metacard type 'attribute-group', caching tags '[attribute-group]'

...
```

Now we will verify the alternate technique for declaring access-controlled tags works as expected. Be sure to clear (`log:clear`) and tail (`log:tail`) the logs. Download, unzip, and drop this modified version of [catalog-ui-search-2.15.0-SNAPSHOT.jar.zip](https://github.com/codice/ddf/files/3140241/catalog-ui-search-2.15.0-SNAPSHOT.jar.zip) into the `DDF_HOME/deploy/` directory. This jar's blueprint has been modified to leverage the new multi-tag support for the _attribute-group_ metacard type. While the _query-template_ and _workspace_ logs should be unchanged, ensure the logs for _attribute-group_ look like:
```
...

Found set of tags [tag1, tag2]
Found access-controlled metacard type 'attribute-group', caching tags '[tag1, tag2]'

...
```

#### Any background context you want to provide?
For some access controlled metacards that share the same data structure (metacard type) but have otherwise distinguishable characteristics, such as actual content of the data, purpose of the data, or sharing scope of the data, there is currently no facility for metacard types to "opt in" for pre-query policy optimizations across multiple tags. The relationship is currently limited to be 1-to-1. There are cases where new metacards that reuse existing types, but are identified by their own tag, should also benefit from pre-query policy optimizations. 

#### What are the relevant tickets?
For Jira:
[DDF-4249](https://codice.atlassian.net/browse/DDF-4249)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
