### PR TITLE
DDF-5153 Added security attributes to query metacards

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/metacard/QueryMetacardTypeImpl.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/metacard/QueryMetacardTypeImpl.java
@@ -33,6 +33,7 @@ import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.SecurityAttributes;
 import ddf.catalog.data.types.Core;
 import java.util.HashSet;
 import java.util.Set;
@@ -174,6 +175,8 @@ public class QueryMetacardTypeImpl extends MetacardTypeImpl {
             false /* tokenized */,
             false /* multivalued */,
             BasicTypes.BOOLEAN_TYPE));
+
+    QUERY_DESCRIPTORS.addAll(new SecurityAttributes().getAttributeDescriptors());
 
     QUERY_ATTRIBUTE_NAMES =
         QUERY_DESCRIPTORS.stream().map(AttributeDescriptor::getName).collect(Collectors.toSet());

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
@@ -33,6 +33,7 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Security;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Date;
@@ -100,6 +101,15 @@ public class QueryBasic {
   @SerializedName("phonetics")
   private Boolean phonetics;
 
+  @SerializedName("accessAdministrators")
+  private List<String> accessAdministrators;
+
+  @SerializedName("accessIndividuals")
+  private List<String> accessIndividuals;
+
+  @SerializedName("accessIndividualsRead")
+  private List<String> accessIndividualsRead;
+
   public QueryBasic(Metacard metacard) {
     this.metacardId = getAttributeValue(metacard, Core.ID, String.class);
     this.title = getAttributeValue(metacard, Core.TITLE, String.class);
@@ -123,6 +133,13 @@ public class QueryBasic {
     this.facets = getAttributeValues(metacard, FACETS, String.class);
     this.spellcheck = getAttributeValue(metacard, SPELLCHECK, Boolean.class);
     this.phonetics = getAttributeValue(metacard, PHONETICS, Boolean.class);
+
+    this.accessAdministrators =
+        getAttributeValues(metacard, Security.ACCESS_ADMINISTRATORS, String.class);
+    this.accessIndividuals =
+        getAttributeValues(metacard, Security.ACCESS_INDIVIDUALS, String.class);
+    this.accessIndividualsRead =
+        getAttributeValues(metacard, Security.ACCESS_INDIVIDUALS_READ, String.class);
   }
 
   public Metacard getMetacard() {
@@ -147,6 +164,14 @@ public class QueryBasic {
     metacard.setAttribute(new AttributeImpl(FACETS, (Serializable) this.facets));
     metacard.setAttribute(new AttributeImpl(SPELLCHECK, this.spellcheck));
     metacard.setAttribute(new AttributeImpl(PHONETICS, this.phonetics));
+    metacard.setAttribute(
+        new AttributeImpl(
+            Security.ACCESS_ADMINISTRATORS, (Serializable) this.accessAdministrators));
+    metacard.setAttribute(
+        new AttributeImpl(Security.ACCESS_INDIVIDUALS, (Serializable) this.accessIndividuals));
+    metacard.setAttribute(
+        new AttributeImpl(
+            Security.ACCESS_INDIVIDUALS_READ, (Serializable) this.accessIndividualsRead));
 
     return new QueryMetacardImpl(metacard);
   }


### PR DESCRIPTION
#### What does this PR do?
- Add the security attributes to query metacards to enable sharing of queries. 

#### Who is reviewing it? 
@rececoffin 
@Bdthomson 

#### Select relevant component teams: 
@codice/data 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler 
@vinamartin

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Add a new user to DDF. 
2. Ingest a query metacard as a different user. 
3. Update the query metacard to contain the email address for your new user. 
4. Verify that this new user can retrieve this query. 

#### Any background context you want to provide?
- None

#### What are the relevant tickets?
Fixes: #5153 

#### Screenshots
<!--(if appropriate)-->
- None 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
