### PR TITLE
DDF-5361 Update policy file for installing a feature that drops a config file

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -396,7 +396,7 @@ grant codeBase "file:/admin-ui" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}metadata${/}-", "read";
 }
 
-grant codeBase "file:/admin-configuration-configupdater" {
+grant codeBase "file:/admin-configuration-configupdater/sync-installer-impl" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}*", "read,write,delete";
 }
 


### PR DESCRIPTION
#### What does this PR do?
Forward port from 2.16.x PR: https://github.com/codice/ddf/pull/5362
Fixes an AC exception that happens when Installing a feature that drops a config file, causing the installation to fail
#### Who is reviewing it? 
@austinsteffes @tyler30clemens 

#### Ask 2 committers to review/merge the PR and tag them here.
@blen-desta 
@stustison

#### How should this be tested?
Successful CI.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5361 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
