### PR TITLE
DDF-4873 Add totalHits to ignored attributes

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -30,6 +30,7 @@ const IGNORED_WORKSPACE_ATTRIBUTES = [
   'id',
   'subscribed',
   'serverPageIndex',
+  'totalHits',
 ]
 
 /**


### PR DESCRIPTION
#### What does this PR do?
 - We update totalHits when search results are returned, so we need to ignore this model change.  Otherwise, every time results are returned the workspace will appear to need saving.

#### Who is reviewing it? 
@Bdthomson 
@djblue 
@cantstoptheunk 
@bellcc  

#### How should this be tested?
Create a search.
Save the workspace.
Run a search (must return results).
Note that the workspace appears to need saving.

#### Any background context you want to provide?
I don't think this is the only attribute we need to mark as ignored, but it's a start.  We've also added some spellcheck features that might be causing a similar issue.  I couldn't get the spellcheck things to show up though (I think they're off by default, and I couldn't get the Admin UI working).

#### What are the relevant tickets?
For GH Issues:
Fixes: #4873 

#### Screenshots
<img width="563" alt="Screen Shot 2019-05-24 at 2 27 19 PM" src="https://user-images.githubusercontent.com/11984853/58303060-ab109a00-7e31-11e9-9fee-6640730d7ae1.png">
