### PR TITLE
[2.16.x] DDF-5071 Remove old css 

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/css/searchPage.css
+++ b/ui/packages/catalog-ui-search/src/main/webapp/css/searchPage.css
@@ -65,21 +65,6 @@ table {
   border-bottom: 6px solid #242424;
 }
 
-body {
-  background-image: -moz-linear-gradient(top, #252525, #252a30);
-  background-image: -webkit-gradient(
-    linear,
-    0 0,
-    0 100%,
-    from(#252525),
-    to(#252a30)
-  );
-  background-image: -webkit-linear-gradient(top, #252525, #252a30);
-  background-image: -o-linear-gradient(top, #252525, #252a30);
-  background-image: linear-gradient(to bottom, #252525, #252a30);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff252525', endColorstr='#ff252a30', GradientType=0);
-}
-
 .nav-tabs .open .dropdown-toggle {
   background-color: #252525;
 }


### PR DESCRIPTION
Port of this PR https://github.com/codice/ddf/pull/5073

-->

#### What does this PR do?
Removes old search page css from standard search. At some point it started winning out in terms of specificity for rules, which mucked with some of the Intrigue styling, such as the consent banner and the initial loading.
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewkfiedler 
@garrettfreibott
@Bdthomson
@adimka
@vinamartin 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Verify that the consent banner background and text color contrast with one another.

#### What are the relevant tickets?
Fixes: #5071 
