### PR TITLE
DDF-5317 Change serialized name in QueryBasic to "src"

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/query/data/model/QueryBasic.java
@@ -76,7 +76,7 @@ public class QueryBasic {
   @SerializedName("enterprise")
   private Boolean enterprise;
 
-  @SerializedName("sources")
+  @SerializedName("src")
   private List<String> sources;
 
   @SerializedName("sorts")

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -366,7 +366,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
         ImmutableMap.<String, Object>builder()
             .put(Core.TITLE, "title")
             .put(QUERY_CQL, "query")
-            .put("sources", sources)
+            .put("src", sources)
             .build();
 
     Response res =
@@ -376,7 +376,7 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
     Map body = parse(res);
     String id = (String) body.get("id");
     assertNotNull(id);
-    assertThat(body.get("sources"), is(sources));
+    assertThat(body.get("src"), is(sources));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Updates @SerializedName in QueryBasic, so hitting QueryMetacardApplication's endpoints will serialize "src" into QueryBasic's sources variable. 


#### Who is reviewing it? 
@Bdthomson 
@stevenmalmgren 
@vinamartin 

#### Ask 2 committers to review/merge the PR and tag them here.
@troymohl
@vinamartin

#### How should this be tested?

- Use Postman to POST to this endpoint: https://localhost:8993/search/catalog/internal/queries
  - You're sending "src", but the response should still come back as "sources". 
  - The body should look something like this:

```
{
    "cql": "(\"anyText\" ILIKE 'postman')",
    "filterTree": "{\"type\":\"AND\",\"filters\":[{\"type\":\"ILIKE\",\"property\":\"anyText\",\"value\":\"postman\"}]}",
    "excludeUnnecessaryAttributes": true,
    "count": 250,
    "start": 1,
    "federation": "selected",
    "sorts": [
        {
            "attribute": "modified",
            "direction": "descending"
        }
    ],
    "serverPageIndex": 1,
    "type": "advanced",
    "isLocal": false,
    "isOutdated": true,
    "spellcheck": false,
    "phonetics": false,
    "src": [
        "DDF"
    ],
    "id": "acba7b4c-1c9c-4a86-8ff7-eca0ea861be4",
    "totalHits": 0,
    "title": "postman"
}
```

#### What are the relevant tickets?
Fixes: #5317 

#### Screenshots
![image](https://user-images.githubusercontent.com/22667297/64718814-c7d1eb80-d47b-11e9-9e2d-c770bd8badea.png)

#### Checklist:
- [ ] Documentation Updated
  - N/A
- [ ] Update / Add Threat Dragon models
  - N/A
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
  - N/A

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
