### PR TITLE
Revert "remove non-existent dependency (#5213)" and restores source

### DIFF
--- a/features/security/pom.xml
+++ b/features/security/pom.xml
@@ -177,6 +177,12 @@
         </dependency>
         <dependency>
             <groupId>ddf.security.sts</groupId>
+            <artifactId>security-sts-usernametokenvalidator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.security.sts</groupId>
             <artifactId>security-sts-realm</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -268,6 +268,7 @@
         <feature>security-core-api</feature>
         <bundle>mvn:ddf.security.sts/security-sts-x509validator/${project.version}</bundle>
         <feature>parser-xml</feature>
+        <bundle>mvn:ddf.security.sts/security-sts-usernametokenvalidator/${project.version}</bundle>
     </feature>
 
     <feature name="security-sts-realm" version="${project.version}"

--- a/platform/security/sts/pom.xml
+++ b/platform/security/sts/pom.xml
@@ -29,6 +29,7 @@
         <module>security-sts-server</module>
         <module>security-sts-samlvalidator</module>
         <module>security-sts-x509validator</module>
+        <module>security-sts-usernametokenvalidator</module>
         <module>security-sts-ldapclaimshandler</module>
         <module>security-sts-ldaplogin</module>
         <module>security-sts-x509delegationhandler</module>

