### PR TITLE
DDF-5119 Suppress jackson-databind CVE-2018-11307

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -594,6 +594,7 @@
         <notes>
             These CVEs against jackson-databind only affect versions 2.9.7 and lower.
         </notes>
+        <cve>CVE-2018-11307</cve>
         <cve>CVE-2018-14719</cve>
         <cve>CVE-2018-14718</cve>
         <cve>CVE-2018-14721</cve>


### PR DESCRIPTION
#### What does this PR do?
OWASP is failing builds for the CVE-2018-11307 for jackson-databind dependency in ehcache jar. This PR suppresses that CVE because version 2.9.8 is what is visibly seen within the project. Solr does not use Batis, and it does not have the exploit for the polymorphic handling / default typing for jackson.

#### Who is reviewing it? 
@kcover 
@austinsteffes 
@Kjames5269 

#### Select relevant component teams: 
@codice/build 

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@stustison
@rzwiefel 

#### How should this be tested?
CI build 

#### What are the relevant tickets?
Fixes: #5119

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
