### PR TITLE
[2.16.x] DDF-5315 Suppress beanutils from Artemis dependency

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -213,6 +213,7 @@
         <cve>CVE-2015-8768</cve>
         <cve>CVE-2016-2108</cve>
         <cve>CVE-2016-2109</cve>
+        <cve>CVE-2018-20997</cve>
     </suppress>
     <suppress>
         <notes>
@@ -626,5 +627,13 @@
             dependencies have upgraded.
         </notes>
         <cve>CVE-2019-14379</cve>
+    </suppress>
+    <suppress>
+        <notes>
+            This CVE is coming from artemis. Suppressing the CVE until Artemis is removed from DDF.
+            https://github.com/codice/ddf/issues/5315
+        </notes>
+        <gav regex="true">^commons-beanutils:commons-beanutils:.*$</gav>
+        <cve>CVE-2019-10086</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
##### ABBREVIATED REVIEW BETWEEN 2.16.X AND MASTER IS IN EFFECT
Link to 2.16.x PR: #5316 

#### What does this PR do?
Suppresses CVE warning for a dependency required by Artemis.

#### Who is reviewing it? 
@austinsteffes 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.

@brjeter
@clockard 
@stustison

#### How should this be tested?
Full build with OWASP

#### Any background context you want to provide?
The final solution to this will be to move the Artemis feature into a separate repository and compose it into distributions as required vs embedding directly into DDF.

Suppress additional CVE against jruby-complete.

#### What are the relevant tickets?
Work for: #5315 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
