### PR TITLE
DDF-4859 fixes slashes in CDM policy documentation

### DIFF
--- a/distribution/docs/src/main/resources/content/_managing/_configuring/content-directory-monitor.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/content-directory-monitor.adoc
@@ -35,7 +35,7 @@ After adding permissions, a system restart is required for them to take effect.
 . permission java.io.FilePermission "<DIRECTORY_PATH>", "read";
 . permission java.io.FilePermission "<DIRECTORY_PATH>${/}-", "read, write";
 
-Trailing slashes after <DIRECTORY_PATH> have no effect on the permissions granted. For example, adding a permission for "/test/path" and "/test/path/" are equivalent. The recursive forms "/test/path${/}-", and "/test/path/${/}-" are also equivalent.
+Trailing slashes after <DIRECTORY_PATH> have no effect on the permissions granted. For example, adding a permission for "${/}test${/}path" and "${/}test${/}path${/}" are equivalent. The recursive forms "${/}test${/}path${/}-", and "${/}test${/}path${/}${/}-" are also equivalent.
 
 Line 1 gives the CDM the permissions to read from the monitored directory path. Line 2 gives the CDM the permissions to recursively read and write from the monitored directory path, specified by the directory path's suffix "${/}-".
 


### PR DESCRIPTION
What does this PR do?
Master port of https://github.com/codice/ddf/pull/4860
Fixes slashes in CDM policy documentation

Who is reviewing it?
@tyler30clemens @ahoffer

Select relevant component teams:
@codice/docs

Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@emmberk
@ricklarsen - Documentation

How should this be tested?
quick build and check docs

Any background context you want to provide?
No.

What are the relevant tickets?
Fixes: #4859