### PR TITLE
DDF-4249 Do not simplify filters prior to introspection because not all custom filter functions support evaluation

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/TagAggregationVisitor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/accesscontrol/TagAggregationVisitor.java
@@ -41,15 +41,30 @@ import org.slf4j.LoggerFactory;
  * guaranteed any result in the list will have at least one tag found in {@link #getTags()}. If this
  * cannot be guaranteed, the resultant tag set will be empty.
  *
- * <p>Run this visitor against a simplified filter. Running against filters without optimized logic
- * is not supported. If no other algorithms are available, {@link
- * org.geotools.filter.visitor.SimplifyingFilterVisitor} can be used.
- *
  * <p>Note that {@link PropertyIsNotEqualTo} is not implemented, despite it potentially referencing
  * metacard tags. That's because aggregation can only effectively operate on what is known to be
  * true, not necessarily what is known to be false. This is because true predicates narrow down the
  * result space in deterministic ways without the need of the entire taxonomy or database schema to
  * compute the truthy alternative for a falsey filter, which would be prohibitively large.
+ *
+ * <p>For best results, run this visitor against a simplified filter. Running against filters
+ * without optimized logic is only partially supported. Tags within the following logical operators
+ * will be propagated up the tree correctly:
+ *
+ * <ul>
+ *   <li>AND within an AND
+ *   <li>OR within an OR
+ * </ul>
+ *
+ * <p>Tags within the following logical operators <b>will be ignored</b>:
+ *
+ * <ul>
+ *   <li>NOT within a NOT
+ * </ul>
+ *
+ * <p>Given the vast majority of filters will not explicitly contain double negation, and the UI
+ * already does some optimization work for us, skipping policy optimization on these kinds of
+ * filters is acceptable.
  */
 @SuppressWarnings("squid:S1192" /* Constants not actually helpful for log statements */)
 public class TagAggregationVisitor extends TagBaseVisitor {


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where `NEAR` filters would cause the access control pre-query plugin to throw an exception. 

Also introduces some logging improvements in the pre-query plugin itself.

#### Who is reviewing it? 
@Bdthomson 
@mojogitoverhere 

#### Select relevant component teams: 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@jrnorth

#### How should this be tested?
Use the CSW endpoint to conduct a search, ensuring the filter contains the `NEAR` / proximity function, and verify no exception is thrown and the search succeeds as expected. Unzip and install DDF using `profile:install standard`. 

Using Postman or a similar tool, `POST` the following to `https://localhost:8993/services/csw` and verify the following response. It need not return results as long as it does not throw an exception. 

##### Post Body
```
<?xml version="1.0" ?>
<GetRecords xmlns="http://www.opengis.net/cat/csw/2.0.2"
            xmlns:ogc="http://www.opengis.net/ogc"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:gml="http://www.opengis.net/gml"
            service="CSW"
            version="2.0.2"
            maxRecords="10"
            startPosition="1"
            resultType="results"
            outputFormat="application/xml"
            xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 ../../../csw/2.0.2/CSW-discovery.xsd">
    <Query>
        <ElementSetName>full</ElementSetName>
        <Constraint version="1.1.0">
            <ogc:Filter>
            	<ogc:PropertyIsEqualTo>
            		<ogc:Function name="proximity">
            			<ogc:Literal>title</ogc:Literal>
            			<ogc:Literal>2</ogc:Literal>
            			<ogc:Literal>my name</ogc:Literal>
            		</ogc:Function>
            		<ogc:Literal>true</ogc:Literal>
            	</ogc:PropertyIsEqualTo>
            </ogc:Filter>
        </Constraint>
    </Query>
</GetRecords> 
```

##### Expected Return Body
```
<?xml version='1.0' encoding='UTF-8'?>
<csw:GetRecordsResponse xmlns:dct="http://purl.org/dc/terms/" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:ows="http://www.opengis.net/ows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0.2">
    <csw:SearchStatus timestamp="2019-05-02T15:36:19.724-07:00"/>
    <csw:SearchResults numberOfRecordsMatched="0" numberOfRecordsReturned="0" nextRecord="0" recordSchema="http://www.opengis.net/cat/csw/2.0.2" elementSet="full"></csw:SearchResults>
</csw:GetRecordsResponse>
```

#### Any background context you want to provide?
Simplifying OGC filters involves, in some cases, evaluating functions and replacing them with literals. Some of DDF's custom filter functions (i.e the `ProximityFunction`) do not support evaluation, and instead serve as placeholders that only exist to support the transformation to a Solr query. Instead of simplifying filters prior to processing them, the pre-query plugin will now do the best it can regardless if the filter is logically simplified or not. This means certain filters, such as those containing double negation, might not get optimized with policy information when they otherwise **could**, but those cases are so rare they are not worth supporting. Unit tests / javadoc were added to further clarify what the plugin can and cannot do. 

#### What are the relevant tickets?
For Jira:
[DDF-4249](https://codice.atlassian.net/browse/DDF-4249)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
