### PR TITLE
DDF-5418 Fix the No LoginService found exceptions in the feature Component Tests

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.web.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.web.cfg
@@ -71,11 +71,3 @@ org.ops4j.pax.web.ssl.protocols.excluded=SSLv3,TLSv1
 org.ops4j.pax.web.server.maxThreads=300
 org.ops4j.pax.web.server.minThreads=10
 org.ops4j.pax.web.server.idleTimeout=60000
-
-#######################################
-# Jetty Server Authenticator Settings
-#######################################
-
-# Set the authmethod/realmname so that our JettyAuthenticator is used
-org.ops4j.pax.web.default.authmethod=DDF
-org.ops4j.pax.web.default.realmname=DDF

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -104,7 +104,16 @@
     </feature>
 
     <feature name="platform-paxweb-jettyconfig" version="${project.version}"
-             description="Custom Session Manager">
+      description="Custom Session Manager">
+        <config name="org.ops4j.pax.web" append="true">
+#######################################
+# Jetty Server Authenticator Settings
+#######################################
+
+# Set the authmethod/realmname so that our JettyAuthenticator is used
+org.ops4j.pax.web.default.authmethod=DDF
+org.ops4j.pax.web.default.realmname=DDF
+        </config>
         <feature version="${spring.version}_1">spring</feature>
         <feature>apache-commons</feature>
         <feature>security-core-api</feature>


### PR DESCRIPTION
#### What does this PR do?
Instead of having the Jetty Authenticator properties set out-of-the-box, only set them when the platform-paxwebjettyconfig feature installed.

This shouldn't have any functional effect on the system as-is, since the platform-paxwebjettyconfig feature is installed at the beginning of the standard installation. The reason for doing this for the feature Component Tests get `No LoginService found` exceptions in the logs (see the issue for more details).

#### Who is reviewing it? 
@lamhuy 

#### Select relevant component teams: 
@codice/test

#### Ask 2 committers to review/merge the PR and tag them here.
@AzGoalie 
@paouelle 
@ryeats 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5418 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
