### PR TITLE
DDF-04836 Prevents double GZIP of Intrigue backend JSON APIs

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/SparkServlet.java
@@ -124,6 +124,20 @@ public class SparkServlet extends HttpServlet {
 
     after(
         (request, response) -> {
+          if (response.raw().containsHeader("Content-Encoding")) {
+            return;
+          }
+
+          String acceptEncoding = request.headers("Accept-Encoding");
+
+          boolean shouldGzip =
+              StringUtils.isNotBlank(acceptEncoding)
+                  && acceptEncoding.toLowerCase().contains("gzip");
+
+          if (!shouldGzip) {
+            return;
+          }
+
           response.header("Content-Encoding", "gzip");
         });
   }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
@@ -14,7 +14,6 @@
 package org.codice.ddf.catalog.ui.query;
 
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static spark.Spark.after;
 import static spark.Spark.before;
 import static spark.Spark.exception;
 import static spark.Spark.get;
@@ -106,8 +105,6 @@ public class QueryApplication implements SparkApplication, Function {
           CqlQueryResponse cqlQueryResponse = util.executeCqlQuery(cqlRequest);
           return GSON.toJson(cqlQueryResponse);
         });
-
-    after("/cql", (req, res) -> res.header("Content-Encoding", "gzip"));
 
     post("/cql/transform/:transformerId", cqlTransformHandler, GSON::toJson);
 


### PR DESCRIPTION
#### What does this PR do?

Selectively gzips request based on accept headers and previous content encoding.

#### Who is reviewing it? 

@rzwiefel 
@andrewkfiedler 
@tbatie 
@bellcc 
@gjvera 
@mojogitoverhere 

#### How should this be tested?

- `mvn clean install` in `catalog/ui/catalog-ui-search`, quick build the rest
- disable web sockets in admin ui
- ensure query work in intrigue

#### Any background context you want to provide?

#4837 adds GZIP, but some endpoints were already gzipping their content. This resulted in gzipping the content twice which the browser cannot decode. This PR should disable the second round of gzipping.

#### What are the relevant tickets?

For GH Issues:
Fixes: #4836
