### PR TITLE
DDF-4826 Broaden scope of karaf deployer blueprint policy

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -200,7 +200,7 @@ grant codeBase "file:/platform-osgi-configadmin" {
 }
 
 grant codeBase "file:/org.apache.karaf.deployer.blueprint/org.apache.karaf.deployer.kar" {
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}definitions${/}-", "read";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}-", "read";
 }
 
 grant codeBase "file:/org.apache.karaf.jaas.modules" {


### PR DESCRIPTION
Increased scope from ddfhome/etc/definitions to ddfhome/etc

#### What does this PR do?
Broaden scope of karaf deployer blueprint policy
#### Who is reviewing it? 
@stustison @jordanwilking @bellcc @tbatie @glenhein 
#### Select relevant component teams: 
@codice/security 

#### How should this be tested?
- Ensure CI Passes
- Build and install locally and ensure it installs correctly. Insure config files inside of `<DDF_HOME>/etc` are read successfully. Add Config to test if none exist.

#### What are the relevant tickets?
Fixes: #4826

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [NA] Documentation Updated
- [NA] Update / Add Threat Dragon models
  - Deployer must be able to read all configurations under ETC
- [NA] Update / Add Unit Tests
- [NA] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
