### PR TITLE
DDF-4936 Made InputStream use try-with-resources in FileSystemStorage…

### DIFF
--- a/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
+++ b/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java
@@ -653,8 +653,9 @@ public class FileSystemStorageProvider implements StorageProvider {
           new ByteSource() {
             @Override
             public InputStream openStream() throws IOException {
-              InputStream fileInputStream = new FileInputStream(contentItemPath.toFile());
-              return crypter.decrypt(fileInputStream);
+              try (InputStream fileInputStream = new FileInputStream(contentItemPath.toFile())) {
+                return crypter.decrypt(fileInputStream);
+              }
             }
           };
 


### PR DESCRIPTION
#### What does this PR do?
This InputStream should be created in a try-with-resources block to ensure it gets closed:

https://github.com/codice/ddf/blob/0bdc0943000be6396f8ab00023855b2b87512b3d/catalog/core/catalog-core-localstorageprovider/src/main/java/org/codice/ddf/catalog/content/impl/FileSystemStorageProvider.java#L656

#### Who is reviewing it? 
@austinsteffes 
@ahoffer 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@clockard 
@stustison 

#### How should this be tested?
CI build and testers discretion 
Could follow steps from this PR #4607 

#### What are the relevant tickets?
For GH Issues:
Fixes: #4936 

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
