### PR TITLE
DDF-04914 Address Multiple OWASP Issues

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -188,6 +188,15 @@
     </suppress>
     <suppress>
         <notes>
+            DDF version was changed to 2.16.0 and OWASP thinks a custom bundle with the word “camel”
+            This CVE applies to Camel versions 2.16.0 through 2.18.1. At the time of this writing,
+            DDF uses Camel version camel 2.22.1 (see root POM file), which is not subject to this
+            vulnerability.
+        </notes>
+        <cve>CVE-2016-8749</cve>
+    </suppress>
+    <suppress>
+        <notes>
             These CVEs are all related to asciidoc and jruby vulnerabilities which are only used
             when the documentation is building.
         </notes>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -188,8 +188,9 @@
     </suppress>
     <suppress>
         <notes>
+            This CVE applies to Camel versions 2.16.0 through 2.18.1.
             DDF version was changed to 2.16.0 and OWASP thinks a custom bundle with the word “camel”
-            This CVE applies to Camel versions 2.16.0 through 2.18.1. At the time of this writing,
+            means DDF uses version 2.16.0 of Camel. This is not true. At the time of this writing,
             DDF uses Camel version camel 2.22.1 (see root POM file), which is not subject to this
             vulnerability.
         </notes>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -597,5 +597,13 @@
         </notes>
         <cve>CVE-2019-0232</cve>
     </suppress>
+    <suppress>
+        <notes>
+            This vulnerability is related to the use of Apache Hadoop YARN. YARN is a resource
+            management application for Hadoop. DDF only include Hadoop JAR files to support Solr
+            dependencies. DDF does not make use of YARN.
+        </notes>
+        <cve>CVE-2018-8029</cve>
+    </suppress>
 
 </suppressions>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -164,6 +164,7 @@
         <cve>CVE-2016-5007</cve>
         <cve>CVE-2016-3674</cve>
         <cve>CVE-2016-7048</cve>
+        <cve>CVE-2019-8457</cve>
     </suppress>
     <suppress>
         <notes>


### PR DESCRIPTION
#### What does this PR do?
UPDATED: Added a suppression for CVE-2019-8457 sql-lite which is a dependency of the geowebcache server. 

Addresses finding for CVE-2018-8029. DDF does use version of JARs affected by this CVE. However, the vulnerability is specific to the user account for a Apache YARN, a Hadoop resource manager. DDF does not make use of YARN.

#### Who is reviewing it? 
@brjeter @austinsteffes @tyler30clemens @clockard 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.

@bdeining
@blen-desta
@garrettfreibott

#### How should this be tested?
Either pass a CI build or build locally with the -Powasp profile.
#### Any background context you want to provide?
No.

#### What are the relevant tickets?
#4914 

#### Screenshots
None.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
