### PR TITLE
Add null checking to SubjectUtils

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -329,5 +329,14 @@
         <cve>CVE-2016-6811</cve>
         <cve>CVE-2017-3162</cve>
     </suppress>
+    <suppress>
+        <notes>
+            This CVE affects jackson-databind up to version 2.9.9.1. This is pulled in primarily by
+            ehcache, which cannot be upgraded until DDF's other dependencies (such as CXF) upgrade.
+            This CVE will be addressed by upgrading from ehcache2 to latest ehcache3, once the other
+            dependencies have upgraded.
+        </notes>
+        <cve>CVE-2019-14379</cve>
+    </suppress>
 
 </suppressions>

--- a/platform/security/platform-security-core-api/src/main/java/ddf/security/SubjectUtils.java
+++ b/platform/security/platform-security-core-api/src/main/java/ddf/security/SubjectUtils.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
@@ -314,6 +315,7 @@ public final class SubjectUtils {
         .flatMap(Collection::stream)
         .map(AttributeStatement::getAttributes)
         .flatMap(Collection::stream)
+        .filter(SubjectUtils::attributeValuesAreNonNull)
         .collect(
             Collectors.toMap(
                 Attribute::getName,
@@ -379,5 +381,9 @@ public final class SubjectUtils {
     public int compare(SecurityAssertion assertion1, SecurityAssertion assertion2) {
       return Integer.compare(assertion1.getWeight(), assertion2.getWeight());
     }
+  }
+
+  private static boolean attributeValuesAreNonNull(Attribute attribute) {
+    return !attribute.getValues().stream().allMatch(Objects::isNull);
   }
 }


### PR DESCRIPTION
<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
Adds null checking to `SubjectUtils.getSubjectAttributes`.

#### Who is reviewing it? 
@blen-desta 
@garrettfreibott 
@stustison 
@bdeining 

#### How should this be tested?
Easy:
1. Build, run, and install DDF.
2. Login and logout using 2 different methods (PKI and BASIC, for example).

More Involved:
1. Build, run, and install DDF with debugging enabled.
2. Put a breakpoint at the top of `SubjectUtils.getSubjectAttributes`.
3. Log into DDF and perform operations until the breakpoint is hit.
4. (Feel free to message me about clarifying this one) Modify the subject object so on of its attributes contains a list containing only `null`.
5. Step through the rest of the `getSubjectAttributes` method. It should not error out.

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #5160 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
