### PR TITLE
DDF-5308 Fix Histogram loading, increase selection interface speed

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -150,6 +150,9 @@ module.exports = Backbone.AssociatedModel.extend({
   addSelectedResult(metacard) {
     this.getSelectedResults().add(metacard)
   },
+  setSelectedResults(results) {
+    this.getSelectedResults().reset(results.models || results)
+  },
   removeSelectedResult(metacard) {
     this.getSelectedResults().remove(metacard)
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/input/password/input-password.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/input/password/input-password.tsx
@@ -28,7 +28,7 @@ type State = {
   showPassword: boolean
 }
 
-const Root = styled<{}, 'div'>('div')`
+const Root = styled.div`
   width: 100%;
 
   input {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-indicator/result-indicator.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-indicator/result-indicator.tsx
@@ -23,7 +23,7 @@ const Flex = styled.div`
   height: 100%;
 `
 
-const ColorBand = styled<{ bandColor: string }, 'div'>('div')`
+const ColorBand = styled.div<{ bandColor: string }>`
   width: 100%;
   height: 100%;
   background: ${props => props.bandColor};

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/selection-checkbox/selection-checkbox.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/selection-checkbox/selection-checkbox.view.js
@@ -77,7 +77,7 @@ const SelectAllToggle = createToggle({
       this.options.selectionInterface.clearSelectedResults()
     } else {
       const currentResults = this.options.selectionInterface.getActiveSearchResults()
-      this.options.selectionInterface.addSelectedResult(currentResults.models)
+      this.options.selectionInterface.setSelectedResults(currentResults.models)
     }
   },
   isSelected() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/selection-interface/selection-interface.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/selection-interface/selection-interface.model.js
@@ -120,6 +120,9 @@ module.exports = Backbone.AssociatedModel.extend({
   addToActiveSearchResults(results) {
     this.get('activeSearchResults').add(results.models || results)
   },
+  setSelectedResults(results) {
+    this.get('selectedResults').reset(results.models || results)
+  },
   getSelectedResults() {
     return this.get('selectedResults')
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/metacards/tabs-metacards.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/metacards/tabs-metacards.view.js
@@ -52,29 +52,10 @@ const MetacardsTabsView = TabsView.extend({
     this.determineAvailableContent()
     TabsView.prototype.initialize.call(this)
     const debounceDetermineContent = _.debounce(this.handleMetacardChange, 200)
+
     this.listenTo(
       this.selectionInterface.getSelectedResults(),
-      'update',
-      debounceDetermineContent
-    )
-    this.listenTo(
-      this.selectionInterface.getSelectedResults(),
-      'add',
-      debounceDetermineContent
-    )
-    this.listenTo(
-      this.selectionInterface.getSelectedResults(),
-      'remove',
-      debounceDetermineContent
-    )
-    this.listenTo(
-      this.selectionInterface.getSelectedResults(),
-      'reset',
-      debounceDetermineContent
-    )
-    this.listenTo(
-      this.selectionInterface.getSelectedResults(),
-      'refreshdata',
+      'add remove reset refreshdata update',
       debounceDetermineContent
     )
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/histogram/histogram.view.js
@@ -425,7 +425,7 @@ module.exports = Marionette.LayoutView.extend({
   handleEmpty() {
     this.$el.toggleClass(
       'is-empty',
-      this.options.selectionInterface.getActiveSearchResults().length === 0
+      this.options.selectionInterface.getCurrentQuery() === undefined
     )
   },
   handleResize() {
@@ -460,23 +460,14 @@ module.exports = Marionette.LayoutView.extend({
     )
     this.listenTo(
       this.options.selectionInterface.getSelectedResults(),
-      'update',
+      'update add remove update',
       this.updateHistogram
     )
+
     this.listenTo(
-      this.options.selectionInterface.getSelectedResults(),
-      'add',
-      this.updateHistogram
-    )
-    this.listenTo(
-      this.options.selectionInterface.getSelectedResults(),
-      'remove',
-      this.updateHistogram
-    )
-    this.listenTo(
-      this.options.selectionInterface.getSelectedResults(),
+      this.options.selectionInterface.getActiveSearchResults(),
       'reset',
-      this.updateHistogram
+      this.onRender
     )
 
     this.listenTo(

--- a/ui/packages/catalog-ui-search/src/main/webapp/extension-points/navigator/navigator.presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/extension-points/navigator/navigator.presentation.tsx
@@ -39,18 +39,15 @@ export const Divider = () => {
   return <div className="is-divider" />
 }
 
-export const Root = styled<Props, 'div'>('div')`
+export const Root = styled.div<Props>`
   height: 100%;
   width: 100%;
   overflow: auto;
 `
 
-export const WorkspacesSave = styled<
-  {
-    isSaved: Props['isSaved']
-  },
-  'div'
->('div')`
+export const WorkspacesSave = styled.div<{
+  isSaved: Props['isSaved']
+}>`
   position: absolute;
   right: 0px;
   top: 0px;
@@ -76,12 +73,9 @@ export const WorkspacesIndicator = styled.div`
   display: inline-block;
 `
 
-export const SourcesIndicator = styled<
-  {
-    hasUnavailableSources: Props['hasUnavailableSources']
-  },
-  'span'
->('span')`
+export const SourcesIndicator = styled.span<{
+  hasUnavailableSources: Props['hasUnavailableSources']
+}>`
   opacity: ${props => (props.hasUnavailableSources ? '1' : '0')};
   transform: ${props =>
     props.hasUnavailableSources ? 'scale(1)' : 'scale(0)'};

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/store.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/store.js
@@ -116,6 +116,9 @@ module.exports = new (Backbone.Model.extend({
   getSelectedResults() {
     return this.get('content').get('selectedResults')
   },
+  setSelectedResults(results) {
+    this.get('content').setSelectedResults(results)
+  },
   clearSelectedResults() {
     this.getSelectedResults().reset()
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/alert-settings/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/alert-settings/presentation.tsx
@@ -28,7 +28,7 @@ type Props = {
   onPersistenceChange: (v: Value) => any
 }
 
-const Root = styled<{}, 'div'>('div')`
+const Root = styled.div`
   width: 100%;
   height: 100%;
   overflow: auto;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/blacklist-item/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/blacklist-item/presentation.tsx
@@ -37,7 +37,7 @@ const collapseAnimation = (initialHeight: string) => {
   `
 }
 
-const Root = styled<Props, 'div'>('div')`
+const Root = styled.div<Props>`
   border-top: 1px solid;
   border-bottom: 1px solid;
   border-color: ${props =>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/histogram/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/histogram/index.tsx
@@ -45,7 +45,7 @@ const Warning = styled.span`
 export const HistogramContainer = () => (
   <React.Fragment>
     <Empty className="histogram-empty">
-      <h3>Please select a result set to display on the histogram.</h3>
+      <h3>Please select a search to display the histogram.</h3>
     </Empty>
     <Attribute className="histogram-attribute" />
     <NoData className="histogram-no-matching-data">

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/layer-item/presentation/layer-item.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/layer-item/presentation/layer-item.tsx
@@ -19,7 +19,7 @@ import { PresentationProps } from '.'
 
 import { LayerRearrange, LayerAlpha, LayerInteractions, LayerName } from '.'
 
-const Root = styled<PresentationProps, 'div'>('div')`
+const Root = styled.div<PresentationProps>`
   display: block;
   white-space: nowrap;
   width: 100%;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/map-info/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/map-info/presentation.tsx
@@ -24,7 +24,7 @@ type Props = {
   coordinates: Coordinates
 }
 
-const Root = styled<Props, 'div'>('div')`
+const Root = styled.div<Props>`
   font-family: 'Inconsolata', 'Lucida Console', monospace;
   background: ${props => props.theme.backgroundModal};
   display: block;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu-action/menu-action.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu-action/menu-action.tsx
@@ -32,7 +32,7 @@ type Props = {
   children?: any
 }
 
-const ModifiedMenuItem = styled<Props>(MenuItem)`
+const ModifiedMenuItem = styled(MenuItem)<Props>`
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu-selection/menu-selection.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu-selection/menu-selection.tsx
@@ -25,7 +25,7 @@ type Props = {
   children?: any
 }
 
-const ModifiedMenuItem = styled<Props>(MenuItem)`
+const ModifiedMenuItem = styled(MenuItem)<Props>`
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/navigation-behavior/navigation-behavior.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/navigation-behavior/navigation-behavior.tsx
@@ -26,7 +26,7 @@ type State = {
   open: boolean
 }
 
-const Wrapper = styled<{}, 'div'>('div')`
+const Wrapper = styled.div`
   > *:not(.composed-menu):hover:not(button),
   > *.is-active:not(.composed-menu):not(button),
   .composed-menu > *:not(.composed-menu):hover:not(button),

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/navigation-left/navigation-left.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/navigation-left/navigation-left.tsx
@@ -38,7 +38,7 @@ export interface Props {
   logo: string
 }
 
-const Root = styled<Props, 'div'>('div')`
+const Root = styled.div<Props>`
   position: relative;
   overflow: hidden;
   cursor: pointer;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/navigation-right/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/navigation-right/presentation.tsx
@@ -34,7 +34,7 @@ const unseenNotifications = keyframes`
   }
 `
 
-const Root = styled<Props, 'div'>('div')`
+const Root = styled.div<Props>`
   ${CustomElement} white-space: nowrap;
   overflow: hidden;
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/navigation/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/navigation/presentation.tsx
@@ -39,7 +39,7 @@ const NavigationRight = styled.div`
   transition: width ${props => props.theme.coreTransitionTime} ease-in-out;
 `
 
-const NavigationMiddle = styled<Props, 'div'>('div')`
+const NavigationMiddle = styled.div<Props>`
   width: ${props => {
     if (props.hasLogo) {
       if (props.hasUnavailable || props.hasUnsaved) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/button/button.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/button/button.tsx
@@ -111,7 +111,7 @@ type RootProps = {
   fadeUntilHover?: boolean
 }
 
-const Root = styled<RootProps, 'button'>('button')`
+const Root = styled.button<RootProps>`
     max-width: 100%;
     white-space: nowrap;
     overflow: hidden;
@@ -184,7 +184,7 @@ type IconProps = {
   text?: string
 }
 
-const Icon = styled<IconProps, 'span'>('span')`
+const Icon = styled.span<IconProps>`
   margin: 0px
     ${props =>
       props.text !== undefined && props.text !== ''
@@ -197,7 +197,7 @@ type TextProps = {
   inText?: boolean
 }
 
-const Text = styled<TextProps, 'span'>('span')`
+const Text = styled.span<TextProps>`
   font-size: ${props =>
     props.inText ? 'inherit !important' : props.theme.mediumFontSize};
 `

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/dropdown/dropdown.tsx
@@ -133,7 +133,7 @@ export const withDropdown = <P extends withContext>(
   }
 }
 
-const DropdownWrapper = styled<{ open: boolean }, 'div'>('div')`
+const DropdownWrapper = styled.div<{ open: boolean }>`
   display: block;
   position: absolute;
   z-index: ${props => props.theme.zIndexDropdown};

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/result-sort/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/result-sort/presentation.tsx
@@ -28,7 +28,7 @@ type Props = {
   collection: Backbone.Collection<Backbone.Model>
 }
 
-const Root = styled<Props, 'div'>('div')`
+const Root = styled.div<Props>`
   display: block;
   padding: ${props => props.theme.minimumSpacing};
   min-width: 500px;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/save-button/save-button.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/save-button/save-button.tsx
@@ -21,7 +21,7 @@ type SaveButtonProps = {
   isSaved: boolean
 }
 
-const Root = styled<SaveButtonProps, 'div'>('div')`
+const Root = styled.div<SaveButtonProps>`
   display: inline-block;
   vertical-align: top;
   overflow: hidden;
@@ -38,7 +38,7 @@ const Root = styled<SaveButtonProps, 'div'>('div')`
   }};
 `
 
-const SaveIcon = styled<SaveButtonProps, 'span'>('span')`
+const SaveIcon = styled.span<SaveButtonProps>`
   color: inherit;
   opacity: ${props => (props.isSaved ? 0 : 1)};
   transform: scale(${props => (props.isSaved ? 2 : 1)});
@@ -50,7 +50,7 @@ const SaveIcon = styled<SaveButtonProps, 'span'>('span')`
       ease-out 0s;
 `
 
-const CheckIcon = styled<SaveButtonProps, 'span'>('span')`
+const CheckIcon = styled.span<SaveButtonProps>`
   visibility: visible;
   transition: transform
       ${props => props.theme.multiple(2, props.theme.coreTransitionTime, 's')}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/search-settings/search-settings.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/search-settings/search-settings.tsx
@@ -44,7 +44,7 @@ const QuerySettings = styled.div`
   }
 `
 
-const EditorFooter = styled<Props, 'div'>('div')`
+const EditorFooter = styled.div<Props>`
   display: ${props => (props.showFooter ? 'block' : 'none')};
   button {
     display: inline-block;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/source-item/source-item.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/source-item/source-item.tsx
@@ -23,7 +23,7 @@ type RootProps = {
   available: boolean
 }
 
-const Root = styled<RootProps, 'div'>('div')`
+const Root = styled.div<RootProps>`
   width: 100%;
   height: auto;
   white-space: nowrap;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/sources-summary/sources-summary.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/sources-summary/sources-summary.tsx
@@ -17,7 +17,7 @@ import styled from 'styled-components'
 import { hot } from 'react-hot-loader'
 import { FormattedMessage } from 'react-intl'
 
-const Root = styled<{}, 'div'>('div')`
+const Root = styled.div`
   display: block;
   width: 100%;
   height: auto;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/sources/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/sources/presentation.tsx
@@ -19,17 +19,15 @@ import SourceItem from '../source-item'
 import SourcesSummary from '../sources-summary'
 import { hot } from 'react-hot-loader'
 
-const Root = styled<{}, 'div'>('div')`
+const Root = styled.div`
   display: block;
   height: 100%;
   width: 100%;
   overflow: hidden;
-  ${props => {
-    return ChangeBackground(props.theme.backgroundContent)
-  }};
+  ${props => ChangeBackground(props.theme.backgroundContent)};
 `
 
-const SourcesCenter = styled<{}, 'div'>('div')`
+const SourcesCenter = styled.div`
   margin: auto;
   max-width: ${props => {
     return props.theme.screenBelow(props.theme.mediumScreenSize)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/table-export/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/table-export/presentation.tsx
@@ -20,7 +20,7 @@ import styled from 'styled-components'
 import Number from '../input-wrappers/number'
 const properties = require('../../js/properties.js')
 
-const Root = styled<{}, 'div'>('div')`
+const Root = styled.div`
   display: block;
   height: 100%;
   width: 100%;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/unsaved-indicator/unsaved-indicator.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/unsaved-indicator/unsaved-indicator.tsx
@@ -21,7 +21,7 @@ interface Props {
   style?: React.CSSProperties
 }
 
-const Root = styled<Props, 'span'>('span')`
+const Root = styled.span<Props>`
   display: inline-block;
   line-height: inherit;
   vertical-align: top;
@@ -29,19 +29,14 @@ const Root = styled<Props, 'span'>('span')`
     return props.theme.warningColor
   }};
 
-  transition: ${props => {
-    return `transform ${props.theme.coreTransitionTime} ease-out, opacity ${
-      props.theme.coreTransitionTime
+  transition: ${({ theme }) => {
+    return `transform ${theme.coreTransitionTime} ease-out, opacity ${
+      theme.coreTransitionTime
     } ease-out;`
   }};
 
-  transform: ${props => {
-    return `scale(${props.shown ? 1 : 2});`
-  }};
-
-  opacity: ${props => {
-    return props.shown ? 1 : 0
-  }};
+  transform: ${props => `scale(${props.shown ? 1 : 2});`};
+  opacity: ${props => (props.shown ? 1 : 0)};
 `
 
 export default function UnsavedIndicator(props: Props) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/user-blacklist/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/user-blacklist/presentation.tsx
@@ -47,7 +47,7 @@ const EmptyBlacklist = styled.div`
     linear;
 `
 
-const ItemsWrapper = styled<Props, 'div'>('div')`
+const ItemsWrapper = styled.div<Props>`
   overflow: hidden;
   ${props =>
     props.clearing

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/user-settings/user-settings.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/user-settings/user-settings.tsx
@@ -39,7 +39,7 @@ type State = {
   component?: JSX.Element
 }
 
-const Root = styled<State, 'div'>('div')`
+const Root = styled.div<State>`
   width: 100%;
   height: 100%;
   position: relative;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/user/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/user/presentation.tsx
@@ -17,7 +17,7 @@ import styled from 'styled-components'
 import { Button, buttonTypeEnum } from '../presentation/button'
 import { hot } from 'react-hot-loader'
 
-const Root = styled<{}, 'div'>('div')`
+const Root = styled.div`
   width: 100%;
   height: 100%;
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/presentation.tsx
@@ -37,7 +37,7 @@ type Props = {
   isShareable: boolean
 }
 
-const Root = styled<{}, 'div'>('div')`
+const Root = styled.div`
   width: 100%;
   color: ${props => readableColor(props.theme.background)};
 `

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-title/workspace-title.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-title/workspace-title.tsx
@@ -27,7 +27,7 @@ type Props = {
   saved: boolean
 }
 
-const Root = styled<{}, 'div'>('div')`
+const Root = styled.div`
   width: 100%;
   height: 100%;
   position: relative;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspaces/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspaces/presentation.tsx
@@ -28,7 +28,7 @@ type RootProps = {
   hasUnsaved: boolean
 }
 
-const Root = styled<RootProps, 'div'>('div')`
+const Root = styled.div<RootProps>`
   ${CustomElement} ${props =>
     ChangeBackground(
       props.theme.backgroundContent


### PR DESCRIPTION
#### What does this PR do?
- Fixes an issue where the histogram wouldn't work unless you had loaded it AFTER running a search.
- Adds a new method to selection interface called `setSelectedResults` that when used is twice as fast as calling `clearSelectedResults` followed by `addSelectedResults`. (See attached video)
- Normalizes the `styled-components` syntax when passing custom props into components.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewkfiedler 
@djblue 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@adimka
@vinamartin

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- Open histogram before running a search. Make sure it updates correctly.

#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #5308 

#### Screenshots
<!--(if appropriate)-->
[Speed Up Video](https://github.com/codice/ddf/files/3596995/SelectionInterfaceSpeedup.mp4.zip)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
