### PR TITLE
DDF-5357 Fixes memory leak in theme

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/theme/theme.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/theme/theme.tsx
@@ -276,7 +276,7 @@ class ThemeContainer extends React.Component<
     this.watchScreenSize()
   }
   componentWillUnmount() {
-    $(window).off(this.id)
+    $(window).off(`.${this.id}`)
     this.isDestroyed = true // we have a throttled listener that updates state, so we need this!
   }
   watchScreenSize() {


### PR DESCRIPTION
#### What does this PR do?
 - Without a dot at the front, this `off` wasn't removing the events for the instance.  This caused them to build up over time.

#### How should this be tested?
Easiest is to verify by checking out master and seeing the behavior there first.  Open the chrome dev tools, go to the memory section.  Have a workspace with two searches.  Switch back and forth between them a few times so that results render.  On the memory section, take a heap snapshot.  Filter to theme.  Note the number of objects.  Switch back and forth searches a few more times.  Take another heap snapshot.  Note the number of objects (should be higher on master).

Do the same thing on this PR and note the number of objects remains constant between multiple switches.

I'll attach some screenshots of the snapshots as proof.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5357 

#### Screenshots
This branch after a few switches
<img width="440" alt="Screen Shot 2019-09-20 at 5 26 40 PM" src="https://user-images.githubusercontent.com/11984853/65365317-53125600-dbcd-11e9-8bf8-88948897cbc6.png">

This branch after a few more switches (note the constant amount of objects for theme)
<img width="422" alt="Screen Shot 2019-09-20 at 5 26 35 PM" src="https://user-images.githubusercontent.com/11984853/65365321-586fa080-dbcd-11e9-9141-3971bb532f0b.png">


Master after the same activity.  
<img width="508" alt="Screen Shot 2019-09-20 at 5 28 54 PM" src="https://user-images.githubusercontent.com/11984853/65365326-5d345480-dbcd-11e9-8bd3-66191a89d87c.png">

Master after a few more switches.
<img width="483" alt="Screen Shot 2019-09-20 at 5 34 51 PM" src="https://user-images.githubusercontent.com/11984853/65365330-63c2cc00-dbcd-11e9-9e6a-47d21db08960.png">

