### PR TITLE
DDF-5084 Updated EventProcessor to be optional for PubSub for better shutdown

### DIFF
--- a/catalog/core/catalog-core-impl/pubsub-tracker/src/main/java/ddf/catalog/pubsub/tracker/SubscriptionTracker.java
+++ b/catalog/core/catalog-core-impl/pubsub-tracker/src/main/java/ddf/catalog/pubsub/tracker/SubscriptionTracker.java
@@ -63,16 +63,20 @@ public class SubscriptionTracker {
         SubscriptionTracker.class.getName(),
         serviceId);
 
-    try {
-      String subscriptionId = provider.createSubscription(subscription);
-      LOGGER.debug(
-          "{} Provider has created the subscription for request ({}): {}",
-          provider.getClass().getName(),
-          serviceId,
-          subscriptionId);
-      services.put(serviceId, subscriptionId);
-    } catch (EventException e) {
-      LOGGER.info("Error in creating subscription. {}", serviceId, e);
+    if (provider != null) {
+      try {
+        String subscriptionId = provider.createSubscription(subscription);
+        LOGGER.debug(
+            "{} Provider has created the subscription for request ({}): {}",
+            provider.getClass().getName(),
+            serviceId,
+            subscriptionId);
+        services.put(serviceId, subscriptionId);
+      } catch (EventException e) {
+        LOGGER.info("Error in creating subscription. {}", serviceId, e);
+      }
+    } else {
+      LOGGER.debug("EventProcessor was null.");
     }
 
     LOGGER.debug("EXITING: {}", methodName);
@@ -93,16 +97,20 @@ public class SubscriptionTracker {
             SubscriptionTracker.class.getName(),
             serviceId);
 
-        try {
-          provider.deleteSubscription(subscriptionId);
+        if (provider != null) {
+          try {
+            provider.deleteSubscription(subscriptionId);
 
-          LOGGER.debug("Subscription ({}) has been deleted.", serviceId);
+            LOGGER.debug("Subscription ({}) has been deleted.", serviceId);
 
-          // cleanup the reference in our map
-          services.remove(serviceId);
+            // cleanup the reference in our map
+            services.remove(serviceId);
 
-        } catch (EventException e) {
-          LOGGER.info("Error in deleting subscription. ", serviceId, e);
+          } catch (EventException e) {
+            LOGGER.info("Error in deleting subscription. ", serviceId, e);
+          }
+        } else {
+          LOGGER.debug("EventProcessor was null.");
         }
       }
     }

--- a/catalog/core/catalog-core-impl/pubsub-tracker/src/main/resources/OSGI-INF/blueprint/events_blueprint.xml
+++ b/catalog/core/catalog-core-impl/pubsub-tracker/src/main/resources/OSGI-INF/blueprint/events_blueprint.xml
@@ -15,7 +15,7 @@
 
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
     
-    <reference id="pubsubprovider" interface="ddf.catalog.event.EventProcessor"/>
+    <reference id="pubsubprovider" interface="ddf.catalog.event.EventProcessor" availability="optional"/>
     			
     <bean id="subscriptionTracker" class="ddf.catalog.pubsub.tracker.SubscriptionTracker"
           init-method="startUp" destroy-method="cleanUp">


### PR DESCRIPTION
#### What does this PR do?
Updates EventProcessor to be optional for PubSub because the bundles were getting stuck waiting after the necessary `catalog-core-standardframework` was destroyed. This occurs whenever subscriptions are created, and can take longer than 10min to shutdown. This fixes that issue. 
#### Who is reviewing it? 
@austinsteffes 
@Kjames5269 

#### Ask 2 committers to review/merge the PR and tag them here.
@ahoffer
@brjeter
@clockard 

#### How should this be tested?
1. Install
2. Add subscription in downstream product (see me for how to do so if necessary)
3. Shutdown
4. Verify this took no more than 3min to do so

#### What are the relevant tickets?
Fixes: #5084 


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
