### PR TITLE
DDF-5223 Allow parsing of empty time strings in CQL

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -23,7 +23,7 @@ const comparisonClass = 'Comparison',
   logicalClass = 'Logical',
   spatialClass = 'Spatial',
   temporalClass = 'Temporal',
-  timePatter = /([0-9]{4})(-([0-9]{2})(-([0-9]{2})(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?/i,
+  timePatter = /((([0-9]{4})(-([0-9]{2})(-([0-9]{2})(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?)|^'')/i,
   patterns = {
     //Allows for non-standard single-quoted property names
     PROPERTY: /^([_a-zA-Z]\w*|"[^"]+"|'[^']+')/,
@@ -609,7 +609,7 @@ function write(filter) {
             ' ' +
             filter.type +
             ' ' +
-            filter.value.toString(dateTimeFormat)
+            (filter.value ? filter.value.toString(dateTimeFormat) : "''")
           )
         case 'DURING':
           return (
@@ -617,9 +617,9 @@ function write(filter) {
             ' ' +
             filter.type +
             ' ' +
-            filter.from.toString(dateTimeFormat) +
+            (filter.from ? filter.from.toString(dateTimeFormat) : "''") +
             '/' +
-            filter.to.toString(dateTimeFormat)
+            (filter.to ? filter.to.toString(dateTimeFormat) : "''")
           )
       }
       break

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -23,7 +23,7 @@ const comparisonClass = 'Comparison',
   logicalClass = 'Logical',
   spatialClass = 'Spatial',
   temporalClass = 'Temporal',
-  timePatter = /((([0-9]{4})(-([0-9]{2})(-([0-9]{2})(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?)|^'')/i,
+  timePattern = /((([0-9]{4})(-([0-9]{2})(-([0-9]{2})(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?)|^'')/i,
   patterns = {
     //Allows for non-standard single-quoted property names
     PROPERTY: /^([_a-zA-Z]\w*|"[^"]+"|'[^']+')/,
@@ -44,8 +44,8 @@ const comparisonClass = 'Comparison',
     AFTER: /^AFTER/i,
     DURING: /^DURING/i,
     RELATIVE: /^'RELATIVE\([A-Za-z0-9.]*\)'/i,
-    TIME: new RegExp('^' + timePatter.source),
-    TIME_PERIOD: new RegExp('^' + timePatter.source + '/' + timePatter.source),
+    TIME: new RegExp('^' + timePattern.source),
+    TIME_PERIOD: new RegExp('^' + timePattern.source + '/' + timePattern.source),
     GEOMETRY(text) {
       const type = /^(POINT|LINESTRING|POLYGON|MULTIPOINT|MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION)/.exec(
         text

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.js
@@ -45,7 +45,9 @@ const comparisonClass = 'Comparison',
     DURING: /^DURING/i,
     RELATIVE: /^'RELATIVE\([A-Za-z0-9.]*\)'/i,
     TIME: new RegExp('^' + timePattern.source),
-    TIME_PERIOD: new RegExp('^' + timePattern.source + '/' + timePattern.source),
+    TIME_PERIOD: new RegExp(
+      '^' + timePattern.source + '/' + timePattern.source
+    ),
     GEOMETRY(text) {
       const type = /^(POINT|LINESTRING|POLYGON|MULTIPOINT|MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION)/.exec(
         text

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/cql.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/cql.spec.js
@@ -110,6 +110,17 @@ describe('tokenize', () => {
       it('serializes a filter function', () => {
         expect(cql.write(cqlFilter)).to.equal(cqlString)
       })
+
+      it('parses an empty time string', () => {
+        const cqlString = '("created" BEFORE \'\')'
+        const cqlFilter = {
+          property: 'created',
+          type: 'BEFORE',
+          value: null,
+        }
+        const filter = cql.simplify(cql.read(cqlString))
+        expect(filter).to.deep.include(cqlFilter)
+      })
     })
 
   describe('CQL and UserQL translation functions', () => {
@@ -130,6 +141,16 @@ describe('tokenize', () => {
       expect(result).equals(
         '"anyText" ILIKE \'this % is \\% a \\_ test _ \\* \\?\''
       )
+    })
+
+    it('parses a UserQL string with an empty time string', () => {
+      const filter = {
+        property: 'created',
+        type: 'BEFORE',
+        value: '',
+      }
+      const result = cql.write(filter)
+      expect(result).equals('"created" BEFORE \'\'')
     })
 
     it('parses multiple CQL characters in a row into UserQL', () => {


### PR DESCRIPTION
#### What does this PR do?
Allow for empty strings in front end CQL parsing. Other attributes are allowed to be empty. This change is necessary for a downstream project to filter out empty strings in queries.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@hayleynorton 
@andrewzimmer 
@willwill96 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@gordocanchola 

#### How should this be tested?
Verify there are no regressions in querying

#### What are the relevant tickets?
Fixes: #5223 

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
