### PR TITLE
DDF-5311 Added support for upgrading some security configs with migration

### DIFF
--- a/distribution/docs/src/main/resources/content/_managing/_configuring/reusing-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/reusing-configurations.adoc
@@ -76,5 +76,13 @@ The same step-by-step process above can be followed when migrating configuration
 ** Keystores
 ** Truststores
 ** Service wrapper `*.conf` files, if the ${branding} is installed as a service
-** Content Directory Monitor Configuration (including URL Resource Reader)
+** Select AdminUI Configurations, Including:
+*** Content Directory Monitor
+*** URL Resource Reader
+*** Web Context Policy Manager
+*** Security STS Guest Claims Handler
+*** Security STS Server
+*** Session
+[WARNING]
+If a supported configuration is being imported across versions, any corresponding `.config` files in the etc directory will not be put into the etc directory of the importing system.
 * There is a list of specific ${branding} versions that have been tested that can be found in `etc/migration.properties` under the property `supported.versions`, as a comma-delimited list. The system will only allow importing configurations from those versions.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/reusing-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/reusing-configurations.adoc
@@ -76,13 +76,13 @@ The same step-by-step process above can be followed when migrating configuration
 ** Keystores
 ** Truststores
 ** Service wrapper `*.conf` files, if the ${branding} is installed as a service
-** Select AdminUI Configurations, Including:
+** Select ${admin-console} configurations, including:
 *** Content Directory Monitor
 *** URL Resource Reader
 *** Web Context Policy Manager
-*** Security STS Guest Claims Handler
+*** Guest Claims Configuration
 *** Security STS Server
 *** Session
 [WARNING]
-If a supported configuration is being imported across versions, any corresponding `.config` files in the etc directory will not be put into the etc directory of the importing system.
+If a supported configuration is being imported across versions, any corresponding `.config` files in the `etc` directory will not be put into the `etc` directory of the importing system.
 * There is a list of specific ${branding} versions that have been tested that can be found in `etc/migration.properties` under the property `supported.versions`, as a comma-delimited list. The system will only allow importing configurations from those versions.

--- a/features/migration/pom.xml
+++ b/features/migration/pom.xml
@@ -112,6 +112,11 @@
             <classifier>features</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/features/migration/src/main/feature/feature.xml
+++ b/features/migration/src/main/feature/feature.xml
@@ -51,6 +51,7 @@
         <feature>platform-migration-utils</feature>
         <bundle>mvn:ddf.platform.migration/platform-migration/${project.version}</bundle>
         <bundle>mvn:com.google.code.gson/gson/${gson.version}</bundle>
+        <bundle>mvn:ddf.admin.core/admin-core-api/${project.version}</bundle>
     </feature>
 
     <feature name="io" version="${project.version}" description="I/O Utilities">

