### PR TITLE
DDF-04824 Bumps usng.js version in catalog-ui-search

### DIFF
--- a/ui/packages/catalog-ui-search/package.json
+++ b/ui/packages/catalog-ui-search/package.json
@@ -96,7 +96,7 @@
     "terraformer": "1.0.5",
     "terraformer-wkt-parser": "1.1.0",
     "urijs": "1.19.1",
-    "usng.js": "0.4.1",
+    "usng.js": "0.4.2",
     "uuid": "2.0.2",
     "vis": "4.15.0",
     "wellknown": "https://github.com/connexta/wellknown.git#4d9ae612e7e308509ec76400b258c9db1581ea82",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -17734,9 +17734,9 @@ username@3.0.0:
     execa "^0.7.0"
     mem "^1.1.0"
 
-usng.js@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/usng.js/-/usng.js-0.4.1.tgz#9503dc594b45dd20320906c22daa2b36b4dd8378"
+usng.js@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/usng.js/-/usng.js-0.4.2.tgz#51946e0c0393c18140775823b1604394d0f5f5a6"
 
 utf-8-validate@1.2.x:
   version "1.2.2"


### PR DESCRIPTION
#### What does this PR do?

Bumps usng.js version in catalog-ui-search

#### Who is reviewing it? 

@rymach 
@andrewkfiedler 
@bdeining 
@samuelechu 

#### How should this be tested?

- `yarn install`
- `yarn start` in `ui/packages/catalog-ui-search`
- ensure warning is gone from webpack build output
- ensure no regression in location component

#### What are the relevant tickets?

Fixes: #4824 