--- a/platform/security/sts/security-sts-usernametokenvalidator/pom.xml
+++ b/platform/security/sts/security-sts-usernametokenvalidator/pom.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>security-sts-pom</artifactId>
+        <groupId>ddf.security.sts</groupId>
+        <version>2.17.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>security-sts-usernametokenvalidator</artifactId>
+    <name>DDF :: Security :: STS :: Username Token Validator</name>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-ws-security</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf.services.sts</groupId>
+            <artifactId>cxf-services-sts-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.jaas</groupId>
+            <artifactId>org.apache.karaf.jaas.config</artifactId>
+            <version>${karaf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util-unavailableurls</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-parser-xml</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-parser-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>httpclient,httpcore,platform-util-unavailableurls,ddf-security-common,platform-util</Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-artifact-size</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <ArtifactSizeEnforcerRule
+                                    implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
+                                    <maxArtifactSize>1.4_MB</maxArtifactSize>
+                                </ArtifactSizeEnforcerRule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.73</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.58</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.46</minimum>
+                                        </limit>
+
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/security/sts/security-sts-usernametokenvalidator/src/main/java/org/codice/ddf/security/validator/username/UsernameTokenValidator.java
+++ b/platform/security/sts/security-sts-usernametokenvalidator/src/main/java/org/codice/ddf/security/validator/username/UsernameTokenValidator.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ * <p>
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codice.ddf.security.validator.username;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.security.auth.callback.CallbackHandler;
+import javax.xml.bind.JAXBElement;
+import org.apache.cxf.helpers.DOMUtils;
+import org.apache.cxf.sts.QNameConstants;
+import org.apache.cxf.sts.STSPropertiesMBean;
+import org.apache.cxf.sts.request.ReceivedToken;
+import org.apache.cxf.sts.token.validator.TokenValidator;
+import org.apache.cxf.sts.token.validator.TokenValidatorParameters;
+import org.apache.cxf.sts.token.validator.TokenValidatorResponse;
+import org.apache.cxf.ws.security.sts.provider.model.secext.UsernameTokenType;
+import org.apache.karaf.jaas.config.JaasRealm;
+import org.apache.wss4j.common.bsp.BSPEnforcer;
+import org.apache.wss4j.common.crypto.Crypto;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.principal.CustomTokenPrincipal;
+import org.apache.wss4j.common.principal.WSUsernameTokenPrincipalImpl;
+import org.apache.wss4j.dom.WSConstants;
+import org.apache.wss4j.dom.engine.WSSConfig;
+import org.apache.wss4j.dom.handler.RequestData;
+import org.apache.wss4j.dom.message.token.UsernameToken;
+import org.apache.wss4j.dom.validate.Credential;
+import org.apache.wss4j.dom.validate.JAASUsernameTokenValidator;
+import org.apache.wss4j.dom.validate.Validator;
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.ParserConfigurator;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.security.common.FailedLoginDelayer;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/** This class validates a wsse UsernameToken. */
+public class UsernameTokenValidator implements TokenValidator {
+
+  private final Parser parser;
+
+  private final FailedLoginDelayer failedLoginDelayer;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UsernameTokenValidator.class);
+
+  protected Map<String, Validator> validators = new ConcurrentHashMap<>();
+
+  public UsernameTokenValidator(Parser parser, FailedLoginDelayer failedLoginDelayer) {
+    this.parser = parser;
+    this.failedLoginDelayer = failedLoginDelayer;
+  }
+
+  public void addRealm(ServiceReference<JaasRealm> serviceReference) {
+    Bundle bundle = FrameworkUtil.getBundle(UsernameTokenValidator.class);
+    if (null != bundle) {
+      JaasRealm realm = bundle.getBundleContext().getService(serviceReference);
+      LOGGER.trace("Adding validator for JaasRealm {}", realm.getName());
+      JAASUsernameTokenValidator validator = new JAASUsernameTokenValidator();
+      validator.setContextName(realm.getName());
+      validators.put(realm.getName(), validator);
+    }
+  }
+
+  public void removeRealm(ServiceReference<JaasRealm> serviceReference) {
+    Bundle bundle = FrameworkUtil.getBundle(UsernameTokenValidator.class);
+    if (null != bundle) {
+      JaasRealm realm = bundle.getBundleContext().getService(serviceReference);
+      LOGGER.trace("Removing validator for JaasRealm {}", realm.getName());
+      validators.remove(realm.getName());
+    }
+  }
+
+  /**
+   * Return true if this TokenValidator implementation is capable of validating the ReceivedToken
+   * argument.
+   */
+  public boolean canHandleToken(ReceivedToken validateTarget) {
+    return canHandleToken(validateTarget, null);
+  }
+
+  /**
+   * Return true if this TokenValidator implementation is capable of validating the ReceivedToken
+   * argument. The realm is ignored in this token Validator.
+   */
+  public boolean canHandleToken(ReceivedToken validateTarget, String realm) {
+    if (validateTarget.getToken() instanceof UsernameTokenType) {
+      return true;
+    }
+    return false;
+  }
+
+  /** Validate a Token using the given TokenValidatorParameters. */
+  public TokenValidatorResponse validateToken(TokenValidatorParameters tokenParameters) {
+    LOGGER.debug("Validating UsernameToken");
+
+    if (parser == null) {
+      throw new IllegalStateException("XMLParser must be configured.");
+    }
+
+    if (failedLoginDelayer == null) {
+      throw new IllegalStateException("Failed Login Delayer must be configured");
+    }
+
+    STSPropertiesMBean stsProperties = tokenParameters.getStsProperties();
+    Crypto sigCrypto = stsProperties.getSignatureCrypto();
+    CallbackHandler callbackHandler = stsProperties.getCallbackHandler();
+
+    RequestData requestData = new RequestData();
+    requestData.setSigVerCrypto(sigCrypto);
+    WSSConfig wssConfig = WSSConfig.getNewInstance();
+    requestData.setWssConfig(wssConfig);
+    requestData.setCallbackHandler(callbackHandler);
+
+    TokenValidatorResponse response = new TokenValidatorResponse();
+    ReceivedToken validateTarget = tokenParameters.getToken();
+    validateTarget.setState(ReceivedToken.STATE.INVALID);
+    response.setToken(validateTarget);
+
+    if (!validateTarget.isUsernameToken()) {
+      return response;
+    }
+
+    //
+    // Turn the JAXB UsernameTokenType into a DOM Element for validation
+    //
+    UsernameTokenType usernameTokenType = (UsernameTokenType) validateTarget.getToken();
+    JAXBElement<UsernameTokenType> tokenType =
+        new JAXBElement<>(
+            QNameConstants.USERNAME_TOKEN, UsernameTokenType.class, usernameTokenType);
+    Document doc = DOMUtils.createDocument();
+    Element rootElement = doc.createElement("root-element");
+
+    List<String> ctxPath = new ArrayList<>(1);
+    ctxPath.add(UsernameTokenType.class.getPackage().getName());
+
+    Element usernameTokenElement = null;
+
+    ParserConfigurator configurator =
+        parser.configureParser(ctxPath, UsernameTokenValidator.class.getClassLoader());
+    try {
+      parser.marshal(configurator, tokenType, rootElement);
+      usernameTokenElement = (Element) rootElement.getFirstChild();
+    } catch (ParserException ex) {
+      LOGGER.info("Unable to parse username token", ex);
+      return response;
+    }
+
+    //
+    // Validate the token
+    //
+    try {
+      boolean allowNamespaceQualifiedPasswordTypes =
+          requestData.isAllowNamespaceQualifiedPasswordTypes();
+      UsernameToken ut =
+          new UsernameToken(
+              usernameTokenElement, allowNamespaceQualifiedPasswordTypes, new BSPEnforcer());
+      // The parsed principal is set independent whether validation is successful or not
+      response.setPrincipal(new CustomTokenPrincipal(ut.getName()));
+      if (ut.getPassword() == null) {
+        failedLoginDelayer.delay(ut.getName());
+
+        return response;
+      }
+
+      Credential credential = new Credential();
+      credential.setUsernametoken(ut);
+      // Only this section is new, the rest is copied from the apache class
+      Set<Map.Entry<String, Validator>> entries = validators.entrySet();
+      for (Map.Entry<String, Validator> entry : entries) {
+        try {
+          entry.getValue().validate(credential, requestData);
+          validateTarget.setState(ReceivedToken.STATE.VALID);
+          break;
+        } catch (WSSecurityException ex) {
+          LOGGER.debug("Unable to validate user against {}" + entry.getKey(), ex);
+        }
+      }
+      if (ReceivedToken.STATE.INVALID.equals(validateTarget.getState())) {
+        failedLoginDelayer.delay(ut.getName());
+
+        return response;
+      }
+      // end new section
+
+      Principal principal =
+          createPrincipal(
+              ut.getName(), ut.getPassword(), ut.getPasswordType(), ut.getNonce(), ut.getCreated());
+
+      response.setPrincipal(principal);
+      response.setTokenRealm(null);
+      validateTarget.setState(ReceivedToken.STATE.VALID);
+      validateTarget.setPrincipal(principal);
+    } catch (WSSecurityException ex) {
+      LOGGER.debug("Unable to validate token.", ex);
+    }
+
+    return response;
+  }
+
+  /** Create a principal based on the authenticated UsernameToken. */
+  private Principal createPrincipal(
+      String username,
+      String passwordValue,
+      String passwordType,
+      String nonce,
+      String createdTime) {
+    boolean hashed = false;
+    if (WSConstants.PASSWORD_DIGEST.equals(passwordType)) {
+      hashed = true;
+    }
+    WSUsernameTokenPrincipalImpl principal = new WSUsernameTokenPrincipalImpl(username, hashed);
+    if (nonce != null) {
+      principal.setNonce(nonce.getBytes(StandardCharsets.UTF_8));
+    }
+    principal.setPassword(passwordValue);
+    principal.setCreatedTime(createdTime);
+    principal.setPasswordType(passwordType);
+    return principal;
+  }
+}

