### PR TITLE
DDF-05092 Always set the WFS 1.1 generic feature converter coordinate order

### DIFF
--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/pom.xml
@@ -12,7 +12,6 @@
  *
  **/
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -28,6 +27,10 @@
   <packaging>bundle</packaging>
 
   <dependencies>
+    <dependency>
+      <groupId>org.codice.ddf.spatial</groupId>
+      <artifactId>spatial-wfs-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.codice.ddf.spatial</groupId>
       <artifactId>spatial-wfs-featuretransformer-api</artifactId>
@@ -63,13 +66,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>ddf.jaxb</groupId>
-      <artifactId>spatial-wfs-v2_0_0-schema-bindings</artifactId>
-      <version>${ddf.jaxb.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codice.ddf.spatial</groupId>
-      <artifactId>spatial-wfs-v2_0_0-converter</artifactId>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api</artifactId>
     </dependency>
     <dependency>
       <groupId>ddf.catalog.core</groupId>
@@ -80,51 +78,34 @@
       <artifactId>platform-util</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codice.ddf.spatial</groupId>
-      <artifactId>spatial-wfs-v2_0_0-common</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.codice.ddf</groupId>
       <artifactId>geospatial</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.ogc</groupId>
-      <artifactId>gml-v_3_1_1</artifactId>
-      <version>${jvnet-ogc.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.ogc</groupId>
-      <artifactId>gml-v_3_2_1-schema</artifactId>
-      <version>1.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.ogc</groupId>
-      <artifactId>filter-v_1_1_0</artifactId>
-      <version>${jvnet-ogc.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.ogc</groupId>
-      <artifactId>filter-v_2_0_0-schema</artifactId>
-      <version>1.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.ogc</groupId>
-      <artifactId>ows-v_1_1_0-schema</artifactId>
-      <version>1.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codice.ddf.spatial</groupId>
-      <artifactId>spatial-ogc-common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codice.ddf.spatial</groupId>
       <artifactId>spatial-wfs-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>ddf.jaxb</groupId>
-      <artifactId>spatial-wfs-v1_0_0-schema-bindings</artifactId>
-      <version>${ddf.jaxb.version}</version>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codice.ddf.spatial</groupId>
+      <artifactId>spatial-ogc-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ws.xmlschema</groupId>
+      <artifactId>xmlschema-core</artifactId>
+      <version>2.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 
@@ -133,49 +114,24 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package/>
             <Embed-Dependency>
               catalog-core-api-impl,
-              filter-v_2_0_0-schema,
               geospatial,
-              gml-v_3_2_1-schema,
               jaxb2-basics-runtime;version="0.11.0",
-              ows-v_1_1_0-schema,
               platform-util,
               spatial-ogc-common,
               spatial-wfs-common,
               spatial-wfs-converter,
-              spatial-wfs-v1_0_0-schema-bindings,
               spatial-wfs-v1_1_0-common,
-              spatial-wfs-v1_1_0-converter,
-              spatial-wfs-v2_0_0-common,
-              spatial-wfs-v2_0_0-converter,
-              spatial-wfs-v2_0_0-schema-bindings
+              spatial-wfs-v1_1_0-converter
             </Embed-Dependency>
           </instructions>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>check-artifact-size</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <ArtifactSizeEnforcerRule
-                    implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
-                  <maxArtifactSize>3.1_MB</maxArtifactSize>
-                </ArtifactSizeEnforcerRule>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -195,19 +151,18 @@
                     <limit implementation="org.codice.jacoco.LenientLimit">
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.70</minimum>
+                      <minimum>0.95</minimum>
                     </limit>
                     <limit implementation="org.codice.jacoco.LenientLimit">
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.60</minimum>
+                      <minimum>0.67</minimum>
                     </limit>
                     <limit implementation="org.codice.jacoco.LenientLimit">
                       <counter>COMPLEXITY</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.40</minimum>
+                      <minimum>0.70</minimum>
                     </limit>
-
                   </limits>
                 </rule>
               </rules>

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/main/java/org/codice/ddf/spatial/ogc/wfs/transformer/xstream/XStreamWfs11FeatureTransformer.java
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/main/java/org/codice/ddf/spatial/ogc/wfs/transformer/xstream/XStreamWfs11FeatureTransformer.java
@@ -118,8 +118,8 @@ public class XStreamWfs11FeatureTransformer implements FeatureTransformer<Featur
       featureConverter = getGenericFeatureConverter(metacardMapper);
     } else {
       featureConverter = getGenericFeatureConverter(featureType);
-      featureConverter.setCoordinateOrder(coordinateOrder);
     }
+    featureConverter.setCoordinateOrder(coordinateOrder);
 
     return featureConverter;
   }

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/test/java/org/codice/ddf/spatial/ogc/wfs/transformer/xstream/XStreamWfs11FeatureTransformerTest.java
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/test/java/org/codice/ddf/spatial/ogc/wfs/transformer/xstream/XStreamWfs11FeatureTransformerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Core;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -187,7 +188,8 @@ public class XStreamWfs11FeatureTransformerTest {
   private MetacardMapper mockMetacardMapper() {
     MetacardMapper metacardMapper = mock(MetacardMapper.class);
     when(metacardMapper.getFeatureType()).thenReturn(PETER_PAN_NAME.toString());
-    when(metacardMapper.getMetacardAttribute(MAPPED_ATTRIBUTE)).thenReturn("title");
+    when(metacardMapper.getMetacardAttribute(MAPPED_ATTRIBUTE)).thenReturn(Core.TITLE);
+    when(metacardMapper.getMetacardAttribute("SpatialData")).thenReturn(Core.LOCATION);
     return metacardMapper;
   }
 }

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/test/java/org/codice/ddf/spatial/ogc/wfs/transformer/xstream/XStreamWfs11FeatureTransformerTest.java
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/test/java/org/codice/ddf/spatial/ogc/wfs/transformer/xstream/XStreamWfs11FeatureTransformerTest.java
@@ -13,9 +13,13 @@
  */
 package org.codice.ddf.spatial.ogc.wfs.transformer.xstream;
 
+import static java.util.Collections.singletonList;
+import static org.codice.ddf.libs.geo.util.GeospatialUtil.LAT_LON_ORDER;
+import static org.codice.ddf.libs.geo.util.GeospatialUtil.LON_LAT_ORDER;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +65,7 @@ public class XStreamWfs11FeatureTransformerTest {
 
   @Test
   public void testMetacardMappers() throws IOException {
-    transformer.setMetacardMappers(Collections.singletonList(mockMetacardMapper()));
+    transformer.setMetacardMappers(singletonList(mockMetacardMapper()));
 
     try (InputStream inputStream =
         new BufferedInputStream(getClass().getResourceAsStream("/FeatureMember.xml"))) {
@@ -73,13 +77,47 @@ public class XStreamWfs11FeatureTransformerTest {
   }
 
   @Test
+  public void testCoordinatesAreSwappedWhenCoordinateOrderIsLatLon() throws Exception {
+    transformer.setMetacardMappers(singletonList(mockMetacardMapper()));
+
+    try (final InputStream inputStream =
+        new BufferedInputStream(getClass().getResourceAsStream("/FeatureMember.xml"))) {
+      final Optional<Metacard> metacardOptional =
+          transformer.apply(inputStream, mockWfsMetadata(LAT_LON_ORDER));
+
+      assertThat(
+          "The feature transformer should have returned a metacard but didn't.",
+          metacardOptional.isPresent(),
+          is(true));
+      assertThat(metacardOptional.get().getLocation(), is("POINT (-123.26 49.4)"));
+    }
+  }
+
+  @Test
+  public void testCoordinatesAreNotSwappedWhenCoordinateOrderIsLonLat() throws Exception {
+    transformer.setMetacardMappers(singletonList(mockMetacardMapper()));
+
+    try (final InputStream inputStream =
+        new BufferedInputStream(getClass().getResourceAsStream("/FeatureMember.xml"))) {
+      final Optional<Metacard> metacardOptional =
+          transformer.apply(inputStream, mockWfsMetadata(LON_LAT_ORDER));
+
+      assertThat(
+          "The feature transformer should have returned a metacard but didn't.",
+          metacardOptional.isPresent(),
+          is(true));
+      assertThat(metacardOptional.get().getLocation(), is("POINT (49.4 -123.26)"));
+    }
+  }
+
+  @Test
   public void testFeatureConverters() throws IOException {
     FeatureConverterFactory featureConverterFactory = mock(FeatureConverterFactory.class);
     when(featureConverterFactory.getFeatureType()).thenReturn(PETER_PAN_NAME.toString());
 
     FeatureConverter featureConverter = new GenericFeatureConverter(mockMetacardMapper());
     when(featureConverterFactory.createConverter()).thenReturn(featureConverter);
-    transformer.setFeatureConverterFactories(Collections.singletonList(featureConverterFactory));
+    transformer.setFeatureConverterFactories(singletonList(featureConverterFactory));
 
     try (InputStream inputStream =
         new BufferedInputStream(getClass().getResourceAsStream("/FeatureMember.xml"))) {
@@ -124,11 +162,17 @@ public class XStreamWfs11FeatureTransformerTest {
   private WfsMetadata<FeatureTypeType> mockWfsMetadata() {
     WfsMetadata<FeatureTypeType> wfsMetadata = mock(WfsMetadata.class);
     when(wfsMetadata.getId()).thenReturn(SOURCE_ID);
-    when(wfsMetadata.getFeatureMemberNodeNames()).thenReturn(Collections.singletonList("PeterPan"));
+    when(wfsMetadata.getFeatureMemberNodeNames()).thenReturn(singletonList("PeterPan"));
     when(wfsMetadata.getActiveFeatureMemberNodeName()).thenReturn("PeterPan");
 
-    when(wfsMetadata.getDescriptors()).thenReturn(Collections.singletonList(mockFeatureType()));
+    when(wfsMetadata.getDescriptors()).thenReturn(singletonList(mockFeatureType()));
 
+    return wfsMetadata;
+  }
+
+  private WfsMetadata<FeatureTypeType> mockWfsMetadata(final String coordinateOrder) {
+    final WfsMetadata<FeatureTypeType> wfsMetadata = mockWfsMetadata();
+    when(wfsMetadata.getCoordinateOrder()).thenReturn(coordinateOrder);
     return wfsMetadata;
   }
 

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/test/resources/Neverland_FeatureType.xsd
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/test/resources/Neverland_FeatureType.xsd
@@ -48,5 +48,5 @@
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
-    <xsd:element name="PeterPAN" substitutionGroup="gml:_Feature" type="neverland:Peterpan_Type"/>
+    <xsd:element name="PeterPAN" substitutionGroup="gml:_Feature" type="neverland:PeterPan_Type"/>
 </xsd:schema>


### PR DESCRIPTION
#### What does this PR do?
In the case that a metacard mapper was present, the coordinate order was not set, which caused the generic feature converter to not flip the coordinates of lat/lon features when it should have. This PR ensures the coordinate order is always set on the generic feature converter so it knows when to flip the coordinates.

#### Who is reviewing it? 
@glenhein 
@leo-sakh 
@bennuttle 
@gjvera 

#### Select relevant component teams: 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith
@troymohl

#### How should this be tested?
1. In the Admin UI, open the Spatial app.
2. Click `Metacard to WFS Feature Map`.
3. For `Feature Type`, enter `{http://stategeothermaldata.org/uri-gin/aasg/xmlschema/welllog/0.8}AZWellLogs`.
4. For `Metacard Geography to WFS Feature Property Mapping`, enter `ext.AZWellLogs.Shape`.
5. Click `Save changes`.
6. Create a WFS 1.1.0 source with the URL http://services.azgs.az.gov/ArcGIS/services/aasggeothermal/AZWellLogs/MapServer/WFSServer
7. Open Intrigue and swap the 3D map for the 2D map.
8. Run a * query against the WFS source.
9. Verify the results are displayed on the map in Arizona.
10. Go back to the Admin UI, edit the source, and change the coordinate order to Lon/Lat.
11. Rerun the query in Intrigue and verify the results are displayed below the map.
a. Wait for the results from the source. The results from the cache will come back first and will still be displayed in Arizona.
12. Change the coordinate order back to Lat/Lon, rerun the query and verify the results are back in Arizona.

#### What are the relevant tickets?
Fixes: #5092 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.