### PR TITLE
DDF-05014 Add extensibility to settings pane

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/user-settings/user-settings.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/user-settings/user-settings.tsx
@@ -26,7 +26,7 @@ export type SettingsComponent = {
   text: string
   icon: string
   onClick?: () => void
-  children?: any
+  children?: React.ReactNode
 }
 
 export type withExtensions = {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/user-settings/user-settings.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/user-settings/user-settings.tsx
@@ -25,6 +25,8 @@ export type SettingsComponent = {
   component: JSX.Element
   text: string
   icon: string
+  onClick?: () => void
+  children?: any
 }
 
 export type withExtensions = {
@@ -169,11 +171,17 @@ class UserSettings extends React.Component<Props, State> {
               buttonType={buttonTypeEnum.neutral}
               text={extension.text}
               icon={extension.icon}
-              onClick={() => {
-                this.updateComponent(extension.component)
-              }}
+              onClick={
+                typeof extension.onClick === 'function'
+                  ? extension.onClick
+                  : () => {
+                      this.updateComponent(extension.component)
+                    }
+              }
               disabled={Boolean(component)}
-            />
+            >
+              {extension.children}
+            </NavigationButton>
           ))}
         </div>
         <div className="user-settings-content">


### PR DESCRIPTION
#### What does this PR do?
Allow settings components to render children
Allow settings components to pass in their own onClick handlers

#### Who is reviewing it? 
@andrewzimmer 
@Corey-Collins 
@willwill96 
@hayleynorton 

#### Ask 2 committers to review/merge the PR and tag them here.
@adimka
@bdeining

#### How should this be tested?
Verify that all items in the settings pane still function as desired
Verify that there are no errors in the developer console
Test downstream

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #5014 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
