### PR TITLE
DDF-5395 Cleanup after itests instead of resetting the system after every class

### DIFF
--- a/distribution/test/itests/README.md
+++ b/distribution/test/itests/README.md
@@ -1,3 +1,14 @@
+# Writing Integration Tests
+
+## Cleaning up after each test
+There are several operations a test can perform that will permanently change the state of the running container. **It's the responsibility of the tests themselves to clean up after performing these state-changing operations.**
+The most common state-changing operations and the best way to clean up after them are as follows:
+
+* **Creating or updating a configuration:** Save the returned Config properties to a static field on the itest class and then update the configuration with those properties in the `AfterExam`.
+* **Creating or updating a Managed Service:** Save off the pid of the managed service, and then stop the Managed Service using that.
+* **Ingesting or updating a record:** Resetting or deleting the record
+* **Starting or stopping a configuration:** Reset it by starting or stopping the configuration.
+
 # How to Debug Integration Tests
 
 ## Remote Debugging

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.SE
 import static org.codice.ddf.itests.common.csw.CswQueryBuilder.PROPERTY_IS_LIKE;
 import static org.hamcrest.Matchers.hasXPath;
 import static org.ops4j.pax.exam.CoreOptions.cleanCaches;
+import static org.ops4j.pax.exam.CoreOptions.composite;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.options;
@@ -75,6 +76,8 @@ import org.codice.ddf.itests.common.config.UrlResourceReaderConfigurator;
 import org.codice.ddf.itests.common.csw.CswQueryBuilder;
 import org.codice.ddf.itests.common.security.SecurityPolicyConfigurator;
 import org.codice.ddf.test.common.LoggingUtils;
+import org.codice.ddf.test.common.annotations.BeforeSuite;
+import org.codice.ddf.test.common.annotations.ExamResultLogger;
 import org.codice.ddf.test.common.annotations.PaxExamRule;
 import org.codice.ddf.test.common.annotations.PostTestConstruct;
 import org.junit.Rule;
