### PR TITLE
DDF-4977 - Only run back end spellcheck when enabled

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -228,6 +228,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         SolrQuery realTimeQuery = getRealTimeQuery(query, solrFilterDelegate.getIds());
         solrResponse = client.query(realTimeQuery, METHOD.POST);
       } else {
+        query.setParam("spellcheck", userSpellcheckIsOn);
         solrResponse = client.query(query, METHOD.POST);
       }
 

--- a/platform/solr/solr-schema/src/main/resources/solr/conf/schema.xml
+++ b/platform/solr/solr-schema/src/main/resources/solr/conf/schema.xml
@@ -133,10 +133,6 @@
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
     </fieldType>
-    <field name="spellcheckfield" type="text_suggest" multiValued="true" indexed="true" stored="false" omitNorms="true"/>
-    <!-- Copy each field that should contribute to the spellcheck dictionary -->
-    <copyField source="title_txt" dest="spellcheckfield"/>
-    <copyField source="description_txt" dest="spellcheckfield"/>
 
     <fieldType name="text_phonetics" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">

--- a/platform/solr/solr-schema/src/main/resources/solr/conf/solrconfig.xml
+++ b/platform/solr/solr-schema/src/main/resources/solr/conf/solrconfig.xml
@@ -707,17 +707,8 @@
   <requestHandler name="/select" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="echoParams">explicit</str>
-      <str name="spellcheck">true</str>
+      <str name="spellcheck">false</str>
       <str name="spellcheck.dictionary">filebased</str>
-      <!-- Uncomment the lines below to enable the data index based dictionary and then comment
-           out the filebased dictionary lines above. WARNING: Doing so may expose sensitive data
-           if not every user is allowed to see all of the suggestion words from the data index.
-           Additionally, the data index will not correct words that are misspelled within the data
-           already. In fact, it will assume that all of the data is a correct spelling. In essence,
-           changing this configuration makes it work more as a data suggester rather than a
-           spellchecking capability. -->
-      <!--       <str name="spellcheck.dictionary">indexbased</str>
-            <str name="spellcheck.dictionary">wordbreak</str> -->
       <str name="spellcheck.extendedResults">true</str>
       <str name="spellcheck.count">10</str>
       <str name="spellcheck.alternativeTermCount">5</str>
@@ -840,31 +831,6 @@
       <str name="sourceLocation">dictionary.txt</str>
       <str name="spellcheckIndexDir">./spellcheckerFile</str>
       <str name="characterEncoding">UTF-8</str>
-    </lst>
-    <lst name="spellchecker">
-      <str name="name">indexbased</str>
-      <str name="field">spellcheckfield</str>
-      <str name="classname">solr.IndexBasedSpellChecker</str>
-      <str name="distanceMeasure">org.apache.lucene.search.spell.LevenshteinDistance</str>
-      <str name="accuracy">0.5</str>
-      <int name="maxEdits">1</int>
-      <int name="minPrefix">1</int>
-      <int name="maxInspections">5</int>
-      <int name="minQueryLength">4</int>
-      <str name="maxQueryFrequency">0.01</str>
-      <str name="buildOnCommit">true</str>
-    </lst>
-    <lst name="spellchecker">
-      <str name="name">wordbreak</str>
-      <str name="classname">solr.WordBreakSolrSpellChecker</str>
-      <str name="field">spellcheckfield</str>
-      <!-- should multiple words from the query be combined in a dictionary search -->
-      <str name="combineWords">true</str>
-      <!-- should words from the query be broken in a dictionary search -->
-      <str name="breakWords">true</str>
-      <int name="maxChanges">5</int>
-      <int name="minBreakLength">3</int>
-      <str name="buildOnCommit">true</str>
     </lst>
   </searchComponent>
 


### PR DESCRIPTION

#### What does this PR do?
Removes index based spellcheck from performing dictionary builds on commit and changes the configuration so that the back end spellcheck capability is only executed if enabled in the query itself as opposed to always executing and only handling the results if it is enabled.

#### Who is reviewing it? 
@brjeter 
@cantstoptheunk 
@pklinef 

#### Select relevant component teams: 
@codice/solr 
#### Ask 2 committers to review/merge the PR and tag them here.

@rzwiefel
@troymohl

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #4977 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
