### PR TITLE
DDF-5275 Escaped negative numbers for equality queries and increased coverage

### DIFF
--- a/catalog/core/catalog-core-solr/pom.xml
+++ b/catalog/core/catalog-core-solr/pom.xml
@@ -221,17 +221,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.84</minimum>
+                                            <minimum>0.86</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.76</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -947,7 +947,14 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
     String mappedPropertyName = getMappedPropertyName(propertyName, format, true);
 
     SolrQuery query = new SolrQuery();
-    query.setQuery(" " + mappedPropertyName + ":" + literal.toString());
+    String literalString = literal.toString();
+
+    // Negative numbers must be escaped
+    if (literalString.startsWith("-")) {
+      literalString = "\\" + literalString;
+    }
+
+    query.setQuery(" " + mappedPropertyName + ":" + literalString);
 
     return query;
   }

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
@@ -37,13 +37,13 @@ public class SolrFilterDelegateTest {
 
   private DynamicSchemaResolver mockResolver = mock(DynamicSchemaResolver.class);
 
-  private SolrFilterDelegate toTest = new SolrFilterDelegate(mockResolver, Collections.EMPTY_MAP);
+  private SolrFilterDelegate toTest = new SolrFilterDelegate(mockResolver, Collections.emptyMap());
 
   @Test(expected = UnsupportedOperationException.class)
   public void intersectsWithNullWkt() {
     // given null WKT and a valid property name
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
     // when the delegate intersects
     toTest.intersects("testProperty", null);
@@ -62,7 +62,7 @@ public class SolrFilterDelegateTest {
   public void intersectsWithInvalidJtsWkt() {
     // given a geospatial property
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
 
     // when the delegate intersects on WKT not handled by JTS
@@ -76,7 +76,7 @@ public class SolrFilterDelegateTest {
   public void intersectsWithValidJtsWkt() {
     // given a geospatial property
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
 
     // when the delegate intersects on WKT not handled by JTS
@@ -92,7 +92,7 @@ public class SolrFilterDelegateTest {
   public void selfIntersectingPolygon() {
     String wkt = "POLYGON((0 0, 10 0, 10 20, 5 -5, 0 20, 0 0))";
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
     SolrQuery query = toTest.contains("testProperty", wkt);
     assertThat(
@@ -105,7 +105,7 @@ public class SolrFilterDelegateTest {
   public void squarePolygon() {
     String wkt = "POLYGON ((0 10, 0 30, 20 30, 20 10, 0 10))";
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
     SolrQuery query = toTest.contains("testProperty", wkt);
     assertThat(
@@ -118,7 +118,7 @@ public class SolrFilterDelegateTest {
   public void nonIntersectingPolygon() {
     String wkt = "POLYGON((5 -5, 0 0, 0 20, 10 20, 10 0, 5 -5))";
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
     SolrQuery query = toTest.contains("testProperty", wkt);
     assertThat(
@@ -132,7 +132,7 @@ public class SolrFilterDelegateTest {
     // in the case of a self-intersecting polygon with a hole the hole is lost in the conversion
     String wkt = "POLYGON ((0 0, 0 10, 13 3, 13 9, 0 0), (1 4, 1 7, 3 6, 3 4, 1 4))";
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
     SolrQuery query = toTest.contains("testProperty", wkt);
     assertThat(
@@ -146,7 +146,7 @@ public class SolrFilterDelegateTest {
     String wkt =
         "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))";
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
     SolrQuery query = toTest.contains("testProperty", wkt);
     assertThat(
@@ -159,7 +159,7 @@ public class SolrFilterDelegateTest {
   public void polygonWithHole() {
     String wkt = "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))";
     stub(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.EMPTY_MAP))
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .toReturn("testProperty_geohash_index");
     SolrQuery query = toTest.contains("testProperty", wkt);
     assertThat(
@@ -171,7 +171,8 @@ public class SolrFilterDelegateTest {
   @Test
   public void reservedSpecialCharactersIsEqual() {
     // given a text property
-    stub(mockResolver.getField("testProperty", AttributeFormat.STRING, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField(
+            "testProperty", AttributeFormat.STRING, true, Collections.emptyMap()))
         .toReturn("testProperty_txt_index");
 
     // when searching for exact reserved characters
@@ -188,11 +189,12 @@ public class SolrFilterDelegateTest {
   @Test
   public void reservedSpecialCharactersIsLike() {
     // given a tokenized text property
-    stub(mockResolver.getField("testProperty", AttributeFormat.STRING, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField(
+            "testProperty", AttributeFormat.STRING, true, Collections.emptyMap()))
         .toReturn("testProperty_txt");
-    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.EMPTY_MAP))
+    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .toReturn(SchemaFields.TOKENIZED);
-    stub(mockResolver.getCaseSensitiveField("testProperty_txt_tokenized", Collections.EMPTY_MAP))
+    stub(mockResolver.getCaseSensitiveField("testProperty_txt_tokenized", Collections.emptyMap()))
         .toReturn("testProperty_txt_tokenized_tokenized");
 
     // when searching for like reserved characters
@@ -260,7 +262,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testPropertyIsEqualToEmpty() {
-    stub(mockResolver.getField("title", AttributeFormat.STRING, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("title", AttributeFormat.STRING, true, Collections.emptyMap()))
         .toReturn("title_txt");
 
     String searchPhrase = "";
@@ -272,9 +274,113 @@ public class SolrFilterDelegateTest {
     assertThat(isEqualTo.getQuery(), is(expectedQuery));
   }
 
+  @Test
+  public void testPropertyIsEqualToInteger() {
+    stub(mockResolver.getField("anumber", AttributeFormat.INTEGER, true, Collections.emptyMap()))
+        .toReturn("anumber_int");
+
+    int searchPhrase = 1;
+    String expectedQuery = "anumber_int:1";
+
+    SolrQuery isEqualTo = toTest.propertyIsEqualTo("anumber", searchPhrase);
+
+    assertThat(isEqualTo.getQuery().trim(), is(expectedQuery));
+  }
+
+  @Test
+  public void testPropertyIsEqualToShort() {
+    stub(mockResolver.getField("anumber", AttributeFormat.SHORT, true, Collections.emptyMap()))
+        .toReturn("anumber_shr");
+
+    short searchPhrase = 1;
+    String expectedQuery = "anumber_shr:1";
+
+    SolrQuery isEqualTo = toTest.propertyIsEqualTo("anumber", searchPhrase);
+
+    assertThat(isEqualTo.getQuery().trim(), is(expectedQuery));
+  }
+
+  @Test
+  public void testPropertyIsEqualToLong() {
+    stub(mockResolver.getField("anumber", AttributeFormat.LONG, true, Collections.emptyMap()))
+        .toReturn("anumber_lng");
+
+    long searchPhrase = 1;
+    String expectedQuery = "anumber_lng:1";
+
+    SolrQuery isEqualTo = toTest.propertyIsEqualTo("anumber", searchPhrase);
+
+    assertThat(isEqualTo.getQuery().trim(), is(expectedQuery));
+  }
+
+  @Test
+  public void testPropertyIsEqualToFloat() {
+    stub(mockResolver.getField("anumber", AttributeFormat.FLOAT, true, Collections.emptyMap()))
+        .toReturn("anumber_flt");
+
+    float searchPhrase = 1;
+    String expectedQuery = "anumber_flt:1.0";
+
+    SolrQuery isEqualTo = toTest.propertyIsEqualTo("anumber", searchPhrase);
+
+    assertThat(isEqualTo.getQuery().trim(), is(expectedQuery));
+  }
+
+  @Test
+  public void testPropertyIsEqualToNegativeFloat() {
+    stub(mockResolver.getField("anumber", AttributeFormat.FLOAT, true, Collections.emptyMap()))
+        .toReturn("anumber_flt");
+
+    float searchPhrase = -1;
+    String expectedQuery = "anumber_flt:\\-1.0";
+
+    SolrQuery isEqualTo = toTest.propertyIsEqualTo("anumber", searchPhrase);
+
+    assertThat(isEqualTo.getQuery().trim(), is(expectedQuery));
+  }
+
+  @Test
+  public void testPropertyIsEqualToDouble() {
+    stub(mockResolver.getField("anumber", AttributeFormat.FLOAT, true, Collections.emptyMap()))
+        .toReturn("anumber_dbl");
+
+    double searchPhrase = 1;
+    String expectedQuery = "anumber_dbl:1.0";
+
+    SolrQuery isEqualTo = toTest.propertyIsEqualTo("anumber", searchPhrase);
+
+    assertThat(isEqualTo.getQuery().trim(), is(expectedQuery));
+  }
+
+  @Test
+  public void testPropertyIsEqualToNegativeInteger() {
+    stub(mockResolver.getField("anumber", AttributeFormat.INTEGER, true, Collections.emptyMap()))
+        .toReturn("anumber_int");
+
+    int searchPhrase = -1;
+    String expectedQuery = "anumber_int:\\-1";
+
+    SolrQuery isEqualTo = toTest.propertyIsEqualTo("anumber", searchPhrase);
+
+    assertThat(isEqualTo.getQuery().trim(), is(expectedQuery));
+  }
+
+  @Test
+  public void testPropertyIsEqualToBoolean() {
+    stub(mockResolver.getField("aboolean", AttributeFormat.BOOLEAN, true, Collections.emptyMap()))
+        .toReturn("aboolean_bln");
+
+    boolean searchPhrase = true;
+    String expectedQuery = "aboolean_bln:true";
+
+    SolrQuery isEqualTo = toTest.propertyIsEqualTo("aboolean", searchPhrase);
+
+    assertThat(isEqualTo.getQuery().trim(), is(expectedQuery));
+  }
+
   @Test(expected = UnsupportedOperationException.class)
   public void testPropertyIsEqualToNull() {
-    stub(mockResolver.getField("title", AttributeFormat.STRING, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("title", AttributeFormat.STRING, true, Collections.emptyMap()))
         .toReturn("title_txt");
 
     String searchPhrase = null;
@@ -299,7 +405,7 @@ public class SolrFilterDelegateTest {
   @Test
   public void testPropertyIsLikeTermAndWildcard() {
     stub(mockResolver.anyTextFields()).toReturn(Collections.singletonList("metadata_txt").stream());
-    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.EMPTY_MAP))
+    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .toReturn(SchemaFields.TOKENIZED);
 
     String searchPhrase = "abc-123*";
@@ -313,7 +419,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testPropertyIsLikeEmpty() {
-    stub(mockResolver.getField("title", AttributeFormat.STRING, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("title", AttributeFormat.STRING, false, Collections.emptyMap()))
         .toReturn("title_txt");
 
     String searchPhrase = "";
@@ -327,7 +433,7 @@ public class SolrFilterDelegateTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void testPropertyIsNull() {
-    stub(mockResolver.getField("title", AttributeFormat.STRING, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("title", AttributeFormat.STRING, false, Collections.emptyMap()))
         .toReturn("title_txt");
 
     String searchPhrase = null;
@@ -339,7 +445,7 @@ public class SolrFilterDelegateTest {
   @Test
   public void testPropertyIsLikeWildcardNoTokens() {
     stub(mockResolver.anyTextFields()).toReturn(Collections.singletonList("metadata_txt").stream());
-    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.EMPTY_MAP))
+    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .toReturn(SchemaFields.TOKENIZED);
 
     String searchPhrase = "title*";
@@ -354,7 +460,7 @@ public class SolrFilterDelegateTest {
   @Test
   public void testPropertyIsLikeMultipleTermsWithWildcard() {
     stub(mockResolver.anyTextFields()).toReturn(Collections.singletonList("metadata_txt").stream());
-    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.EMPTY_MAP))
+    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .toReturn(SchemaFields.TOKENIZED);
 
     String searchPhrase = "abc 123*";
@@ -368,9 +474,9 @@ public class SolrFilterDelegateTest {
   @Test
   public void testPropertyIsLikeCaseSensitiveWildcard() {
     stub(mockResolver.anyTextFields()).toReturn(Collections.singletonList("metadata_txt").stream());
-    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.EMPTY_MAP))
+    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .toReturn(SchemaFields.TOKENIZED);
-    stub(mockResolver.getCaseSensitiveField("metadata_txt_tokenized", Collections.EMPTY_MAP))
+    stub(mockResolver.getCaseSensitiveField("metadata_txt_tokenized", Collections.emptyMap()))
         .toReturn("metadata_txt_tokenized_has_case");
 
     String searchPhrase = "abc-123*";
@@ -384,7 +490,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testTemporalBefore() {
-    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.emptyMap()))
         .toReturn("created_date");
 
     String expectedQuery = " created_date:[ * TO 1995-11-24T23:59:56.765Z } ";
@@ -394,7 +500,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testTemporalAfter() {
-    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.emptyMap()))
         .toReturn("created_date");
 
     String expectedQuery = " created_date:{ 1995-11-24T23:59:56.765Z TO * ] ";
@@ -404,7 +510,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testDatePropertyGreaterThan() {
-    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.emptyMap()))
         .toReturn("created_date");
 
     String expectedQuery = " created_date:{ 1995-11-24T23:59:56.765Z TO * ] ";
@@ -414,7 +520,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testDatePropertyGreaterThanOrEqualTo() {
-    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.emptyMap()))
         .toReturn("created_date");
 
     String expectedQuery = " created_date:[ 1995-11-24T23:59:56.765Z TO * ] ";
@@ -425,7 +531,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testDatePropertyLessThan() {
-    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.emptyMap()))
         .toReturn("created_date");
 
     String expectedQuery = " created_date:[ * TO 1995-11-24T23:59:56.765Z } ";
@@ -435,7 +541,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testDatePropertyLessThanOrEqualTo() {
-    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.emptyMap()))
         .toReturn("created_date");
 
     String expectedQuery = " created_date:[ * TO 1995-11-24T23:59:56.765Z ] ";
@@ -445,7 +551,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testDatePropertyIsBetween() {
-    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("created", AttributeFormat.DATE, false, Collections.emptyMap()))
         .toReturn("created_date");
 
     String expectedQuery =
@@ -458,7 +564,7 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testNumberIsBetweenLongs() {
-    stub(mockResolver.getField("altitude", AttributeFormat.LONG, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("altitude", AttributeFormat.LONG, true, Collections.emptyMap()))
         .toReturn("altitude");
 
     String expectedQuery = " altitude:[ -100 TO 100] ";
@@ -472,7 +578,7 @@ public class SolrFilterDelegateTest {
   @Test
   public void testNumberIsBetweenFloats() {
 
-    stub(mockResolver.getField("altitude", AttributeFormat.FLOAT, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("altitude", AttributeFormat.FLOAT, true, Collections.emptyMap()))
         .toReturn("altitude");
 
     String expectedQuery = " altitude:[ -100.3 TO 0.4] ";
@@ -487,7 +593,7 @@ public class SolrFilterDelegateTest {
   @Test
   public void testNumberIsBetweenInts() {
 
-    stub(mockResolver.getField("altitude", AttributeFormat.INTEGER, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("altitude", AttributeFormat.INTEGER, true, Collections.emptyMap()))
         .toReturn("altitude");
 
     String expectedQuery = " altitude:[ -100 TO 0] ";
@@ -501,7 +607,7 @@ public class SolrFilterDelegateTest {
   @Test
   public void testNumberIsBetweenShorts() {
 
-    stub(mockResolver.getField("altitude", AttributeFormat.SHORT, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("altitude", AttributeFormat.SHORT, true, Collections.emptyMap()))
         .toReturn("altitude");
 
     String expectedQuery = " altitude:[ 0 TO 50] ";
@@ -516,7 +622,7 @@ public class SolrFilterDelegateTest {
   @Test
   public void testNumberIsBetweenFloatAndInt() {
 
-    stub(mockResolver.getField("altitude", AttributeFormat.FLOAT, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("altitude", AttributeFormat.FLOAT, true, Collections.emptyMap()))
         .toReturn("altitude");
 
     String expectedQuery = " altitude:[ -100.567 TO 0.0] ";
@@ -586,9 +692,9 @@ public class SolrFilterDelegateTest {
 
   @Test
   public void testPropertyIsInProximityTo() {
-    stub(mockResolver.getField("title", AttributeFormat.STRING, true, Collections.EMPTY_MAP))
+    stub(mockResolver.getField("title", AttributeFormat.STRING, true, Collections.emptyMap()))
         .toReturn("title_txt");
-    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.EMPTY_MAP))
+    stub(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .toReturn(SchemaFields.TOKENIZED);
 
     String expectedQuery = "(title_txt_tokenized:\"a proximity string\" ~2)";

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
@@ -1598,7 +1598,7 @@ public class SolrProviderQuery {
     float floatFieldValue = 4.435f;
 
     String intField = "count";
-    int intFieldValue = 4;
+    int intFieldValue = -4;
 
     String longField = "milliseconds";
     long longFieldValue = 9876543293L;
@@ -1622,7 +1622,7 @@ public class SolrProviderQuery {
     create(Collections.singletonList(customMetacard1), provider);
 
     // searching double field with int value
-    greaterThanQueryAssertion(doubleField, intFieldValue, 1);
+    greaterThanQueryAssertion(doubleField, 4, 1);
 
     // searching float field with double value
     greaterThanQueryAssertion(floatField, 4.0, 1);
@@ -1631,10 +1631,12 @@ public class SolrProviderQuery {
     greaterThanQueryAssertion(longField, intFieldValue, 1);
 
     // searching int field with long value
-    greaterThanQueryAssertion(intField, 3L, 1);
+    greaterThanQueryAssertion(intField, -6L, 1);
 
     // searching int field with long value
     greaterThanQueryAssertion(shortField, 0L, 1);
+
+    equalToQueryAssertion(intField, intFieldValue, 1);
   }
 
   @Test()
@@ -1747,6 +1749,28 @@ public class SolrProviderQuery {
       filter = getFilterBuilder().attribute(fieldName).greaterThan().number((Long) fieldValue);
     } else if (fieldValue instanceof Float) {
       filter = getFilterBuilder().attribute(fieldName).greaterThan().number((Float) fieldValue);
+    }
+
+    SourceResponse response = provider.query(new QueryRequestImpl(new QueryImpl(filter)));
+
+    assertThat(response.getResults().size(), is(equalTo(count)));
+  }
+
+  private void equalToQueryAssertion(String fieldName, Serializable fieldValue, int count)
+      throws UnsupportedQueryException {
+
+    Filter filter = null;
+
+    if (fieldValue instanceof Double) {
+      filter = getFilterBuilder().attribute(fieldName).equalTo().number((Double) fieldValue);
+    } else if (fieldValue instanceof Integer) {
+      filter = getFilterBuilder().attribute(fieldName).equalTo().number((Integer) fieldValue);
+    } else if (fieldValue instanceof Short) {
+      filter = getFilterBuilder().attribute(fieldName).equalTo().number((Short) fieldValue);
+    } else if (fieldValue instanceof Long) {
+      filter = getFilterBuilder().attribute(fieldName).equalTo().number((Long) fieldValue);
+    } else if (fieldValue instanceof Float) {
+      filter = getFilterBuilder().attribute(fieldName).equalTo().number((Float) fieldValue);
     }
 
     SourceResponse response = provider.query(new QueryRequestImpl(new QueryImpl(filter)));


### PR DESCRIPTION
<!--
** For commits created to resolve GH Issues during the pilot and beyond, please prefix the
issue number with a 0 until we roll over at issue #10000, ie: `DDF-0####`. This kludgy solution
will avoid overlap with issues created in Jira.**

See https://github.com/codice/ddf/wiki/%5BGH-ISSUES-PILOT%5D-Pull-Request-Guidelines
for more info.
-->

<!--
Uncomment this block and include PR # of change against 2.13.x where appropriate.
When doing so, it is reasonable to delete much of the rest of the PR description, leaving only:
- This uncommented block with link to 2.13.x PR
- Reviewers tagged
- Teams tagged
- Committers tagged
- The link to the "Notes on Review Process"

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
Link to 2.13.x PR: #XXXX
____
-->

#### What does this PR do?
DDF generates invalid Solr queries for "=" relationships for numerics when the value is negative. This means the user cannot query for an exact negative value of numeric fields.
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 

@codice/test 
@codice/ui 
@codice/website 
-->
@codice/solr 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@clockard
@pklinef

#### How should this be tested?
ingest a file that contains a numeric value (ex. media.height)
issue query from the ui (ex. media.height=-1)
observe no errors and correct query is issued against sor

<!--(List steps with links to updated documentation)-->
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #5275

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
