### PR TITLE
DDF-5338 Use setTimeout to put child render at the top of the stack

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.view.js
@@ -112,7 +112,7 @@ module.exports = TabsView.extend({
   },
   determineContent() {
     if (this.selectionInterface.getSelectedResults().length === 1) {
-      this.determineContentFromType()
+      setTimeout(() => this.determineContentFromType(), 0)
     }
   },
   determineAvailableContent() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/metacards/tabs-metacards.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/metacards/tabs-metacards.view.js
@@ -99,7 +99,7 @@ const MetacardsTabsView = TabsView.extend({
   },
   determineContent() {
     if (this.selectionInterface.getSelectedResults().length > 1) {
-      this.determineContentFromType()
+      setTimeout(() => this.determineContentFromType(), 0)
     }
   },
   determineAvailableContent() {


### PR DESCRIPTION
#### What does this PR do?
Prevents rendering of the tabs view inside of inspector until other operations have finished.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin 
@rzwiefel 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
I haven't found a way to actually break this in DDF but it can be replicated in downstream packages with UI heavy visualizations.

#### Any background context you want to provide?


#### What are the relevant tickets?
Fixes: #5338 

#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
