### PR TITLE
[2.17.x] DDF-5263 Fix improper SLF4J usages

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/callables/GetConfigurationProperties.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/callables/GetConfigurationProperties.java
@@ -79,7 +79,7 @@ public class GetConfigurationProperties implements Callable<Dictionary<String, O
     }
 
     if (configurationSet.size() > 1) {
-      LOGGER.error(String.format("Multiple Configuration objects returned for query %s", query));
+      LOGGER.error("Multiple Configuration objects returned for query {}", query);
       throw new IllegalArgumentException("Property name/value pair isn't unique");
     }
 

--- a/platform/admin/admin-configuration-configupdater/src/main/java/org/codice/ddf/admin/configuration/ConfigurationUpdater.java
+++ b/platform/admin/admin-configuration-configupdater/src/main/java/org/codice/ddf/admin/configuration/ConfigurationUpdater.java
@@ -251,8 +251,7 @@ public class ConfigurationUpdater implements ConfigurationPersistencePlugin {
         Files.delete(fileFromCache.toPath());
         SecurityLogger.audit("Removed a deleted config [{}]", fileFromCache.getAbsolutePath());
       } catch (IOException e) {
-        LOGGER.debug(
-            format("Problem deleting config file [%s]: ", fileFromCache.getAbsolutePath()), e);
+        LOGGER.debug("Problem deleting config file [{}]: ", fileFromCache.getAbsolutePath(), e);
         SecurityLogger.audit("Failure to delete config file [{}]", fileFromCache.getAbsolutePath());
         // Synchronous with config admin, so we can report the failure to the UI this way
         throw e;

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ExportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ExportMigrationConfigurationAdminContext.java
@@ -197,9 +197,7 @@ public class ExportMigrationConfigurationAdminContext {
         }
       } catch (MalformedURLException | URISyntaxException e) {
         path = constructPathForBasename(configuration);
-        LOGGER.debug(
-            String.format("failed to parse %s property from '%s'; ", DirectoryWatcher.FILENAME, o),
-            e);
+        LOGGER.debug("failed to parse {} property from '{}'; ", DirectoryWatcher.FILENAME, o, e);
         context
             .getReport()
             .record(

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/assertion/jwt/impl/SecurityAssertionJwt.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/assertion/jwt/impl/SecurityAssertionJwt.java
@@ -184,9 +184,13 @@ public class SecurityAssertionJwt implements SecurityAssertion {
       try {
         return (String) attributes.get(claim);
       } catch (NoSuchElementException e) {
-        LOGGER.debug(
-            "Could not find username claim [%s] in jwt claims [%s]",
-            claim, String.join(",", attributes.keySet()), e);
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug(
+              "Could not find username claim [{}] in jwt claims [{}]",
+              claim,
+              String.join(",", attributes.keySet()),
+              e);
+        }
       }
     }
 

--- a/platform/security/encryption/platform-security-encryption-crypter/src/main/java/ddf/security/encryption/crypter/Crypter.java
+++ b/platform/security/encryption/platform-security-encryption-crypter/src/main/java/ddf/security/encryption/crypter/Crypter.java
@@ -354,11 +354,11 @@ public class Crypter {
 
     Properties properties = getAssociatedDataProperties();
     if (properties.containsKey(primaryKeyId)) {
-      LOGGER.debug("Found MAC (%s) in property file (%s).", primaryKeyId, associatedDataPath);
+      LOGGER.debug("Found MAC ({}) in property file ({}).", primaryKeyId, associatedDataPath);
       return Base64.getDecoder().decode(properties.getProperty(primaryKeyId));
     }
     LOGGER.debug(
-        "Could not find key (%s) in properties file (%s).", primaryKeyId, associatedDataPath);
+        "Could not find key ({}) in properties file ({}).", primaryKeyId, associatedDataPath);
 
     try {
       byte[] generatedAssociatedData = generateAssociatedData();

--- a/platform/security/encryption/platform-security-encryption-impl/src/main/java/ddf/security/encryption/impl/EncryptionServiceImpl.java
+++ b/platform/security/encryption/platform-security-encryption-impl/src/main/java/ddf/security/encryption/impl/EncryptionServiceImpl.java
@@ -62,7 +62,7 @@ public class EncryptionServiceImpl implements EncryptionService {
     try {
       return crypter.decrypt(encryptedValue);
     } catch (CrypterException e) {
-      LOGGER.debug("Failed to decrypt string of value %s.", encryptedValue, e);
+      LOGGER.debug("Failed to decrypt string of value {}.", encryptedValue, e);
       return encryptedValue;
     }
   }


### PR DESCRIPTION
#### What does this PR do?
- SLF4J logging statements should use parameterized logging   (https://www.slf4j.org/faq.html#logging_performance) instead of String.format().
- Parameterized logging statements need to use {} as the formatting anchor, not Java-style formatting anchors like %s.

#### Who is reviewing it? 
@bennuttle 
@gjvera 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@jlcsmith 

#### How should this be tested?
Full build is sufficient.

#### What are the relevant tickets?
Fixes: #5263 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.