### PR TITLE
DDF-4811 Match the coordinate order of each WFS 1.1.0 query to that of its source

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -286,7 +286,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.74</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -286,12 +286,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.74</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.65</minimum>
+                                            <minimum>0.64</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -286,17 +286,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.73</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.64</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.61</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/CoordinateStrategy.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/CoordinateStrategy.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
+
+import static java.util.stream.Collectors.joining;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+import java.util.Arrays;
+import java.util.List;
+
+interface CoordinateStrategy {
+  String toString(Coordinate coordinate);
+
+  default String toString(final Coordinate[] coordinates) {
+    return Arrays.stream(coordinates).map(this::toString).collect(joining(" "));
+  }
+
+  List<Double> lowerCorner(Envelope envelope);
+
+  List<Double> upperCorner(Envelope envelope);
+}

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LatLonCoordinateStrategy.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LatLonCoordinateStrategy.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
+
+import static java.util.Arrays.asList;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+import java.util.List;
+
+class LatLonCoordinateStrategy implements CoordinateStrategy {
+  @Override
+  public String toString(final Coordinate coordinate) {
+    return coordinate.y + "," + coordinate.x;
+  }
+
+  @Override
+  public List<Double> lowerCorner(final Envelope envelope) {
+    return asList(envelope.getMinY(), envelope.getMinX());
+  }
+
+  @Override
+  public List<Double> upperCorner(final Envelope envelope) {
+    return asList(envelope.getMaxY(), envelope.getMaxX());
+  }
+}

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LonLatCoordinateStrategy.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LonLatCoordinateStrategy.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
+
+import static java.util.Arrays.asList;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+import java.util.List;
+
+class LonLatCoordinateStrategy implements CoordinateStrategy {
+  @Override
+  public String toString(final Coordinate coordinate) {
+    return coordinate.x + "," + coordinate.y;
+  }
+
+  @Override
+  public List<Double> lowerCorner(final Envelope envelope) {
+    return asList(envelope.getMinX(), envelope.getMinY());
+  }
+
+  @Override
+  public List<Double> upperCorner(final Envelope envelope) {
+    return asList(envelope.getMaxX(), envelope.getMaxY());
+  }
+}

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
@@ -27,7 +27,6 @@ import com.vividsolutions.jts.io.WKTWriter;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.filter.impl.SimpleFilterDelegate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -1211,22 +1210,6 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
     }
 
     return bufferedWkt;
