### PR TITLE
DDF-5126 Granted standardframework module permission for URL Resource Reader

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -84,7 +84,7 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
 //   directory being monitored.
 //
 // DO NOT MODIFY THE NEXT LINE. It specifies which  modules are granted permission.
-grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader" {
+grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader/catalog-core-standardframework" {
 
 
      // EXAMPLE. The two lines that begin with "permission" enable the URL Resource Reader to


### PR DESCRIPTION
### What does this PR do? 
It was discovered that the URL Resource Reader was failing to work with resources outside of certain directories because it needed the `catalog-core-standardframework` module to have permissions. This PR fixes that to allow it to work with other directories as well. 

#### Who is reviewing it? 
@austinsteffes 
@Kjames5269 

#### Ask 2 committers to review/merge the PR and tag them here.
@ahoffer
@brjeter
@stustison


#### How should this be tested?
(see me for test resources and finer details)
0. Create path outside of DDF and put image resource there
1. Unzip and edit `configurations.policy` file to have permissions to directory in step 0
2. Install standard 
3. Edit URL Resource Reader configuration to have access to path in step 0
4. Ingest xml resource through command line (make sure resource-uri property is same as step 0)
5. Go to Intrigue and hit download button on ingested product
6. Verify no issues and image is returned 

#### What are the relevant tickets?
Work for: #5126 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
