### PR TITLE
Update rest assured logging and removed unused formatter lines

### DIFF
--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -1347,7 +1347,6 @@ public class TestCatalog extends AbstractIntegrationTest {
     String partialSampleData =
         new String(Arrays.copyOfRange(sampleDataByteArray, offset, sampleDataByteArray.length));
 
-    // @formatter:off
     given()
         .headers(
             HttpHeaders.CONTENT_TYPE,
@@ -1364,7 +1363,6 @@ public class TestCatalog extends AbstractIntegrationTest {
         .assertThat()
         .header(CswConstants.ACCEPT_RANGES_HEADER, is(equalTo(CswConstants.BYTES)))
         .body(is(partialSampleData));
-    // @formatter:on
 
     delete(metacardId);
   }
@@ -1384,7 +1382,6 @@ public class TestCatalog extends AbstractIntegrationTest {
 
     String invalidRange = "100";
 
-    // @formatter:off
     given()
         .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_XML)
         .header(CswConstants.RANGE_HEADER, invalidRange)
@@ -1395,7 +1392,6 @@ public class TestCatalog extends AbstractIntegrationTest {
         .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(400));
-    // @formatter:on
 
     delete(metacardId);
   }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -300,7 +300,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             .header(HttpHeaders.CONTENT_TYPE, "application/json")
             .expect()
             .log()
-            .all()
+            .ifValidationFails()
             .statusCode(HttpStatus.SC_CREATED)
             .when()
             .post(REST_PATH.getUrl())
@@ -312,7 +312,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .get(url)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(hasXPath("/metacard[@id='" + id + "']"))
         .body(
@@ -336,7 +336,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             .header(HttpHeaders.CONTENT_TYPE, "application/json")
             .expect()
             .log()
-            .all()
+            .ifValidationFails()
             .statusCode(HttpStatus.SC_CREATED)
             .when()
             .post(REST_PATH.getUrl())
@@ -352,7 +352,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .body(getFileContent(JSON_RECORD_RESOURCE_PATH + "/UpdatedSimpleGeoJsonRecord"))
         .expect()
         .log()
-        .all()
+        .ifValidationFails()
         .statusCode(HttpStatus.SC_BAD_REQUEST)
         .when()
         .put(new DynamicUrl(REST_PATH, id).getUrl());
@@ -375,7 +375,7 @@ public class TestCatalog extends AbstractIntegrationTest {
             .header(HttpHeaders.CONTENT_TYPE, "text/xml")
             .expect()
             .log()
-            .all()
+            .ifValidationFails()
             .statusCode(HttpStatus.SC_CREATED)
             .when()
             .post(REST_PATH.getUrl())
@@ -389,7 +389,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .body(writer.toString())
         .expect()
         .log()
-        .all()
+        .ifValidationFails()
         .statusCode(HttpStatus.SC_OK)
         .when()
         .put(new DynamicUrl(REST_PATH, id).getUrl());
@@ -400,7 +400,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .get(REST_PATH.getUrl() + id)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(hasXPath("/metacard[@id='" + id + "']"))
         .body(
@@ -850,7 +850,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .get(url)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(
             hasXPath("//metacard/dateTime[@name='modified']/value", startsWith("2015-08-10")),
@@ -935,7 +935,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .get(firstUrl)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         // Check that the updated attributes were changed.
         .body(
@@ -952,7 +952,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .get(secondUrl)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         // Check that the updated attributes were changed.
         .body(
@@ -1096,7 +1096,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .get(url)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         // Check that the attributes about to be removed in the update are present.
         .body(
@@ -1121,7 +1121,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .get(url)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         // Check that the updated attributes were removed.
         .body(
@@ -1259,7 +1259,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .body(getSimpleXml("foo:bar"))
         .expect()
         .log()
-        .all()
+        .ifValidationFails()
         .statusCode(HttpStatus.SC_BAD_REQUEST)
         .when()
         .put(new DynamicUrl(REST_PATH, metacardId).getUrl());
@@ -1321,7 +1321,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .post(CSW_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .body(is(SAMPLE_DATA));
@@ -1358,7 +1358,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .post(CSW_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .assertThat()
@@ -1392,7 +1392,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .post(CSW_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(400));
     // @formatter:on
@@ -1455,7 +1455,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .header(HttpHeaders.CONTENT_TYPE, "application/json")
         .expect()
         .log()
-        .all()
+        .ifValidationFails()
         .statusCode(400)
         .when()
         .post(REST_PATH.getUrl());
@@ -1577,7 +1577,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     return given()
         .expect()
         .log()
-        .all()
+        .ifValidationFails()
         .statusCode(HttpStatus.SC_OK)
         .when()
         .get(URI.create(format(metacardUrlFormat, source, metacardId)))
@@ -1590,7 +1590,7 @@ public class TestCatalog extends AbstractIntegrationTest {
         .header(HttpHeaders.CONTENT_TYPE, contentType)
         .expect()
         .log()
-        .all()
+        .ifValidationFails()
         .statusCode(HttpStatus.SC_CREATED)
         .when()
         .post(REST_PATH.getUrl())
@@ -1959,7 +1959,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
       getOpenSearch("xml", null, null, "q=*")
           .log()
-          .all()
+          .ifValidationFails()
           .assertThat()
           .body(hasXPath(newMetacardXpath + "/type", is(newMetacardTypeName)))
           .body(
@@ -2045,7 +2045,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
       getOpenSearch("xml", null, null, "q=*")
           .log()
-          .all()
+          .ifValidationFails()
           .assertThat()
           // The metacard had a title, so it should not have been set to the default
           .body(hasXPath(metacard3XPath + "/string[@name='title']/value", is("Metacard-3")))
@@ -2136,7 +2136,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
       getOpenSearch("xml", null, null, "q=*")
           .log()
-          .all()
+          .ifValidationFails()
           .assertThat()
           .body(hasXPath(metacard1XPath + "/string[@name='title']/value", is(updatedTitle1)))
           .body(
@@ -2194,7 +2194,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
       getOpenSearch("xml", null, null, "q=*")
           .log()
-          .all()
+          .ifValidationFails()
           .assertThat()
           .body(hasXPath(basicMetacardXpath + "/type", is(basicMetacardTypeName)))
           .body(hasXPath(basicMetacardXpath + "/int[@name='page-count']/value", is("55")))
@@ -2232,7 +2232,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
       getOpenSearch("xml", null, null, "q=*")
           .log()
-          .all()
+          .ifValidationFails()
           .assertThat()
           .body(hasXPath(basicMetacardXpath + "/type", is(basicMetacardTypeName)))
           .body(hasXPath(basicMetacardXpath + "/int[@name='page-count']/value", is("55")))
@@ -2336,7 +2336,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
       getOpenSearch("xml", null, null, "q=*")
           .log()
-          .all()
+          .ifValidationFails()
           .assertThat()
           .body(
               hasXPath(
@@ -2352,7 +2352,7 @@ public class TestCatalog extends AbstractIntegrationTest {
 
       getOpenSearch("xml", null, null, "q=*")
           .log()
-          .all()
+          .ifValidationFails()
           .assertThat()
           .body(
               hasXPath(
@@ -2509,7 +2509,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     // query - check if sanitized properly
     getOpenSearch("xml", null, null, "q=*")
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(
             hasXPath(format(METACARD_X_PATH, id) + "/string[@name='title']/value", is("file.bin")));
@@ -2541,7 +2541,7 @@ public class TestCatalog extends AbstractIntegrationTest {
     // query - check if sanitized properly
     getOpenSearch("xml", null, null, "q=*")
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(
             hasXPath(

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -188,7 +188,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
     getSecurityPolicy().configureRestForGuest();
     return given()
         .log()
-        .all()
+        .ifValidationFails()
         .header("Content-Type", "application/json")
         .header("X-Requested-With", "XMLHttpRequest");
   }
@@ -197,7 +197,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
     getSecurityPolicy().configureRestForBasic();
     return given()
         .log()
-        .all()
+        .ifValidationFails()
         .header("Content-Type", "application/json")
         .auth()
         .preemptive()
@@ -209,7 +209,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
     getSecurityPolicy().configureRestForBasic();
     return given()
         .log()
-        .all()
+        .ifValidationFails()
         .header("Content-Type", "application/json")
         .auth()
         .preemptive()

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -1505,7 +1505,7 @@ public class TestFederation extends AbstractIntegrationTest {
       // This query will put the ingested metacards from the BeforeExam method into the cache
       given()
           .log()
-          .all()
+          .ifValidationFails()
           .contentType("application/json")
           .auth()
           .basic(LOCALHOST_USERNAME, LOCALHOST_PASSWORD)
@@ -1516,7 +1516,7 @@ public class TestFederation extends AbstractIntegrationTest {
           .post(cqlUrl)
           .then()
           .log()
-          .all()
+          .ifValidationFails()
           .statusCode(200);
 
       // CacheBulkProcessor could take up to 10 seconds to flush the cached results into solr

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -251,7 +251,7 @@ public class TestRegistry extends AbstractIntegrationTest {
             .header("Content-Type", "text/xml")
             .expect()
             .log()
-            .all()
+            .ifValidationFails()
             .statusCode(200)
             .when()
             .post(CSW_PATH.getUrl());
@@ -275,13 +275,13 @@ public class TestRegistry extends AbstractIntegrationTest {
         .basic(ADMIN, ADMIN)
         .body(getCswRegistryUpdate(regID, "New Node Name", "2014-02-26T17:16:34.996Z", id))
         .log()
-        .all()
+        .ifValidationFails()
         .header("Content-Type", "text/xml")
         .when()
         .post(CSW_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(400);
   }
@@ -304,7 +304,7 @@ public class TestRegistry extends AbstractIntegrationTest {
             .header("Content-Type", "text/xml")
             .expect()
             .log()
-            .all()
+            .ifValidationFails()
             .statusCode(200)
             .when()
             .post(CSW_PATH.getUrl());
@@ -537,7 +537,7 @@ public class TestRegistry extends AbstractIntegrationTest {
             .header("Content-Type", "text/xml")
             .expect()
             .log()
-            .all()
+            .ifValidationFails()
             .statusCode(200)
             .when()
             .post(CSW_PATH.getUrl());
@@ -598,7 +598,7 @@ public class TestRegistry extends AbstractIntegrationTest {
             .header("Content-Type", "text/xml")
             .expect()
             .log()
-            .all()
+            .ifValidationFails()
             .statusCode(200)
             .when()
             .post(CSW_PATH.getUrl());

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
@@ -409,7 +409,7 @@ public class TestSecurity extends AbstractIntegrationTest {
             .get(url)
             .then()
             .log()
-            .all()
+            .ifValidationFails()
             .assertThat()
             .statusCode(equalTo(200))
             .assertThat()
@@ -424,7 +424,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(url)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200));
 
@@ -435,7 +435,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(ADMIN_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(403));
   }
@@ -460,7 +460,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(url)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(401));
 
@@ -473,7 +473,7 @@ public class TestSecurity extends AbstractIntegrationTest {
             .get(url)
             .then()
             .log()
-            .all()
+            .ifValidationFails()
             .assertThat()
             .statusCode(equalTo(200))
             .assertThat()
@@ -488,7 +488,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(url)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200));
 
@@ -499,7 +499,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(ADMIN_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200));
 
@@ -652,7 +652,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(openSearchQuery)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .assertThat()
@@ -702,7 +702,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(openSearchQuery)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .assertThat()
@@ -717,7 +717,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(cswQuery)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .assertThat()
@@ -741,7 +741,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(cswQueryUnavail)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(500));
 
@@ -761,7 +761,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(unavailableOpenSearchQuery)
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .assertThat()
@@ -789,7 +789,7 @@ public class TestSecurity extends AbstractIntegrationTest {
     // mostly testing the same stuff that this is hitting
     given()
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "helloWorld")
@@ -799,7 +799,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(SERVICE_ROOT.getUrl() + "/sdk/SoapTransportService")
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(
             HasXPath.hasXPath(
@@ -822,7 +822,7 @@ public class TestSecurity extends AbstractIntegrationTest {
     // mostly testing the same stuff that this is hitting
     given()
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "helloWorld")
@@ -832,7 +832,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(INSECURE_SERVICE_ROOT.getUrl() + "/sdk/SoapTransportService")
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(
             HasXPath.hasXPath(
@@ -862,7 +862,7 @@ public class TestSecurity extends AbstractIntegrationTest {
             PASSWORD,
             certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -872,7 +872,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService")
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
   }
@@ -895,7 +895,7 @@ public class TestSecurity extends AbstractIntegrationTest {
             PASSWORD,
             certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -905,7 +905,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService")
         .then()
         .log()
-        .all();
+        .ifValidationFails();
   }
 
   @Test
@@ -925,7 +925,7 @@ public class TestSecurity extends AbstractIntegrationTest {
             PASSWORD,
             certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -935,7 +935,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService")
         .then()
         .log()
-        .all();
+        .ifValidationFails();
   }
 
   @Test
@@ -957,7 +957,7 @@ public class TestSecurity extends AbstractIntegrationTest {
             PASSWORD,
             certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -967,7 +967,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService")
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
   }
@@ -991,7 +991,7 @@ public class TestSecurity extends AbstractIntegrationTest {
             PASSWORD,
             certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -1001,7 +1001,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService")
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(HasXPath.hasXPath("//*[local-name()='Assertion']"));
   }
@@ -1020,7 +1020,7 @@ public class TestSecurity extends AbstractIntegrationTest {
 
     given()
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -1030,7 +1030,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService")
         .then()
         .log()
-        .all();
+        .ifValidationFails();
   }
 
   @Test
@@ -1047,7 +1047,7 @@ public class TestSecurity extends AbstractIntegrationTest {
 
     given()
         .log()
-        .all()
+        .ifValidationFails()
         .body(body)
         .header("Content-Type", "text/xml; charset=utf-8")
         .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -1057,7 +1057,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .post(SERVICE_ROOT.getUrl() + "/SecurityTokenService")
         .then()
         .log()
-        .all();
+        .ifValidationFails();
   }
 
   @Test
@@ -1079,7 +1079,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                 PASSWORD,
                 certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
             .log()
-            .all()
+            .ifValidationFails()
             .body(body)
             .header("Content-Type", "text/xml; charset=utf-8")
             .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -1107,7 +1107,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(ADMIN_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200));
   }
@@ -1124,7 +1124,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                 PASSWORD,
                 certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
             .log()
-            .all()
+            .ifValidationFails()
             .body(body)
             .header("Content-Type", "text/xml; charset=utf-8")
             .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -1157,7 +1157,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(ADMIN_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200));
   }
@@ -1174,7 +1174,7 @@ public class TestSecurity extends AbstractIntegrationTest {
                 PASSWORD,
                 certAuthSettings().sslSocketFactory(SSLSocketFactory.getSystemSocketFactory()))
             .log()
-            .all()
+            .ifValidationFails()
             .body(body)
             .header("Content-Type", "text/xml; charset=utf-8")
             .header("SOAPAction", "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue")
@@ -1207,7 +1207,7 @@ public class TestSecurity extends AbstractIntegrationTest {
         .get(ADMIN_PATH.getUrl())
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(401));
   }
@@ -1254,14 +1254,14 @@ public class TestSecurity extends AbstractIntegrationTest {
     // a timestamp was added to the response
     given()
         .log()
-        .all()
+        .ifValidationFails()
         .body(SAMPLE_SOAP)
         .header("Content-Type", "application/json")
         .when()
         .post(SERVICE_ROOT + "/sdk/SoapTransportService")
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .body(hasXPath("/Envelope/Header/Security/Timestamp"));
@@ -1273,14 +1273,14 @@ public class TestSecurity extends AbstractIntegrationTest {
     // encrypted data was added to the response
     given()
         .log()
-        .all()
+        .ifValidationFails()
         .body(SAMPLE_SOAP)
         .header("Content-Type", "application/json")
         .when()
         .post(SERVICE_ROOT + "/sdk/SoapAsymmetricService")
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .body(hasXPath("/Envelope/Header/Security/EncryptedData"));
@@ -1292,14 +1292,14 @@ public class TestSecurity extends AbstractIntegrationTest {
     // a signature was added to the response
     given()
         .log()
-        .all()
+        .ifValidationFails()
         .body(SAMPLE_SOAP)
         .header("Content-Type", "application/xml")
         .when()
         .post(SERVICE_ROOT + "/sdk/SoapSymmetricService")
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .statusCode(equalTo(200))
         .body(hasXPath("/Envelope/Header/Security/Signature/SignatureValue"));

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
@@ -731,7 +731,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
     response
         .then()
         .log()
-        .all()
+        .ifValidationFails()
         .assertThat()
         .body(
             hasXPath(

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSingleSignOn.java
@@ -238,27 +238,25 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
 
     // Update the config
     Configuration config = getAdminConfig().getConfiguration(pid, null);
-    // @formatter:off
+
     config.update(
         new Hashtable<String, Object>() {
           {
             put(param, value);
           }
         });
-    // @formatter:on
 
     // We have to make sure the config has been updated before we can use it
-    // @formatter:off
+
     expect("Configs to update")
         .within(2, TimeUnit.MINUTES)
         .until(() -> config.getProperties() != null && (config.getProperties().get(param) != null));
-    // @formatter:on
   }
 
   private ResponseHelper getSearchResponse(boolean isPassiveRequest, String url) throws Exception {
 
     // We should be redirected to the IdP when we first try to hit the search page
-    // @formatter:off
+
     Response searchResponse =
         given()
             .header("User-Agent", BROWSER_USER_AGENT)
@@ -268,14 +266,14 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(302)
             .when()
             .get(url == null ? SEARCH_URL.getUrl() : url);
-    // @formatter:on
+
     // Because we get back a 302, we know the redirect location is in the header
     ResponseHelper searchHelper = new ResponseHelper(searchResponse);
     searchHelper.parseHeader();
 
     // We get bounced to a login page which has the parameters we need to pass to the IdP
     // embedded on the page in a JSON Object
-    // @formatter:off
+
     Response redirectResponse =
         given()
             .header("User-Agent", BROWSER_USER_AGENT)
@@ -284,7 +282,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(200)
             .when()
             .get(searchHelper.redirectUrl);
-    // @formatter:on
 
     // The body has the parameters we passed it plus some extra, so we need to parse again
     ResponseHelper redirectHelper = new ResponseHelper(redirectResponse);
@@ -308,18 +305,16 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
   }
 
   private String getUserName() {
-    // @formatter:off
+
     Response response = get(WHO_AM_I_URL.getUrl()).then().extract().response();
     return response.jsonPath().get("karaf.name");
-    // @formatter:on
   }
 
   private String getUserName(Map<String, String> cookies) {
-    // @formatter:off
+
     Response response =
         given().cookies(cookies).when().get(WHO_AM_I_URL.getUrl()).then().extract().response();
     return response.jsonPath().get("idp.name");
-    // @formatter:on
   }
 
   private String setupHttpRequestUsingBinding(Binding requestBinding, Binding metadataBinding)
@@ -351,7 +346,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
 
   private ResponseHelper performHttpRequestUsingBinding(
       Binding binding, String relayState, String encodedRequest) throws Exception {
-    // @formatter:off
+
     Response idpResponse =
         given()
             .auth()
@@ -369,7 +364,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(200)
             .when()
             .get(IDP_URL.getUrl() + "/sso");
-    // @formatter:on
+
     return new ResponseHelper(idpResponse);
   }
 
@@ -407,7 +402,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
     String mockAuthnRequest = setupHttpRequestUsingBinding(Binding.REDIRECT, Binding.REDIRECT);
     String encodedRequest = RestSecurity.deflateAndBase64Encode(mockAuthnRequest);
 
-    // @formatter:off
     given()
         .auth()
         .preemptive()
@@ -420,7 +414,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
         .statusCode(400)
         .when()
         .get(IDP_URL.getUrl() + "/sso");
-    // @formatter:on
   }
 
   @Test
@@ -428,7 +421,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
     ResponseHelper searchHelper = getSearchResponse(false, null);
 
     // We're using an AJAX call, so anything other than 200 means not authenticated
-    // @formatter:off
+
     given()
         .auth()
         .preemptive()
@@ -439,7 +432,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
         .statusCode(not(200))
         .when()
         .get(searchHelper.redirectUrl);
-    // @formatter:on
   }
 
   @Test
@@ -448,7 +440,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
     // Note that PKI is passive (as opposed to username/password which is not)
     ResponseHelper searchHelper = getSearchResponse(true, null);
 
-    // @formatter:off
     given()
         .auth()
         .certificate(
@@ -462,14 +453,12 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
         .statusCode(200)
         .when()
         .get(searchHelper.redirectUrl);
-    // @formatter:on
   }
 
   @Test
   public void testGuestAuth() throws Exception {
     ResponseHelper searchHelper = getSearchResponse(false, null);
 
-    // @formatter:off
     given()
         .param("AuthMethod", "guest")
         .params(searchHelper.params)
@@ -478,7 +467,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
         .statusCode(200)
         .when()
         .get(searchHelper.redirectUrl);
-    // @formatter:on
   }
 
   @Test
@@ -493,7 +481,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
 
     // Pass our credentials to the IDP, it should redirect us to the Assertion Consumer Service.
     // The redirect is currently done via javascript and not an HTTP redirect.
-    // @formatter:off
+
     Response idpResponse =
         given()
             .auth()
@@ -505,7 +493,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(200)
             .when()
             .get(searchHelper.redirectUrl);
-    // @formatter:on
 
     ResponseHelper idpHelper = new ResponseHelper(idpResponse);
 
@@ -525,7 +512,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
         is(both(greaterThanOrEqualTo(0)).and(lessThanOrEqualTo(80))));
 
     // After passing the SAML Assertion to the ACS, we should be redirected back to Search.
-    // @formatter:off
+
     String body =
         String.format(
             "SAMLResponse=%s&RelayState=%s",
@@ -542,7 +529,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(anyOf(is(307), is(303)))
             .when()
             .post(searchHelper.params.get("ACSURL"));
-    // @formatter:on
 
     ResponseHelper acsHelper = new ResponseHelper(acsResponse);
     acsHelper.parseHeader();
@@ -568,7 +554,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
     Response acsResponse = loginUser("admin", "admin");
 
     // Create logout request
-    // @formatter:off
+
     Response createLogoutRequest =
         given()
             .cookies(acsResponse.getCookies())
@@ -576,20 +562,18 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(200)
             .when()
             .get(LOGOUT_REQUEST_URL.getUrl());
-    // @formatter:on
 
     ResponseHelper createLogoutHelper = new ResponseHelper(createLogoutRequest);
     createLogoutHelper.parseBody();
 
     // Logout via url returned in logout request
-    // @formatter:off
+
     given()
         .expect()
         .statusCode(200)
         .body(containsString("You are now signed out."))
         .when()
         .get(createLogoutHelper.get("url"));
-    // @formatter:on
 
     // Verify admin user is no longer logged in
     assertThat(getUserName(), not("admin"));
@@ -604,7 +588,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
 
     // Pass our credentials to the IDP, it should redirect us to the Assertion Consumer Service.
     // The redirect is currently done via javascript and not an HTTP redirect.
-    // @formatter:off
+
     Response idpResponse =
         given()
             .auth()
@@ -616,13 +600,12 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(200)
             .when()
             .get(searchHelper.redirectUrl);
-    // @formatter:on
 
     ResponseHelper idpHelper = new ResponseHelper(idpResponse);
     assertThat(idpHelper.parseBody(), is(Binding.POST));
 
     // After passing the SAML Assertion to the ACS, we should be redirected back to Search.
-    // @formatter:off
+
     String body =
         String.format(
             "SAMLResponse=%s&RelayState=%s",
@@ -638,7 +621,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(anyOf(is(307), is(303)))
             .when()
             .post(searchHelper.params.get("ACSURL"));
-    // @formatter:on
 
     ResponseHelper acsHelper = new ResponseHelper(acsResponse);
     acsHelper.parseHeader();
@@ -667,7 +649,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
 
     // Pass our credentials to the IDP, it should redirect us to the Assertion Consumer Service.
     // The redirect is currently done via javascript and not an HTTP redirect.
-    // @formatter:off
+
     Response idpResponse =
         given()
             .auth()
@@ -679,7 +661,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(200)
             .when()
             .get(searchHelper.redirectUrl);
-    // @formatter:on
 
     ResponseHelper idpHelper = new ResponseHelper(idpResponse);
 
@@ -699,7 +680,7 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
         is(both(greaterThanOrEqualTo(0)).and(lessThanOrEqualTo(80))));
 
     // After passing the SAML Assertion to the ACS, we should be redirected back to Search.
-    // @formatter:off
+
     String body =
         String.format(
             "SAMLResponse=%s&RelayState=%s",
@@ -716,7 +697,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
             .statusCode(anyOf(is(307), is(303)))
             .when()
             .post(searchHelper.params.get("ACSURL"));
-    // @formatter:on
 
     ResponseHelper acsHelper = new ResponseHelper(acsResponse);
     acsHelper.parseHeader();
@@ -727,7 +707,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
     // The federated query using username/password against the IDP auth type on all of /services
     // would fail without ECP
 
-    // @formatter:off
     response
         .then()
         .log()
@@ -741,7 +720,6 @@ public class TestSingleSignOn extends AbstractIntegrationTest {
                     + RECORD_TITLE_1
                     + "']"),
             hasXPath("/metacards/metacard/geometry/value"));
-    // @formatter:on
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
- Updates Itest Rest Assured logging to change from `log().all()` to `log().ifValidationFailed()`. This will help not pollute the build logs with http logging for successful itests (but still include failed test logs)
  - The rest assured docs state that `log().all()` is primarily a debugging mechanism for when writing tests
- Removes unused formatter statements that are no longer needed/respected.


Currently no ticket, let me know if anyone thinks its necessary to track.
#### Who is reviewing it? 
@codice/test
anyone

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