@@ -162,6 +165,8 @@ public abstract class AbstractIntegrationTest {
   protected static String ddfHome;
 
   @Rule public PaxExamRule paxExamRule = new PaxExamRule(this);
+
+  @Rule public ExamResultLogger resultLogger = new ExamResultLogger();
 
   @Rule public Stopwatch stopwatch = new TestMethodTimer();
 
@@ -406,6 +411,15 @@ public abstract class AbstractIntegrationTest {
     manager.waitForSystemBaseState();
   }
 
+  @BeforeSuite
+  public void beforeSuite() throws Exception {
+    try {
+      waitForSystemReady();
+    } catch (Exception e) {
+      LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeSuite: ");
+    }
+  }
+
   /**
    * Configures the pax exam test container
    *
@@ -596,6 +610,8 @@ public abstract class AbstractIntegrationTest {
     return options(
         editConfigurationFilePut(
             LOGGER_CONFIGURATION_FILE_PATH, "log4j2.rootLogger.level", globalLogLevel),
+        // Always print the start/stop/result of individual test methods
+        composite(createSetLogLevelOption("org.codice.ddf.test.common.annotations", "INFO")),
         when(StringUtils.isNotEmpty(itestLevel))
             .useOptions(
                 combineOptions(

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/SynchronizedConfiguration.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/SynchronizedConfiguration.java
@@ -15,6 +15,7 @@ package org.codice.ddf.itests.common;
 
 import static org.junit.Assert.fail;
 
+import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -51,8 +52,9 @@ public class SynchronizedConfiguration {
     this.configAdmin = configAdmin;
   }
 
-  public final void updateConfig() throws Exception {
+  public final Dictionary<String, Object> updateConfig() throws Exception {
     Configuration config = configAdmin.getConfiguration(pid, location);
+    Dictionary<String, Object> oldProps = config.getProperties();
     config.update(new Hashtable<>(configProps));
 
     long timeoutLimit = System.currentTimeMillis() + CONFIG_UPDATE_MAX_WAIT_MILLIS;
@@ -75,5 +77,7 @@ public class SynchronizedConfiguration {
         }
       }
     }
+
+    return oldProps;
   }
 }

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/config/ConfigureTestCommons.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/config/ConfigureTestCommons.java
@@ -62,7 +62,7 @@ public class ConfigureTestCommons {
       AdminConfig configAdmin)
       throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
-    properties.put("attributeMap", securityAttributeMappings);
+    properties.put("attributeMap", securityAttributeMappings.toArray(new String[0]));
     properties.put("filterErrors", filterErrors);
     properties.put("filterWarnings", filterWarnings);
     return configureMetacardValidityFilterPlugin(properties, configAdmin);
@@ -95,7 +95,7 @@ public class ConfigureTestCommons {
       AdminConfig configAdmin)
       throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
-    properties.put("enforcedMetacardValidators", enforcedValidators);
+    properties.put("enforcedMetacardValidators", enforcedValidators.toArray(new String[0]));
     properties.put("enforceErrors", enforceErrors);
     properties.put("enforceWarnings", enforceWarnings);
     return configureValidationMarkerPlugin(properties, configAdmin);
@@ -125,7 +125,7 @@ public class ConfigureTestCommons {
       List<String> intersectAttributes, List<String> unionAttributes, AdminConfig configAdmin)
       throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
-    properties.put("intersectMetacardAttributes", intersectAttributes);
+    properties.put("intersectMetacardAttributes", intersectAttributes.toArray(new String[0]));
     properties.put("unionMetacardAttributes", unionAttributes);
     return configureMetacardAttributeSecurityFiltering(properties, configAdmin);
   }
@@ -157,9 +157,9 @@ public class ConfigureTestCommons {
       AdminConfig configAdmin)
       throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
-    properties.put("matchAllMappings", matchAllMappings);
-    properties.put("matchOneMappings", matchOneAttributes);
-    properties.put("environmentAttributes", environmentAttributes);
+    properties.put("matchAllMappings", matchAllMappings.toArray(new String[0]));
+    properties.put("matchOneMappings", matchOneAttributes.toArray(new String[0]));
+    properties.put("environmentAttributes", environmentAttributes.toArray(new String[0]));
     return configureAuthZRealm(properties, configAdmin);
   }
 
@@ -188,8 +188,8 @@ public class ConfigureTestCommons {
       List<String> featurePolicies, List<String> servicePolicies, AdminConfig configAdmin)
       throws IOException {
     Dictionary<String, Object> properties = new DictionaryMap<>();
-    properties.put("featurePolicies", featurePolicies);
-    properties.put("servicePolicies", servicePolicies);
+    properties.put("featurePolicies", featurePolicies.toArray(new String[0]));
+    properties.put("servicePolicies", servicePolicies.toArray(new String[0]));
     return configureAdminConfigPolicy(properties, configAdmin);
   }
 

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/opensearch/OpenSearchFeature.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/opensearch/OpenSearchFeature.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.itests.common.ServiceManager;
+import org.osgi.service.cm.Configuration;
 
 public class OpenSearchFeature {
 
@@ -25,7 +26,7 @@ public class OpenSearchFeature {
 
   public static final String FACTORY_PID = "OpenSearchSource";
 
-  public static void createManagedService(
+  public static Configuration createManagedService(
       ServiceManager serviceManager, String sourceId, String user, String pass) throws IOException {
     Map propertyMap = new HashMap();
     propertyMap.putAll(serviceManager.getMetatypeDefaults(SYMBOLIC_NAME, FACTORY_PID));
@@ -35,6 +36,6 @@ public class OpenSearchFeature {
     propertyMap.put("username", user);
     propertyMap.put("password", pass);
 
-    serviceManager.createManagedService(FACTORY_PID, propertyMap);
+    return serviceManager.createManagedService(FACTORY_PID, propertyMap);
   }
 }

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalog.java
@@ -103,8 +103,6 @@ import org.codice.ddf.persistence.PersistentItem;
 import org.codice.ddf.persistence.PersistentStore;
 import org.codice.ddf.persistence.PersistentStore.PersistenceType;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
-import org.codice.ddf.test.common.LoggingUtils;
-import org.codice.ddf.test.common.annotations.BeforeExam;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.json.simple.JSONObject;
@@ -176,15 +174,6 @@ public class TestCatalog extends AbstractIntegrationTest {
             XML_RECORD_RESOURCE_PATH + "/SimpleXmlNoDecMetacard", ImmutableMap.of("uri", uri));
   }
 
-  @BeforeExam
-  public void beforeExam() {
-    try {
-      waitForSystemReady();
-    } catch (Exception e) {
-      LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
-    }
-  }
-
   @Before
   public void setup() {
     urlResourceReaderConfigurator = getUrlResourceReaderConfigurator();
@@ -194,7 +183,7 @@ public class TestCatalog extends AbstractIntegrationTest {
   public void tearDown() throws IOException {
     urlResourceReaderConfigurator.setUrlResourceReaderRootDirs(
         DEFAULT_URL_RESOURCE_READER_ROOT_RESOURCE_DIRS);
-    clearCatalog();
+    clearCatalogAndWait();
   }
 
   @Test
@@ -2281,7 +2270,6 @@ public class TestCatalog extends AbstractIntegrationTest {
   }
 
   private void persistToWorkspace(int size) throws Exception {
-    getServiceManager().startFeature(true, "search-ui-app");
     // Generate very large data block
     Map<String, String> map = Maps.newHashMap();
     for (int i = 0; i < size; i++) {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestCatalogSearchUi.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.codice.ddf.itests.common.AbstractIntegrationTest;
 import org.codice.ddf.test.common.LoggingUtils;
+import org.codice.ddf.test.common.annotations.AfterExam;
 import org.codice.ddf.test.common.annotations.BeforeExam;
 import org.codice.gsonsupport.GsonTypeAdapters.LongDoubleTypeAdapter;
 import org.junit.After;
@@ -131,10 +132,11 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
           .put("csw:Record", "CSW Record XML")
           .build();
 
+  private static Map<String, Object> originalPolicyManagerProps = null;
+
   @BeforeExam
   public void beforeExam() throws Exception {
     try {
-      waitForSystemReady();
       getServiceManager().waitForHttpEndpoint(WORKSPACES_API_PATH.getUrl());
       getServiceManager().waitForHttpEndpoint(QUERY_TEMPLATES_API_PATH.getUrl());
       getServiceManager().waitForHttpEndpoint(RESULT_TEMPLATES_API_PATH.getUrl());
@@ -142,6 +144,13 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
 
     } catch (Exception e) {
       LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
+    }
+  }
+
+  @AfterExam
+  public void afterExam() throws Exception {
+    if (originalPolicyManagerProps != null) {
+      getSecurityPolicy().updateWebContextPolicy(originalPolicyManagerProps);
     }
   }
 
@@ -185,6 +194,10 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
   }
 
   private RequestSpecification asGuest() throws Exception {
+    Map<String, Object> policyManagerProps = getSecurityPolicy().configureRestForGuest();
+    if (originalPolicyManagerProps == null) {
+      originalPolicyManagerProps = policyManagerProps;
+    }
     getSecurityPolicy().configureRestForGuest();
     return given()
         .log()
@@ -194,7 +207,10 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
   }
 
   private RequestSpecification asUser(String username, String password) throws Exception {
-    getSecurityPolicy().configureRestForBasic();
+    Map<String, Object> policyManagerProps = getSecurityPolicy().configureRestForBasic();
+    if (originalPolicyManagerProps == null) {
+      originalPolicyManagerProps = policyManagerProps;
+    }
     return given()
         .log()
         .ifValidationFails()
@@ -206,7 +222,10 @@ public class TestCatalogSearchUi extends AbstractIntegrationTest {
   }
 
   private RequestSpecification asAdmin() throws Exception {
-    getSecurityPolicy().configureRestForBasic();
+    Map<String, Object> policyManagerProps = getSecurityPolicy().configureRestForBasic();
+    if (originalPolicyManagerProps == null) {
+      originalPolicyManagerProps = policyManagerProps;
+    }
     return given()
         .log()
         .ifValidationFails()

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFanout.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.MediaType;
 import org.apache.http.HttpStatus;
@@ -53,12 +54,13 @@ public class TestFanout extends AbstractIntegrationTest {
   // Using default resource tag as the one to blacklist
   private static final List<String> TAG_BLACKLIST = Collections.singletonList("resource");
 
+  private static Map<String, Object> oldPolicyManagerProps;
+
   @BeforeExam
   public void beforeExam() throws Exception {
     try {
-      waitForSystemReady();
-      getSecurityPolicy().configureWebContextPolicy("/=IDP|GUEST", null, null);
-      waitForSystemReady();
+      oldPolicyManagerProps =
+          getSecurityPolicy().configureWebContextPolicy("/=IDP|GUEST", null, null);
 
       getCatalogBundle().setFanout(true);
       getCatalogBundle().waitForCatalogProvider();
@@ -70,6 +72,9 @@ public class TestFanout extends AbstractIntegrationTest {
 
   @AfterExam
   public void afterExam() throws Exception {
+    if (oldPolicyManagerProps != null) {
+      getSecurityPolicy().updateWebContextPolicy(oldPolicyManagerProps);
+    }
     getCatalogBundle().setFanout(false);
     getCatalogBundle().setFanoutTagBlacklist(TAG_BLACKLIST);
     getCatalogBundle().waitForCatalogProvider();

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFtp.java
@@ -85,8 +85,6 @@ public class TestFtp extends AbstractIntegrationTest {
   @BeforeExam
   public void beforeExam() throws Exception {
     try {
-      waitForSystemReady();
-
       System.setProperty(FTP_PORT_PROPERTY, FTP_PORT.getPort());
       getServiceManager().startFeature(true, FTP_ENDPOINT_FEATURE);
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSecurityAuditPlugin.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSecurityAuditPlugin.java
@@ -55,9 +55,7 @@ public class TestSecurityAuditPlugin extends AbstractIntegrationTest {
 
   @BeforeExam
   public void beforeExam() throws Exception {
-    waitForSystemReady();
     getSecurityPolicy().configureRestForGuest();
-    waitForSystemReady();
   }
 
   @After

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestPlatform.java
@@ -51,12 +51,6 @@ public class TestPlatform extends AbstractIntegrationTest {
   @BeforeExam
   public void beforeTest() throws Exception {
     try {
-      waitForSystemReady();
-      // Start the services needed for testing.
-      getServiceManager().startFeature(true, "metrics-reporting");
-      getServiceManager().waitForAllBundles();
-      // We need to start the Search UI to test that it redirects properly
-
       // Must explicitly add basic auth to log in with a username and password
       getSecurityPolicy().configureRestForBasic();
     } catch (Exception e) {

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSolrCommands.java
@@ -55,7 +55,6 @@ public class TestSolrCommands extends AbstractIntegrationTest {
   @BeforeExam
   public void beforeExam() throws Exception {
     try {
-      waitForSystemReady();
       basePort = getBasePort();
       getServiceManager().startFeature(true, getDefaultRequiredApps());
       getServiceManager().waitForAllBundles();

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/annotations/BeforeSuite.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/annotations/BeforeSuite.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.test.common.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Pax Exam OSGi containers cannot execute <code>@BeforeClass</code> in the container. <code>
+ * @BeforeSuite</code> will execute before each suite has run. See {@link PaxExamRule} for usage
+ * examples.
+ *
+ * @see PaxExamRule
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BeforeSuite {}

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/annotations/ExamResultLogger.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/annotations/ExamResultLogger.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.test.common.annotations;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExamResultLogger extends TestWatcher {
+  protected static final Logger LOGGER = LoggerFactory.getLogger(ExamResultLogger.class);
+
+  @Override
+  protected void failed(Throwable e, Description description) {
+    LOGGER.info("FAILURE: {} failed.", description.getMethodName());
+  }
+
+  @Override
+  protected void succeeded(Description description) {
+    LOGGER.info("SUCCESS: {} passed.", description.getMethodName());
+  }
+}

--- a/libs/test-common/src/main/java/org/codice/ddf/test/common/annotations/PaxExamRule.java
+++ b/libs/test-common/src/main/java/org/codice/ddf/test/common/annotations/PaxExamRule.java
@@ -63,6 +63,8 @@ public class PaxExamRule implements TestRule {
 
   private static boolean firstRun = true;
 
+  private static boolean firstSuiteRun = true;
+
   private static boolean setupFailed = false;
 
   private static int testCount;
@@ -105,6 +107,17 @@ public class PaxExamRule implements TestRule {
       failRule(testClassName, throwable, BEFORE_EXAM_FAILURE_MESSAGE);
     }
 
+    if (firstSuiteRun) {
+      try {
+        firstSuiteRun = false;
+        runAnnotations(BeforeSuite.class, testClass);
+      } catch (Throwable throwable) {
+        setupFailed = true;
+        LOGGER.error("Failed to setup SUITE for " + testClassName, throwable);
+        failRule(testClassName, throwable, BEFORE_EXAM_FAILURE_MESSAGE);
+      }
+    }
+
     if (firstRun) {
       LOGGER.info("Starting test(s) for {}", testClassName);
       firstRun = false;
@@ -128,8 +141,6 @@ public class PaxExamRule implements TestRule {
   }
 
   private void finished(Description description) {
-    LOGGER.info("Finished {} ({}/{})", description.getMethodName(), testsExecuted, testCount);
-
     if (testsExecuted == testCount) {
       resetStaticFields();
 


### PR DESCRIPTION
#### What does this PR do?
Currently, the whole container resets after each itest class. Instead, the tests now properly clean up afterwards to save some time. I've seen about 3-4 minutes shaved off due to this change.

#### Who is reviewing it? 
@clockard
@coyotesqrl 
@pklinef 
@shaundmorris
@stustison 
@AzGoalie 

#### Select relevant component teams: 
@codice/build 
@codice/continuous-integration 

#### How should this be tested?
CI

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5395 

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
