### PR TITLE
DDF-2824 added conditional to docs templates

### DIFF
--- a/distribution/docs/src/main/resources/templates/architectures.ftl
+++ b/distribution/docs/src/main/resources/templates/architectures.ftl
@@ -13,4 +13,7 @@ include::config.adoc[]
 
 <#include "build/developing.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/developing.ftl
+++ b/distribution/docs/src/main/resources/templates/developing.ftl
@@ -15,4 +15,7 @@ include::config.adoc[]
 
 <#include "build/development-guidelines.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/documentation.ftl
+++ b/distribution/docs/src/main/resources/templates/documentation.ftl
@@ -62,4 +62,7 @@ include::config.adoc[]
 [appendix]
 <#include "build/metadata-reference.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/integrating.ftl
+++ b/distribution/docs/src/main/resources/templates/integrating.ftl
@@ -13,4 +13,7 @@ include::config.adoc[]
 
 <#include "build/integrating.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/managing.ftl
+++ b/distribution/docs/src/main/resources/templates/managing.ftl
@@ -13,4 +13,7 @@ include::config.adoc[]
 
 <#include "build/managing.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/metadata.ftl
+++ b/distribution/docs/src/main/resources/templates/metadata.ftl
@@ -14,4 +14,7 @@ include::config.adoc[]
 
 <#include "build/metadata-reference.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/overview.ftl
+++ b/distribution/docs/src/main/resources/templates/overview.ftl
@@ -13,4 +13,7 @@ include::config.adoc[]
 
 <#include "build/introduction.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/quickstart.ftl
+++ b/distribution/docs/src/main/resources/templates/quickstart.ftl
@@ -13,4 +13,7 @@ include::config.adoc[]
 
 <#include "build/quickstart.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/reference.ftl
+++ b/distribution/docs/src/main/resources/templates/reference.ftl
@@ -16,4 +16,7 @@ include::config.adoc[]
 
 <#include "build/reference.ftl">
 
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]

--- a/distribution/docs/src/main/resources/templates/using.ftl
+++ b/distribution/docs/src/main/resources/templates/using.ftl
@@ -15,4 +15,8 @@ include::config.adoc[]
 
 <#include "build/using.ftl">
 
+
+ifdef::backend-html5[]
+
 include::${project.build.directory}/asciidoctor-ready-${project.version}/scripts.html[]
+endif::backend-html5[]


### PR DESCRIPTION

#### What does this PR do?

Cleans up log warnings within the Documentation module build (it works without these changes, but has warnings in the build logs about `conversion missing for backend pdf`. The scripts being included have no effect on the pdf build, so the templates now perform a check and skip including them during pdf generation. 

#### Who is reviewing it? 

@codice/docs 

#### Ask 2 committers to review/merge the PR and tag them here.

@adimka
@ahoffer
@brjeter
@lessarderic
@ricklarsen - Documentation

#### How should this be tested?

build the docs module with `mvn clean install -Prelease`. the noise in the log should be gone.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