--- a/platform/migration/platform-migration/pom.xml
+++ b/platform/migration/platform-migration/pom.xml
@@ -141,6 +141,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
@@ -128,7 +128,6 @@ public class ImportMigrationConfigurationAdminContext {
         Stream.of(entries)
             .filter(ImportMigrationConfigurationAdminEntry::isManagedServiceFactory)
             .collect(Collectors.groupingBy(ImportMigrationConfigurationAdminEntry::getFactoryPid));
-    context.getReport().doAfterCompletion(this::deleteUnexportedConfigurationsAfterCompletion);
   }
 
   public Stream<ImportMigrationConfigurationAdminEntry> memoryEntries() {
@@ -325,7 +324,7 @@ public class ImportMigrationConfigurationAdminContext {
 
   @SuppressWarnings(
       "PMD.UnusedFormalParameter" /* report parameter is required as this method is used as a functional interface */)
-  private void deleteUnexportedConfigurationsAfterCompletion(MigrationReport report) {
+  protected void deleteUnexportedConfigurationsAfterCompletion(MigrationReport report) {
     if (isValid) {
       Stream.concat(
               managedServicesToDelete.values().stream(),

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
@@ -323,8 +323,9 @@ public class ImportMigrationConfigurationAdminContext {
   }
 
   @SuppressWarnings(
-      "PMD.UnusedFormalParameter" /* report parameter is required as this method is used as a functional interface */)
-  protected void deleteUnexportedConfigurationsAfterCompletion(MigrationReport report) {
+      "PMD.UnusedFormalParameter" /* report parameter is required as this method is used as a functional interface
+                                  and is being called in the ConfigurationAdminMigratable class */)
+  void deleteUnexportedConfigurationsAfterCompletion(MigrationReport report) {
     if (isValid) {
       Stream.concat(
               managedServicesToDelete.values().stream(),

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminEntry.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminEntry.java
@@ -46,7 +46,7 @@ public class ImportMigrationConfigurationAdminEntry {
 
   @Nullable private final String factoryPid;
 
-  private final String pid;
+  private String pid;
 
   @Nullable private final Configuration memoryConfiguration;
 
@@ -125,6 +125,10 @@ public class ImportMigrationConfigurationAdminEntry {
 
   public String getPid() {
     return pid;
+  }
+
+  public void setPid(String pid) {
+    this.pid = pid;
   }
 
   public boolean isManagedServiceFactory() {

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminEntry.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminEntry.java
@@ -40,7 +40,7 @@ public class ImportMigrationConfigurationAdminEntry {
 
   private final ConfigurationAdmin configurationAdmin;
 
-  private final Dictionary<String, Object> properties;
+  private Dictionary<String, Object> properties;
 
   @Nullable private final String bundleLocation;
 
@@ -125,6 +125,14 @@ public class ImportMigrationConfigurationAdminEntry {
 
   public String getPid() {
     return pid;
+  }
+
+  public Dictionary<String, Object> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Dictionary<String, Object> properties) {
+    this.properties = properties;
   }
 
   public void setPid(String pid) {

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
@@ -47,7 +47,9 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.collections.ListUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.fileinstall.internal.DirectoryWatcher;
 import org.apache.karaf.system.SystemService;
@@ -136,6 +138,15 @@ public class ConfigurationAdminMigratableTest {
   private static final String DDF_CUSTOM_MIME_TYPE_RESOLVER_FILENAME =
       String.format("%s-csw.config", DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
 
+  private static final String STS_GUEST_CLAIMS_HANDLER_PID = "ddf.security.sts.guestclaims";
+
+  private static final String STS_SERVER_PID = "ddf.security.sts";
+
+  private static final String WEB_CONTEXT_POLICY_MANAGER_PID =
+      "org.codice.ddf.security.policy.context.impl.PolicyManager";
+
+  private static final String SECURITY_SESSION_PID = "ddf.security.http.impl.HttpSessionFactory";
+
   private static final List<PersistenceStrategy> STRATEGIES =
       ImmutableList.of(new CfgStrategy(), new ConfigStrategy());
 
@@ -158,13 +169,17 @@ public class ConfigurationAdminMigratableTest {
 
   @Mock private MigrationReport migrationReport;
 
-  private Configuration[] configurations;
+  private List<Configuration> configurations;
 
   @Before
   public void setup() throws Exception {
     setup(DDF_HOME, SUPPORTED_VERSION);
-    setupConfigAdminForExportSystem(DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
-    configurations = setupConfigAdminForImportSystem(DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
+    setupConfigAdminForExportSystem(
+        Collections.emptyList(),
+        Collections.singletonList(DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID));
+    setupConfigAdminForImportSystem(
+        Collections.emptyList(),
+        Collections.singletonList(DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID));
   }
 
   @Test
@@ -291,7 +306,7 @@ public class ConfigurationAdminMigratableTest {
         .createFactoryConfiguration(eq(DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID), isNull());
     ArgumentCaptor<Dictionary<String, ?>> argumentCaptor =
         ArgumentCaptor.forClass(Dictionary.class);
-    verify(configurations[0]).update(argumentCaptor.capture());
+    verify(configurations.get(0)).update(argumentCaptor.capture());
     Map<String, ?> dictionayAsMap = convertToMap(argumentCaptor.getValue());
     assertThat(
         dictionayAsMap,
@@ -312,13 +327,17 @@ public class ConfigurationAdminMigratableTest {
   @Test
   public void testDoExportDoVersionUpgradeImport() throws Exception {
     // Setup Export
-    String[] factoryPids = {CONTENT_DIRECTORY_MONITOR_FACTORY_PID, URL_RESOURCE_READER_FACTORY_PID};
-    Configuration[] exportedConfigurations =
-        setupConfigAdminForExportSystem(
-            CONTENT_DIRECTORY_MONITOR_FACTORY_PID,
+    List<String> pids =
+        Arrays.asList(
             URL_RESOURCE_READER_FACTORY_PID,
-            DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
-    when(exportedConfigurations[1].getPid()).thenReturn(URL_RESOURCE_READER_FACTORY_PID);
+            STS_GUEST_CLAIMS_HANDLER_PID,
+            STS_SERVER_PID,
+            WEB_CONTEXT_POLICY_MANAGER_PID,
+            SECURITY_SESSION_PID);
+    List<String> factoryPids =
+        Arrays.asList(
+            CONTENT_DIRECTORY_MONITOR_FACTORY_PID, DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
+    setupConfigAdminForExportSystem(pids, factoryPids);
     Path exportDir = tempDir.getRoot().toPath().toRealPath();
     final String tag = String.format(DDF_EXPORTED_TAG_TEMPLATE, DDF_HOME);
     final Path configFile = setupConfigFile(tag, CONTENT_DIRECTORY_MONITOR_FILENAME);
@@ -364,12 +383,7 @@ public class ConfigurationAdminMigratableTest {
     // Clean up ddf home, so we can import into a clean directory
     FileUtils.deleteDirectory(ddfHome.toRealPath().toFile());
     setup(DDF_HOME, IMPORTING_PRODUCT_VERSION);
-    configurations =
-        setupConfigAdminForImportSystem(
-            CONTENT_DIRECTORY_MONITOR_FACTORY_PID,
-            URL_RESOURCE_READER_FACTORY_PID,
-            DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
-    when(configurations[1].getPid()).thenReturn(URL_RESOURCE_READER_FACTORY_PID);
+    setupConfigAdminForImportSystem(pids, factoryPids);
 
     // intercept doImport() to verify exported files from etc
     ConfigurationAdminMigratable iCam =
@@ -396,16 +410,23 @@ public class ConfigurationAdminMigratableTest {
 
     // Verify that the config admin in the system being imported into gets the factory configuration
     // from the system being exported from.
-    for (int i = 0; i < factoryPids.length; i++) {
-      verify(configurationAdminForImport).createFactoryConfiguration(eq(factoryPids[i]), isNull());
-      ArgumentCaptor<Dictionary<String, ?>> argumentCaptor =
-          ArgumentCaptor.forClass(Dictionary.class);
-      verify(configurations[i]).update(argumentCaptor.capture());
-      Map<String, ?> dictionayAsMap = convertToMap(argumentCaptor.getValue());
-      assertThat(
-          dictionayAsMap,
-          allOf(aMapWithSize(1), hasEntry("schema", "http://www.opengis.net/cat/csw/2.0.2")));
-      // Does not have filename because felix.fileinstall is removed
+    // Using legacy for lops due to exception handling
+    for (String fPid : factoryPids) {
+      if (!fPid.equals(DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID)) {
+        verify(configurationAdminForImport).createFactoryConfiguration(eq(fPid), isNull());
+      }
+    }
+    for (Configuration config : configurations) {
+      if (!config.getPid().contains(DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID)) {
+        ArgumentCaptor<Dictionary<String, ?>> argumentCaptor =
+            ArgumentCaptor.forClass(Dictionary.class);
+        verify(config).update(argumentCaptor.capture());
+        Map<String, ?> dictionayAsMap = convertToMap(argumentCaptor.getValue());
+        assertThat(
+            dictionayAsMap,
+            allOf(aMapWithSize(1), hasEntry("schema", "http://www.opengis.net/cat/csw/2.0.2")));
+        // Does not have filename because felix.fileinstall is removed
+      }
     }
   }
 
@@ -429,46 +450,36 @@ public class ConfigurationAdminMigratableTest {
     return map;
   }
 
-  private Configuration[] setupConfigAdminForExportSystem(String... configFactoryPids)
+  private void setupConfigAdminForExportSystem(List<String> pids, List<String> configFactoryPids)
       throws Exception {
-    Configuration[] configurations = getConfigurationsForExportSystem(configFactoryPids);
-    when(configurationAdminForExport.listConfigurations(isNull())).thenReturn(configurations);
+    List<Configuration> configs =
+        pids.stream().map(this::getConfigurationForExportSystem).collect(Collectors.toList());
+    List<Configuration> factoryConfigs =
+        configFactoryPids
+            .stream()
+            .map(this::getFactoryConfigurationForExportSystem)
+            .collect(Collectors.toList());
+    configurations = ListUtils.union(configs, factoryConfigs);
+    when(configurationAdminForExport.listConfigurations(isNull()))
+        .thenReturn(configurations.toArray(new Configuration[0]));
     when(exportMigrationContext.entries(any(), eq(false), any())).thenReturn(Stream.empty());
-    return configurations;
   }
 
-  private Configuration[] setupConfigAdminForImportSystem(String... configFactoryPids)
+  private void setupConfigAdminForImportSystem(List<String> pids, List<String> configFactoryPids)
       throws Exception {
-    Configuration[] configurations = getConfigurationsForImportSystem(configFactoryPids);
-    when(configurationAdminForImport.listConfigurations(isNull())).thenReturn(configurations);
-    // Create a new factory Configuration object with a new PID. The properties of the new
-    // Configuration
-    // object are null until the first time that its Configuration.update(Dictionary) method is
-    // called.
-    for (int i = 0; i < configFactoryPids.length; i++) {
-      when(configurations[i].getPid())
-          .thenReturn(
-              String.format("%s.8e3c2b12-9807-482a-aaa7-d3d317973581", configFactoryPids[i]));
-      when(configurationAdminForImport.createFactoryConfiguration(
-              eq(configFactoryPids[i]), isNull()))
-          .thenReturn(configurations[i]);
-    }
-    return configurations;
+    List<Configuration> configs =
+        pids.stream().map(this::getConfigurationForImportSystem).collect(Collectors.toList());
+    List<Configuration> factoryConfigs =
+        configFactoryPids
+            .stream()
+            .map(this::getFactoryConfigurationForImportSystem)
+            .collect(Collectors.toList());
+    configurations = ListUtils.union(configs, factoryConfigs);
+    when(configurationAdminForImport.listConfigurations(isNull()))
+        .thenReturn(configurations.toArray(new Configuration[0]));
   }
 
-  private Configuration[] getConfigurationsForExportSystem(String... configFactoryPids) {
-    return Arrays.stream(configFactoryPids)
-        .map(this::getConfigurationForExportSystem)
-        .toArray(Configuration[]::new);
-  }
-
-  private Configuration[] getConfigurationsForImportSystem(String... configFactoryPids) {
-    return Arrays.stream(configFactoryPids)
-        .map(this::getConfigurationForImportSystem)
-        .toArray(Configuration[]::new);
-  }
-
-  private Configuration getConfigurationForExportSystem(String configFactoryPid) {
+  private Configuration getFactoryConfigurationForExportSystem(String configFactoryPid) {
     Configuration config = mock(Configuration.class);
     Dictionary<String, Object> props = new Hashtable<>();
     try {
@@ -492,10 +503,44 @@ public class ConfigurationAdminMigratableTest {
     return config;
   }
 
-  private Configuration getConfigurationForImportSystem(String configFactoryPid) {
+  private Configuration getConfigurationForExportSystem(String pid) {
     Configuration config = mock(Configuration.class);
-    when(config.getPid()).thenReturn(configFactoryPid);
+    Dictionary<String, Object> props = new Hashtable<>();
+    try {
+      props.put(
+          DirectoryWatcher.FILENAME,
+          ddfHome.resolve("etc").toRealPath().resolve(String.format("%s.config", pid)).toUri());
+    } catch (IOException e) {
+      fail("Unable to resolve configuration path");
+    }
+    props.put("service.pid", pid);
+    props.put("schema", "http://www.opengis.net/cat/csw/2.0.2");
+    when(config.getProperties()).thenReturn(props);
+    when(config.getPid()).thenReturn(pid);
+    return config;
+  }
+
+  private Configuration getFactoryConfigurationForImportSystem(String configFactoryPid) {
+    Configuration config = mock(Configuration.class);
+    // Create a new factory Configuration object with a new PID. The properties of the new
+    // Configuration
+    // object are null until the first time that its Configuration.update(Dictionary) method is
+    // called.
+    when(config.getPid())
+        .thenReturn(String.format("%s.8e3c2b12-9807-482a-aaa7-d3d317973581", configFactoryPid));
     when(config.getFactoryPid()).thenReturn(configFactoryPid);
+    try {
+      when(configurationAdminForImport.createFactoryConfiguration(eq(configFactoryPid), isNull()))
+          .thenReturn(config);
+    } catch (IOException e) {
+      // Can't happen since this is mocking the createFactoryConfiguration method.
+    }
+    return config;
+  }
+
+  private Configuration getConfigurationForImportSystem(String pid) {
+    Configuration config = mock(Configuration.class);
+    when(config.getPid()).thenReturn(pid);
     return config;
   }
 


### PR DESCRIPTION
#### What does this PR do? 
Port from 2.16.x: #5320 
Second commit contains additional logic

Adds support for upgrading `Web Context Policy Manger`, `Guest Claims Configuration`, `STS Server`, and `Session` security configurations with migration across versions.

#### Who is reviewing it? 
@austinsteffes 
@ahoffer 

#### Select relevant component teams: 
@codice/core-apis  

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@paouelle

#### How should this be tested?
See #5320 

#### What are the relevant tickets?
Fixes: #5311 

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
