### PR TITLE
DDF-4850 Fix issue where dropdown input will prevent the user from using the wildcard (*) operator

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/select/filterHelper.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/select/filterHelper.js
@@ -14,30 +14,37 @@
  **/
 function matchesFilter(filterValue, str, matchcase) {
   filterValue = getAppropriateString(filterValue, matchcase)
+  filterValue = escapeRegExp(filterValue)
+  str = escapeRegExp(str)
   const reg = new RegExp('\\b' + filterValue + '.*')
   if (getAppropriateString(str, matchcase).match(reg) !== null) {
     return true
   }
-  if (
-    wordStartsWithFilter(getWords(str, matchcase), filterValue) === undefined
-  ) {
-    return false
-  }
-  return true
+  return (
+    wordStartsWithFilter(getWords(str, matchcase), filterValue) !== undefined
+  )
 }
+
 function getAppropriateString(str, matchcase) {
   str = str.toString()
   return matchcase === true ? str : str.toLowerCase()
 }
+
 function getWords(str, matchcase) {
   //Handle camelcase
   str = str.replace(/([A-Z])/g, ' $1')
   str = getAppropriateString(str, matchcase)
   //Handle dashes, dots, and spaces
-  return str.split(/[-\.\s]+/)
+  return str.split(/[-.\s]+/)
 }
