### PR TITLE
DDF-5165 Fix a bug causing query metacards to have the wrong tag

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -538,12 +538,12 @@ public class MetacardApplication implements SparkApplication {
           Map<String, Object> incoming =
               GSON.fromJson(util.safeGetBody(req), MAP_STRING_TO_OBJECT_TYPE);
 
-          List<Metacard> queries =
+          List<QueryMetacardImpl> queries =
               ((List<Map<String, Object>>)
                       incoming.getOrDefault(
                           WorkspaceConstants.WORKSPACE_QUERIES, Collections.emptyList()))
                   .stream()
-                  .map(transformer::transform)
+                  .map(this::jsonToQueryMetacard)
                   .collect(Collectors.toList());
 
           queryMetacardsHandler.create(Collections.emptyList(), queries);
@@ -567,11 +567,12 @@ public class MetacardApplication implements SparkApplication {
           Map<String, Object> updatedWorkspace =
               GSON.fromJson(util.safeGetBody(req), MAP_STRING_TO_OBJECT_TYPE);
 
-          List<Metacard> updatedQueryMetacards =
+          List<QueryMetacardImpl> updatedQueryMetacards =
               ((List<Map<String, Object>>)
-                      updatedWorkspace.getOrDefault("queries", Collections.emptyList()))
+                      updatedWorkspace.getOrDefault(
+                          WorkspaceConstants.WORKSPACE_QUERIES, Collections.emptyList()))
                   .stream()
-                  .map(transformer::transform)
+                  .map(this::jsonToQueryMetacard)
                   .collect(Collectors.toList());
 
           List<String> updatedQueryIds =
@@ -1160,6 +1161,12 @@ public class MetacardApplication implements SparkApplication {
   private Metacard saveMetacard(Metacard metacard)
       throws IngestException, SourceUnavailableException {
     return catalogFramework.create(new CreateRequestImpl(metacard)).getCreatedMetacards().get(0);
+  }
+
+  private QueryMetacardImpl jsonToQueryMetacard(final Map<String, Object> queryJson) {
+    final QueryMetacardImpl queryMetacard = new QueryMetacardImpl();
+    transformer.transformIntoMetacard(queryJson, queryMetacard);
+    return queryMetacard;
   }
 
   private static class ByteSourceWrapper extends ByteSource {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/metacard/QueryMetacardImpl.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/metacard/QueryMetacardImpl.java
@@ -43,7 +43,6 @@ public class QueryMetacardImpl extends MetacardImpl {
 
   public QueryMetacardImpl(Metacard wrappedMetacard) {
     super(wrappedMetacard, TYPE);
-    setTags(Collections.singleton(QUERY_TAG));
 
     for (AttributeDescriptor attrDesc : TYPE.getAttributeDescriptors()) {
       Attribute attr = wrappedMetacard.getAttribute(attrDesc.getName());
@@ -54,6 +53,8 @@ public class QueryMetacardImpl extends MetacardImpl {
         this.setAttribute(new AttributeImpl(attr.getName(), attr.getValue()));
       }
     }
+    // Set tags last in case tags from the wrapped metacard were copied above
+    setTags(Collections.singleton(QUERY_TAG));
   }
 
   public static QueryMetacardImpl from(Metacard metacard) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/AssociatedQueryMetacardsHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/AssociatedQueryMetacardsHandler.java
@@ -40,14 +40,13 @@ public class AssociatedQueryMetacardsHandler {
     this.catalogFramework = catalogFramework;
   }
 
-  public void create(List<String> existingQueryIds, List<Metacard> updatedQueryMetacards)
+  public void create(List<String> existingQueryIds, List<QueryMetacardImpl> updatedQueryMetacards)
       throws IngestException, SourceUnavailableException {
     List<Metacard> createMetacards =
         updatedQueryMetacards
             .stream()
             .filter(Objects::nonNull)
             .filter(query -> !existingQueryIds.contains(query.getId()))
-            .map(QueryMetacardImpl::new)
             .collect(Collectors.toList());
     if (!createMetacards.isEmpty()) {
       catalogFramework.create(new CreateRequestImpl(createMetacards));
@@ -70,7 +69,7 @@ public class AssociatedQueryMetacardsHandler {
   public void update(
       List<String> existingQueryIds,
       List<QueryMetacardImpl> existingQueryMetacards,
-      List<Metacard> updatedQueryMetacards)
+      List<QueryMetacardImpl> updatedQueryMetacards)
       throws IngestException, SourceUnavailableException {
     Map<String, QueryMetacardImpl> existingQueryMap =
         existingQueryMetacards
@@ -81,7 +80,6 @@ public class AssociatedQueryMetacardsHandler {
             .stream()
             .filter(query -> existingQueryIds.contains(query.getId()))
             .filter(query -> hasChanges(existingQueryMap.get(query.getId()), query))
-            .map(QueryMetacardImpl::new)
             .collect(Collectors.toList());
     if (!updateMetacards.isEmpty()) {
       String[] updateMetacardIds =

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/AssociatedQueryMetacardsHandlerTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/metacard/workspace/transformer/impl/AssociatedQueryMetacardsHandlerTest.java
@@ -20,9 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import ddf.catalog.CatalogFramework;
-import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteRequest;
@@ -56,7 +54,8 @@ public class AssociatedQueryMetacardsHandlerTest {
 
   @Test
   public void testCreateQueryMetacards() throws IngestException, SourceUnavailableException {
-    List<Metacard> updatedQueryMetacards = Collections.singletonList(new MetacardImpl());
+    List<QueryMetacardImpl> updatedQueryMetacards =
+        Collections.singletonList(new QueryMetacardImpl());
     doReturn(mock(CreateResponse.class)).when(catalogFramework).create(any(CreateRequest.class));
 
     queryMetacardsHandler.create(Collections.emptyList(), updatedQueryMetacards);


### PR DESCRIPTION
#### What does this PR do?
When creating or updating query metacards, MetacardApplication always transformed the incoming query JSON to a workspace metacard before handing it to AssociatedQueryMetacardsHandler, who transformed it to a query metacard using QueryMetacardImpl's copy constructor. Recently, the 'metacard-tags' attribute was added to the query metacard type. QueryMetacardImpl's copy constructor set its tag to 'query' and then copied all of the query metacard type's attributes from the source metacard to itself. Since the query metacard type's attributes now contain 'metacard-tags', the tags of the source metacard were copied too, overwriting the tag of 'query' that had already been set. In this case, the source metacard was a workspace metacard so all query metacards that were created in this manner had a tag of 'workspace' instead of 'query'.

MetacardApplication now transforms query JSON into query metacards instead of workspace metacards so no further transformations are needed.

QueryMetacardImpl now sets its tag after copying attributes from the source metacard to prevent it from being overwritten.

#### Who is reviewing it? 
@bellcc 
@cantstoptheunk 
@rececoffin  

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@rzwiefel

#### How should this be tested?
1. Create a workspace with at least one query. Open Solr, search for `metacard-tags_txt:query` and verify that you see all the queries you created and that they have the `query` tag and **not** the `workspace` tag.
2. Verify that you can make updates to both your queries and workspace and that they are correctly updated in Solr after you save the workspace.
3. Verify that you can duplicate a workspace. Use Solr to verify that the workspace and query metacards were correctly copied.

#### What are the relevant tickets?
Fixes: #5165 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.