### PR TITLE
DDF-04950 Update setenv script to not override EXTRA_JAVA_OPTS if it already contains a value

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -44,7 +44,11 @@ LINUX="Linux"
 
 if [ "$OS" != "${OS%$LINUX*}" ]; then
    if [ -e /dev/urandom ]; then
-      EXTRA_JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom"
+      if [ -z "$EXTRA_JAVA_OPTS" ]; then
+         EXTRA_JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom"
+      else
+         EXTRA_JAVA_OPTS="$EXTRA_JAVA_OPTS -Djava.security.egd=file:/dev/./urandom"
+      fi
    fi
 fi
 

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -60,7 +60,7 @@ rem SET KARAF_BASE
 rem Additional available Karaf options
 rem SET KARAF_OPTS=
 rem Uncomment out the line below to enable cxf logging interceptors
-rem set EXTRA_JAVA_OPTS="-Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true"
+rem set EXTRA_JAVA_OPTS="%EXTRA_JAVA_OPTS% -Dcom.sun.xml.ws.transport.http.HttpAdapter.dump=true"
 
 set DDF_HOME_PERM=%DDF_HOME:/=\%
 set DDF_HOME_PERM=%DDF_HOME_PERM:\bin\..=\%


### PR DESCRIPTION
#### What does this PR do?
Updates the setenv script to prevent overriding the EXTRA_JAVA_OPTS environment variable if it already contains a value prior to running the script (this only applies on linux machines). The script will just append the existing value of the variable to the new value set within the script. 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
@codice/build 

#### Ask 2 committers to review/merge the PR and tag them here.
@ryeats
@stustison
@beyelerb 

#### How should this be tested?
On a Linux machine, perform the following steps:
1. Prior to running DDF, set the EXTRA_JAVA_OPTS environment variable to some value such as:
"-Dhttps.proxyHost=test"
2. Run the DDF start script to start DDF.
3. Inside of the Karaf console, execute the command: "system:property", and verify the "https.proxyHost=test" entry within the output exists.

#### Any background context you want to provide?
Prior to this PR, the setenv script would would wipe away any value already set to the EXTRA_JAVA_OPTS system variable and override it with some other value (on linux). This PR allows a user to set any additional variables to EXTRA_JAVA_OPTS prior to running DDF start script, such as                       
"-Dhttps.proxyHost=... -Dhttps.proxyPort=....", so that they can be set as additional system properties used by the JVM.

#### What are the relevant tickets?
For GH Issues:
Fixes: #4950 