+
 function wordStartsWithFilter(words, filter) {
   return words.find(word => word.indexOf(filter) === 0)
+}
+
+// Note that dot "." cannot be escaped since it's one of the attribute name delimiters AND a regex symbol
+function escapeRegExp(string) {
+  return string.replace(/[*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
 }
 
 export { matchesFilter, getAppropriateString }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/select/filterHelper.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/select/filterHelper.spec.js
@@ -16,41 +16,50 @@ import { expect } from 'chai'
 
 const filterHelper = require('./filterHelper.js')
 
-function testAllSubstrings(testString, str, matchcase, expectation) {
-  let i
-  for (i = 0; i < testString.length; i++) {
-    const filterValue = testString.substring(0, i)
-    expect(filterHelper.matchesFilter(filterValue, str, matchcase)).to.equal(
-      expectation
-    )
+function testAllSubstrings(
+  testFilterString,
+  stringToEval,
+  matchcase,
+  expectation
+) {
+  for (let i = 0; i < testFilterString.length; i++) {
+    const filterValue = testFilterString.substring(0, i)
+    expect(
+      filterHelper.matchesFilter(filterValue, stringToEval, matchcase)
+    ).to.equal(expectation)
   }
 }
 
-function testWholeStrings(testString, str, matchcase, expectation) {
-  expect(filterHelper.matchesFilter(testString, str, matchcase)).to.equal(
-    expectation
-  )
+function testWholeStrings(
+  testFilterString,
+  stringToEval,
+  matchcase,
+  expectation
+) {
+  expect(
+    filterHelper.matchesFilter(testFilterString, stringToEval, matchcase)
+  ).to.equal(expectation)
 }
 
-describe('filter attrs', () => {
+describe('filter helper functions', () => {
   it('filter anyText', () => {
-    const str = 'anyText'
+    const stringToEval = 'anyText'
     const matchcase = false
 
     const positiveTestStrings = ['text', 'any', 'anytext', 'ANYTEXT', 'aNyTeXt']
     const negativeTestStrings = ['test', 'anyG', 'any text', 'anyText ', 'az']
 
-    positiveTestStrings.forEach(string => {
-      testAllSubstrings(string, str, matchcase, true)
+    positiveTestStrings.forEach(testFilterString => {
+      testAllSubstrings(testFilterString, stringToEval, matchcase, true)
     })
 
-    negativeTestStrings.forEach(string => {
-      testWholeStrings(string, str, matchcase, false)
+    negativeTestStrings.forEach(testFilterString => {
+      testWholeStrings(testFilterString, stringToEval, matchcase, false)
     })
   })
 
   it('filter aString.WithDots-andDashes', () => {
-    const str = 'aString.WithDots-andDashes'
+    const stringToEval = 'aString.WithDots-andDashes'
     const matchcase = false
 
     const positiveTestStrings = [
@@ -66,31 +75,31 @@ describe('filter attrs', () => {
     ]
     const negativeTestStrings = ['az', 'thdo', 'ndDash', 'aString-']
 
-    positiveTestStrings.forEach(string => {
-      testAllSubstrings(string, str, matchcase, true)
+    positiveTestStrings.forEach(testFilterString => {
+      testAllSubstrings(testFilterString, stringToEval, matchcase, true)
     })
-    negativeTestStrings.forEach(string => {
-      testWholeStrings(string, str, matchcase, false)
+    negativeTestStrings.forEach(testFilterString => {
+      testWholeStrings(testFilterString, stringToEval, matchcase, false)
     })
   })
 
   it('filter ALLCAPSSTRING', () => {
-    const str = 'ALLCAPSSTRING'
+    const stringToEval = 'ALLCAPSSTRING'
     const matchcase = false
 
     const positiveTestStrings = ['ALLCAPSSTRING', 'allcapsstring']
     const negativeTestStrings = ['z', 'CA', 'STR', 'ING']
 
-    positiveTestStrings.forEach(string => {
-      testAllSubstrings(string, str, matchcase, true)
+    positiveTestStrings.forEach(testFilterString => {
+      testAllSubstrings(testFilterString, stringToEval, matchcase, true)
     })
-    negativeTestStrings.forEach(string => {
-      testWholeStrings(string, str, matchcase, false)
+    negativeTestStrings.forEach(testFilterString => {
+      testWholeStrings(testFilterString, stringToEval, matchcase, false)
     })
   })
 
   it('filter matches case', () => {
-    const str = 'aCamelCasedString'
+    const stringToEval = 'aCamelCasedString'
     const matchcase = true
 
     const positiveTestStrings = [
@@ -108,16 +117,16 @@ describe('filter attrs', () => {
       'acamelcasedstring',
     ]
 
-    positiveTestStrings.forEach(string => {
-      testAllSubstrings(string, str, matchcase, true)
+    positiveTestStrings.forEach(testFilterString => {
+      testAllSubstrings(testFilterString, stringToEval, matchcase, true)
     })
-    negativeTestStrings.forEach(string => {
-      testWholeStrings(string, str, matchcase, false)
+    negativeTestStrings.forEach(testFilterString => {
+      testWholeStrings(testFilterString, stringToEval, matchcase, false)
     })
   })
 
-  it('filter spaces', () => {
-    const str = 'A few strings divided by spaces'
+  it('can filter spaces', () => {
+    const stringToEval = 'A few strings divided by spaces'
     const matchcase = false
 
     const positiveTestStrings = [
@@ -135,11 +144,33 @@ describe('filter attrs', () => {
       'rings',
     ]
 
-    positiveTestStrings.forEach(string => {
-      testAllSubstrings(string, str, matchcase, true)
+    positiveTestStrings.forEach(testFilterString => {
+      testAllSubstrings(testFilterString, stringToEval, matchcase, true)
     })
-    negativeTestStrings.forEach(string => {
-      testWholeStrings(string, str, matchcase, false)
+    negativeTestStrings.forEach(testFilterString => {
+      testWholeStrings(testFilterString, stringToEval, matchcase, false)
+    })
+  })
+
+  // Note that dot "." cannot be escaped since it's one of the attribute name delimiters AND a regex symbol
+  it('treat regex literals no differently except dot', () => {
+    const regexSymbols = [
+      '\\',
+      '*',
+      '+',
+      '^',
+      '$',
+      '?',
+      '(',
+      ')',
+      '[',
+      ']',
+      '|',
+      '{',
+      '}',
+    ]
+    regexSymbols.forEach(symbol => {
+      testWholeStrings(symbol, symbol, false, true)
     })
   })
 })


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where the dropdown input will not accept the wildcard symbol or display it as an autocomplete option. If an attribute is configured to use faceting, this can be reproduced. 

#### Who is reviewing it? 
@mojogitoverhere 
@gjvera 
@willwill96 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@djblue

#### How should this be tested?
Refer to the reproduction instructions from the issue (#4850). 

#### Any background context you want to provide?
Faceting is a feature that allows attributes to be configured to support "autocomplete". This is done by querying the catalog for all occurrences of the attribute and generating a list of unique results that the user may pick from. 

#### What are the relevant tickets?
Fixes: #4850 

#### Screenshots
**How it should behave**
![How it should behave](https://user-images.githubusercontent.com/7215534/58057370-7773fe00-7b19-11e9-8411-30fb26ca49b2.png)

**How it actually behaves**
![How it actually behaves](https://user-images.githubusercontent.com/7215534/58057387-835fc000-7b19-11e9-900d-6166b9ae71fd.png)

**Behavior with the fix**
![Behavior with fix](https://user-images.githubusercontent.com/7215534/58057537-126cd800-7b1a-11e9-9ede-ddc5df2a46f7.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
