### PR TITLE
[2.16.x] DDF-5354 Added support for registry/sources configs with migration

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/migration.properties
+++ b/distribution/ddf-common/src/main/resources/etc/migration.properties
@@ -4,4 +4,4 @@
 #
 
 # A comma-delimited list of DDF versions that are supported for upgrading from
-supported.versions = 2.13.3,2.13.4,2.13.5,2.13.6,2.13.7,2.13.8,2.13.9,2.13.10,2.14.0,2.14.1,2.15.0,2.16.0,2.16.1
+supported.versions = 2.13.3,2.13.4,2.13.5,2.13.6,2.13.7,2.13.8,2.13.9,2.13.10,2.14.0,2.14.1,2.15.0,2.16.0,2.16.1,2.16.2

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/reusing-configurations.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/reusing-configurations.adoc
@@ -76,13 +76,15 @@ The same step-by-step process above can be followed when migrating configuration
 ** Keystores
 ** Truststores
 ** Service wrapper `*.conf` files, if the ${branding} is installed as a service
-** Select AdminUI Configurations, Including:
+** Select ${admin-console} configurations, including:
 *** Content Directory Monitor
 *** URL Resource Reader
 *** Web Context Policy Manager
 *** Security STS Guest Claims Handler
 *** Security STS Server
 *** Session
+*** All Catalog Source configurations
+*** All Registry configurations
 [WARNING]
-If a supported configuration is being imported across versions, any corresponding `.config` files in the etc directory will not be put into the etc directory of the importing system.
+If a supported configuration is being imported across versions, any corresponding `.config` files in the `etc` directory will not be put into the `etc` directory of the importing system.
 * There is a list of specific ${branding} versions that have been tested that can be found in `etc/migration.properties` under the property `supported.versions`, as a comma-delimited list. The system will only allow importing configurations from those versions.

--- a/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
+++ b/platform/migration/platform-migration/src/main/java/org/codice/ddf/configuration/admin/ImportMigrationConfigurationAdminContext.java
@@ -323,8 +323,9 @@ public class ImportMigrationConfigurationAdminContext {
   }
 
   @SuppressWarnings(
-      "PMD.UnusedFormalParameter" /* report parameter is required as this method is used as a functional interface */)
-  protected void deleteUnexportedConfigurationsAfterCompletion(MigrationReport report) {
+      "PMD.UnusedFormalParameter" /* report parameter is required as this method is used as a functional interface
+                                  and is being called in the ConfigurationAdminMigratable class */)
+  void deleteUnexportedConfigurationsAfterCompletion(MigrationReport report) {
     if (isValid) {
       Stream.concat(
               managedServicesToDelete.values().stream(),

--- a/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
+++ b/platform/migration/platform-migration/src/test/java/org/codice/ddf/configuration/admin/ConfigurationAdminMigratableTest.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.configuration.admin;
 
+import static org.codice.ddf.configuration.admin.ConfigurationAdminMigratable.ACCEPTED_ENTRY_PIDS;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThan;
@@ -137,15 +138,6 @@ public class ConfigurationAdminMigratableTest {
 
   private static final String DDF_CUSTOM_MIME_TYPE_RESOLVER_FILENAME =
       String.format("%s-csw.config", DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
-
-  private static final String STS_GUEST_CLAIMS_HANDLER_PID = "ddf.security.sts.guestclaims";
-
-  private static final String STS_SERVER_PID = "ddf.security.sts";
-
-  private static final String WEB_CONTEXT_POLICY_MANAGER_PID =
-      "org.codice.ddf.security.policy.context.impl.PolicyManager";
-
-  private static final String SECURITY_SESSION_PID = "ddf.security.http.impl.HttpSessionFactory";
 
   private static final List<PersistenceStrategy> STRATEGIES =
       ImmutableList.of(new CfgStrategy(), new ConfigStrategy());
@@ -327,17 +319,15 @@ public class ConfigurationAdminMigratableTest {
   @Test
   public void testDoExportDoVersionUpgradeImport() throws Exception {
     // Setup Export
-    List<String> pids =
-        Arrays.asList(
-            URL_RESOURCE_READER_FACTORY_PID,
-            STS_GUEST_CLAIMS_HANDLER_PID,
-            STS_SERVER_PID,
-            WEB_CONTEXT_POLICY_MANAGER_PID,
-            SECURITY_SESSION_PID);
     List<String> factoryPids =
         Arrays.asList(
-            CONTENT_DIRECTORY_MONITOR_FACTORY_PID, DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
-    setupConfigAdminForExportSystem(pids, factoryPids);
+            CONTENT_DIRECTORY_MONITOR_FACTORY_PID,
+            "Csw_Registry_Store",
+            "Csw_Federation_Profile_Source",
+            "Test_Service",
+            DDF_CUSTOM_MIME_TYPE_RESOLVER_FACTORY_PID);
+
+    setupConfigAdminForExportSystem(ACCEPTED_ENTRY_PIDS, factoryPids);
     Path exportDir = tempDir.getRoot().toPath().toRealPath();
     final String tag = String.format(DDF_EXPORTED_TAG_TEMPLATE, DDF_HOME);
     final Path configFile = setupConfigFile(tag, CONTENT_DIRECTORY_MONITOR_FILENAME);
@@ -383,7 +373,7 @@ public class ConfigurationAdminMigratableTest {
     // Clean up ddf home, so we can import into a clean directory
     FileUtils.deleteDirectory(ddfHome.toRealPath().toFile());
     setup(DDF_HOME, IMPORTING_PRODUCT_VERSION);
-    setupConfigAdminForImportSystem(pids, factoryPids);
+    setupConfigAdminForImportSystem(ACCEPTED_ENTRY_PIDS, factoryPids);
 
     // intercept doImport() to verify exported files from etc
     ConfigurationAdminMigratable iCam =


### PR DESCRIPTION
#### What does this PR do?
Added support for upgrading registry and source configurations with migration across accepted versions

#### Who is reviewing it? 
@austinsteffes 
@ahoffer 

#### Select relevant component teams: 
@codice/core-apis 


#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@paouelle


#### How should this be tested?
1. Install an old release version of DDF that is in the list of "supported versions" and create registry and source configurations
2. Run `migration:export`, which creates 3 files under the etc/exported directory
3. Shutdown
4. Start up a DDF built on this PR's changes
5. Install with `profile:install standard`
6. Copy all 3 files from step 2 into this newly installed DDF under /exported.
7. Run `migration:import -f`
8. After the system automatically restarts, verify all config changes are present in the new DDF and they work

#### What are the relevant tickets?
Work for: #5354 

#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
