### PR TITLE
DDF-04584 Suppress stopkey file error message on Windows

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr.bat
@@ -45,14 +45,9 @@ IF "%COMMAND%"=="start" (
 
 
 IF "%COMMAND%"=="stop" (
-REM Github DDF issue 4584
-REM Suppress error message about missing STOPKEY file. The script that calls ddfsolr.bat
-REM first calls stop to shutdown any current running Solr instances on the designated port.
-REM Because stop is called before start, there will never be a STOPKEY file
-REM and in those cases the missing file message is spurious.
-   SET /P STOP_KEY=<%STOPKEY_FILE% > nul 2> nul
+   IF EXIST %STOPKEY_FILE% SET /P STOP_KEY=<%STOPKEY_FILE%
    CALL %SOLR_EXEC% stop -p !solr.http.port!
-   DEL %STOPKEY_FILE%
+   IF EXIST %STOPKEY_FILE% DEL %STOPKEY_FILE%
 )
 
 EXIT /B

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr.bat
@@ -45,6 +45,7 @@ IF "%COMMAND%"=="start" (
 
 
 IF "%COMMAND%"=="stop" (
+REM Github DDF issue 4584
 REM Suppress error message about missing STOPKEY file. The script that calls ddfsolr.bat
 REM first calls stop to shutdown any current running Solr instances on the designated port.
 REM Because stop is called before start, there will never be a STOPKEY file

--- a/distribution/ddf-common/src/main/resources/bin/ddfsolr.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddfsolr.bat
@@ -45,7 +45,11 @@ IF "%COMMAND%"=="start" (
 
 
 IF "%COMMAND%"=="stop" (
-   SET /P STOP_KEY=<%STOPKEY_FILE%
+REM Suppress error message about missing STOPKEY file. The script that calls ddfsolr.bat
+REM first calls stop to shutdown any current running Solr instances on the designated port.
+REM Because stop is called before start, there will never be a STOPKEY file
+REM and in those cases the missing file message is spurious.
+   SET /P STOP_KEY=<%STOPKEY_FILE% > nul 2> nul
    CALL %SOLR_EXEC% stop -p !solr.http.port!
    DEL %STOPKEY_FILE%
 )


### PR DESCRIPTION
#### What does this PR do?
Suppress error message about missing STOPKEY file. The script that calls ddfsolr.bat first calls stop to shutdown any current running Solr instances on the designated port. Because stop is called before start, there will never be a STOPKEY file and in those cases the missing file message is spurious.

#### Who is reviewing it? 
@nsuvarna @brjeter @tyler30clemens @austinsteffes 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann
@brjeter
@mcalcote
@rzwiefel

#### How should this be tested?
Can only be tested on Window -- Windows specific change.
When starting DDF, the error message "The system cannot find the specified file" should no longer be printed to the terminal.

#### What are the relevant tickets?

Fixes: #4584

#### Screenshots
![image](https://user-images.githubusercontent.com/133284/58040062-55fb1e00-7ae9-11e9-8f66-cd29662273c2.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
