### PR TITLE
DDF-4832 Several configuration bug fixes (do not squash)

### DIFF
--- a/platform/admin/admin-configuration-configupdater/src/main/java/org/codice/ddf/admin/configuration/ConfigurationUpdater.java
+++ b/platform/admin/admin-configuration-configupdater/src/main/java/org/codice/ddf/admin/configuration/ConfigurationUpdater.java
@@ -155,11 +155,11 @@ public class ConfigurationUpdater implements ConfigurationPersistencePlugin {
    * will be updated on disk if necessary.
    */
   private void doHandleStore(ConfigurationContext context) throws IOException {
-    String pid = context.getServicePid();
-    File fileFromConfigAdmin = context.getConfigFile();
+    final String pid = context.getServicePid();
+    final File fileFromConfigAdmin = context.getConfigFile();
 
-    CachedConfigData cachedConfigData = pidDataMap.get(pid);
-    File fileFromCache = (cachedConfigData != null) ? cachedConfigData.getFelixFile() : null;
+    final CachedConfigData cachedConfigData = pidDataMap.get(pid);
+    final File fileFromCache = (cachedConfigData != null) ? cachedConfigData.getFelixFile() : null;
 
     if (fileFromCache == null && fileFromConfigAdmin == null) {
       // This config doesn't have an etc file, so we ignore this case (1)
@@ -167,16 +167,26 @@ public class ConfigurationUpdater implements ConfigurationPersistencePlugin {
       return;
     }
 
-    String appropriatePid =
+    final String appropriatePid =
         (context.getFactoryPid() == null) ? context.getServicePid() : context.getFactoryPid();
 
     if (fileFromCache == null) {
       // An etc config file was just dropped and we're seeing it for the first time (2)
-      LOGGER.debug("Tracking pid {}", pid);
-      CachedConfigData createdConfigData = new CachedConfigData(context);
-      pidDataMap.put(pid, createdConfigData);
+      final CachedConfigData createdConfigData = new CachedConfigData(context);
       processUpdate(
           appropriatePid, fileFromConfigAdmin, context.getSanitizedProperties(), createdConfigData);
+      if (fileFromConfigAdmin.exists()) {
+        LOGGER.debug(
+            "Tracking pid [{}] for installed configuration [{}]",
+            pid,
+            fileFromConfigAdmin.getAbsolutePath());
+        pidDataMap.put(pid, createdConfigData);
+      } else {
+        LOGGER.debug(
+            "Associated file [{}] for pid [{}] did not exist, will not track",
+            fileFromConfigAdmin.getAbsolutePath(),
+            pid);
+      }
       return;
     }
 

--- a/platform/admin/admin-configuration-configupdater/src/main/java/org/codice/ddf/admin/configuration/ConfigurationUpdater.java
+++ b/platform/admin/admin-configuration-configupdater/src/main/java/org/codice/ddf/admin/configuration/ConfigurationUpdater.java
@@ -201,9 +201,11 @@ public class ConfigurationUpdater implements ConfigurationPersistencePlugin {
       }
       if (fileFromCache.exists()) {
         // The felix file prop was removed, which we can revert if the file exists (3)
-        LOGGER.info(
-            "{} has been illegally removed, reverting to [{}]", FELIX_FILENAME, fileFromCache);
-        context.setProperty(FELIX_FILENAME, fileFromCache.getAbsolutePath());
+        // Should revert to URI form since Felix's ConfigInstaller uses that as a key
+        final String revertedFilename = fileFromCache.getAbsoluteFile().toURI().toString();
+        LOGGER.debug(
+            "{} has been illegally removed, reverting to [{}]", FELIX_FILENAME, revertedFilename);
+        context.setProperty(FELIX_FILENAME, revertedFilename);
         processUpdate(
             appropriatePid, fileFromCache, context.getSanitizedProperties(), cachedConfigData);
         return;

--- a/platform/admin/admin-configuration-configupdater/src/test/java/org/codice/ddf/admin/configuration/ConfigurationUpdaterTest.java
+++ b/platform/admin/admin-configuration-configupdater/src/test/java/org/codice/ddf/admin/configuration/ConfigurationUpdaterTest.java
@@ -241,7 +241,8 @@ public class ConfigurationUpdaterTest {
     installer.initialize(configs);
     installer.handleStore(mockContext);
 
-    verify(mockContext).setProperty(eq(FELIX_FILENAME), eq(fileB.getAbsolutePath()));
+    verify(mockContext)
+        .setProperty(eq(FELIX_FILENAME), eq(fileB.getAbsoluteFile().toURI().toString()));
   }
 
   @Test(expected = IllegalStateException.class)

--- a/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
+++ b/platform/admin/core/admin-core-impl/src/main/java/org/codice/ddf/admin/core/impl/AdminConsoleService.java
@@ -88,6 +88,8 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
 
   private static final String ILLEGAL_PID_MESSAGE = "Argument pid cannot be null or empty";
 
+  private static final String ILLEGAL_TABLE_MESSAGE = "Argument configurationTable cannot be null";
+
   /**
    * Constructor for use in unit tests. Needed for testing listServices() and getService().
    *
@@ -382,40 +384,37 @@ public class AdminConsoleService extends StandardMBean implements AdminConsoleSe
       throw loggedException(ILLEGAL_PID_MESSAGE);
     }
     if (configurationTable == null) {
-      throw loggedException("Argument configurationTable cannot be null");
+      throw loggedException(ILLEGAL_TABLE_MESSAGE);
     }
 
-    Configuration config = configurationAdmin.getConfiguration(pid, location);
-
+    final Configuration config = configurationAdmin.getConfiguration(pid, location);
     if (isPermittedToViewService(config.getPid())) {
       final Metatype metatype = configurationAdminImpl.findMetatypeForConfig(config);
-      List<Map.Entry<String, Object>> configEntries = new ArrayList<>();
-
-      CollectionUtils.addAll(configEntries, configurationTable.entrySet().iterator());
-
       if (metatype == null) {
         throw loggedException("Could not find metatype for " + pid);
       }
-      // now we have to filter each property based on its cardinality
+
+      final List<Map.Entry<String, Object>> configEntries = new ArrayList<>();
+      CollectionUtils.addAll(configEntries, configurationTable.entrySet().iterator());
       CollectionUtils.transform(
           configEntries, new CardinalityTransformer(metatype.getAttributeDefinitions(), pid));
 
-      Dictionary<String, Object> newConfigProperties = new Hashtable<>();
+      final Dictionary<String, Object> configProperties = config.getProperties();
+      final Dictionary<String, Object> newConfigProperties =
+          (configProperties != null) ? configProperties : new Hashtable<>();
 
       // If the configuration entry is a password, and its updated configuration value is
       // "password", do not update the password.
       for (Map.Entry<String, Object> configEntry : configEntries) {
-        String configEntryKey = configEntry.getKey();
+        final String configEntryKey = configEntry.getKey();
         Object configEntryValue =
             sanitizeUIConfiguration(pid, configEntryKey, configEntry.getValue());
         if (configEntryValue.equals("password")) {
           for (Map<String, Object> metatypeProperties : metatype.getAttributeDefinitions()) {
             if (metatypeProperties.get("id").equals(configEntry.getKey())
-                && AttributeDefinition.PASSWORD == (Integer) metatypeProperties.get("type")) {
-              Dictionary<String, Object> configProperties = config.getProperties();
-              if (configProperties != null) {
-                configEntryValue = configProperties.get(configEntryKey);
-              }
+                && AttributeDefinition.PASSWORD == (Integer) metatypeProperties.get("type")
+                && configProperties != null) {
+              configEntryValue = configProperties.get(configEntryKey);
               break;
             }
           }

--- a/platform/osgi/platform-osgi-configadmin/src/main/java/org/codice/felix/cm/file/ConfigurationContextImpl.java
+++ b/platform/osgi/platform-osgi-configadmin/src/main/java/org/codice/felix/cm/file/ConfigurationContextImpl.java
@@ -15,6 +15,7 @@ package org.codice.felix.cm.file;
 
 import static java.lang.String.format;
 import static org.osgi.framework.Constants.SERVICE_PID;
+import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_BUNDLELOCATION;
 import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_FACTORYPID;
 
 import java.io.File;
@@ -71,6 +72,7 @@ public class ConfigurationContextImpl implements ConfigurationContext {
           Arrays.asList(
               SERVICE_PID,
               SERVICE_FACTORYPID,
+              SERVICE_BUNDLELOCATION,
               FELIX_FILENAME,
               FELIX_NEW_CONFIG,
               SERVICE_FACTORY_PIDLIST,
@@ -101,9 +103,14 @@ public class ConfigurationContextImpl implements ConfigurationContext {
 
     Dictionary<String, Object> propsCopy = copyDictionary(props);
 
-    // No guarantee these are in the props dictionary so do not assign from the removal
+    // No guarantee these are in the props dictionary so do not assign from the removal, just parse
+    // from the pid argument
     propsCopy.remove(SERVICE_PID);
     propsCopy.remove(SERVICE_FACTORYPID);
+
+    // Props we don't need to keep around for any particular reason, but don't want in the sanitized
+    // data
+    propsCopy.remove(SERVICE_BUNDLELOCATION);
     propsCopy.remove(PROPERTY_REVISION);
 
     this.servicePid = pid;
@@ -165,7 +172,7 @@ public class ConfigurationContextImpl implements ConfigurationContext {
 
     ConfigurationContextImpl context = (ConfigurationContextImpl) o;
 
-    return servicePid != null ? servicePid.equals(context.servicePid) : context.servicePid == null;
+    return Objects.equals(servicePid, context.servicePid);
   }
 
   // Contexts can be used in a set

--- a/platform/osgi/platform-osgi-configadmin/src/test/java/org/codice/felix/cm/file/ConfigurationContextImplTest.java
+++ b/platform/osgi/platform-osgi-configadmin/src/test/java/org/codice/felix/cm/file/ConfigurationContextImplTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.osgi.framework.Constants.SERVICE_PID;
+import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_BUNDLELOCATION;
 import static org.osgi.service.cm.ConfigurationAdmin.SERVICE_FACTORYPID;
 
 import java.io.File;
@@ -238,6 +239,7 @@ public class ConfigurationContextImplTest {
   public void testGetSanitizedData() {
     testProps.put(SERVICE_PID, TEST_PID);
     testProps.put(SERVICE_FACTORYPID, TEST_PID);
+    testProps.put(SERVICE_BUNDLELOCATION, TEST_PID);
     testProps.put(FELIX_FILENAME, temporaryFile.toURI());
     testProps.put(FELIX_NEW_CONFIG, true);
     testProps.put(SERVICE_FACTORY_PIDLIST, new ArrayList<>());


### PR DESCRIPTION
**Do not squash the commits - they have been logically separated by issue & resolution**
#### What does this PR do?
Fixes separate root causes that are combining to form strange symptoms, such as the automatic duplication of source configurations and the leaking of internal properties into etc files. 

#### Who is reviewing it? 
##### Required
@mojogitoverhere 
@gjvera 

##### Optional
@Bdthomson 
@andrewzimmer 
@paouelle
@brjeter

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@troymohl

#### How should this be tested?
1. Verify the reproduction instructions (https://github.com/codice/ddf/issues/4832) no longer yield duplicate configurations. 
1. Also verify that no `service.bundleLocation` properties gets written to etc files after an update via the Admin UI. 

#### What are the relevant tickets?
Fixes: #4832 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
