### PR TITLE
DDF-4828 fix Incorrect buffer for Polygons

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.base.line.js
@@ -76,6 +76,23 @@ class GeometryRenderView extends Marionette.View {
     }
   }
 
+  constructDottedLinePrimitive = coordinates => {
+    const color = this.model.get('color')
+
+    return {
+      width: 4,
+      material: Cesium.Material.fromType('PolylineDash', {
+        color: color
+          ? Cesium.Color.fromCssColorString(color)
+          : Cesium.Color.KHAKI,
+        dashLength: 16.0,
+        dashPattern: 7.0,
+      }),
+      id: 'userDrawing',
+      positions: Cesium.Cartesian3.fromDegreesArray(_.flatten(coordinates)),
+    }
+  }
+
   listenForCameraChange = () => {
     this.map.scene.camera.moveStart.addEventListener(
       this.handleCameraMoveStart,


### PR DESCRIPTION
#### What does this PR do?
Currently polygons are being buffered as linestrings causing the buffer the extend both inward/outward. This gives the buffer the appearance of being split between the two directions, and this can also result in inner shapes being created within the polygon that appear to be "holes" in the search area
With this fix, the polygon will only buffer outward and another polygon with dotted lines will be added to represent the originally drawn shape (demo video below)
#### Who is reviewing it? 
@Bdthomson @hayleynorton @lamhuy 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@djblue 
#### How should this be tested?
- build / install / run
- ingest records with location data
- create several `anyGeo` searches with different polygons and verify that the correct results 
- repeat many times with different shapes/buffers on both 2d/3d maps
#### Any background context you want to provide?
#### What are the relevant tickets?
For GH Issues:
Fixes: #4828 

#### Screenshots
demo video:
[buffer-2d-3d.mp4.zip](https://github.com/codice/ddf/files/3184222/buffer-2d-3d.mp4.zip)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
