### PR TITLE
DDF-5243 Add security access individuals on create query route

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/QueryMetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/QueryMetacardApplication.java
@@ -168,7 +168,7 @@ public class QueryMetacardApplication implements SparkApplication {
         (req, res) -> {
           String body = endpointUtil.safeGetBody(req);
           QueryBasic query = GSON.fromJson(body, QueryBasic.class);
-          query.setOwner(getSubjectIdentifier());
+          query.setOwnerAndAccessIndividuals(getSubjectIdentifier());
 
           CreateRequest createRequest = new CreateRequestImpl(query.getMetacard());
           CreateResponse createResponse = catalogFramework.create(createRequest);

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
@@ -195,8 +195,9 @@ public class QueryBasic {
     return this.sorts.stream().map(GSON::toJson).collect(Collectors.toList());
   }
 
-  public void setOwner(String owner) {
+  public void setOwnerAndAccessIndividuals(String owner) {
     this.owner = owner;
+    this.accessIndividuals = Collections.singletonList(owner);
   }
 
   private static <T> T getAttributeValue(Metacard metacard, String name, Class<T> type) {


### PR DESCRIPTION
### What does this PR do?
Adds security.access-individuals to query metacard when created using the `/queries` route.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@blen-desta 
@bellcc 
@jlcsmith 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@rzwiefel 
@vinamartin

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Create a custom user 1, create a search.
Create a custom user 2, hit the queries endpoint route, verify you don't see user 1's search.

Example User files

`users.attributes`
```json
{
    "admin" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"admin@localhost.local",
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role": ["admin","manager","viewer","system-admin","systembundles"]
    },
    "localhost" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"system@localhost.local",
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role": ["admin","manager","viewer","system-user","system-admin","system-history","data-manager","systembundles"]
    }
,
    "user1" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"user1@connextatest.com",
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role": ["blue"]
    },
    "user2" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"user2@connextatest.com",
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role": ["blue"]
    },
    "user3" : {
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":"user3@connextatest.com",
        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role": ["green"]
    }
}
```

`users.properties`
```
# DDF Changes: changed username/pw to admin/admin, added localhost certificate user
admin=admin,group,admin,manager,viewer,system-admin,systembundles,ssh
localhost=localhost,group,admin,manager,viewer,system-user,system-admin,system-history,localhost-data-manager,systembundles,ssh
user1=user1,blue
user2=user2,blue
user3=user3,green
```

#### Any background context you want to provide?
Setting the `metacard.owner` is not enough to prevent users from seeing eachothers queries.

#### What are the relevant tickets?
Fixes: #5243 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
