### PR TITLE
[2.17.x] DDF-5219 Remove background from dropdown elements

### DIFF
--- a/ui/packages/catalog-ui-search/package.json
+++ b/ui/packages/catalog-ui-search/package.json
@@ -6,6 +6,7 @@
   "license": "LGPL-3.0",
   "scripts": {
     "fmt": "ace format -w",
+    "format": "ace format",
     "prestart": "ace disable-idp",
     "start": "node --max_old_space_size=8192 ../../node_modules/@connexta/ace/bin.js start",
     "pretest": "ace bundle --env=test",

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/dropdown/dropdown.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/dropdown/dropdown.js
@@ -169,7 +169,6 @@ const Component = styled.div`
   display: block;
   white-space: nowrap;
   position: relative;
-  background: ${props => props.theme.backgroundDropdown};
 `
 
 class Dropdown extends React.Component {


### PR DESCRIPTION
#### What does this PR do?
 
Removes background color from dropdown components.

See https://github.com/codice/ddf/pull/5220

#### Who is reviewing it?
 
@jordanwilking
@rzwiefel
#### Select relevant component teams:

@codice/ui
#### Ask 2 committers to review/merge the PR and tag them here.
 
@adimka
@vinamartin
#### How should this be tested?

Opening up dropdowns and making sure they weren't relying on this background color being set.
#### Any background context you want to provide?
#### What are the relevant tickets?
 
Fixes: #5219
#### Screenshots
##### Before
 
<img alt="" height="300px" src="https://user-images.githubusercontent.com/7236299/63127970-a824d180-bf68-11e9-8d56-35767a012ad6.png">
##### After
 
<img alt="" height="200px" src="https://user-images.githubusercontent.com/7236299/63128076-eae6a980-bf68-11e9-9fc8-7383314f9bb8.png">
#### Checklist:
 
     * [ ]  Documentation Updated
 
     * [ ]  Update / Add Threat Dragon models
 
     * [ ]  Update / Add Unit Tests
 
     * [ ]  Update / Add Integration Tests
 
 
#### Notes on Review Process
 
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews.
#### Review Comment Legend:
 
     * ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
 
     * ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
 
     * ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.

