### PR TITLE
DDF-#04993 Allows for empty dates in search forms

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizer.java
@@ -108,6 +108,11 @@ class AttributeValueNormalizer {
     if (iso != null) {
       return Objects.toString(iso.toEpochMilli());
     }
+
+    if (value.equals("")) {
+      return "";
+    }
+
     // Edge case for relative date function
     if (EXPECTED_RELATIVE_FUNCTION_PATTERN.matcher(value).matches()) {
       return value;


### PR DESCRIPTION
#### What does this PR do?
This PR allows date type fields to be saved with an empty value in search forms. Previously on save an ambiguous error would appear and the search form could not be saved. Seeing as other fields may be saved with blank fields it was not clear that was the issue.
#### Who is reviewing it? 

@rzwiefel 
@Lambeaux 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@rzwiefel 
@Lambeaux 

#### How should this be tested?
This should be tested by saving a search form with an empty date attribute.
1. Create a search form with the datetime.start before filter and an empty field.
<img width="645" alt="Screen Shot 2019-10-01 at 1 24 23 PM" src="https://user-images.githubusercontent.com/51682089/65997777-db56ed80-e44e-11e9-8b4d-0ade8d289b27.png">
2. Access Workspaces -> create a new workspace or access an existing one
3. Select Create a search -> select the ellipses menu and choose "Use Another Search Form"
4. Select the form you made in step 1 and ensure the datetime.start filter value is empty (the placeholder will be present) when it is initialized. 

#### What are the relevant tickets?
Fixes: #04993

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
