### PR TITLE
[2.16.x] DDF-5331 Updated OperationPlugin to specify correct action for use in…

### DIFF
--- a/catalog/security/catalog-security-operationplugin/src/main/java/ddf/catalog/security/operation/plugin/OperationPlugin.java
+++ b/catalog/security/catalog-security-operationplugin/src/main/java/ddf/catalog/security/operation/plugin/OperationPlugin.java
@@ -42,20 +42,20 @@ public class OperationPlugin implements AccessPlugin {
 
   @Override
   public CreateRequest processPreCreate(CreateRequest input) throws StopProcessingException {
-    checkOperation(input);
+    checkOperation(input, CollectionPermission.CREATE_ACTION);
     return input;
   }
 
   @Override
   public UpdateRequest processPreUpdate(
       UpdateRequest input, Map<String, Metacard> existingMetacards) throws StopProcessingException {
-    checkOperation(input);
+    checkOperation(input, CollectionPermission.UPDATE_ACTION);
     return input;
   }
 
   @Override
   public DeleteRequest processPreDelete(DeleteRequest input) throws StopProcessingException {
-    checkOperation(input);
+    checkOperation(input, CollectionPermission.DELETE_ACTION);
     return input;
   }
 
@@ -66,7 +66,7 @@ public class OperationPlugin implements AccessPlugin {
 
   @Override
   public QueryRequest processPreQuery(QueryRequest input) throws StopProcessingException {
-    checkOperation(input);
+    checkOperation(input, CollectionPermission.READ_ACTION);
     return input;
   }
 
@@ -77,7 +77,7 @@ public class OperationPlugin implements AccessPlugin {
 
   @Override
   public ResourceRequest processPreResource(ResourceRequest input) throws StopProcessingException {
-    checkOperation(input);
+    checkOperation(input, CollectionPermission.READ_ACTION);
     return input;
   }
 
@@ -94,7 +94,7 @@ public class OperationPlugin implements AccessPlugin {
    * @param operation The operation to check
    * @throws StopProcessingException
    */
-  private void checkOperation(Operation operation) throws StopProcessingException {
+  private void checkOperation(Operation operation, String action) throws StopProcessingException {
     if (!operation.hasProperties()
         || !operation.containsPropertyName(PolicyPlugin.OPERATION_SECURITY)) {
       return;
@@ -112,7 +112,7 @@ public class OperationPlugin implements AccessPlugin {
     Map<String, Set<String>> perms =
         (Map<String, Set<String>>) operation.getPropertyValue(PolicyPlugin.OPERATION_SECURITY);
     KeyValueCollectionPermission securityPermission =
-        new KeyValueCollectionPermission(CollectionPermission.READ_ACTION, perms);
+        new KeyValueCollectionPermission(action, perms);
 
     if (!subject.isPermitted(securityPermission)) {
       throw new StopProcessingException(


### PR DESCRIPTION
… policy evaluation

##### ABBREVIATED REVIEW BETWEEN 2.13.X AND MASTER IS IN EFFECT
https://github.com/codice/ddf/issues/5331

#### What does this PR do?
#### Who is reviewing it? 
@roelens8 
@bakejeyner 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@blen-desta
@stustison

#### How should this be tested?
Turn on DEBUG logging for XACMLClient and verify that for workspace saves, uploads, edits, that the action passed to the XACML PDP is something other than READ (should be at least one instance of WRITE or UPDATE during those operations)
#### Any background context you want to provide?
Action was hard-coded to READ in the previous version, this limited what could be checked in the XACML policy.
#### What are the relevant tickets?
Fixes: #5331 

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