-  }
-
-  private String latLonCoordinateString(final Coordinate[] coordinates) {
-    return Arrays.stream(coordinates).map(this::latLonCoordinateString).collect(joining(" "));
-  }
-
-  private String latLonCoordinateString(final Coordinate coordinate) {
-    return coordinate.y + "," + coordinate.x;
-  }
-
-  private String lonLatCoordinateString(final Coordinate[] coordinates) {
-    return Arrays.stream(coordinates).map(this::lonLatCoordinateString).collect(joining(" "));
-  }
-
-  private String lonLatCoordinateString(final Coordinate coordinate) {
-    return coordinate.x + "," + coordinate.y;
   }
 
   /**

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -564,7 +564,7 @@ public class WfsSource extends AbstractWfsSource {
 
           this.featureTypeFilters.put(
               featureMetacardType.getFeatureType(),
-              new WfsFilterDelegate(featureMetacardType, supportedGeo));
+              new WfsFilterDelegate(featureMetacardType, supportedGeo, coordinateOrder));
 
           mcTypeRegs.put(ftSimpleName, featureMetacardType);
 

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
 
+import static org.codice.ddf.libs.geo.util.GeospatialUtil.LAT_LON_ORDER;
+
 import ddf.catalog.Constants;
 import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
@@ -82,7 +84,6 @@ import org.apache.ws.commons.schema.XmlSchema;
 import org.codice.ddf.configuration.DictionaryMap;
 import org.codice.ddf.cxf.client.ClientFactoryFactory;
 import org.codice.ddf.cxf.client.SecureCxfClientFactory;
-import org.codice.ddf.libs.geo.util.GeospatialUtil;
 import org.codice.ddf.platform.util.StandardThreadFactoryBuilder;
 import org.codice.ddf.spatial.ogc.catalog.MetadataTransformer;
 import org.codice.ddf.spatial.ogc.catalog.common.AvailabilityCommand;
@@ -182,7 +183,7 @@ public class WfsSource extends AbstractWfsSource {
 
   private String password;
 
-  private String coordinateOrder = GeospatialUtil.LAT_LON_ORDER;
+  private String coordinateOrder = LAT_LON_ORDER;
 
   private Boolean disableCnCheck = Boolean.FALSE;
 
@@ -564,7 +565,7 @@ public class WfsSource extends AbstractWfsSource {
 
           this.featureTypeFilters.put(
               featureMetacardType.getFeatureType(),
-              new WfsFilterDelegate(featureMetacardType, supportedGeo, coordinateOrder));
+              new WfsFilterDelegate(featureMetacardType, supportedGeo, getCoordinateStrategy()));
 
           mcTypeRegs.put(ftSimpleName, featureMetacardType);
 
@@ -1127,6 +1128,12 @@ public class WfsSource extends AbstractWfsSource {
 
   public String getCoordinateOrder() {
     return this.coordinateOrder;
+  }
+
+  private CoordinateStrategy getCoordinateStrategy() {
+    return LAT_LON_ORDER.equals(coordinateOrder)
+        ? new LatLonCoordinateStrategy()
+        : new LonLatCoordinateStrategy();
   }
 
   public void setWfsMetacardTypeRegistry(WfsMetacardTypeRegistry wfsMetacardTypeRegistry) {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LatLonCoordinateStrategyTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LatLonCoordinateStrategyTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+import org.junit.Test;
+
+public class LatLonCoordinateStrategyTest {
+  private final LatLonCoordinateStrategy latLonCoordinateStrategy = new LatLonCoordinateStrategy();
+
+  @Test
+  public void toStringSingleCoordinateReturnsCommaSeparatedCoordinateValuesInLatLonOrder() {
+    assertThat(latLonCoordinateStrategy.toString(new Coordinate(10, 20)), is("20.0,10.0"));
+  }
+
+  @Test
+  public void toStringMultipleCoordinatesReturnsSpaceSeparatedCoordinatePairsInLatLonOrder() {
+    assertThat(
+        latLonCoordinateStrategy.toString(
+            new Coordinate[] {new Coordinate(10, 20), new Coordinate(20, 30)}),
+        is("20.0,10.0 30.0,20.0"));
+  }
+
+  @Test
+  public void lowerCornerReturnsEnvelopeMinimumValuesInLatLonOrder() {
+    final Envelope envelope = new Envelope(10, 20, 30, 40);
+    assertThat(latLonCoordinateStrategy.lowerCorner(envelope), contains(30.0, 10.0));
+  }
+
+  @Test
+  public void upperCornerReturnsEnvelopeMaximumValuesInLatLonOrder() {
+    final Envelope envelope = new Envelope(10, 20, 30, 40);
+    assertThat(latLonCoordinateStrategy.upperCorner(envelope), contains(40.0, 20.0));
+  }
+}

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LonLatCoordinateStrategyTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LonLatCoordinateStrategyTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Envelope;
+import org.junit.Test;
+
+public class LonLatCoordinateStrategyTest {
+  private final LonLatCoordinateStrategy lonLatCoordinateStrategy = new LonLatCoordinateStrategy();
+
+  @Test
+  public void toStringSingleCoordinateReturnsCommaSeparatedCoordinateValuesInLatLonOrder() {
+    assertThat(lonLatCoordinateStrategy.toString(new Coordinate(10, 20)), is("10.0,20.0"));
+  }
+
+  @Test
+  public void toStringMultipleCoordinatesReturnsSpaceSeparatedCoordinatePairsInLatLonOrder() {
+    assertThat(
+        lonLatCoordinateStrategy.toString(
+            new Coordinate[] {new Coordinate(10, 20), new Coordinate(20, 30)}),
+        is("10.0,20.0 20.0,30.0"));
+  }
+
+  @Test
+  public void lowerCornerReturnsEnvelopeMinimumValuesInLatLonOrder() {
+    final Envelope envelope = new Envelope(10, 20, 30, 40);
+    assertThat(lonLatCoordinateStrategy.lowerCorner(envelope), contains(10.0, 30.0));
+  }
+
+  @Test
+  public void upperCornerReturnsEnvelopeMaximumValuesInLatLonOrder() {
+    final Envelope envelope = new Envelope(10, 20, 30, 40);
+    assertThat(lonLatCoordinateStrategy.upperCorner(envelope), contains(20.0, 40.0));
+  }
+}

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LonLatCoordinateStrategyTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/LonLatCoordinateStrategyTest.java
@@ -25,12 +25,12 @@ public class LonLatCoordinateStrategyTest {
   private final LonLatCoordinateStrategy lonLatCoordinateStrategy = new LonLatCoordinateStrategy();
 
   @Test
-  public void toStringSingleCoordinateReturnsCommaSeparatedCoordinateValuesInLatLonOrder() {
+  public void toStringSingleCoordinateReturnsCommaSeparatedCoordinateValuesInLonLatOrder() {
     assertThat(lonLatCoordinateStrategy.toString(new Coordinate(10, 20)), is("10.0,20.0"));
   }
 
   @Test
-  public void toStringMultipleCoordinatesReturnsSpaceSeparatedCoordinatePairsInLatLonOrder() {
+  public void toStringMultipleCoordinatesReturnsSpaceSeparatedCoordinatePairsInLonLatOrder() {
     assertThat(
         lonLatCoordinateStrategy.toString(
             new Coordinate[] {new Coordinate(10, 20), new Coordinate(20, 30)}),
@@ -38,13 +38,13 @@ public class LonLatCoordinateStrategyTest {
   }
 
   @Test
-  public void lowerCornerReturnsEnvelopeMinimumValuesInLatLonOrder() {
+  public void lowerCornerReturnsEnvelopeMinimumValuesInLonLatOrder() {
     final Envelope envelope = new Envelope(10, 20, 30, 40);
     assertThat(lonLatCoordinateStrategy.lowerCorner(envelope), contains(10.0, 30.0));
   }
 
   @Test
-  public void upperCornerReturnsEnvelopeMaximumValuesInLatLonOrder() {
+  public void upperCornerReturnsEnvelopeMaximumValuesInLonLatOrder() {
     final Envelope envelope = new Envelope(10, 20, 30, 40);
     assertThat(lonLatCoordinateStrategy.upperCorner(envelope), contains(20.0, 40.0));
   }

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -14,8 +14,6 @@
 package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
 
 import static java.util.Arrays.asList;
-import static org.codice.ddf.libs.geo.util.GeospatialUtil.LAT_LON_ORDER;
-import static org.codice.ddf.libs.geo.util.GeospatialUtil.LON_LAT_ORDER;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -408,7 +406,7 @@ public class WfsFilterDelegateTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testWFSFilterDelegateNullSchema() {
-    new WfsFilterDelegate(null, null, LAT_LON_ORDER);
+    new WfsFilterDelegate(null, null, new LatLonCoordinateStrategy());
   }
 
   @Test
@@ -507,7 +505,8 @@ public class WfsFilterDelegateTest {
   @Test(expected = IllegalArgumentException.class)
   public void testPropertyIsEqualToStringStringBooleanAnyTextNullMetacardType() {
 
-    WfsFilterDelegate delegate = new WfsFilterDelegate(null, SUPPORTED_GEO, LAT_LON_ORDER);
+    WfsFilterDelegate delegate =
+        new WfsFilterDelegate(null, SUPPORTED_GEO, new LatLonCoordinateStrategy());
     delegate.propertyIsEqualTo(Metacard.ANY_TEXT, LITERAL, true);
   }
 
@@ -1261,7 +1260,7 @@ public class WfsFilterDelegateTest {
   @Test(expected = IllegalArgumentException.class)
   public void testBlacklistedGeoProperty() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), new LatLonCoordinateStrategy());
 
     when(featureMetacardType.getAttributeDescriptor(MOCK_GEOM))
         .thenReturn(
@@ -1273,7 +1272,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testBeyondFilter() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.BEYOND.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.BEYOND.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter.isSetSpatialOps(), is(true));
@@ -1283,7 +1282,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testBeyondAsNotDwithin() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter.getLogicOps().getValue(), is(instanceOf(UnaryLogicOpType.class)));
@@ -1293,7 +1292,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testBeyondFilterUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter, nullValue());
@@ -1302,7 +1301,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testContainsFilter() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.CONTAINS.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.CONTAINS.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.contains(Metacard.ANY_GEO, POLYGON);
     assertBinarySpatialOpFilter(filter);
@@ -1310,7 +1309,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testContainsUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.contains(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1319,7 +1318,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testCrossesFilter() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.CROSSES.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.CROSSES.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.crosses(Metacard.ANY_GEO, POLYGON);
 
@@ -1328,7 +1327,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testCrossesUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.crosses(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1337,7 +1336,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testDisjointFilter() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.DISJOINT.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.DISJOINT.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.disjoint(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
@@ -1346,7 +1345,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testDisjointAsNotBBox() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LON_LAT_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), new LonLatCoordinateStrategy());
 
     FilterType filter = delegate.disjoint(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getLogicOps().getValue(), is(instanceOf(UnaryLogicOpType.class)));
@@ -1368,7 +1367,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testDWithinFilterPolygon() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertDistanceBufferFilter(filter);
@@ -1377,7 +1376,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testDWithinFilterPoint() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POINT, DISTANCE);
     assertDistanceBufferFilter(filter);
@@ -1386,7 +1385,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testDwithinAsNotBeyond() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.BEYOND.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.BEYOND.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter.getLogicOps().getValue(), is(instanceOf(UnaryLogicOpType.class)));
@@ -1401,7 +1400,8 @@ public class WfsFilterDelegateTest {
   @Test
   public void testDwithinAsIntersects() throws JAXBException, SAXException, IOException {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(
+            SPATIAL_OPERATORS.INTERSECTS.getValue(), new LatLonCoordinateStrategy());
     /**
      * Made distance a large value so if the original WKT and the buffered WKT are plotted at:
      * http://openlayers.org/dev/examples/vector-formats.html one can easily see the buffer.
@@ -1416,7 +1416,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testDwithinUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter, nullValue());
@@ -1425,7 +1425,8 @@ public class WfsFilterDelegateTest {
   @Test
   public void testIntersects() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(
+            SPATIAL_OPERATORS.INTERSECTS.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
 
@@ -1435,7 +1436,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testIntersectsAsBoundingBox() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LON_LAT_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), new LonLatCoordinateStrategy());
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BBOXType.class)));
@@ -1456,7 +1457,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testIntersectsAsNotDisjoint() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.DISJOINT.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.DISJOINT.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
 
@@ -1469,7 +1470,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testIntersectsUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1478,7 +1479,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testOverlapsFilter() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.OVERLAPS.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.OVERLAPS.getValue(), new LatLonCoordinateStrategy());
     FilterType filter = delegate.overlaps(Metacard.ANY_GEO, POLYGON);
 
     assertBinarySpatialOpFilter(filter);
@@ -1486,7 +1487,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testOverlapsUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, new LatLonCoordinateStrategy());
     FilterType filter = delegate.overlaps(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1495,7 +1496,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testTouchesFilter() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.TOUCHES.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.TOUCHES.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.touches(Metacard.ANY_GEO, POLYGON);
 
@@ -1504,7 +1505,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testTouchesUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, new LatLonCoordinateStrategy());
     FilterType filter = delegate.touches(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1513,7 +1514,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testWithinFilter() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.WITHIN.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.WITHIN.getValue(), new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.within(Metacard.ANY_GEO, POLYGON);
 
@@ -1522,7 +1523,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testWithinUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, new LatLonCoordinateStrategy());
     FilterType filter = delegate.within(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1535,7 +1536,7 @@ public class WfsFilterDelegateTest {
 
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue());
     WfsFilterDelegate delegate =
-        new WfsFilterDelegate(featureMetacardType, supportedGeo, LAT_LON_ORDER);
+        new WfsFilterDelegate(featureMetacardType, supportedGeo, new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, notNullValue());
@@ -1546,7 +1547,7 @@ public class WfsFilterDelegateTest {
   @Test(expected = IllegalArgumentException.class)
   public void testSingleGmlPropertyBlacklisted() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.CONTAINS.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.CONTAINS.getValue(), new LatLonCoordinateStrategy());
     when(featureMetacardType.getAttributeDescriptor(MOCK_GEOM))
         .thenReturn(
             new FeatureAttributeDescriptor(
@@ -1561,7 +1562,7 @@ public class WfsFilterDelegateTest {
 
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue());
     WfsFilterDelegate delegate =
-        new WfsFilterDelegate(featureMetacardType, supportedGeo, LAT_LON_ORDER);
+        new WfsFilterDelegate(featureMetacardType, supportedGeo, new LatLonCoordinateStrategy());
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1570,14 +1571,15 @@ public class WfsFilterDelegateTest {
   @Test(expected = IllegalArgumentException.class)
   public void testBadPolygonWkt() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(
+            SPATIAL_OPERATORS.INTERSECTS.getValue(), new LatLonCoordinateStrategy());
     delegate.intersects(Metacard.ANY_GEO, "junk");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testBadPointWkt() {
     WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), new LatLonCoordinateStrategy());
     delegate.dwithin(Metacard.ANY_GEO, "junk", DISTANCE);
   }
 
@@ -1591,7 +1593,7 @@ public class WfsFilterDelegateTest {
         new WfsFilterDelegate(
             featureMetacardType,
             Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue()),
-            LAT_LON_ORDER);
+            new LatLonCoordinateStrategy());
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1601,7 +1603,8 @@ public class WfsFilterDelegateTest {
   public void testGeoFilterNullMetacardType() {
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.BEYOND.getValue());
 
-    WfsFilterDelegate delegate = new WfsFilterDelegate(null, supportedGeo, LAT_LON_ORDER);
+    WfsFilterDelegate delegate =
+        new WfsFilterDelegate(null, supportedGeo, new LatLonCoordinateStrategy());
 
     delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
   }
@@ -1609,7 +1612,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testBoundingBoxLatLonOrder() {
     final WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), new LatLonCoordinateStrategy());
 
     final FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BBOXType.class)));
@@ -1629,7 +1632,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testBoundingBoxLonLatOrder() {
     final WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LON_LAT_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), new LonLatCoordinateStrategy());
 
     final FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BBOXType.class)));
@@ -1649,7 +1652,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testPointLatLonOrder() {
     final WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), new LatLonCoordinateStrategy());
 
     final FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POINT, DISTANCE);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(DistanceBufferType.class)));
@@ -1665,7 +1668,7 @@ public class WfsFilterDelegateTest {
   @Test
   public void testPointLonLatOrder() {
     final WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LON_LAT_ORDER);
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), new LonLatCoordinateStrategy());
 
     final FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POINT, DISTANCE);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(DistanceBufferType.class)));
@@ -1681,7 +1684,8 @@ public class WfsFilterDelegateTest {
   @Test
   public void testPolygonLatLonOrder() {
     final WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(
+            SPATIAL_OPERATORS.INTERSECTS.getValue(), new LatLonCoordinateStrategy());
 
     final FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
@@ -1705,7 +1709,8 @@ public class WfsFilterDelegateTest {
   @Test
   public void testPolygonLonLatOrder() {
     final WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LON_LAT_ORDER);
+        setupFilterDelegate(
+            SPATIAL_OPERATORS.INTERSECTS.getValue(), new LonLatCoordinateStrategy());
 
     final FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
@@ -1729,7 +1734,8 @@ public class WfsFilterDelegateTest {
   @Test
   public void testLineStringLatLonOrder() {
     final WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
+        setupFilterDelegate(
+            SPATIAL_OPERATORS.INTERSECTS.getValue(), new LatLonCoordinateStrategy());
 
     final FilterType filter = delegate.intersects(Metacard.ANY_GEO, LINESTRING);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
@@ -1746,7 +1752,8 @@ public class WfsFilterDelegateTest {
   @Test
   public void testLineStringLonLatOrder() {
     final WfsFilterDelegate delegate =
-        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LON_LAT_ORDER);
+        setupFilterDelegate(
+            SPATIAL_OPERATORS.INTERSECTS.getValue(), new LonLatCoordinateStrategy());
 
     final FilterType filter = delegate.intersects(Metacard.ANY_GEO, LINESTRING);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
@@ -1923,7 +1930,8 @@ public class WfsFilterDelegateTest {
   }
 
   private WfsFilterDelegate createDelegate() {
-    return new WfsFilterDelegate(featureMetacardType, SUPPORTED_GEO, LAT_LON_ORDER);
+    return new WfsFilterDelegate(
+        featureMetacardType, SUPPORTED_GEO, new LatLonCoordinateStrategy());
   }
 
   private WfsFilterDelegate createIntegerDelegate() {
@@ -1957,7 +1965,8 @@ public class WfsFilterDelegateTest {
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(DistanceBufferType.class)));
   }
 
-  private WfsFilterDelegate setupFilterDelegate(String spatialOpType, String coordinateOrder) {
+  private WfsFilterDelegate setupFilterDelegate(
+      String spatialOpType, CoordinateStrategy coordinateStrategy) {
     List<String> gmlProps = new ArrayList<>();
     gmlProps.add(MOCK_GEOM);
 
@@ -1968,7 +1977,7 @@ public class WfsFilterDelegateTest {
                 MOCK_GEOM, MOCK_GEOM, true, false, false, false, BasicTypes.STRING_TYPE));
 
     List<String> supportedGeo = Collections.singletonList(spatialOpType);
-    return new WfsFilterDelegate(featureMetacardType, supportedGeo, coordinateOrder);
+    return new WfsFilterDelegate(featureMetacardType, supportedGeo, coordinateStrategy);
   }
 
   private void whenTextualStringType() {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -14,6 +14,8 @@
 package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
 
 import static java.util.Arrays.asList;
+import static org.codice.ddf.libs.geo.util.GeospatialUtil.LAT_LON_ORDER;
+import static org.codice.ddf.libs.geo.util.GeospatialUtil.LON_LAT_ORDER;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -52,6 +54,10 @@ import net.opengis.filter.v_1_1_0.FilterType;
 import net.opengis.filter.v_1_1_0.UnaryLogicOpType;
 import net.opengis.gml.v_3_1_1.DirectPositionType;
 import net.opengis.gml.v_3_1_1.EnvelopeType;
+import net.opengis.gml.v_3_1_1.LineStringType;
+import net.opengis.gml.v_3_1_1.LinearRingType;
+import net.opengis.gml.v_3_1_1.PointType;
+import net.opengis.gml.v_3_1_1.PolygonType;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.FeatureAttributeDescriptor;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.FeatureMetacardType;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs11Constants.SPATIAL_OPERATORS;
@@ -84,7 +90,9 @@ public class WfsFilterDelegateTest {
 
   private static final List<String> SUPPORTED_GEO = asList("Intersects", "BBox", "Within");
 
-  private static final String POLYGON = "POLYGON ((30 -10, 30 30, 10 30, 10 -10, 30 -10))";
+  private static final String POLYGON = "POLYGON ((40 -10, 40 30, 10 30, 10 -10, 40 -10))";
+
+  private static final String LINESTRING = "LINESTRING (30 10, 10 30, 50 40)";
 
   private static final String POINT = "POINT (30 -10)";
 
@@ -400,7 +408,7 @@ public class WfsFilterDelegateTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testWFSFilterDelegateNullSchema() {
-    new WfsFilterDelegate(null, null);
+    new WfsFilterDelegate(null, null, LAT_LON_ORDER);
   }
 
   @Test
@@ -499,7 +507,7 @@ public class WfsFilterDelegateTest {
   @Test(expected = IllegalArgumentException.class)
   public void testPropertyIsEqualToStringStringBooleanAnyTextNullMetacardType() {
 
-    WfsFilterDelegate delegate = new WfsFilterDelegate(null, SUPPORTED_GEO);
+    WfsFilterDelegate delegate = new WfsFilterDelegate(null, SUPPORTED_GEO, LAT_LON_ORDER);
     delegate.propertyIsEqualTo(Metacard.ANY_TEXT, LITERAL, true);
   }
 
@@ -1252,7 +1260,8 @@ public class WfsFilterDelegateTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testBlacklistedGeoProperty() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LAT_LON_ORDER);
 
     when(featureMetacardType.getAttributeDescriptor(MOCK_GEOM))
         .thenReturn(
@@ -1263,7 +1272,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testBeyondFilter() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.BEYOND.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.BEYOND.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter.isSetSpatialOps(), is(true));
@@ -1272,7 +1282,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testBeyondAsNotDwithin() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter.getLogicOps().getValue(), is(instanceOf(UnaryLogicOpType.class)));
@@ -1282,7 +1293,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testBeyondFilterUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
 
     FilterType filter = delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter, nullValue());
@@ -1290,7 +1301,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testContainsFilter() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.CONTAINS.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.CONTAINS.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.contains(Metacard.ANY_GEO, POLYGON);
     assertBinarySpatialOpFilter(filter);
@@ -1298,7 +1310,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testContainsUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
 
     FilterType filter = delegate.contains(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1306,7 +1318,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testCrossesFilter() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.CROSSES.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.CROSSES.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.crosses(Metacard.ANY_GEO, POLYGON);
 
@@ -1315,7 +1328,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testCrossesUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
 
     FilterType filter = delegate.crosses(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1323,7 +1336,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testDisjointFilter() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.DISJOINT.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.DISJOINT.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.disjoint(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
@@ -1331,7 +1345,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testDisjointAsNotBBox() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LON_LAT_ORDER);
 
     FilterType filter = delegate.disjoint(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getLogicOps().getValue(), is(instanceOf(UnaryLogicOpType.class)));
@@ -1347,12 +1362,13 @@ public class WfsFilterDelegateTest {
 
     DirectPositionType upperCorner = envelope.getUpperCorner();
     assertThat("The bounding box's upper corner was null.", upperCorner, is(notNullValue()));
-    assertThat(upperCorner.getValue(), is(asList(30.0, 30.0)));
+    assertThat(upperCorner.getValue(), is(asList(40.0, 30.0)));
   }
 
   @Test
   public void testDWithinFilterPolygon() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertDistanceBufferFilter(filter);
@@ -1360,7 +1376,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testDWithinFilterPoint() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POINT, DISTANCE);
     assertDistanceBufferFilter(filter);
@@ -1368,7 +1385,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testDwithinAsNotBeyond() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.BEYOND.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.BEYOND.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter.getLogicOps().getValue(), is(instanceOf(UnaryLogicOpType.class)));
@@ -1382,7 +1400,8 @@ public class WfsFilterDelegateTest {
    */
   @Test
   public void testDwithinAsIntersects() throws JAXBException, SAXException, IOException {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
     /**
      * Made distance a large value so if the original WKT and the buffered WKT are plotted at:
      * http://openlayers.org/dev/examples/vector-formats.html one can easily see the buffer.
@@ -1397,7 +1416,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testDwithinUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
 
     FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POLYGON, DISTANCE);
     assertThat(filter, nullValue());
@@ -1405,7 +1424,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testIntersects() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
 
@@ -1414,7 +1434,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testIntersectsAsBoundingBox() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LON_LAT_ORDER);
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BBOXType.class)));
@@ -1429,12 +1450,13 @@ public class WfsFilterDelegateTest {
 
     DirectPositionType upperCorner = envelope.getUpperCorner();
     assertThat("The bounding box's upper corner was null.", upperCorner, is(notNullValue()));
-    assertThat(upperCorner.getValue(), is(asList(30.0, 30.0)));
+    assertThat(upperCorner.getValue(), is(asList(40.0, 30.0)));
   }
 
   @Test
   public void testIntersectsAsNotDisjoint() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.DISJOINT.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.DISJOINT.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
 
@@ -1447,7 +1469,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testIntersectsUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1455,7 +1477,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testOverlapsFilter() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.OVERLAPS.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.OVERLAPS.getValue(), LAT_LON_ORDER);
     FilterType filter = delegate.overlaps(Metacard.ANY_GEO, POLYGON);
 
     assertBinarySpatialOpFilter(filter);
@@ -1463,7 +1486,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testOverlapsUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
     FilterType filter = delegate.overlaps(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1471,7 +1494,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testTouchesFilter() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.TOUCHES.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.TOUCHES.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.touches(Metacard.ANY_GEO, POLYGON);
 
@@ -1480,7 +1504,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testTouchesUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
     FilterType filter = delegate.touches(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1488,7 +1512,8 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testWithinFilter() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.WITHIN.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.WITHIN.getValue(), LAT_LON_ORDER);
 
     FilterType filter = delegate.within(Metacard.ANY_GEO, POLYGON);
 
@@ -1497,7 +1522,7 @@ public class WfsFilterDelegateTest {
 
   @Test
   public void testWithinUnsupported() {
-    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP);
+    WfsFilterDelegate delegate = setupFilterDelegate(NO_OP, LAT_LON_ORDER);
     FilterType filter = delegate.within(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1509,7 +1534,8 @@ public class WfsFilterDelegateTest {
     whenGeom(MOCK_GEOM, MOCK_GEOM2, true, true);
 
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue());
-    WfsFilterDelegate delegate = new WfsFilterDelegate(featureMetacardType, supportedGeo);
+    WfsFilterDelegate delegate =
+        new WfsFilterDelegate(featureMetacardType, supportedGeo, LAT_LON_ORDER);
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, notNullValue());
@@ -1519,7 +1545,8 @@ public class WfsFilterDelegateTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testSingleGmlPropertyBlacklisted() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.CONTAINS.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.CONTAINS.getValue(), LAT_LON_ORDER);
     when(featureMetacardType.getAttributeDescriptor(MOCK_GEOM))
         .thenReturn(
             new FeatureAttributeDescriptor(
@@ -1533,7 +1560,8 @@ public class WfsFilterDelegateTest {
     whenGeom(MOCK_GEOM, MOCK_GEOM2, false, false);
 
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue());
-    WfsFilterDelegate delegate = new WfsFilterDelegate(featureMetacardType, supportedGeo);
+    WfsFilterDelegate delegate =
+        new WfsFilterDelegate(featureMetacardType, supportedGeo, LAT_LON_ORDER);
 
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
     assertThat(filter, nullValue());
@@ -1541,13 +1569,15 @@ public class WfsFilterDelegateTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testBadPolygonWkt() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
     delegate.intersects(Metacard.ANY_GEO, "junk");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testBadPointWkt() {
-    WfsFilterDelegate delegate = setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue());
+    WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
     delegate.dwithin(Metacard.ANY_GEO, "junk", DISTANCE);
   }
 
@@ -1560,7 +1590,8 @@ public class WfsFilterDelegateTest {
     WfsFilterDelegate delegate =
         new WfsFilterDelegate(
             featureMetacardType,
-            Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue()));
+            Collections.singletonList(SPATIAL_OPERATORS.INTERSECTS.getValue()),
+            LAT_LON_ORDER);
     FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
 
     assertThat(filter, nullValue());
@@ -1570,9 +1601,163 @@ public class WfsFilterDelegateTest {
   public void testGeoFilterNullMetacardType() {
     List<String> supportedGeo = Collections.singletonList(SPATIAL_OPERATORS.BEYOND.getValue());
 
-    WfsFilterDelegate delegate = new WfsFilterDelegate(null, supportedGeo);
+    WfsFilterDelegate delegate = new WfsFilterDelegate(null, supportedGeo, LAT_LON_ORDER);
 
     delegate.beyond(Metacard.ANY_GEO, POLYGON, DISTANCE);
+  }
+
+  @Test
+  public void testBoundingBoxLatLonOrder() {
+    final WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LAT_LON_ORDER);
+
+    final FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
+    assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BBOXType.class)));
+
+    final BBOXType bboxType = (BBOXType) filter.getSpatialOps().getValue();
+    final EnvelopeType envelope = bboxType.getEnvelope().getValue();
+
+    final DirectPositionType lowerCorner = envelope.getLowerCorner();
+    assertThat("The bounding box's lower corner was null.", lowerCorner, is(notNullValue()));
+    assertThat(lowerCorner.getValue(), is(asList(-10.0, 10.0)));
+
+    final DirectPositionType upperCorner = envelope.getUpperCorner();
+    assertThat("The bounding box's upper corner was null.", upperCorner, is(notNullValue()));
+    assertThat(upperCorner.getValue(), is(asList(30.0, 40.0)));
+  }
+
+  @Test
+  public void testBoundingBoxLonLatOrder() {
+    final WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.BBOX.getValue(), LON_LAT_ORDER);
+
+    final FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
+    assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BBOXType.class)));
+
+    final BBOXType bboxType = (BBOXType) filter.getSpatialOps().getValue();
+    final EnvelopeType envelope = bboxType.getEnvelope().getValue();
+
+    final DirectPositionType lowerCorner = envelope.getLowerCorner();
+    assertThat("The bounding box's lower corner was null.", lowerCorner, is(notNullValue()));
+    assertThat(lowerCorner.getValue(), is(asList(10.0, -10.0)));
+
+    final DirectPositionType upperCorner = envelope.getUpperCorner();
+    assertThat("The bounding box's upper corner was null.", upperCorner, is(notNullValue()));
+    assertThat(upperCorner.getValue(), is(asList(40.0, 30.0)));
+  }
+
+  @Test
+  public void testPointLatLonOrder() {
+    final WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LAT_LON_ORDER);
+
+    final FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POINT, DISTANCE);
+    assertThat(filter.getSpatialOps().getValue(), is(instanceOf(DistanceBufferType.class)));
+
+    final DistanceBufferType distanceBufferType =
+        (DistanceBufferType) filter.getSpatialOps().getValue();
+    assertThat(distanceBufferType.getGeometry().getValue(), is(instanceOf(PointType.class)));
+
+    final PointType pointType = (PointType) distanceBufferType.getGeometry().getValue();
+    assertThat(pointType.getCoordinates().getValue(), is("-10.0,30.0"));
+  }
+
+  @Test
+  public void testPointLonLatOrder() {
+    final WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.DWITHIN.getValue(), LON_LAT_ORDER);
+
+    final FilterType filter = delegate.dwithin(Metacard.ANY_GEO, POINT, DISTANCE);
+    assertThat(filter.getSpatialOps().getValue(), is(instanceOf(DistanceBufferType.class)));
+
+    final DistanceBufferType distanceBufferType =
+        (DistanceBufferType) filter.getSpatialOps().getValue();
+    assertThat(distanceBufferType.getGeometry().getValue(), is(instanceOf(PointType.class)));
+
+    final PointType pointType = (PointType) distanceBufferType.getGeometry().getValue();
+    assertThat(pointType.getCoordinates().getValue(), is("30.0,-10.0"));
+  }
+
+  @Test
+  public void testPolygonLatLonOrder() {
+    final WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
+
+    final FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
+    assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
+
+    final BinarySpatialOpType binarySpatialOpType =
+        (BinarySpatialOpType) filter.getSpatialOps().getValue();
+    assertThat(binarySpatialOpType.getGeometry().getValue(), is(instanceOf(PolygonType.class)));
+
+    final PolygonType polygonType = (PolygonType) binarySpatialOpType.getGeometry().getValue();
+    assertThat(
+        polygonType.getExterior().getValue().getRing().getValue(),
+        is(instanceOf(LinearRingType.class)));
+
+    final LinearRingType linearRingType =
+        (LinearRingType) polygonType.getExterior().getValue().getRing().getValue();
+    assertThat(
+        linearRingType.getCoordinates().getValue(),
+        is("-10.0,40.0 30.0,40.0 30.0,10.0 -10.0,10.0 -10.0,40.0"));
+  }
+
+  @Test
+  public void testPolygonLonLatOrder() {
+    final WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LON_LAT_ORDER);
+
+    final FilterType filter = delegate.intersects(Metacard.ANY_GEO, POLYGON);
+    assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
+
+    final BinarySpatialOpType binarySpatialOpType =
+        (BinarySpatialOpType) filter.getSpatialOps().getValue();
+    assertThat(binarySpatialOpType.getGeometry().getValue(), is(instanceOf(PolygonType.class)));
+
+    final PolygonType polygonType = (PolygonType) binarySpatialOpType.getGeometry().getValue();
+    assertThat(
+        polygonType.getExterior().getValue().getRing().getValue(),
+        is(instanceOf(LinearRingType.class)));
+
+    final LinearRingType linearRingType =
+        (LinearRingType) polygonType.getExterior().getValue().getRing().getValue();
+    assertThat(
+        linearRingType.getCoordinates().getValue(),
+        is("40.0,-10.0 40.0,30.0 10.0,30.0 10.0,-10.0 40.0,-10.0"));
+  }
+
+  @Test
+  public void testLineStringLatLonOrder() {
+    final WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LAT_LON_ORDER);
+
+    final FilterType filter = delegate.intersects(Metacard.ANY_GEO, LINESTRING);
+    assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
+
+    final BinarySpatialOpType binarySpatialOpType =
+        (BinarySpatialOpType) filter.getSpatialOps().getValue();
+    assertThat(binarySpatialOpType.getGeometry().getValue(), is(instanceOf(LineStringType.class)));
+
+    final LineStringType lineStringType =
+        (LineStringType) binarySpatialOpType.getGeometry().getValue();
+    assertThat(lineStringType.getCoordinates().getValue(), is("10.0,30.0 30.0,10.0 40.0,50.0"));
+  }
+
+  @Test
+  public void testLineStringLonLatOrder() {
+    final WfsFilterDelegate delegate =
+        setupFilterDelegate(SPATIAL_OPERATORS.INTERSECTS.getValue(), LON_LAT_ORDER);
+
+    final FilterType filter = delegate.intersects(Metacard.ANY_GEO, LINESTRING);
+    assertThat(filter.getSpatialOps().getValue(), is(instanceOf(BinarySpatialOpType.class)));
+
+    final BinarySpatialOpType binarySpatialOpType =
+        (BinarySpatialOpType) filter.getSpatialOps().getValue();
+    assertThat(binarySpatialOpType.getGeometry().getValue(), is(instanceOf(LineStringType.class)));
+
+    final LineStringType lineStringType =
+        (LineStringType) binarySpatialOpType.getGeometry().getValue();
+    assertThat(lineStringType.getCoordinates().getValue(), is("30.0,10.0 10.0,30.0 50.0,40.0"));
   }
 
   private JAXBElement<FilterType> getFilterTypeJaxbElement(FilterType filterType) {
@@ -1738,7 +1923,7 @@ public class WfsFilterDelegateTest {
   }
 
   private WfsFilterDelegate createDelegate() {
-    return new WfsFilterDelegate(featureMetacardType, SUPPORTED_GEO);
+    return new WfsFilterDelegate(featureMetacardType, SUPPORTED_GEO, LAT_LON_ORDER);
   }
 
   private WfsFilterDelegate createIntegerDelegate() {
@@ -1772,7 +1957,7 @@ public class WfsFilterDelegateTest {
     assertThat(filter.getSpatialOps().getValue(), is(instanceOf(DistanceBufferType.class)));
   }
 
-  private WfsFilterDelegate setupFilterDelegate(String spatialOpType) {
+  private WfsFilterDelegate setupFilterDelegate(String spatialOpType, String coordinateOrder) {
     List<String> gmlProps = new ArrayList<>();
     gmlProps.add(MOCK_GEOM);
 
@@ -1783,7 +1968,7 @@ public class WfsFilterDelegateTest {
                 MOCK_GEOM, MOCK_GEOM, true, false, false, false, BasicTypes.STRING_TYPE));
 
     List<String> supportedGeo = Collections.singletonList(spatialOpType);
-    return new WfsFilterDelegate(featureMetacardType, supportedGeo);
+    return new WfsFilterDelegate(featureMetacardType, supportedGeo, coordinateOrder);
   }
 
   private void whenTextualStringType() {


### PR DESCRIPTION
#### What does this PR do?
Updates the WFS 1.1.0 `FilterDelegate` to use the configured coordinate order of its corresponding source to determine the coordinate order to use when it constructs the query.

#### Who is reviewing it?
@Corey-Collins 
@samuelechu 
@leo-sakh 
@glenhein 

#### Select relevant component teams: 
@codice/io 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@jlcsmith

#### How should this be tested?
1. Run `log:set info org.apache.cxf` and `log:set warn org.apache.camel`.
2. Create a WFS 1.1.0 source with the URL http://services.azgs.az.gov/ArcGIS/services/aasggeothermal/AZWellLogs/MapServer/WFSServer
3. Run various `anyGeo` queries against the source, using `Line`, `Polygon`, `Point-Radius`, and `Bounding Box`.
a. When you run a query there will be a `GetFeature` XML blob printed in the logs that contains the geospatial query. Use this to verify each query's correctness.
b. For each query, run it as both `Lat/Lon` and `Lon/Lat` and verify the outgoing `GetFeature` XML has the right coordinate order in both cases. Check the `Coordinate Order` in your WFS source's configuration, then run your query and verify that the coordinate order in the `GetFeature` matches. Change the `Coordinate Order` in the source configuration, rerun the same query, and verify the coordinate order in the `GetFeature` changed appropriately.

#### What are the relevant tickets?
Fixes: #4811 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.