### PR TITLE
[2.13.x] DDF-04816 Create stopkey file in script directory

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr
@@ -28,6 +28,7 @@ SCRIPTDIR=$(dirname $0)
 HOME_DIR=$(cd "${SCRIPTDIR}/.."; pwd -P)
 GET=${SCRIPTDIR}/get_property
 SOLR_EXEC=${HOME_DIR}/solr/bin/solr
+STOPKEY_FILE=${SCRIPTDIR}/SOLR_STOPKEY
 
 # Read port from custom.system.properties file
 SOLR_PORT=$($GET "solr.http.port")
@@ -56,7 +57,7 @@ generate_stopkey() {
     # The urandom stream does not spit out valid UTF-8 characters.
     # Tell Mac OS to not interpret the bytes as charcters with LC_ALL=C
     export STOP_KEY=`cat /dev/urandom | env LC_CTYPE=C tr -dc a-z0-9 | head -c 8`
-    echo $STOP_KEY >& STOPKEY
+    echo $STOP_KEY >& ${STOPKEY_FILE}
 }
 
 
@@ -73,9 +74,9 @@ start_solr() {
 
 stop_solr() {
 
-	if [ -f STOPKEY ]; then
-	    export STOP_KEY=`cat STOPKEY`;
-	    rm STOPKEY;
+	if [ -f "${STOPKEY_FILE}" ]; then
+	    export STOP_KEY=`cat ${STOPKEY_FILE}`;
+	    rm ${STOPKEY_FILE};
 	fi
     $SOLR_EXEC stop -p $SOLR_PORT;
 


### PR DESCRIPTION
#### What does this PR do?
Ensure that  the Solr stopkey file is generated in the correct directory for *NIX systems.

#### Who is reviewing it? 
@austinsteffes @brendan-hofmann @brjeter @tyler30clemens 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@vinamartin 
@brendan-hofmann 
@brjeter 

#### How should this be tested?
Can only be testing on *NIX systems.
1. Build and unzip DDF distro
2. Start DDF from OUTSIDE the bin directory. For example `ddf-distro/bin/ddf`
3. Check that the SOLR_STOPKEY file exists in the bin directory  `ddf-distro/bin` and NOT in the directory where the command was run.

#### What are the relevant tickets?
Fixes: #4816

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
