### PR TITLE
[2.16.x] DDF-5298 Added support for upgrading CDM configurations with migration

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/migration.properties
+++ b/distribution/ddf-common/src/main/resources/etc/migration.properties
@@ -4,4 +4,4 @@
 #
 
 # A comma-delimited list of DDF versions that are supported for upgrading from
-supported.versions = 2.13.3,2.13.4,2.13.5,2.13.6,2.13.7,2.13.8,2.13.9,2.14.0,2.14.1,2.15.0
+supported.versions = 2.13.3,2.13.4,2.13.5,2.13.6,2.13.7,2.13.8,2.13.9,2.13.10,2.14.0,2.14.1,2.15.0,2.16.0,2.16.1

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/reusing-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/reusing-configurations.adoc
@@ -76,4 +76,5 @@ The same step-by-step process above can be followed when migrating configuration
 ** Keystores
 ** Truststores
 ** Service wrapper `*.conf` files, if the ${branding} is installed as a service
+** Content Directory Monitor Configuration (including URL Resource Reader)
 * There is a list of specific ${branding} versions that have been tested that can be found in `etc/migration.properties` under the property `supported.versions`, as a comma-delimited list. The system will only allow importing configurations from those versions.

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratable.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratable.java
@@ -136,8 +136,7 @@ public class ConfigurationAdminMigratable implements Migratable {
         .memoryEntries()
         .filter(
             s ->
-                (s.getFactoryPid() != null
-                        && s.getFactoryPid().equals(CONTENT_DIRECTORY_MONITOR_FPID))
+                CONTENT_DIRECTORY_MONITOR_FPID.equals(s.getFactoryPid())
                     || s.getPid().equals(URL_RESOURCE_READER_PID))
         .forEach(ImportMigrationConfigurationAdminEntry::restore);
   }

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratable.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratable.java
@@ -46,6 +46,12 @@ public class ConfigurationAdminMigratable implements Migratable {
    */
   private static final String CURRENT_VERSION = "1.0";
 
+  private static final String CONTENT_DIRECTORY_MONITOR_FPID =
+      "org.codice.ddf.catalog.content.monitor.ContentDirectoryMonitor";
+
+  private static final String URL_RESOURCE_READER_PID =
+      "ddf.catalog.resource.impl.URLResourceReader";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationAdminMigratable.class);
 
   private final ConfigurationAdmin configurationAdmin;
@@ -116,9 +122,24 @@ public class ConfigurationAdminMigratable implements Migratable {
   public void doImport(ImportMigrationContext context) {
     final ImportMigrationConfigurationAdminContext adminContext =
         new ImportMigrationConfigurationAdminContext(
-            context, this, configurationAdmin, getConfigurations(context));
-
+            context, this, configurationAdmin, getConfigurations(context), true);
     adminContext.memoryEntries().forEach(ImportMigrationConfigurationAdminEntry::restore);
+  }
+
+  @Override
+  public void doVersionUpgradeImport(ImportMigrationContext context) {
+    final ImportMigrationConfigurationAdminContext adminContext =
+        new ImportMigrationConfigurationAdminContext(
+            context, this, configurationAdmin, getConfigurations(context), false);
+
+    adminContext
+        .memoryEntries()
+        .filter(
+            s ->
+                (s.getFactoryPid() != null
+                        && s.getFactoryPid().equals(CONTENT_DIRECTORY_MONITOR_FPID))
+                    || s.getPid().equals(URL_RESOURCE_READER_PID))
+        .forEach(ImportMigrationConfigurationAdminEntry::restore);
   }
 
   @SuppressWarnings(

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
@@ -299,6 +299,7 @@ public class ImportMigrationConfigurationAdminContext {
               Objects.toString(properties.remove(ConfigurationAdmin.SERVICE_BUNDLELOCATION), null);
         } else {
           properties.remove("felix.fileinstall.filename");
+          properties.remove(ConfigurationAdmin.SERVICE_BUNDLELOCATION);
         }
         final String factoryPid =
             Objects.toString(properties.remove(ConfigurationAdmin.SERVICE_FACTORYPID), null);

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
@@ -67,6 +67,8 @@ public class ImportMigrationConfigurationAdminContext {
 
   private final ConfigurationAdmin configurationAdmin;
 
+  private final boolean restoreWithBundleLocation;
+
   /**
    * Keeps track of all managed services in memory that were not found in the export file so we know
    * what to delete at the end.
@@ -89,7 +91,8 @@ public class ImportMigrationConfigurationAdminContext {
       ImportMigrationContext context,
       ConfigurationAdminMigratable admin,
       ConfigurationAdmin configurationAdmin,
-      Configuration[] memoryConfigs) {
+      Configuration[] memoryConfigs,
+      boolean restoreWithBundleLocation) {
     Validate.notNull(context, "invalid null context");
     Validate.notNull(admin, "invalid null configuration admin migratable");
     Validate.notNull(configurationAdmin, "invalid null configuration admin");
@@ -97,6 +100,7 @@ public class ImportMigrationConfigurationAdminContext {
     this.context = context;
     this.admin = admin;
     this.configurationAdmin = configurationAdmin;
+    this.restoreWithBundleLocation = restoreWithBundleLocation;
     // categorize memory configurations
     this.managedServicesToDelete =
         Stream.of(memoryConfigs)
@@ -289,8 +293,13 @@ public class ImportMigrationConfigurationAdminContext {
             .record(
                 new MigrationException("Import error: missing pid from configuration [%s].", path));
       } else {
-        final String bundleLocation =
-            Objects.toString(properties.remove(ConfigurationAdmin.SERVICE_BUNDLELOCATION), null);
+        String bundleLocation = null;
+        if (restoreWithBundleLocation) {
+          bundleLocation =
+              Objects.toString(properties.remove(ConfigurationAdmin.SERVICE_BUNDLELOCATION), null);
+        } else {
+          properties.remove("felix.fileinstall.filename");
+        }
         final String factoryPid =
             Objects.toString(properties.remove(ConfigurationAdmin.SERVICE_FACTORYPID), null);
 

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminEntry.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminEntry.java
@@ -140,7 +140,7 @@ public class ImportMigrationConfigurationAdminEntry {
     // factory
     // config object. If there was none than null would have been exported and passed in to these
     // next
-    // 2 calls. When that happens, the location wuld automatically be set to the first bundle that
+    // 2 calls. When that happens, the location will automatically be set to the first bundle that
     // // registers a managed service or a managed service factory
     if (isManagedServiceFactory()) {
       return configurationAdmin.createFactoryConfiguration(factoryPid, bundleLocation);


### PR DESCRIPTION
### What does this PR do? 
Adds support for upgrading CDM and URL Resource Reader configurations with migration across versions.

#### Who is reviewing it? 
@austinsteffes 
@ahoffer 

#### Select relevant component teams: 
@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@paouelle


#### How should this be tested?
1. Install an old release version of DDF that is in the list of "supported versions" and create CDM and URL Resource Reader configurations (including configurations.policy change) 
2. Run migration:export, which creates 3 files under the `etc/exported directory`
3. Shutdown
4. Start up a DDF built on this PR's changes
5. Install with `profile:install standard`
6. Copy all 3 files from step 2 into this newly installed DDF under <ddf-home>/exported.
7. Run `migration:import -f`
8. After the system automatically restarts, verify all config changes are present in the new DDF and CDM works

#### What are the relevant tickets?
Work for: #5298 

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
