### PR TITLE
DDF-5228 Updates usage of extension providers so they're always applied correctly

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/extensions/marionette.ItemView.attachElContent.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/extensions/marionette.ItemView.attachElContent.js
@@ -18,14 +18,12 @@ import React from 'react'
 const Parser = require('html-react-parser')
 import ExtensionPoints from '../../extension-points'
 
-const Providers = ExtensionPoints.providers
-
 Marionette.ItemView.prototype.attachElContent = function(rendering) {
   this.triggerMethod('before:react:attach', rendering)
   render(
-    <Providers>
+    <ExtensionPoints.providers>
       {React.isValidElement(rendering) ? rendering : Parser(rendering)}
-    </Providers>,
+    </ExtensionPoints.providers>,
     this.el
   )
   this.triggerMethod('after:react:attach', rendering)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/backbone-container/backbone-container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/backbone-container/backbone-container.tsx
@@ -41,6 +41,7 @@ const withListenTo = <P extends WithBackboneProps>(
     }
     render() {
       return (
+        // @ts-ignore
         <Component
           listenTo={this.backbone.listenTo.bind(this.backbone)}
           stopListening={this.backbone.stopListening.bind(this.backbone)}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
@@ -124,7 +124,10 @@ export const withDropdown = <P extends withContext>(
   return function dropdownedComponent(props: Subtract<P, withContext>) {
     return (
       <DropdownContext.Consumer>
-        {context => <Component {...props} dropdownContext={context} />}
+        {context => {
+          // @ts-ignore
+          return <Component {...props} dropdownContext={context} />
+        }}
       </DropdownContext.Consumer>
     )
   }


### PR DESCRIPTION
#### What does this PR do?
 - Because Application setup is called before entry is executed, it's possible for anything executed in setup to receive out of date extension points if they grab an extension point and store it in a variable for later.

#### How should this be tested?
Easiest way is to see if your providers downstream start working more reliably.  There's a good chance people have just been double wrapping because they noticed something wasn't working right, such as a redux store not showing up.

#### What are the relevant tickets?
Fixes: #5228 

