### PR TITLE
[2.15.x] DDF-4962 NPE is thrown when the Solr Response results are empty

### DIFF
--- a/catalog/core/catalog-core-solr/pom.xml
+++ b/catalog/core/catalog-core-solr/pom.xml
@@ -219,12 +219,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.83</minimum>
+                                            <minimum>0.84</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.74</minimum>
+                                            <minimum>0.76</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -251,28 +251,27 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       }
 
       SolrDocumentList docs = solrResponse.getResults();
-      int originalQueryResultsSize = docs.size();
+      int originalQueryResultsSize = 0;
       if (docs != null) {
+        originalQueryResultsSize = docs.size();
         totalHits = docs.getNumFound();
         addDocsToResults(docs, results);
-      }
 
-      if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
-        query.set("q", findQueryToResend(query, solrResponse));
-        QueryResponse solrResponseRequery = client.query(query, METHOD.POST);
-        docs = solrResponseRequery.getResults();
-        if (docs.size() > originalQueryResultsSize) {
-          results = new ArrayList<>();
-          if (docs != null) {
+        if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
+          query.set("q", findQueryToResend(query, solrResponse));
+          QueryResponse solrResponseRequery = client.query(query, METHOD.POST);
+          docs = solrResponseRequery.getResults();
+          if (docs != null && docs.size() > originalQueryResultsSize) {
+            results = new ArrayList<>();
             totalHits = docs.getNumFound();
             addDocsToResults(docs, results);
-          }
 
-          responseProps.put(
-              DID_YOU_MEAN_KEY, (Serializable) getSearchTermFieldValues(solrResponse));
-          responseProps.put(
-              SHOWING_RESULTS_FOR_KEY,
-              (Serializable) getSearchTermFieldValues(solrResponseRequery));
+            responseProps.put(
+                DID_YOU_MEAN_KEY, (Serializable) getSearchTermFieldValues(solrResponse));
+            responseProps.put(
+                SHOWING_RESULTS_FOR_KEY,
+                (Serializable) getSearchTermFieldValues(solrResponseRequery));
+          }
         }
       }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-item/result-item.collection.tsx
@@ -149,7 +149,6 @@ class ResultItems extends React.Component<Props, State> {
     const {
       results,
       className,
-      userSpellcheckIsOn,
       selectionInterface,
       showingResultsForFields,
       didYouMeanFields,
@@ -161,7 +160,7 @@ class ResultItems extends React.Component<Props, State> {
           <div className="result-item-collection-empty">No Results Found</div>
         </ResultItemCollection>
       )
-    } else if (userSpellcheckIsOn) {
+    } else if (this.model.get('spellcheck')) {
       const showingResultsFor = this.createShowResultText(
         showingResultsForFields
       )

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
@@ -25,7 +25,6 @@ const cql = require('../../js/cql.js')
 const ResultSortDropdownView = require('../dropdown/result-sort/dropdown.result-sort.view.js')
 const user = require('../singletons/user-instance.js')
 const ResultStatusView = require('../result-status/result-status.view.js')
-const store = require('../../js/store.js')
 require('../../behaviors/selection.behavior.js')
 import MarionetteRegionContainer from '../../react-component/container/marionette-region-container'
 import ResultItemCollection from '../result-item/result-item.collection'
@@ -121,9 +120,6 @@ const ResultSelector = Marionette.LayoutView.extend({
             .get('result')
             .get('showingResultsForFields')}
           didYouMeanFields={this.model.get('result').get('didYouMeanFields')}
-          userSpellcheckIsOn={this.model
-            .get('result')
-            .get('userSpellcheckIsOn')}
           model={this.model}
         />
         <MarionetteRegionContainer


### PR DESCRIPTION
#### What does this PR do?
Backport to `https://github.com/codice/ddf/pull/4963`

Fixes a potential NPE in SolrMetacardClientImpl in the case where the set of results returns null after a query is run.
Also makes a small change to the spellcheck UI code for a downstream project, and added add unit tests

#### Who is reviewing it? 
@Bdthomson
@bellcc
@andrewkfiedler
@vinamartin

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@pklinef
@vinamartin

#### How should this be tested?
Test spellcheck features, did you mean and showing results for and regression testing on normal searches.

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
