### PR TITLE
DDF-4845 Adding a Did you mean re-query option in Results Panel

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -116,6 +116,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
 
   public static final String SHOWING_RESULTS_FOR_KEY = "showingResultsFor";
 
+  public static final String DID_YOU_MEAN_KEY = "didYouMean";
+
   public static final String SPELLCHECK_KEY = "spellcheck";
 
   public static final int GET_BY_ID_LIMIT = 100;
@@ -254,6 +256,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       }
 
       if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
+        responseProps.put(DID_YOU_MEAN_KEY, (Serializable) getSearchTermFieldValues(solrResponse));
         query.set("q", findQueryToResend(query, solrResponse));
         solrResponse = client.query(query, METHOD.POST);
         docs = solrResponse.getResults();

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -306,7 +306,6 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
 
   private boolean solrSpellcheckHasResults(QueryResponse solrResponse) {
     return solrResponse.getSpellCheckResponse() != null
-        && solrResponse.getResults().size() == 0
         && CollectionUtils.isNotEmpty(solrResponse.getSpellCheckResponse().getCollatedResults());
   }
 

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -230,12 +230,6 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         solrResponse = client.query(query, METHOD.POST);
       }
 
-      SolrDocumentList docs = solrResponse.getResults();
-      if (docs != null) {
-        totalHits = docs.getNumFound();
-        addDocsToResults(docs, results);
-      }
-
       SuggesterResponse suggesterResponse = solrResponse.getSuggesterResponse();
 
       if (suggesterResponse != null) {
@@ -253,6 +247,12 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
                 .collect(Collectors.toList());
 
         responseProps.put(SUGGESTION_RESULT_KEY, (Serializable) suggestionResults);
+      }
+
+      SolrDocumentList docs = solrResponse.getResults();
+      if (docs != null && !userSpellcheckIsOn) {
+        totalHits = docs.getNumFound();
+        addDocsToResults(docs, results);
       }
 
       if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlQueryResponse.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlQueryResponse.java
