### PR TITLE
DDF-05055 Fix value retention across filter comparators

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -336,7 +336,7 @@ the provided value."
         model,
       })
     )
-    this.updateValueFromInput()    
+    this.updateValueFromInput()
     const isEditing = this.$el.hasClass('is-editing')
     if (isEditing || this.options.editing) {
       this.turnOnEditing()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -300,7 +300,6 @@ the provided value."
     }
   },
   determineInput() {
-    this.updateValueFromInput()
     let value = Common.duplicate(this.model.get('value'))
     const currentComparator = this.model.get('comparator')
     value = this.transformValue(value, currentComparator)
@@ -337,7 +336,7 @@ the provided value."
         model,
       })
     )
-
+    this.updateValueFromInput()    
     const isEditing = this.$el.hasClass('is-editing')
     if (isEditing || this.options.editing) {
       this.turnOnEditing()


### PR DESCRIPTION
#### What does this PR do?
Moves the updateValueFromInput call to after the new view is set so the value of the old is not used.
#### Who is reviewing it? 
@rzwiefel @Bdthomson
#### How should this be tested?
Start an advanced query, enter any value. 
Switch to the "near" filter comparator. 
Select "search".
Validate that the query editor closes and the query executes.
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #DDF-05055

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
