### PR TITLE
DDF-5312 User alerts use notifications core

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
@@ -21,6 +21,7 @@ import static spark.Spark.get;
 import static spark.Spark.put;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import ddf.catalog.filter.FilterBuilder;
@@ -216,10 +217,20 @@ public class UserApplication implements SparkApplication {
   }
 
   private Map mapAttributes(Map<String, Object> persistentItem) {
+    Object srcs = persistentItem.getOrDefault("src_txt", Collections.emptySet());
+    if (srcs instanceof String) {
+      srcs = ImmutableSet.of((String) srcs);
+    }
+
+    Object metacardIds = persistentItem.getOrDefault("metacardIds_txt", Collections.emptySet());
+    if (metacardIds instanceof String) {
+      metacardIds = ImmutableSet.of((String) metacardIds);
+    }
+
     return new ImmutableMap.Builder<String, Object>()
         .put("id", persistentItem.get("id_txt"))
-        .put("src", persistentItem.getOrDefault("src_txt", Collections.emptySet()))
-        .put("metacardIds", persistentItem.getOrDefault("metacardIds_txt", Collections.emptySet()))
+        .put("src", srcs)
+        .put("metacardIds", metacardIds)
         .put("queryId", persistentItem.getOrDefault("queryId_txt", ""))
         .put("serverGenerated", persistentItem.getOrDefault("serverGenerated_txt", "true"))
         .put(

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
@@ -15,6 +15,7 @@ package org.codice.ddf.catalog.ui.security.app;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.codice.gsonsupport.GsonTypeAdapters.MAP_STRING_TO_OBJECT_TYPE;
+import static spark.Spark.delete;
 import static spark.Spark.exception;
 import static spark.Spark.get;
 import static spark.Spark.put;
@@ -28,7 +29,6 @@ import ddf.security.SubjectIdentity;
 import ddf.security.SubjectUtils;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
@@ -117,7 +117,7 @@ public class UserApplication implements SparkApplication {
         },
         util::getJson);
 
-    put(
+    delete(
         "/user/notifications",
         APPLICATION_JSON,
         (req, res) -> {
@@ -243,8 +243,10 @@ public class UserApplication implements SparkApplication {
     if (ids.isEmpty()) {
       return;
     }
-    List<Filter> idsToDelete = new ArrayList<>();
-    ids.forEach(id -> idsToDelete.add(filterBuilder.attribute("id").is().equalTo().text(id)));
+    List<Filter> idsToDelete =
+        ids.stream()
+            .map(id -> filterBuilder.attribute("id").is().equalTo().text(id))
+            .collect(Collectors.toList());
     try {
       persistentStore.delete(
           PersistenceType.NOTIFICATION_TYPE.toString(),

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
@@ -48,6 +48,7 @@ import org.codice.ddf.persistence.PersistentStore;
 import org.codice.ddf.persistence.PersistentStore.PersistenceType;
 import org.codice.gsonsupport.GsonTypeAdapters.LongDoubleTypeAdapter;
 import org.geotools.filter.text.ecql.ECQL;
+import org.joda.time.DateTime;
 import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,8 +57,6 @@ import spark.servlet.SparkApplication;
 public class UserApplication implements SparkApplication {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserApplication.class);
-
-  private FilterBuilder filterBuilder;
 
   private static final Gson GSON =
       new GsonBuilder()
@@ -70,6 +69,8 @@ public class UserApplication implements SparkApplication {
   private final PersistentStore persistentStore;
 
   private final SubjectIdentity subjectIdentity;
+
+  private final FilterBuilder filterBuilder;
 
   public UserApplication(
       EndpointUtil util,
@@ -216,12 +217,13 @@ public class UserApplication implements SparkApplication {
 
   private Map mapAttributes(Map<String, Object> persistentItem) {
     return new ImmutableMap.Builder<String, Object>()
-        .put("src", persistentItem.get("src_txt"))
         .put("id", persistentItem.get("id_txt"))
-        .put("metacards", persistentItem.get("metacardIds_txt"))
-        .put("queryId", persistentItem.get("queryId_txt"))
-        .put("serverGenerated", persistentItem.get("serverGenerated_txt"))
-        .put("when", persistentItem.get("when_lng"))
+        .put("src", persistentItem.getOrDefault("src_txt", Collections.emptySet()))
+        .put("metacardIds", persistentItem.getOrDefault("metacardIds_txt", Collections.emptySet()))
+        .put("queryId", persistentItem.getOrDefault("queryId_txt", ""))
+        .put("serverGenerated", persistentItem.getOrDefault("serverGenerated_txt", "true"))
+        .put(
+            "when", persistentItem.getOrDefault("when_lng", DateTime.now().toInstant().getMillis()))
         .build();
   }
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
@@ -203,13 +203,8 @@ public class UserApplication implements SparkApplication {
     try {
       String filter = String.format("user = '%s'", userid);
       List<Map<String, Object>> notificationsList =
-          persistentStore.get(PersistenceType.NOTIFICATION_TYPE.toString(), filter);
-      return notificationsList
-          .stream()
-          .map(
-              json ->
-                  GSON.fromJson((String) json.get("notification_txt"), MAP_STRING_TO_OBJECT_TYPE))
-          .collect(Collectors.toList());
+          persistentStore.get(PersistenceType.NOTIFICATION_TYPE.toString(), filter, 0, 999);
+      return notificationsList.stream().map(this::mapAttributes).collect(Collectors.toList());
     } catch (PersistenceException e) {
       LOGGER.info(
           "PersistenceException while trying to retrieve persisted notifications for user {}",
@@ -217,6 +212,17 @@ public class UserApplication implements SparkApplication {
           e);
     }
     return Collections.emptyList();
+  }
+
+  private Map mapAttributes(Map<String, Object> persistentItem) {
+    return new ImmutableMap.Builder<String, Object>()
+        .put("src", persistentItem.get("src_txt"))
+        .put("id", persistentItem.get("id_txt"))
+        .put("metacards", persistentItem.get("metacardIds_txt"))
+        .put("queryId", persistentItem.get("queryId_txt"))
+        .put("serverGenerated", persistentItem.get("serverGenerated_txt"))
+        .put("when", persistentItem.get("when_lng"))
+        .build();
   }
 
   private Map<String, Object> getSubjectAttributes(Subject subject) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
@@ -22,11 +22,13 @@ import static spark.Spark.put;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import ddf.catalog.filter.FilterBuilder;
 import ddf.security.Subject;
 import ddf.security.SubjectIdentity;
 import ddf.security.SubjectUtils;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.SecurityUtils;
 import org.codice.ddf.catalog.ui.metacard.EntityTooLargeException;
@@ -44,6 +47,8 @@ import org.codice.ddf.persistence.PersistentItem;
 import org.codice.ddf.persistence.PersistentStore;
 import org.codice.ddf.persistence.PersistentStore.PersistenceType;
 import org.codice.gsonsupport.GsonTypeAdapters.LongDoubleTypeAdapter;
+import org.geotools.filter.text.ecql.ECQL;
+import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.servlet.SparkApplication;
@@ -51,6 +56,8 @@ import spark.servlet.SparkApplication;
 public class UserApplication implements SparkApplication {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserApplication.class);
+
+  private FilterBuilder filterBuilder;
 
   private static final Gson GSON =
       new GsonBuilder()
@@ -65,10 +72,14 @@ public class UserApplication implements SparkApplication {
   private final SubjectIdentity subjectIdentity;
 
   public UserApplication(
-      EndpointUtil util, PersistentStore persistentStore, SubjectIdentity subjectIdentity) {
+      EndpointUtil util,
+      PersistentStore persistentStore,
+      SubjectIdentity subjectIdentity,
+      FilterBuilder filterBuilder) {
     this.util = util;
     this.persistentStore = persistentStore;
     this.subjectIdentity = subjectIdentity;
+    this.filterBuilder = filterBuilder;
   }
 
   @Override
@@ -103,6 +114,26 @@ public class UserApplication implements SparkApplication {
           setUserPreferences(subject, preferences);
 
           return preferences;
+        },
+        util::getJson);
+
+    put(
+        "/user/notifications",
+        APPLICATION_JSON,
+        (req, res) -> {
+          Subject subject = (Subject) SecurityUtils.getSubject();
+
+          if (subject.isGuest()) {
+            res.status(401);
+            return ImmutableMap.of("message", "Guest cannot save notifications.");
+          }
+
+          Map<String, List<String>> notification =
+              GSON.fromJson(util.safeGetBody(req), MAP_STRING_TO_OBJECT_TYPE);
+
+          deleteNotifications(notification.get("alerts"));
+
+          return "";
         },
         util::getJson);
 
@@ -152,7 +183,10 @@ public class UserApplication implements SparkApplication {
       if (preferencesList.size() == 1) {
         byte[] json = (byte[]) preferencesList.get(0).get("preferences_json_bin");
 
-        return GSON.fromJson(new String(json, Charset.defaultCharset()), MAP_STRING_TO_OBJECT_TYPE);
+        Map<String, Object> attributes =
+            GSON.fromJson(new String(json, Charset.defaultCharset()), MAP_STRING_TO_OBJECT_TYPE);
+        attributes.put("alerts", getSubjectNotifications(subject));
+        return attributes;
       }
     } catch (PersistenceException e) {
       LOGGER.info(
@@ -162,6 +196,27 @@ public class UserApplication implements SparkApplication {
     }
 
     return Collections.emptyMap();
+  }
+
+  private List getSubjectNotifications(Subject subject) {
+    String userid = subjectIdentity.getUniqueIdentifier(subject);
+    try {
+      String filter = String.format("user = '%s'", userid);
+      List<Map<String, Object>> notificationsList =
+          persistentStore.get(PersistenceType.NOTIFICATION_TYPE.toString(), filter);
+      return notificationsList
+          .stream()
+          .map(
+              json ->
+                  GSON.fromJson((String) json.get("notification_txt"), MAP_STRING_TO_OBJECT_TYPE))
+          .collect(Collectors.toList());
+    } catch (PersistenceException e) {
+      LOGGER.info(
+          "PersistenceException while trying to retrieve persisted notifications for user {}",
+          userid,
+          e);
+    }
+    return Collections.emptyList();
   }
 
   private Map<String, Object> getSubjectAttributes(Subject subject) {
@@ -182,5 +237,23 @@ public class UserApplication implements SparkApplication {
     }
 
     return ImmutableMap.<String, Object>builder().putAll(required).put("email", email).build();
+  }
+
+  private void deleteNotifications(List<String> ids) {
+    if (ids.isEmpty()) {
+      return;
+    }
+    List<Filter> idsToDelete = new ArrayList<>();
+    ids.forEach(id -> idsToDelete.add(filterBuilder.attribute("id").is().equalTo().text(id)));
+    try {
+      persistentStore.delete(
+          PersistenceType.NOTIFICATION_TYPE.toString(),
+          ECQL.toCQL(filterBuilder.anyOf(idsToDelete)));
+    } catch (PersistenceException e) {
+      LOGGER.info(
+          "PersistenceException while trying to delete persisted notifications with ids {} ",
+          ids,
+          e);
+    }
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -167,6 +167,7 @@ Implementation details
         <argument ref="persistentStore"/>
         <argument ref="endpointUtil"/>
         <argument ref="subjectIdentity"/>
+        <argument ref="filterBuilder"/>
     </bean>
 
     <!--

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.view.js
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
+import fetch from '../../react-component/utils/fetch'
 
 const wreqr = require('../../js/wreqr.js')
 const Marionette = require('marionette')
@@ -47,6 +48,13 @@ module.exports = Marionette.ItemView.extend({
   },
   removeModel() {
     this.$el.toggleClass('is-destroyed', true)
+    fetch('./internal/user/notifications', {
+      method: 'put',
+      body: JSON.stringify({ alerts: [this.model.id] }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
     setTimeout(() => {
       this.model.collection.remove(this.model)
       user

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.view.js
@@ -20,7 +20,6 @@ const template = require('./alert-item.hbs')
 const CustomElements = require('../../js/CustomElements.js')
 const store = require('../../js/store.js')
 const Common = require('../../js/Common.js')
-const user = require('../singletons/user-instance.js')
 
 module.exports = Marionette.ItemView.extend({
   template,
@@ -49,7 +48,7 @@ module.exports = Marionette.ItemView.extend({
   removeModel() {
     this.$el.toggleClass('is-destroyed', true)
     fetch('./internal/user/notifications', {
-      method: 'put',
+      method: 'delete',
       body: JSON.stringify({ alerts: [this.model.id] }),
       headers: {
         'Content-Type': 'application/json',
@@ -57,10 +56,6 @@ module.exports = Marionette.ItemView.extend({
     })
     setTimeout(() => {
       this.model.collection.remove(this.model)
-      user
-        .get('user')
-        .get('preferences')
-        .savePreferences()
     }, 250)
   },
   expandAlert() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/user-notifications.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/user-notifications.js
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
+import fetch from '../../react-component/utils/fetch'
 
 const user = require('./user-instance.js')
 const Backbone = require('backbone')
@@ -40,8 +41,22 @@ module.exports = new (Backbone.Collection.extend({
     return this.some(notification => notification.get('unseen'))
   },
   setSeen() {
+    const setSeen = []
     this.forEach(notification => {
       notification.set('unseen', false)
+      if (notification.get('queryId')) {
+        setSeen.push(notification)
+      }
+    })
+    if (setSeen.length === 0) {
+      return
+    }
+    fetch('./internal/user/notifications', {
+      method: 'put',
+      body: JSON.stringify({ alerts: setSeen }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     })
   },
 }))()

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/QueryPolling.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/QueryPolling.js
@@ -20,6 +20,7 @@ const cql = require('./cql.js')
 const CQLUtils = require('./CQLUtils.js')
 const sources = require('../component/singletons/sources-instance.js')
 const moment = require('moment')
+const Common = require('./Common.js')
 require('./jquery.whenAll')
 
 let checkForFailures, startSearch, addFailure, handleReattempts
@@ -195,6 +196,7 @@ startSearch = function(originalQuery, timeRange, queryToRun) {
         const when = Date.now()
         if (metacardIds.length > 0) {
           wreqr.vent.trigger('alerts:add', {
+            id: Common.generateUUID(),
             queryId: originalQuery.id,
             workspaceId: originalQuery.collection.parents[0].id,
             when,

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -17,6 +17,7 @@ import {
   Restrictions,
   Security,
 } from '../../react-component/utils/security/security'
+import fetch from '../../react-component/utils/fetch'
 
 const _ = require('underscore')
 const _get = require('lodash.get')
@@ -263,7 +264,17 @@ User.Preferences = Backbone.AssociatedModel.extend({
       const recievedAt = alert.getTimeComparator()
       return Date.now() - recievedAt > expiration
     })
+    if (expiredAlerts.length === 0) {
+      return
+    }
     this.get('alerts').remove(expiredAlerts)
+    fetch('./internal/user/notifications', {
+      method: 'put',
+      body: JSON.stringify({ alerts: expiredAlerts.map(({ id }) => id) }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
   },
   removeExpiredUploads(expiration) {
     const expiredUploads = this.get('uploads').filter(upload => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -269,7 +269,7 @@ User.Preferences = Backbone.AssociatedModel.extend({
     }
     this.get('alerts').remove(expiredAlerts)
     fetch('./internal/user/notifications', {
-      method: 'put',
+      method: 'delete',
       body: JSON.stringify({ alerts: expiredAlerts.map(({ id }) => id) }),
       headers: {
         'Content-Type': 'application/json',

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -212,6 +212,17 @@ User.Preferences = Backbone.AssociatedModel.extend({
   },
   addAlert(alertDetails) {
     this.get('alerts').add(alertDetails)
+    /*
+    * Add alert to notification core
+    * Alert will be retrieved and sent to the UI by UserApplication.java (getSubjectPreferences()) on refresh
+    */
+    fetch('./internal/user/notifications', {
+      method: 'put',
+      body: JSON.stringify({ alerts: [alertDetails] }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
     this.savePreferences()
   },
   savePreferences() {


### PR DESCRIPTION
#### What does this PR do?
It separates user alerts to be read from their own core, rather than the preferences core. They are still added to the alerts section of the user object before it is sent to the UI, in order to minimize changes needed to the User model. The primary motivation for this change is to fix an issue in a downstream project created by the lack of granularity in the preferences blob.

Deletion of alerts has changed somewhat; upload notifications are still deleted by overwriting the preferences blob, but alert notifications are now deleted by sending their ids to the user/notifications endpoint. A large benefit of this is that it allows us to specify specific alerts to delete, rather than deleting them all for a given user and rewriting them all every time. Another benefit of this is that it won't delete notifications that have been added to solr, but were not in the UI at the time the preferences are saved.
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 
<!--
@codice/solr 
@codice/ui 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@jrnorth
@lambeaux

#### How should this be tested?
Build and unzip DDF. Install the standard profile.
In menu on left-hand side, select upload
Upload some files of your choosing.
Verify that you receive notifications when the upload starts and ends.
Try deleting both of those notifications
Refresh the page, and verify the notification are still not there.
Try changing a few preferences, and make sure they survive a refresh.
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5312 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
