### PR TITLE
DDF-5426 Ensures the "not found" route is the last route

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/router.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/router.js
@@ -25,20 +25,21 @@ import React from 'react'
 import { render } from 'react-dom'
 import ExtensionPoints from '../extension-points'
 
-const { routes } = ExtensionPoints
-
 // notfound route needs to come at the end otherwise no other routes will work
-render(<ReactRouter routeDefinitions={routes} />, Application.App.router.$el[0])
+render(
+  <ReactRouter routeDefinitions={ExtensionPoints.routes} />,
+  Application.App.router.$el[0]
+)
 
 const Router = Backbone.Router.extend({
   preloadRoutes() {
-    Object.keys(routes).forEach(this.preloadRoute)
+    Object.keys(ExtensionPoints.routes).forEach(this.preloadRoute)
   },
   preloadFragment(fragment) {
     this.preloadRoute(this.getRouteNameFromFragment(fragment))
   },
   preloadRoute(routeName) {
-    routes[routeName].preload()
+    ExtensionPoints.routes[routeName].preload()
   },
   getRouteNameFromFragment(fragment) {
     return this.routes[
@@ -47,11 +48,17 @@ const Router = Backbone.Router.extend({
       })
     ]
   },
-  routes: Object.keys(routes).reduce((routesBlob, key) => {
-    const { patterns } = routes[key]
-    patterns.forEach(pattern => (routesBlob[pattern] = key))
-    return routesBlob
-  }, {}),
+  routes: {
+    ...Object.keys(ExtensionPoints.routes).reduce((routesBlob, key) => {
+      if (key === 'notFound') {
+        return routesBlob
+      }
+      const { patterns } = ExtensionPoints.routes[key]
+      patterns.forEach(pattern => (routesBlob[pattern] = key))
+      return routesBlob
+    }, {}),
+    notFound: ExtensionPoints.routes['notFound'],
+  },
   initialize() {
     this.listenTo(wreqr.vent, 'router:preload', this.handlePreload)
     this.listenTo(wreqr.vent, 'router:navigate', this.handleNavigate)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/router.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/router.js
@@ -25,7 +25,6 @@ import React from 'react'
 import { render } from 'react-dom'
 import ExtensionPoints from '../extension-points'
 
-// notfound route needs to come at the end otherwise no other routes will work
 render(
   <ReactRouter routeDefinitions={ExtensionPoints.routes} />,
   Application.App.router.$el[0]
@@ -48,6 +47,7 @@ const Router = Backbone.Router.extend({
       })
     ]
   },
+  // notfound route needs to come at the end otherwise no other routes will work
   routes: {
     ...Object.keys(ExtensionPoints.routes).reduce((routesBlob, key) => {
       if (key === 'notFound') {


### PR DESCRIPTION
#### What does this PR do?
Moves the not found route to the last position to ensure other routes aren't overwritten - for example if the routes are extended. 
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewkfiedler 
@Bdthomson 
@djblue 
@vinamartin 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)-->

@andrewkfiedler
@vinamartin 

#### How should this be tested?
This can be tested by navigating to different routes and ensuring you are directed where you expected. 

#### Any background context you want to provide?
If you wanted to override routes down stream the required order would cause the not found route to be before your extended routes. 
#### What are the relevant tickets?
Fixes: #05426

#### Screenshots


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