--- a/platform/security/sts/security-sts-usernametokenvalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-usernametokenvalidator/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,59 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <type-converters>
+        <bean class="ddf.security.sts.PropertiesConverter"/>
+    </type-converters>
+
+    <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"
+               availability="mandatory"/>
+
+    <bean id="failedLoginDelayer" class="org.codice.ddf.security.common.FailedLoginDelayer"/>
+
+    <bean class="org.codice.ddf.security.validator.username.UsernameTokenValidator"
+          id="userValidator">
+        <argument ref="xmlParser"/>
+        <argument ref="failedLoginDelayer"/>
+    </bean>
+
+    <reference-list interface="org.apache.karaf.jaas.config.JaasRealm">
+        <reference-listener bind-method="addRealm" unbind-method="removeRealm" ref="userValidator"/>
+    </reference-list>
+
+    <service ref="userValidator" interface="org.apache.cxf.sts.token.validator.TokenValidator"/>
+
+</blueprint>
+

--- a/platform/security/sts/security-sts-usernametokenvalidator/src/test/java/org/codice/ddf/security/validator/username/UsernameTokenValidatorTest.java
+++ b/platform/security/sts/security-sts-usernametokenvalidator/src/test/java/org/codice/ddf/security/validator/username/UsernameTokenValidatorTest.java
@@ -1,0 +1,344 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.validator.username;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import org.apache.cxf.common.jaxb.JAXBContextCache;
+import org.apache.cxf.sts.STSPropertiesMBean;
+import org.apache.cxf.sts.request.ReceivedToken;
+import org.apache.cxf.sts.token.validator.TokenValidatorParameters;
+import org.apache.cxf.sts.token.validator.TokenValidatorResponse;
+import org.apache.cxf.ws.security.sts.provider.model.ObjectFactory;
+import org.apache.karaf.jaas.config.JaasRealm;
+import org.apache.wss4j.common.crypto.Crypto;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.dom.handler.RequestData;
+import org.apache.wss4j.dom.validate.Credential;
+import org.apache.wss4j.dom.validate.JAASUsernameTokenValidator;
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.xml.XmlParser;
+import org.codice.ddf.security.common.FailedLoginDelayer;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.ServiceReference;
+
+public class UsernameTokenValidatorTest {
+
+  private final JAASUsernameTokenValidator niceValidator = mock(JAASUsernameTokenValidator.class);
+
+  private final JAASUsernameTokenValidator meanValidator = new JAASUsernameTokenValidator();
+
+  private FailedLoginDelayer failedLoginDelayer;
+
+  @Before
+  public void setup() {
+    try {
+      Credential credential = mock(Credential.class);
+      when(niceValidator.validate(any(Credential.class), any(RequestData.class)))
+          .thenReturn(credential);
+    } catch (WSSecurityException ignore) {
+      // do nothing
+    }
+
+    failedLoginDelayer = mock(FailedLoginDelayer.class);
+  }
+
+  @Test
+  public void testValidateBadTokenNoTokenStore() {
+    UsernameTokenValidator usernameTokenValidator =
+        getUsernameTokenValidator(new XmlParser(), meanValidator);
+    usernameTokenValidator.addRealm(null);
+
+    TokenValidatorParameters tokenValidatorParameters = mock(TokenValidatorParameters.class);
+    STSPropertiesMBean stsPropertiesMBean = mock(STSPropertiesMBean.class);
+    when(stsPropertiesMBean.getSignatureCrypto()).thenReturn(mock(Crypto.class));
+    when(tokenValidatorParameters.getStsProperties()).thenReturn(stsPropertiesMBean);
+    ReceivedToken receivedToken = mock(ReceivedToken.class);
+    doCallRealMethod().when(receivedToken).setState(any(ReceivedToken.STATE.class));
+    doCallRealMethod().when(receivedToken).getState();
+    when(receivedToken.isUsernameToken()).thenReturn(true);
+    when(tokenValidatorParameters.getToken()).thenReturn(receivedToken);
+
+    Set<Class<?>> classes = new HashSet<>();
+    classes.add(ObjectFactory.class);
+    classes.add(org.apache.cxf.ws.security.sts.provider.model.wstrust14.ObjectFactory.class);
+    JAXBContextCache.CachedContextAndSchemas cache = null;
+    try {
+      cache = JAXBContextCache.getCachedContextAndSchemas(classes, null, null, null, false);
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBContext jaxbContext = cache.getContext();
+    Unmarshaller unmarshaller = null;
+    try {
+      if (jaxbContext != null) {
+        unmarshaller = jaxbContext.createUnmarshaller();
+      }
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBElement<?> token = null;
+    if (unmarshaller != null) {
+      try {
+        token =
+            (JAXBElement<?>)
+                unmarshaller.unmarshal(
+                    this.getClass().getResourceAsStream("/user-no-password.xml"));
+      } catch (JAXBException e) {
+        fail(e.getMessage());
+      }
+    }
+    when(receivedToken.getToken()).thenReturn(token.getValue());
+
+    TokenValidatorResponse tokenValidatorResponse =
+        usernameTokenValidator.validateToken(tokenValidatorParameters);
+    assertEquals(ReceivedToken.STATE.INVALID, tokenValidatorResponse.getToken().getState());
+
+    verify(failedLoginDelayer, times(1)).delay(anyString());
+  }
+
+  @Test
+  public void testValidateBadToken() {
+    UsernameTokenValidator usernameTokenValidator =
+        getUsernameTokenValidator(new XmlParser(), meanValidator);
+    usernameTokenValidator.addRealm(null);
+
+    TokenValidatorParameters tokenValidatorParameters = mock(TokenValidatorParameters.class);
+    STSPropertiesMBean stsPropertiesMBean = mock(STSPropertiesMBean.class);
+    when(stsPropertiesMBean.getSignatureCrypto()).thenReturn(mock(Crypto.class));
+    when(tokenValidatorParameters.getStsProperties()).thenReturn(stsPropertiesMBean);
+    ReceivedToken receivedToken = mock(ReceivedToken.class);
+    doCallRealMethod().when(receivedToken).setState(any(ReceivedToken.STATE.class));
+    doCallRealMethod().when(receivedToken).getState();
+    when(receivedToken.isUsernameToken()).thenReturn(true);
+    when(tokenValidatorParameters.getToken()).thenReturn(receivedToken);
+
+    Set<Class<?>> classes = new HashSet<>();
+    classes.add(ObjectFactory.class);
+    classes.add(org.apache.cxf.ws.security.sts.provider.model.wstrust14.ObjectFactory.class);
+    JAXBContextCache.CachedContextAndSchemas cache = null;
+    try {
+      cache = JAXBContextCache.getCachedContextAndSchemas(classes, null, null, null, false);
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBContext jaxbContext = cache.getContext();
+    Unmarshaller unmarshaller = null;
+    try {
+      if (jaxbContext != null) {
+        unmarshaller = jaxbContext.createUnmarshaller();
+      }
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBElement<?> token = null;
+    if (unmarshaller != null) {
+      try {
+        token =
+            (JAXBElement<?>)
+                unmarshaller.unmarshal(this.getClass().getResourceAsStream("/user.xml"));
+      } catch (JAXBException e) {
+        fail(e.getMessage());
+      }
+    }
+    when(receivedToken.getToken()).thenReturn(token.getValue());
+
+    TokenValidatorResponse tokenValidatorResponse =
+        usernameTokenValidator.validateToken(tokenValidatorParameters);
+    assertEquals(ReceivedToken.STATE.INVALID, tokenValidatorResponse.getToken().getState());
+
+    verify(failedLoginDelayer, times(1)).delay(anyString());
+  }
+
+  @Test
+  public void testValidateGoodToken() {
+    UsernameTokenValidator usernameTokenValidator =
+        getUsernameTokenValidator(new XmlParser(), niceValidator);
+    usernameTokenValidator.addRealm(null);
+
+    TokenValidatorParameters tokenValidatorParameters = mock(TokenValidatorParameters.class);
+    STSPropertiesMBean stsPropertiesMBean = mock(STSPropertiesMBean.class);
+    when(stsPropertiesMBean.getSignatureCrypto()).thenReturn(mock(Crypto.class));
+    when(tokenValidatorParameters.getStsProperties()).thenReturn(stsPropertiesMBean);
+    ReceivedToken receivedToken = mock(ReceivedToken.class);
+    doCallRealMethod().when(receivedToken).setState(any(ReceivedToken.STATE.class));
+    doCallRealMethod().when(receivedToken).getState();
+    when(receivedToken.isUsernameToken()).thenReturn(true);
+    when(tokenValidatorParameters.getToken()).thenReturn(receivedToken);
+
+    Set<Class<?>> classes = new HashSet<>();
+    classes.add(ObjectFactory.class);
+    classes.add(org.apache.cxf.ws.security.sts.provider.model.wstrust14.ObjectFactory.class);
+    JAXBContextCache.CachedContextAndSchemas cache = null;
+    try {
+      cache = JAXBContextCache.getCachedContextAndSchemas(classes, null, null, null, false);
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBContext jaxbContext = cache.getContext();
+    Unmarshaller unmarshaller = null;
+    try {
+      if (jaxbContext != null) {
+        unmarshaller = jaxbContext.createUnmarshaller();
+      }
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBElement<?> token = null;
+    if (unmarshaller != null) {
+      try {
+        token =
+            (JAXBElement<?>)
+                unmarshaller.unmarshal(this.getClass().getResourceAsStream("/user.xml"));
+      } catch (JAXBException e) {
+        fail(e.getMessage());
+      }
+    }
+    when(receivedToken.getToken()).thenReturn(token.getValue());
+
+    TokenValidatorResponse tokenValidatorResponse =
+        usernameTokenValidator.validateToken(tokenValidatorParameters);
+    assertEquals(ReceivedToken.STATE.VALID, tokenValidatorResponse.getToken().getState());
+
+    verify(failedLoginDelayer, never()).delay(anyString());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testNoParser() {
+    UsernameTokenValidator usernameTokenValidator = getUsernameTokenValidator(null, meanValidator);
+    usernameTokenValidator.addRealm(null);
+
+    TokenValidatorParameters tokenValidatorParameters = mock(TokenValidatorParameters.class);
+    STSPropertiesMBean stsPropertiesMBean = mock(STSPropertiesMBean.class);
+    when(stsPropertiesMBean.getSignatureCrypto()).thenReturn(mock(Crypto.class));
+    when(tokenValidatorParameters.getStsProperties()).thenReturn(stsPropertiesMBean);
+    ReceivedToken receivedToken = mock(ReceivedToken.class);
+    doCallRealMethod().when(receivedToken).setState(any(ReceivedToken.STATE.class));
+    doCallRealMethod().when(receivedToken).getState();
+    when(receivedToken.isUsernameToken()).thenReturn(true);
+    when(tokenValidatorParameters.getToken()).thenReturn(receivedToken);
+
+    Set<Class<?>> classes = new HashSet<>();
+    classes.add(ObjectFactory.class);
+    classes.add(org.apache.cxf.ws.security.sts.provider.model.wstrust14.ObjectFactory.class);
+    JAXBContextCache.CachedContextAndSchemas cache = null;
+    try {
+      cache = JAXBContextCache.getCachedContextAndSchemas(classes, null, null, null, false);
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBContext jaxbContext = cache.getContext();
+    Unmarshaller unmarshaller = null;
+    try {
+      if (jaxbContext != null) {
+        unmarshaller = jaxbContext.createUnmarshaller();
+      }
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBElement<?> token = null;
+    if (unmarshaller != null) {
+      try {
+        token =
+            (JAXBElement<?>)
+                unmarshaller.unmarshal(
+                    this.getClass().getResourceAsStream("/user-no-password.xml"));
+      } catch (JAXBException e) {
+        fail(e.getMessage());
+      }
+    }
+    when(receivedToken.getToken()).thenReturn(token.getValue());
+
+    usernameTokenValidator.validateToken(tokenValidatorParameters);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testNoFailedDelayer() {
+    UsernameTokenValidator usernameTokenValidator =
+        new UsernameTokenValidator(new XmlParser(), null) {
+          public void addRealm(ServiceReference<JaasRealm> serviceReference) {
+            validators.put("myrealm", meanValidator);
+          }
+        };
+    usernameTokenValidator.addRealm(null);
+
+    TokenValidatorParameters tokenValidatorParameters = mock(TokenValidatorParameters.class);
+    STSPropertiesMBean stsPropertiesMBean = mock(STSPropertiesMBean.class);
+    when(stsPropertiesMBean.getSignatureCrypto()).thenReturn(mock(Crypto.class));
+    when(tokenValidatorParameters.getStsProperties()).thenReturn(stsPropertiesMBean);
+    ReceivedToken receivedToken = mock(ReceivedToken.class);
+    doCallRealMethod().when(receivedToken).setState(any(ReceivedToken.STATE.class));
+    doCallRealMethod().when(receivedToken).getState();
+    when(receivedToken.isUsernameToken()).thenReturn(true);
+    when(tokenValidatorParameters.getToken()).thenReturn(receivedToken);
+
+    Set<Class<?>> classes = new HashSet<>();
+    classes.add(ObjectFactory.class);
+    classes.add(org.apache.cxf.ws.security.sts.provider.model.wstrust14.ObjectFactory.class);
+    JAXBContextCache.CachedContextAndSchemas cache = null;
+    try {
+      cache = JAXBContextCache.getCachedContextAndSchemas(classes, null, null, null, false);
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBContext jaxbContext = cache.getContext();
+    Unmarshaller unmarshaller = null;
+    try {
+      if (jaxbContext != null) {
+        unmarshaller = jaxbContext.createUnmarshaller();
+      }
+    } catch (JAXBException e) {
+      fail(e.getMessage());
+    }
+    JAXBElement<?> token = null;
+    if (unmarshaller != null) {
+      try {
+        token =
+            (JAXBElement<?>)
+                unmarshaller.unmarshal(
+                    this.getClass().getResourceAsStream("/user-no-password.xml"));
+      } catch (JAXBException e) {
+        fail(e.getMessage());
+      }
+    }
+    when(receivedToken.getToken()).thenReturn(token.getValue());
+
+    usernameTokenValidator.validateToken(tokenValidatorParameters);
+  }
+
+  private UsernameTokenValidator getUsernameTokenValidator(
+      final Parser parser, final JAASUsernameTokenValidator validator) {
+    return new UsernameTokenValidator(parser, failedLoginDelayer) {
+      public void addRealm(ServiceReference<JaasRealm> serviceReference) {
+        validators.put("myrealm", validator);
+      }
+    };
+  }
+}

--- a/platform/security/sts/security-sts-usernametokenvalidator/src/test/resources/user-no-password.xml
+++ b/platform/security/sts/security-sts-usernametokenvalidator/src/test/resources/user-no-password.xml
@@ -1,0 +1,19 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<wsse:UsernameToken
+        xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+        xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+        wsu:Id="UsernameToken-1">
+    <wsse:Username>srogers</wsse:Username>
+</wsse:UsernameToken>

--- a/platform/security/sts/security-sts-usernametokenvalidator/src/test/resources/user.xml
+++ b/platform/security/sts/security-sts-usernametokenvalidator/src/test/resources/user.xml
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<wsse:UsernameToken
+        xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+        xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+        wsu:Id="UsernameToken-1">
+    <wsse:Username>srogers</wsse:Username>
+    <wsse:Password
+            Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">password1</wsse:Password>
+</wsse:UsernameToken>


### PR DESCRIPTION
This reverts commit e8135dbeefb21226312182d457eb331b8da8fb24 and restores the source for
the module that is needed.

### Context
The source was mistakenly deleted for security-sts-usernametokenvalidator. However since the feature file and corresponding pom dependency still existed and it was able to find the jar magically because there was a snapshot version built it continued to work (even though the code was deleted). When the feature file reference was removed however the tokenvalidator that was being registered by the ghost bundle all of a sudden stopped working. This adds back the source for usernametokenvalidator and puts back the featurefile references as well since the source now exists again!


@bakejeyner @blen-desta @mcat97 @nsuvarna @samuelechu @jlcsmith 