### PR TITLE
[2.13.x] DDF-04905 Prevent ffmpeg access control exception

### DIFF
--- a/catalog/plugin/catalog-plugin-videothumbnail/src/main/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPlugin.java
+++ b/catalog/plugin/catalog-plugin-videothumbnail/src/main/java/org/codice/ddf/catalog/content/plugin/video/VideoThumbnailPlugin.java
@@ -44,7 +44,6 @@ import javax.activation.MimeType;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecuteResultHandler;
 import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.PumpStreamHandler;
@@ -385,11 +384,8 @@ public class VideoThumbnailPlugin implements PostCreateStoragePlugin, PostUpdate
       LOGGER.info(msg);
       LOGGER.debug(msg, e);
       Throwable cause = e.getCause();
-      // org.apache.commons.exe.Executor's execute() method's signature includes both the
-      // ExecuteException and IOException
-      if (cause instanceof ExecuteException) {
-        throw (ExecuteException) cause;
-      }
+      // org.apache.commons.exe.Executor's execute() method's signature includes a throws clause
+      // for ExecuteException and IOException. ExecuteException is a subclass of IOException.
       if (cause instanceof IOException) {
         throw (IOException) cause;
       }

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -598,4 +598,12 @@
         </notes>
         <cve>CVE-2019-0232</cve>
     </suppress>
+    <suppress>
+        <notes>
+            This vulnerability is related to the use of Apache Hadoop YARN. YARN is a resource
+            management application for Hadoop. DDF only include Hadoop JAR files to support Solr
+            dependencies. DDF does not make use of YARN.
+        </notes>
+        <CVE>CVE-2018-8029</CVE>
+    </suppress>
 </suppressions>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -604,6 +604,6 @@
             management application for Hadoop. DDF only include Hadoop JAR files to support Solr
             dependencies. DDF does not make use of YARN.
         </notes>
-        <CVE>CVE-2018-8029</CVE>
+        <cve>CVE-2018-8029</cve>
     </suppress>
 </suppressions>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -154,6 +154,7 @@
         <cve>CVE-2016-5007</cve>
         <cve>CVE-2016-3674</cve>
         <cve>CVE-2016-7048</cve>
+        <cve>CVE-2019-8457</cve>
     </suppress>
     <suppress>
         <notes>


### PR DESCRIPTION
#### What does this PR do?
Wraps the call to start an OS process (execute ffmpeg) in a do-privilege

#### Who is reviewing it? 
@austinsteffes @tyler30clemens @peterhuffer @brjeter 


#### Ask 2 committers to review/merge the PR and tag them here.
@blen-desta
@emmberk

#### How should this be tested?
@peterhuffer Can you hero this? You've had the best luck reproducing the problem during replication.

#### Any background context you want to provide?
None

#### What are the relevant tickets?
Fixes: #4905 

#### Screenshots
N/A
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
