### PR TITLE
DDF-5232 Suppress Solr CVE that doesn't apply to current DDF Solr Config

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -328,6 +328,8 @@
         <cve>CVE-2018-11766</cve>
         <cve>CVE-2016-6811</cve>
         <cve>CVE-2017-3162</cve>
+        <!-- Remove this once Solr is upgraded to 8.2 -->
+        <cve>CVE-2019-0193</cve>
     </suppress>
     <suppress>
         <notes>
@@ -337,6 +339,14 @@
             dependencies have upgraded.
         </notes>
         <cve>CVE-2019-14379</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+      This is a false positive due to our module name matching the OWASP regex for this CVE
+    ]]></notes>
+        <gav regex="true">^ddf\.security\.idp:security-idp-plugin-requestsubjectvalidator:.*$</gav>
+        <cve>CVE-2017-16026</cve>
     </suppress>
 
 </suppressions>


### PR DESCRIPTION
#### What does this PR do?
Suppresses Solr CVE-2019-0193 that is not hit with current DDF Solr configuration.
CVE: https://nvd.nist.gov/vuln/detail/CVE-2019-0193
Solr analysis: https://issues.apache.org/jira/browse/SOLR-13669 
Also suppressed false positive match on unrelated CVE-2017-16026. This CVE is related to a node module that has nothing to do with the DDF security module OWASP matched. https://nvd.nist.gov/vuln/detail/CVE-2017-16026

#### Who is reviewing it? 
@bdeining  
@bakejeyner 

#### Select relevant component teams: 
@codice/security 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@stustison

#### How should this be tested?

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #5232 

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