@@ -59,7 +59,7 @@ public class CqlQueryResponse {
 
   private final Map<String, List<FacetValueCount>> facets;
 
-  private final List<String> showingResultsForFields;
+  private final List<String> showingResultsForFields, didYouMeanFields;
 
   private final Boolean userSpellcheckIsOn;
 
@@ -143,6 +143,8 @@ public class CqlQueryResponse {
             .collect(Collectors.toList());
 
     this.facets = getFacetResults(queryResponse.getPropertyValue(EXPERIMENTAL_FACET_RESULTS_KEY));
+    this.didYouMeanFields =
+        (List<String>) queryResponse.getProperties().get(SolrMetacardClientImpl.DID_YOU_MEAN_KEY);
     this.showingResultsForFields =
         (List<String>)
             queryResponse.getProperties().get(SolrMetacardClientImpl.SHOWING_RESULTS_FOR_KEY);

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
@@ -138,6 +138,7 @@ class ResultItems extends React.Component<Props, State> {
   rerunQuery() {
     store.getCurrentQuery().set('spellcheck', false)
     store.getCurrentQuery().startSearchFromFirstPage()
+    store.getCurrentQuery().set('spellcheck', true)
   }
 
   render() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
@@ -13,7 +13,7 @@ type Props = {
   showingResultsForFields: any[]
   didYouMeanFields: any[]
   userSpellcheckIsOn: boolean
-  store: any
+  model: any
 }
 
 const ResultItemCollection = styled.div`
@@ -134,10 +134,10 @@ class ResultItems extends React.Component<Props, State> {
     return showingResultsForFields.join(', ')
   }
 
-  rerunQuery(store: any) {
-    store.getCurrentQuery().set('spellcheck', false)
-    store.getCurrentQuery().startSearchFromFirstPage()
-    store.getCurrentQuery().set('spellcheck', true)
+  rerunQuery(model: any) {
+    model.set('spellcheck', false)
+    model.startSearchFromFirstPage()
+    model.set('spellcheck', true)
   }
 
   render() {
@@ -147,7 +147,7 @@ class ResultItems extends React.Component<Props, State> {
       showingResultsForFields,
       didYouMeanFields,
       userSpellcheckIsOn,
-      store,
+      model,
     } = this.props
     if (results.length === 0) {
       return (
@@ -185,7 +185,7 @@ class ResultItems extends React.Component<Props, State> {
           <DidYouMeanContainer>
             <ResendQuery
               onClick={() => {
-                this.rerunQuery(store)
+                this.rerunQuery(model)
               }}
             >
               {didYouMean}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
@@ -4,6 +4,8 @@ import { hot } from 'react-hot-loader'
 import MarionetteRegionContainer from '../../react-component/container/marionette-region-container'
 import styled from '../../react-component/styles/styled-components'
 
+const store = require('../../js/store.js')
+
 const SHOW_MORE_LENGTH = 2
 
 type Props = {
@@ -31,7 +33,7 @@ const ResultItemCollection = styled.div`
 
 const SolrQueryDisplay = styled.div`
   > .solr-query {
-    padding: .25rem;
+    padding: 0.25rem;
     box-shadow: none !important;
     text-align: center;
     font-size: 12px;
@@ -53,11 +55,11 @@ const ResultGroup = styled.div`
 `
 
 const ShowMore = styled.a`
-  padding: .25rem
+  padding: 0.25rem;
 `
 
 const ResendQuery = styled.a`
-  padding: .15rem;
+  padding: 0.15rem;
   box-shadow: none !important;
   text-align: center;
   font-size: 12px;
@@ -127,6 +129,11 @@ class ResultItems extends React.Component<Props, State> {
     return showingResultsForFields.join(', ')
   }
 
+  rerunQuery() {
+    store.getCurrentQuery().set('spellcheck', false)
+    store.getCurrentQuery().startSearchFromFirstPage()
+  }
+
   render() {
     const {
       results,
@@ -143,9 +150,9 @@ class ResultItems extends React.Component<Props, State> {
       )
     } else if (userSpellcheckIsOn) {
       const showingResultsFor = this.createShowResultText(
-          showingResultsForFields
-        )
-      const  didYouMean = this.createDidYouMeanText(didYouMeanFields)
+        showingResultsForFields
+      )
+      const didYouMean = this.createDidYouMeanText(didYouMeanFields)
 
       return (
         <div>
@@ -168,10 +175,12 @@ class ResultItems extends React.Component<Props, State> {
                 )}
             </div>
           </SolrQueryDisplay>
-          <ResendQuery className={className}
-          onClick={() => {
-            
-          }}>
+          <ResendQuery
+            className={className}
+            onClick={() => {
+              this.rerunQuery()
+            }}
+          >
             <div className="solr-query">
               {didYouMean}
               {didYouMeanFields !== null &&

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
@@ -54,8 +54,13 @@ const ResultGroup = styled.div`
   }
 `
 
+const DidYouMeanContainer = styled.div`
+  text-align: center;
+`
+
 const ShowMore = styled.a`
   padding: 0.25rem;
+  font-size: 12px;
 `
 
 const ResendQuery = styled.a`
@@ -64,6 +69,7 @@ const ResendQuery = styled.a`
   text-align: center;
   font-size: 12px;
   text-decoration: none;
+  width: 100%;
 `
 
 type State = {
@@ -175,15 +181,16 @@ class ResultItems extends React.Component<Props, State> {
                 )}
             </div>
           </SolrQueryDisplay>
-          <ResendQuery
-            className={className}
-            onClick={() => {
-              this.rerunQuery()
-            }}
-          >
-            <div className="solr-query">
+          <DidYouMeanContainer>
+            <ResendQuery
+              onClick={() => {
+                this.rerunQuery()
+              }}
+            >
               {didYouMean}
-              {didYouMeanFields !== null &&
+
+            </ResendQuery>
+            {didYouMeanFields !== null &&
                 didYouMeanFields !== undefined &&
                 didYouMeanFields.length > 2 && (
                   <ShowMore
@@ -197,8 +204,8 @@ class ResultItems extends React.Component<Props, State> {
                     {this.state.expandDidYouMeanFieldText ? 'less' : 'more'}
                   </ShowMore>
                 )}
-            </div>
-          </ResendQuery>
+          </DidYouMeanContainer>
+
           {this.createResultItemCollectionView()}
         </div>
       )

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
@@ -11,6 +11,7 @@ type Props = {
   selectionInterface: any
   className?: string
   showingResultsForFields: any[]
+  didYouMeanFields: any[]
   userSpellcheckIsOn: boolean
 }
 
@@ -30,12 +31,10 @@ const ResultItemCollection = styled.div`
 
 const SolrQueryDisplay = styled.div`
   > .solr-query {
-    padding: ${props => props.theme.minimumSpacing};
+    padding: .25rem;
     box-shadow: none !important;
     text-align: center;
     font-size: 12px;
-    white-space: wrap;
-    word-wrap: normal;
   }
 `
 
@@ -53,8 +52,21 @@ const ResultGroup = styled.div`
   }
 `
 
+const ShowMore = styled.a`
+  padding: .25rem
+`
+
+const ResendQuery = styled.a`
+  padding: .15rem;
+  box-shadow: none !important;
+  text-align: center;
+  font-size: 12px;
+  text-decoration: none;
+`
+
 type State = {
-  expandSearchFieldText: boolean
+  expandShowingResultForText: boolean
+  expandDidYouMeanFieldText: boolean
 }
 
 class ResultItems extends React.Component<Props, State> {
@@ -62,7 +74,8 @@ class ResultItems extends React.Component<Props, State> {
     super(props)
 
     this.state = {
-      expandSearchFieldText: false,
+      expandShowingResultForText: false,
+      expandDidYouMeanFieldText: false,
     }
   }
 
@@ -73,7 +86,7 @@ class ResultItems extends React.Component<Props, State> {
       showingResultsForFields !== null
     ) {
       if (
-        !this.state.expandSearchFieldText &&
+        !this.state.expandShowingResultForText &&
         showingResultsForFields.length > 2
       ) {
         showingResultsFor += this.createCondensedResultsForText(
@@ -86,6 +99,21 @@ class ResultItems extends React.Component<Props, State> {
         showingResultsForFields
       )
       return showingResultsFor
+    }
+  }
+
+  createDidYouMeanText(didYouMeanFields: any[]) {
+    let didYouMean = 'Did you mean '
+    if (didYouMeanFields !== undefined && didYouMeanFields !== null) {
+      if (
+        !this.state.expandDidYouMeanFieldText &&
+        didYouMeanFields.length > 2
+      ) {
+        didYouMean += this.createCondensedResultsForText(didYouMeanFields)
+        return didYouMean
+      }
+      didYouMean += this.createExpandedResultsForText(didYouMeanFields)
+      return didYouMean
     }
   }
 
@@ -104,6 +132,7 @@ class ResultItems extends React.Component<Props, State> {
       results,
       className,
       showingResultsForFields,
+      didYouMeanFields,
       userSpellcheckIsOn,
     } = this.props
     if (results.length === 0) {
@@ -114,28 +143,55 @@ class ResultItems extends React.Component<Props, State> {
       )
     } else if (userSpellcheckIsOn) {
       const showingResultsFor = this.createShowResultText(
-        showingResultsForFields
-      )
+          showingResultsForFields
+        )
+      const  didYouMean = this.createDidYouMeanText(didYouMeanFields)
+
       return (
-        <SolrQueryDisplay className={className}>
-          <div className="solr-query">
-            {showingResultsFor}
-            {showingResultsForFields !== null &&
-              showingResultsForFields !== undefined &&
-              showingResultsForFields.length > 2 && (
-                <a
-                  onClick={() => {
-                    this.setState({
-                      expandSearchFieldText: !this.state.expandSearchFieldText,
-                    })
-                  }}
-                >
-                  {this.state.expandSearchFieldText ? 'less' : 'more'}
-                </a>
-              )}
-          </div>
+        <div>
+          <SolrQueryDisplay className={className}>
+            <div className="solr-query">
+              {showingResultsFor}
+              {showingResultsForFields !== null &&
+                showingResultsForFields !== undefined &&
+                showingResultsForFields.length > 2 && (
+                  <ShowMore
+                    onClick={() => {
+                      this.setState({
+                        expandShowingResultForText: !this.state
+                          .expandShowingResultForText,
+                      })
+                    }}
+                  >
+                    {this.state.expandShowingResultForText ? 'less' : 'more'}
+                  </ShowMore>
+                )}
+            </div>
+          </SolrQueryDisplay>
+          <ResendQuery className={className}
+          onClick={() => {
+            
+          }}>
+            <div className="solr-query">
+              {didYouMean}
+              {didYouMeanFields !== null &&
+                didYouMeanFields !== undefined &&
+                didYouMeanFields.length > 2 && (
+                  <ShowMore
+                    onClick={() => {
+                      this.setState({
+                        expandDidYouMeanFieldText: !this.state
+                          .expandDidYouMeanFieldText,
+                      })
+                    }}
+                  >
+                    {this.state.expandDidYouMeanFieldText ? 'less' : 'more'}
+                  </ShowMore>
+                )}
+            </div>
+          </ResendQuery>
           {this.createResultItemCollectionView()}
-        </SolrQueryDisplay>
+        </div>
       )
     } else {
       return this.createResultItemCollectionView()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
@@ -188,22 +188,21 @@ class ResultItems extends React.Component<Props, State> {
               }}
             >
               {didYouMean}
-
             </ResendQuery>
             {didYouMeanFields !== null &&
-                didYouMeanFields !== undefined &&
-                didYouMeanFields.length > 2 && (
-                  <ShowMore
-                    onClick={() => {
-                      this.setState({
-                        expandDidYouMeanFieldText: !this.state
-                          .expandDidYouMeanFieldText,
-                      })
-                    }}
-                  >
-                    {this.state.expandDidYouMeanFieldText ? 'less' : 'more'}
-                  </ShowMore>
-                )}
+              didYouMeanFields !== undefined &&
+              didYouMeanFields.length > 2 && (
+                <ShowMore
+                  onClick={() => {
+                    this.setState({
+                      expandDidYouMeanFieldText: !this.state
+                        .expandDidYouMeanFieldText,
+                    })
+                  }}
+                >
+                  {this.state.expandDidYouMeanFieldText ? 'less' : 'more'}
+                </ShowMore>
+              )}
           </DidYouMeanContainer>
 
           {this.createResultItemCollectionView()}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
@@ -4,8 +4,6 @@ import { hot } from 'react-hot-loader'
 import MarionetteRegionContainer from '../../react-component/container/marionette-region-container'
 import styled from '../../react-component/styles/styled-components'
 
-const store = require('../../js/store.js')
-
 const SHOW_MORE_LENGTH = 2
 
 type Props = {
@@ -15,6 +13,7 @@ type Props = {
   showingResultsForFields: any[]
   didYouMeanFields: any[]
   userSpellcheckIsOn: boolean
+  store: any
 }
 
 const ResultItemCollection = styled.div`
@@ -135,7 +134,7 @@ class ResultItems extends React.Component<Props, State> {
     return showingResultsForFields.join(', ')
   }
 
-  rerunQuery() {
+  rerunQuery(store: any) {
     store.getCurrentQuery().set('spellcheck', false)
     store.getCurrentQuery().startSearchFromFirstPage()
     store.getCurrentQuery().set('spellcheck', true)
@@ -148,6 +147,7 @@ class ResultItems extends React.Component<Props, State> {
       showingResultsForFields,
       didYouMeanFields,
       userSpellcheckIsOn,
+      store,
     } = this.props
     if (results.length === 0) {
       return (
@@ -185,7 +185,7 @@ class ResultItems extends React.Component<Props, State> {
           <DidYouMeanContainer>
             <ResendQuery
               onClick={() => {
-                this.rerunQuery()
+                this.rerunQuery(store)
               }}
             >
               {didYouMean}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
@@ -124,7 +124,7 @@ const ResultSelector = Marionette.LayoutView.extend({
           userSpellcheckIsOn={this.model
             .get('result')
             .get('userSpellcheckIsOn')}
-          store={store}
+          model={this.model}
         />
         <MarionetteRegionContainer
           key={Math.random()}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
@@ -118,6 +118,7 @@ const ResultSelector = Marionette.LayoutView.extend({
           showingResultsForFields={this.model
             .get('result')
             .get('showingResultsForFields')}
+          didYouMeanFields={this.model.get('result').get('didYouMeanFields')}
           userSpellcheckIsOn={this.model
             .get('result')
             .get('userSpellcheckIsOn')}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
@@ -25,9 +25,11 @@ const cql = require('../../js/cql.js')
 const ResultSortDropdownView = require('../dropdown/result-sort/dropdown.result-sort.view.js')
 const user = require('../singletons/user-instance.js')
 const ResultStatusView = require('../result-status/result-status.view.js')
+const store = require('../../js/store.js')
 require('../../behaviors/selection.behavior.js')
 import MarionetteRegionContainer from '../../react-component/container/marionette-region-container'
 import ResultItemCollection from '../result-item/result-item.collection'
+
 const {
   SelectAllToggle,
 } = require('../selection-checkbox/selection-checkbox.view.js')
@@ -122,6 +124,7 @@ const ResultSelector = Marionette.LayoutView.extend({
           userSpellcheckIsOn={this.model
             .get('result')
             .get('userSpellcheckIsOn')}
+          store={store}
         />
         <MarionetteRegionContainer
           key={Math.random()}

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponse.js
@@ -83,6 +83,7 @@ module.exports = Backbone.AssociatedModel.extend({
     merged: true,
     currentlyViewed: false,
     showingResultsForFields: [],
+    didYouMeanFields: [],
     userSpellcheckIsOn: false,
   },
   relations: [
@@ -284,6 +285,7 @@ module.exports = Backbone.AssociatedModel.extend({
 
     return {
       showingResultsForFields: resp.showingResultsForFields,
+      didYouMeanFields: resp.didYouMeanFields,
       userSpellcheckIsOn: resp.userSpellcheckIsOn,
       queuedResults: resp.results,
       results: [],


### PR DESCRIPTION
#### What does this PR do?
Provide a Did you mean option to re-query with spellcheck turned off. Note that the did you mean option will only present itself on the Results panel if spellcheck is turned on. 

![DidYouMean (1)](https://user-images.githubusercontent.com/23177404/58147082-1da52e00-7c16-11e9-91cf-75f146416850.gif)

#### Who is reviewing it? 
@bellcc 
@GabrielFabian 
@andrewkfiedler 
@tbatie 
@derekwilhelm 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@tbatie

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
For Jira:
[](https://codice.atlassian.net/browse/)

For GH Issues:
Fixes: #____

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
