### PR TITLE
[2.13.x] DDF-4826 Broaden scope of karaf deployer blueprint policy

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -195,7 +195,7 @@ grant codeBase "file:/platform-osgi-configadmin" {
 }
 
 grant codeBase "file:/org.apache.karaf.deployer.blueprint/org.apache.karaf.deployer.kar" {
-    permission java.io.FilePermission "${ddf.home.perm}etc${/}definitions${/}-", "read";
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}-", "read";
 }
 
 grant codeBase "file:/org.apache.karaf.jaas.modules" {


### PR DESCRIPTION
#### What does this PR do?
When starting/restarting the system, the org.apache.karaf.deployer.blueprint asks for permission to read all files recursively in the etc directory: `BlueprintDeploymentListener AccessControlException jave.io.FilePermission unable to parse deployed file <DDF_HOME>\etc\....config`. This PR makes it so that permission is granted to read all files in the etc directory. 

#### Who is reviewing it? 
@austinsteffes 
@ahoffer 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter 
@emmberk 
@stustison 

#### How should this be tested?
1. Install DDF through UI and restart system and verify no AccessControlExceptions
2. Manually restart the system and verify no AccessControlExceptions

#### What are the relevant tickets?
For GH Issues:
Work for: #4826  

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
