### PR TITLE
[2.19.x] DDF-05306 Updates MGRS bounding box to use two points vs a single blo…

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -87,13 +87,20 @@ const BoundingBoxLatLon = props => {
 }
 
 const BoundingBoxUsngMgrs = props => {
-  const { usngbb, cursor } = props
+  const { usngbbUpperLeft, usngbbLowerRight, cursor } = props
   return (
     <div className="input-location">
       <TextField
-        label="USNG / MGRS"
-        value={usngbb}
-        onChange={cursor('usngbb')}
+        label="Upper Left"
+        style={{ minWidth: 200 }}
+        value={usngbbUpperLeft}
+        onChange={cursor('usngbbUpperLeft')}
+      />
+      <TextField
+        label="Lower Right"
+        style={{ minWidth: 200 }}
+        value={usngbbLowerRight}
+        onChange={cursor('usngbbLowerRight')}
       />
     </div>
   )


### PR DESCRIPTION
#### What does this PR do?

Updates MGRS bounding box to use two points vs a single block

#### Who is reviewing it? 

@samuelechu 
@adimka
@andrewkfiedler
@bdeining
@millerw8 

#### How should this be tested?

Try using the new upper left and lower right inputs for specifying the usng bounding box.

#### What are the relevant tickets?

Fixes: #5306 

#### Screenshots

![image](https://user-images.githubusercontent.com/1986211/64552097-624ef500-d2eb-11e9-8c2f-c32ecec31942.png)


#### Checklist:

- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
