### PR TITLE
DDF-5117 Fixed location spacing bug in query editor

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
@@ -112,7 +112,7 @@ const Invalid = styled.div`
 `
 
 const Root = styled.div`
-  height: ${props => (props.open ? 'auto' : props.theme.minimumButtonSize)};
+  height: ${props => (props.isOpen ? 'auto' : props.theme.minimumButtonSize)};
 `
 
 const Component = CustomElements.registerReact('location')
@@ -128,7 +128,7 @@ const LocationInput = props => {
     setState((errors = false))
   }
   return (
-    <Root open={props.open}>
+    <Root isOpen={input.label !== undefined}>
       <Component>
         <Dropdown label={input.label || 'Select Location Option'}>
           <Menu value={mode} onChange={cursor('mode')}>
@@ -226,7 +226,6 @@ module.exports = ({ state, setState, options }) => (
           return
         }
         setState(key, value, (errors = false))
-        setState('open', true)
       }
     }}
   />


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug in location attribute filters where the area wasn't expanding when a shape is selected. See screenshot below.
#### Who is reviewing it? 
@willwill96 
@andrewzimmer 
@Corey-Collins 
@zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@adimka 
@bdeining 
#### How should this be tested?
Verify that the spacing is correct in new queries and existing queries in the editor when a shape is and isn't selected
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #5117 
#### Screenshots
Before
![image](https://user-images.githubusercontent.com/39737329/62642169-62ca2980-b902-11e9-97cb-d34a20dcf9d3.png)
After
![image](https://user-images.githubusercontent.com/39737329/62642350-b89ed180-b902-11e9-9edf-fe6b7b9c5167.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
