### PR TITLE
[2.15.x] DDF-4897 Results export view cannot find source id

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-interactions/query-interactions.view.js
@@ -26,6 +26,7 @@ const LoadingView = require('../loading/loading.view.js')
 const QueryAnnotationsView = require('../query-annotations/query-annotations.view.js')
 const properties = require('../../js/properties.js')
 import ResultsExport from '../../react-component/container/results-export'
+import { getExportResults } from '../../react-component/utils/export/export'
 
 const NOT_CLONEABLE_ATTRIBUTES = ['id', 'result', 'hasBeenSaved']
 
@@ -263,15 +264,21 @@ module.exports = Marionette.ItemView.extend({
     )
   },
   handleExport() {
+    const selectedResults = store.getSelectedResults()
+    const exportResults = getExportResults(selectedResults.models)
+
     lightboxInstance.model.updateTitle('Export Results')
     lightboxInstance.model.open()
-    lightboxInstance.showContent(<ResultsExport store={store} />)
+    lightboxInstance.showContent(<ResultsExport results={exportResults} />)
   },
   handleZippedExport() {
+    const selectedResults = store.getSelectedResults()
+    const exportResults = getExportResults(selectedResults.models)
+
     lightboxInstance.model.updateTitle('Export Results (Compressed)')
     lightboxInstance.model.open()
     lightboxInstance.showContent(
-      <ResultsExport store={store} transformer={'zipCompression'} />
+      <ResultsExport results={exportResults} isZipped={true} />
     )
   },
   handleResult() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/export-interaction.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/metacard-interactions/export-interaction.tsx
@@ -3,15 +3,17 @@ import ResultsExport from '../results-export'
 import { Props } from '.'
 import { MetacardInteraction } from '../../presentation/metacard-interactions/metacard-interactions'
 import { hot } from 'react-hot-loader'
+import { getExportResults } from '../../utils/export/export'
 
-const store = require('../../../js/store.js')
 const lightboxInstance = require('../../../component/lightbox/lightbox.view.instance.js')
 
 const onExport = (props: Props) => {
   props.onClose()
   lightboxInstance.model.updateTitle('Export Results')
   lightboxInstance.model.open()
-  lightboxInstance.showContent(<ResultsExport store={store} />)
+  lightboxInstance.showContent(
+    <ResultsExport results={getExportResults(props.model)} />
+  )
 }
 
 export const ExportActions = (props: Props) => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/multi-select-actions/multi-select-actions.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/multi-select-actions/multi-select-actions.tsx
@@ -14,6 +14,7 @@ import { hot } from 'react-hot-loader'
 import MultiSelectActionsPresentation from '../../presentation/multi-select-actions'
 import withListenTo, { WithBackboneProps } from '../backbone-container'
 import ResultsExport from '../results-export'
+import { getExportResults } from '../../utils/export/export'
 
 const lightboxInstance = require('../../../component/lightbox/lightbox.view.instance.js')
 
@@ -41,10 +42,13 @@ class MultiSelectActions extends React.Component<Props, State> {
   }
 
   handleExport = () => {
+    const selectedResults = this.props.selectionInterface.getSelectedResults()
+    const exportResults = getExportResults(selectedResults.models)
+
     lightboxInstance.model.updateTitle('Export Results')
     lightboxInstance.model.open()
     lightboxInstance.showContent(
-      <ResultsExport store={this.props.selectionInterface} />
+      <ResultsExport results={exportResults} isZipped={true} />
     )
   }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/cql/cql.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/cql/cql.tsx
@@ -9,7 +9,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-export const getResultSetCql = (ids: number[]) => {
+export const getResultSetCql = (ids: string[]) => {
   const queries = ids.map(id => `(("id" ILIKE '${id}'))`)
   return `(${queries.join(' OR ')})`
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/export/export.tsx
@@ -24,13 +24,38 @@ export type ResultSet = {
   args?: Object
 }
 
+export const getExportResults = (results: any[]) => {
+  return results.map(result => getExportResult(result))
+}
+
+const getResultId = (result: any) => {
+  return result
+    .get('metacard')
+    .get('properties')
+    .get('id')
+}
+
+const getResultSourceId = (result: any) => {
+  return result
+    .get('metacard')
+    .get('properties')
+    .get('source-id')
+}
+
+export const getExportResult = (result: any) => {
+  return {
+    id: getResultId(result),
+    source: getResultSourceId(result),
+  }
+}
+
 export const getExportOptions = async (type: Transformer) => {
   return await fetch(`./internal/transformers/${type}`)
 }
 
 export const exportResult = async (
   source: string,
-  id: number,
+  id: string,
   transformer: string
 ) => {
   return await fetch(


### PR DESCRIPTION
**Backport to `2.15.x`**

#### What does this PR do?
When exporting a single result you must have that result selected so that the results export view can pick up on that result. If you immediately click on the kebab menu then the result will not be selected and will fail to grab the source ID from the result. 

<img width="401" alt="Screen Shot 2019-05-30 at 11 29 13 AM" src="https://user-images.githubusercontent.com/7646577/58651308-31aff600-82ce-11e9-8777-750937452a74.png">

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@hayleynorton 
@samuelechu 

#### Select relevant component teams: 
@codice/test 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@djblue

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Export a result without selecting it first. 
- Export a couple of results.
- Select more than one result, then click on the kebab menu for an individual result. Verify that only the exported result is the one you attempted to export. 
- Export results as compressed. 

#### Any background context you want to provide?
- None

#### What are the relevant tickets?
For GH Issues:
Fixes: #4897 

#### Screenshots
<!--(if appropriate)-->
- None

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
