### PR TITLE
[2.16.x] DDF-5126 Add doPrivilged for UrlResourceReader

### DIFF
--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -33,7 +33,6 @@ import java.net.URI;
 import java.net.URLConnection;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
-import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -536,9 +535,11 @@ public class URLResourceReader implements ResourceReader {
   private boolean validateFilePath(File resourceFilePath) throws IOException {
     String resourceCanonicalPath;
     try {
-      resourceCanonicalPath = resourceFilePath.getCanonicalPath();
-    } catch (AccessControlException e) {
-      LOGGER.debug("Unable to read path [{}]", resourceFilePath, e);
+      resourceCanonicalPath =
+          AccessController.doPrivileged(
+              (PrivilegedExceptionAction<String>) () -> resourceFilePath.getCanonicalPath());
+    } catch (PrivilegedActionException e) {
+      LOGGER.debug("Unable to read path [{}]", resourceFilePath, e.getException());
       return false;
     }
     LOGGER.debug(


### PR DESCRIPTION
#### What does this PR do?
It was discovered that the URL Resource Reader was failing to work with resources outside of certain directories because it needed a doPrivileged block around the canonical path. This PR fixes that to allow it to work with other directories as well.

#### Who is reviewing it? 
@austinsteffes
@Kjames5269

#### Ask 2 committers to review/merge the PR and tag them here.
@ahoffer 
@brjeter
@stustison

#### How should this be tested?
(see me for test resources and finer details)
0. Create path outside of DDF and put image resource there

1. Unzip and edit configurations.policy file to have permissions to directory in step 0
2. Install standard
3. Edit URL Resource Reader configuration to have access to path in step 0
4. Ingest xml resource through command line (make sure resource-uri property is same as step 0)
5. Go to Intrigue and hit download button on ingested product
6. Verify no issues and image is returned

#### What are the relevant tickets?
Work for: #5126 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
