### PR TITLE
DDF-4320 Decrease Input Transformer Boot Service Poll time to every half second

### DIFF
--- a/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
+++ b/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
@@ -49,7 +49,7 @@ public class InputTransformerBootServiceFlag implements BootServiceFlag {
 
   private static final long DEFAULT_TRANSFORMER_WAIT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
-  private static final long DEFAULT_TRANSFORMER_CHECK_PERIOD_MILLIS = TimeUnit.MILLISECONDS.toMillis(500);
+  private static final long DEFAULT_TRANSFORMER_CHECK_PERIOD_MILLIS = 500;
 
   private static final String TRANSFORMER_ID_PROPERTY = "id";
 

--- a/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
+++ b/catalog/transformer/catalog-transformer-bootflag/src/main/java/org/codice/ddf/catalog/transformer/bootflag/InputTransformerBootServiceFlag.java
@@ -49,7 +49,7 @@ public class InputTransformerBootServiceFlag implements BootServiceFlag {
 
   private static final long DEFAULT_TRANSFORMER_WAIT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
 
-  private static final long DEFAULT_TRANSFORMER_CHECK_PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(20);
+  private static final long DEFAULT_TRANSFORMER_CHECK_PERIOD_MILLIS = TimeUnit.MILLISECONDS.toMillis(500);
 
   private static final String TRANSFORMER_ID_PROPERTY = "id";
 


### PR DESCRIPTION
#### What does this PR do?
Decreases Input Transformer Boot Service poll time to every half second from every 20 seconds

#### Average Speedup - **1.2s (2.6%)**
- 46.6s avg pre change
- 45.4s avg post change

_As ran across 5 individual runs of `profile:install`_

#### Who is reviewing it? 
anyone
#### How should this be tested?
Ensure CDM does not start ingesting before all services are up

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
