### PR TITLE
DDF-5126 Add doPrivileged for UrlResourceReader

### DIFF
--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -33,7 +33,6 @@ import java.net.URI;
 import java.net.URLConnection;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
-import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -536,9 +535,11 @@ public class URLResourceReader implements ResourceReader {
   private boolean validateFilePath(File resourceFilePath) throws IOException {
     String resourceCanonicalPath;
     try {
-      resourceCanonicalPath = resourceFilePath.getCanonicalPath();
-    } catch (AccessControlException e) {
-      LOGGER.debug("Unable to read path [{}]", resourceFilePath, e);
+      resourceCanonicalPath =
+          AccessController.doPrivileged(
+              (PrivilegedExceptionAction<String>) () -> resourceFilePath.getCanonicalPath());
+    } catch (PrivilegedActionException e) {
+      LOGGER.debug("Unable to read path [{}]", resourceFilePath, e.getException());
       return false;
     }
     LOGGER.debug(

--- a/distribution/ddf-common/src/main/resources/security/configurations.policy
+++ b/distribution/ddf-common/src/main/resources/security/configurations.policy
@@ -84,7 +84,7 @@ grant codeBase "file:/catalog-core-directorymonitor/org.apache.camel.camel-core/
 //   directory being monitored.
 //
 // DO NOT MODIFY THE NEXT LINE. It specifies which  modules are granted permission.
-grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader/catalog-core-standardframework" {
+grant codeBase "file:/org.apache.tika.core/catalog-core-urlresourcereader" {
 
 
      // EXAMPLE. The two lines that begin with "permission" enable the URL Resource Reader to


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.16.X AND MASTER IS IN EFFECT
Link to 2.16.x PR: #5139 

#### What does this PR do?
When working on the 2.16.x port, it was discovered that there was a better solution by adding a doPrivileged block instead. This PR reverts the changes from #5128 and uses the better solution. 

#### Who is reviewing it? 
@peterhuffer 
@austinsteffes
@Kjames5269

#### Ask 2 committers to review/merge the PR and tag them here.
@ahoffer
@brjeter
@stustison 

#### How should this be tested?
See #5139 

#### What are the relevant tickets?
Fixes: #5126 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
