### PR TITLE
DDF-5834 Fixed double invokation of query

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -267,6 +267,7 @@ module.exports = Marionette.LayoutView.extend({
           } else if (choice !== false) {
             store.getCurrentQueries().remove(choice)
             store.getCurrentQueries().add(this.model)
+            this.model.startSearch()
             this.endSave()
           }
         }
@@ -274,7 +275,6 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
   endSave() {
-    this.model.startSearch()
     store.setCurrentQuery(this.model)
     this.initialize()
     this.cancel()


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue where queries were executed twice upon initial invocation. 
#### Who is reviewing it? 
@Schachte 
@harrison-tarr 
@nsuvarna 

#### Select relevant component teams: 
@codice/ui

#### Ask 2 committers to review/merge the PR and tag them here.
@djblue
@bdeining
@blen-desta 
@vinamartin 

#### How should this be tested?
1. Run a query and observe only one `cql` item appears in the Network Tab of your browser.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: [#5384](https://github.com/codice/ddf/issues/5384)
Forward port of [#5385](https://github.com/codice/ddf/pull/5385)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
