### PR TITLE
DDF-04909 Replacing calls to Collection.size() with Collection.isEmpty()

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AttributeValidationReportImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AttributeValidationReportImpl.java
@@ -45,7 +45,7 @@ public class AttributeValidationReportImpl implements AttributeValidationReport 
    */
   public void addViolations(Set<ValidationViolation> violations) {
     Preconditions.checkArgument(violations != null, "The violation list cannot be null.");
-    Preconditions.checkArgument(violations.size() > 0, "The violation list cannot be empty.");
+    Preconditions.checkArgument(!violations.isEmpty(), "The violation list cannot be empty.");
 
     attributeValidationViolations.addAll(violations);
   }
@@ -70,7 +70,7 @@ public class AttributeValidationReportImpl implements AttributeValidationReport 
    */
   public void addSuggestedValues(Set<String> values) {
     Preconditions.checkArgument(values != null, "The suggested values cannot be null.");
-    Preconditions.checkArgument(values.size() > 0, "The suggested values cannot be empty.");
+    Preconditions.checkArgument(!values.isEmpty(), "The suggested values cannot be empty.");
 
     suggestedValues.addAll(values);
   }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/MigrateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/MigrateCommand.java
@@ -74,7 +74,7 @@ public class MigrateCommand extends DuplicateCommands {
     final List<CatalogProvider> providers = getCatalogProviders();
 
     if (listProviders) {
-      if (providers.size() == 0) {
+      if (providers.isEmpty()) {
         console.println("There are no available Providers.");
         return null;
       }

--- a/catalog/core/catalog-core-eventcommands/src/main/java/org/codice/ddf/catalog/pubsub/command/DeleteCommand.java
+++ b/catalog/core/catalog-core-eventcommands/src/main/java/org/codice/ddf/catalog/pubsub/command/DeleteCommand.java
@@ -85,7 +85,7 @@ public class DeleteCommand extends SubscriptionsCommand {
     PrintStream console = System.out;
 
     Map<String, ServiceReference<Subscription>> subscriptionIds = getSubscriptions(id, ldapFilter);
-    if (subscriptionIds.size() == 0) {
+    if (subscriptionIds.isEmpty()) {
       console.println(RED_CONSOLE_COLOR + NO_SUBSCRIPTIONS_FOUND_MSG + DEFAULT_CONSOLE_COLOR);
     } else {
       ServiceReference[] serviceReferences =
@@ -124,7 +124,7 @@ public class DeleteCommand extends SubscriptionsCommand {
 
           // Verify the subscription was deleted and print appropriate message to console
           Map<String, ServiceReference<Subscription>> ids = getSubscriptions(subscriptionId, false);
-          if (ids.size() == 0) {
+          if (ids.isEmpty()) {
             console.println(DELETE_MSG + subscriptionId);
             deletedSubscriptionsCount++;
           } else {

--- a/catalog/core/catalog-core-impl/filter-proxy/src/main/java/ddf/catalog/filter/proxy/adapter/GeotoolsFilterAdapterImpl.java
+++ b/catalog/core/catalog-core-impl/filter-proxy/src/main/java/ddf/catalog/filter/proxy/adapter/GeotoolsFilterAdapterImpl.java
@@ -236,7 +236,7 @@ public class GeotoolsFilterAdapterImpl implements FilterAdapter, FilterVisitor, 
       if (results.size() == 1) {
         // removing unused and
         return results.get(0);
-      } else if (results.size() > 0) {
+      } else if (!results.isEmpty()) {
         return ((FilterDelegate<Object>) delegate).and(results);
       }
     }
@@ -260,7 +260,7 @@ public class GeotoolsFilterAdapterImpl implements FilterAdapter, FilterVisitor, 
       for (Filter child : childList) {
         results.add(child.accept(this, delegate));
       }
-      if (results.size() > 0) {
+      if (!results.isEmpty()) {
         return ((FilterDelegate<Object>) delegate).or(results);
       }
     }

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -257,7 +257,7 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
       // String index = XPATH_QUERY_PARSER_PREFIX + StringUtils.join(indexes, operator);
       // query.setParam(FILTER_QUERY_PARAM_NAME, filter, index);
       query.setParam(FILTER_QUERY_PARAM_NAME, filter);
-    } else if (queryParams.size() > 0) {
+    } else if (!queryParams.isEmpty()) {
       // Pass through original filter queries if only a single XPath is present
       query.setParam(FILTER_QUERY_PARAM_NAME, queryParams.toArray(new String[queryParams.size()]));
     }

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/ReportingMetacardValidatorImpl.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/ReportingMetacardValidatorImpl.java
@@ -96,7 +96,7 @@ public class ReportingMetacardValidatorImpl
       }
     }
 
-    if (violations.size() > 0) {
+    if (!violations.isEmpty()) {
       return getReport(violations);
     }
 

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/RequiredAttributesMetacardValidator.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/RequiredAttributesMetacardValidator.java
@@ -115,7 +115,7 @@ public class RequiredAttributesMetacardValidator
         }
       }
 
-      if (violations.size() > 0) {
+      if (!violations.isEmpty()) {
         return getReport(violations);
       }
     }

--- a/catalog/security/catalog-security-filter/src/main/java/ddf/catalog/security/filter/plugin/FilterPlugin.java
+++ b/catalog/security/catalog-security-filter/src/main/java/ddf/catalog/security/filter/plugin/FilterPlugin.java
@@ -303,7 +303,7 @@ public class FilterPlugin implements AccessPlugin {
           // returned metacards are ignored for resource requests
         }
       }
-      if (filterStrategies.size() == 0) {
+      if (filterStrategies.isEmpty()) {
         throw new StopProcessingException("Subject not permitted to receive resource");
       }
     }

--- a/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/transformer/TransformerManager.java
+++ b/catalog/spatial/csw/spatial-csw-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/transformer/TransformerManager.java
@@ -55,7 +55,7 @@ public class TransformerManager {
   public String getTransformerIdForSchema(String schema) {
 
     List<Map<String, Object>> properties = getRelatedTransformerProperties(SCHEMA, schema);
-    if (properties.size() > 0) {
+    if (!properties.isEmpty()) {
       return (String) properties.get(0).get(ID);
     }
     return "";
@@ -63,7 +63,7 @@ public class TransformerManager {
 
   public String getTransformerSchemaForId(String id) {
     List<Map<String, Object>> properties = getRelatedTransformerProperties(ID, id);
-    if (properties.size() > 0) {
+    if (!properties.isEmpty()) {
       return (String) properties.get(0).get(SCHEMA);
     }
     return "";

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswEndpoint.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswEndpoint.java
@@ -775,7 +775,7 @@ public class CswEndpoint implements Csw {
       }
     }
 
-    if (updatedMetacardIdsList.size() > 0) {
+    if (!updatedMetacardIdsList.isEmpty()) {
       String[] updatedMetacardIds = updatedMetacardIdsList.toArray(new String[0]);
       UpdateRequest updateRequest = new UpdateRequestImpl(updatedMetacardIds, updatedMetacards);
 

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactory.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/CswQueryFactory.java
@@ -263,7 +263,7 @@ public class CswQueryFactory {
     }
 
     SortBy normalizedSortBy = null;
-    if (sortBys.size() > 0) {
+    if (!sortBys.isEmpty()) {
       normalizedSortBy = sortBys.get(0);
     }
 

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/GmdTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/GmdTransformer.java
@@ -538,7 +538,7 @@ public class GmdTransformer extends AbstractGmdTransformer implements InputTrans
 
   private void setCountryCodes(List<String> countryCodes, MetacardImpl metacard) {
     List<String> filteredCountryCodes = filterCountryCodes(countryCodes);
-    if (filteredCountryCodes.size() > 0) {
+    if (!filteredCountryCodes.isEmpty()) {
       metacard.setAttribute(Location.COUNTRY_CODE, (Serializable) filteredCountryCodes);
     }
   }

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsResponseExceptionMapper.java
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v1_0_0/catalog/source/WfsResponseExceptionMapper.java
@@ -89,7 +89,7 @@ public class WfsResponseExceptionMapper implements ResponseExceptionMapper<WfsEx
     List<ServiceExceptionType> list =
         new ArrayList<ServiceExceptionType>(report.getServiceException());
 
-    if (list.size() > 0) {
+    if (!list.isEmpty()) {
       Collections.reverse(list);
       StringBuilder exceptionMsg = new StringBuilder();
       for (ServiceExceptionType serviceException : list) {

--- a/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/GeoPdfParserImpl.java
+++ b/catalog/transformer/catalog-transformer-pdf/src/main/java/ddf/catalog/transformer/input/pdf/GeoPdfParserImpl.java
@@ -125,7 +125,7 @@ public class GeoPdfParserImpl implements GeoPdfParser {
       }
     }
 
-    if (polygons.size() == 0) {
+    if (polygons.isEmpty()) {
       LOGGER.debug(
           "No GeoPDF information found on PDF during transformation.  Metacard location will not be set.");
       return null;

--- a/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/MetacardMarshallerImpl.java
+++ b/catalog/transformer/catalog-transformer-xml/src/main/java/ddf/catalog/transformer/xml/MetacardMarshallerImpl.java
@@ -220,7 +220,7 @@ public class MetacardMarshallerImpl implements MetacardMarshaller {
     String attributeName = attribute.getName();
     List<Serializable> values = attribute.getValues();
 
-    if (values.size() > 0) {
+    if (!values.isEmpty()) {
       // The GeometryTransformer creates an XML fragment containing
       // both the name - with namespaces declared - and the value
       if (format != AttributeType.AttributeFormat.GEOMETRY) {

--- a/platform/landing-page/src/main/java/org/codice/ddf/landing/LandingPage.java
+++ b/platform/landing-page/src/main/java/org/codice/ddf/landing/LandingPage.java
@@ -369,7 +369,7 @@ public class LandingPage extends HttpServlet {
 
   // A helper function used in the Handlebars template (index.handlebars).
   public String noAnnouncements(List<String> announcements) {
-    if (announcements.size() == 0) {
+    if (announcements.isEmpty()) {
       return "No announcements";
     } else {
       return "";

--- a/platform/metrics/platform-metrics-reporting/src/main/java/ddf/metrics/reporting/internal/rrd4j/RrdMetricsRetriever.java
+++ b/platform/metrics/platform-metrics-reporting/src/main/java/ddf/metrics/reporting/internal/rrd4j/RrdMetricsRetriever.java
@@ -590,7 +590,7 @@ public class RrdMetricsRetriever implements MetricsRetriever {
   }
 
   private double cumulativeRunningAverage(List<Double> values) {
-    if (values.size() == 0) {
+    if (values.isEmpty()) {
       return 0;
     }
     SummaryStatistics summaryStatistics = new SummaryStatistics();

--- a/platform/security/certificate/security-certificate-keystoreeditor/src/main/java/org/codice/ddf/security/certificate/keystore/editor/KeystoreEditor.java
+++ b/platform/security/certificate/security-certificate-keystoreeditor/src/main/java/org/codice/ddf/security/certificate/keystore/editor/KeystoreEditor.java
@@ -409,7 +409,7 @@ public class KeystoreEditor implements KeystoreEditorMBean {
       errors.add("Some of the required truststore fields are missing");
     }
 
-    if (errors.size() > 0) {
+    if (!errors.isEmpty()) {
       return errors;
     }
 

--- a/platform/security/expansion/security-expansion-impl/src/main/java/ddf/security/expansion/impl/AbstractExpansion.java
+++ b/platform/security/expansion/security-expansion-impl/src/main/java/ddf/security/expansion/impl/AbstractExpansion.java
@@ -254,7 +254,7 @@ public abstract class AbstractExpansion implements Expansion {
     List<String[]> list = expansionTable.get(key);
     if (list != null) {
       result = list.remove(rule);
-      if (list.size() == 0) {
+      if (list.isEmpty()) {
         expansionTable.remove(key);
       }
     }
@@ -269,7 +269,7 @@ public abstract class AbstractExpansion implements Expansion {
    * @param list the list of rules to be added to the corresponding attribute
    */
   public void addExpansionList(String key, List<String[]> list) {
-    if ((key == null) || (key.isEmpty()) || (list == null) || (list.size() == 0)) {
+    if ((key == null) || (key.isEmpty()) || (list == null) || (list.isEmpty())) {
       LOGGER.warn("Attempt to add list of expansion rules with null/empty key or null/empty list.");
       return;
     }

--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/paos/PaosOutInterceptor.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/paos/PaosOutInterceptor.java
@@ -40,7 +40,7 @@ public class PaosOutInterceptor extends AbstractPhaseInterceptor<Message> {
         acceptHeaders = new ArrayList<>();
       }
 
-      if (acceptHeaders.size() == 0) {
+      if (acceptHeaders.isEmpty()) {
         acceptHeaders.add("application/vnd.paos+xml");
         acceptHeaders.add("*/*");
       } else {


### PR DESCRIPTION
#### What does this PR do?
This PR aims to fix issues from SonarQube rule [Collection.isEmpty() should be used to test for emptiness](https://rules.sonarsource.com/java/RSPEC-1155)

SonarQube states that calling `Collection.isEmpty()` is:
- more readable than `Collection.size()`
- can be more performant
  - some Collections implementation have a cost of O(n) when calling `size()`

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
#### Ask 2 committers to review/merge the PR and tag them here.
Sorry, I don't know who I should tag.

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
I asked whether PRs tackling SonarQube issues were welcome on [google groups](https://groups.google.com/forum/?fromgroups#!topic/ddf-developers/Ovdj2lohGow).
#### What are the relevant tickets?
For Jira:
[](https://codice.atlassian.net/browse/)

For GH Issues:
Fixes: #4909 (partially)

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.