### PR TITLE
DDF-04930 URI-encode the result's source and ID in the export URL

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/results-export/results-export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/results-export/results-export.tsx
@@ -174,7 +174,12 @@ class ResultsExport extends React.Component<Props, State> {
       const uriEncodedSource = encodeURIComponent(source)
       const metacardId: any = this.state.selectedResults[0].id
       const uriEncodedMetacardId: any = encodeURIComponent(metacardId)
-      response = await exportResult(uriEncodedSource, uriEncodedMetacardId, transformerId)
+      const uriEncodedTransformerId = encodeURIComponent(transformerId)
+      response = await exportResult(
+        uriEncodedSource,
+        uriEncodedMetacardId,
+        uriEncodedTransformerId
+      )
     }
 
     if (response.status === 200) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/results-export/results-export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/results-export/results-export.tsx
@@ -171,9 +171,10 @@ class ResultsExport extends React.Component<Props, State> {
       })
     } else {
       const source = this.state.selectedResults[0].source
-      const metacardId = this.state.selectedResults[0].id
-
-      response = await exportResult(source, metacardId, transformerId)
+      const uriEncodedSource = encodeURIComponent(source)
+      const metacardId: any = this.state.selectedResults[0].id
+      const uriEncodedMetacardId: any = encodeURIComponent(metacardId)
+      response = await exportResult(uriEncodedSource, uriEncodedMetacardId, transformerId)
     }
 
     if (response.status === 200) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/results-export/results-export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/results-export/results-export.tsx
@@ -141,6 +141,7 @@ class ResultsExport extends React.Component<Props, State> {
       return
     }
 
+    const uriEncodedTransformerId = encodeURIComponent(transformerId)
     let response = null
     const count = this.state.selectedResults.length
 
@@ -149,8 +150,11 @@ class ResultsExport extends React.Component<Props, State> {
         this.state.selectedResults.map((result: Result) => result.id)
       )
       const srcs = Array.from(this.getResultSources())
+      const uriEncodedTransformerIdProp = encodeURIComponent(
+        this.props.transformer
+      )
 
-      response = await exportResultSet(this.props.transformer, {
+      response = await exportResultSet(uriEncodedTransformerIdProp, {
         cql,
         srcs,
         count,
@@ -164,7 +168,7 @@ class ResultsExport extends React.Component<Props, State> {
       )
       const srcs = Array.from(this.getResultSources())
 
-      response = await exportResultSet(transformerId, {
+      response = await exportResultSet(uriEncodedTransformerId, {
         count,
         cql,
         srcs,
@@ -174,7 +178,6 @@ class ResultsExport extends React.Component<Props, State> {
       const uriEncodedSource = encodeURIComponent(source)
       const metacardId: any = this.state.selectedResults[0].id
       const uriEncodedMetacardId: any = encodeURIComponent(metacardId)
-      const uriEncodedTransformerId = encodeURIComponent(transformerId)
       response = await exportResult(
         uriEncodedSource,
         uriEncodedMetacardId,


### PR DESCRIPTION
#### What does this PR do?
The source name and/or ID may contain certain URI reserved characters that should not be left unencoded in the path component, such as '?' and '/'. If these are not URI-encoded then the export URL will be wrong or invalid and will not work.

#### Who is reviewing it? 
@bellcc 
@gjvera 
@BernardIgiri 
@bennuttle

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@djblue

#### How should this be tested?
1. Ingest some records into DDF.
2. Create a loopback federated source whose name has a `/` in it.
3. Run a query on the source.
4. Attempt to export any single result as any file type, although the file type you choose should be one that the given result will support.
5. Verify the export is successful.
6. Optionally, open the network tab of your browser's developer tools and verify the source name in the export request URL is percent-encoded.

#### What are the relevant tickets?
Fixes: #4930 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.