### PR TITLE
DDF-5386 Removing Error In OidcHandlerConfigurationImpl To Prevent Log Flooding

### DIFF
--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
@@ -113,7 +113,7 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     } catch (TechnicalException e) {
       LOGGER.warn(
           "OIDC Configuration could not initialize; this may be due to a configuration issue. See the configuration under \"OIDC Handler Configuration\" in the Admin Console");
-      return null;
+      LOGGER.info(e);
     }
 
     return oidcConfiguration;
@@ -128,7 +128,7 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     } catch (TechnicalException e) {
       LOGGER.warn(
           "OIDC Client could not initialize; this may be due to a configuration issue. See the configuration under \"OIDC Handler Configuration\" in the Admin Console");
-      return null;
+      LOGGER.info(e);
     }
 
     return oidcClient;

--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
@@ -113,7 +113,7 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     } catch (TechnicalException e) {
       LOGGER.warn(
           "OIDC Configuration could not initialize; this may be due to a configuration issue. See the configuration under \"OIDC Handler Configuration\" in the Admin Console");
-      LOGGER.info(e);
+      LOGGER.debug(e);
     }
 
     return oidcConfiguration;
@@ -128,7 +128,7 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     } catch (TechnicalException e) {
       LOGGER.warn(
           "OIDC Client could not initialize; this may be due to a configuration issue. See the configuration under \"OIDC Handler Configuration\" in the Admin Console");
-      LOGGER.info(e);
+      LOGGER.debug(e);
     }
 
     return oidcClient;

--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
@@ -113,7 +113,7 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     } catch (TechnicalException e) {
       LOGGER.warn(
           "OIDC Configuration could not initialize; this may be due to a configuration issue. See the configuration under \"OIDC Handler Configuration\" in the Admin Console");
-      LOGGER.debug(e);
+      LOGGER.debug(e.getMessage());
     }
 
     return oidcConfiguration;
@@ -128,7 +128,7 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     } catch (TechnicalException e) {
       LOGGER.warn(
           "OIDC Client could not initialize; this may be due to a configuration issue. See the configuration under \"OIDC Handler Configuration\" in the Admin Console");
-      LOGGER.debug(e);
+      LOGGER.debug(e.getMessage());
     }
 
     return oidcClient;

--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
@@ -113,7 +113,7 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     } catch (TechnicalException e) {
       LOGGER.warn(
           "OIDC Configuration could not initialize; this may be due to a configuration issue. See the configuration under \"OIDC Handler Configuration\" in the Admin Console");
-      throw e;
+      return null;
     }
 
     return oidcConfiguration;
@@ -128,7 +128,7 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     } catch (TechnicalException e) {
       LOGGER.warn(
           "OIDC Client could not initialize; this may be due to a configuration issue. See the configuration under \"OIDC Handler Configuration\" in the Admin Console");
-      throw e;
+      return null;
     }
 
     return oidcClient;


### PR DESCRIPTION
#### What does this PR do?
Removes throwing error in config impl to prevent flooding logs. (See #5386) 

#### Who is reviewing it? 
@blen-desta 
@bakejeyner 
@garrettfreibott 
@bdeining 
@nsuvarna 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5386 

#### Screenshots
<img width="757" alt="Screen Shot 2019-09-26 at 5 43 13 PM" src="https://user-images.githubusercontent.com/7055226/65734221-d11ba480-e086-11e9-9ca0-c42edd334617.png">
