### PR TITLE
DDF-5469: Fix before and after filter generation

### DIFF
--- a/catalog/core/catalog-core-impl/filter-proxy/pom.xml
+++ b/catalog/core/catalog-core-impl/filter-proxy/pom.xml
@@ -51,6 +51,11 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-cql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/core/catalog-core-impl/filter-proxy/src/main/java/ddf/catalog/filter/proxy/builder/GeotoolsBuilder.java
+++ b/catalog/core/catalog-core-impl/filter-proxy/src/main/java/ddf/catalog/filter/proxy/builder/GeotoolsBuilder.java
@@ -117,19 +117,13 @@ class GeotoolsBuilder {
       case AFTER:
         date = getValue(Date.class);
         if (date != null) {
-          filter =
-              factory.after(
-                  factory.property(attribute),
-                  factory.literal(new DefaultInstant(new DefaultPosition(date))));
+          filter = factory.after(factory.property(attribute), factory.literal(date));
         }
         break;
       case BEFORE:
         date = getValue(Date.class);
         if (date != null) {
-          filter =
-              factory.before(
-                  factory.property(attribute),
-                  factory.literal(new DefaultInstant(new DefaultPosition(date))));
+          filter = factory.before(factory.property(attribute), factory.literal(date));
         }
         break;
       case BETWEEN:

--- a/catalog/core/catalog-core-impl/filter-proxy/src/test/java/ddf/catalog/filter/proxy/builder/test/FilterBuilderTest.java
+++ b/catalog/core/catalog-core-impl/filter-proxy/src/test/java/ddf/catalog/filter/proxy/builder/test/FilterBuilderTest.java
@@ -25,6 +25,7 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import java.util.Date;
+import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.filter.visitor.DefaultExpressionVisitor;
 import org.geotools.filter.visitor.DefaultFilterVisitor;
 import org.junit.Test;
@@ -51,7 +52,6 @@ import org.opengis.filter.temporal.After;
 import org.opengis.filter.temporal.Before;
 import org.opengis.filter.temporal.During;
 import org.opengis.geometry.Geometry;
-import org.opengis.temporal.Instant;
 
 public class FilterBuilderTest {
 
@@ -258,7 +258,7 @@ public class FilterBuilderTest {
     expressionArgument.getValue().getExpression2().accept(expVisitor, null);
     ArgumentCaptor<Literal> literalArgument = ArgumentCaptor.forClass(Literal.class);
     verify(expVisitor).visit(literalArgument.capture(), anyObject());
-    assertEquals(date, ((Instant) literalArgument.getValue().getValue()).getPosition().getDate());
+    assertEquals(date, literalArgument.getValue().getValue());
   }
 
   @Test
@@ -288,6 +288,15 @@ public class FilterBuilderTest {
   }
 
   @Test
+  public void afterFilterIsSymmetricWithCql() throws Exception {
+    FilterBuilder builder = new GeotoolsFilterBuilder();
+    Filter filter = builder.attribute(FOO_ATTRIBUTE).after().date(new Date());
+    String cql = ECQL.toCQL(filter);
+    // will throw an exception if the generated CQL was not valid
+    ECQL.toFilter(cql);
+  }
+
+  @Test
   public void before() {
     FilterVisitor visitor = spy(new DefaultFilterVisitor() {});
     FilterBuilder builder = new GeotoolsFilterBuilder();
@@ -299,6 +308,15 @@ public class FilterBuilderTest {
 
     InOrder inOrder = inOrder(visitor);
     inOrder.verify(visitor, times(2)).visit(isA(Before.class), anyObject());
+  }
+
+  @Test
+  public void beforeFilterIsSymmetricWithCql() throws Exception {
+    FilterBuilder builder = new GeotoolsFilterBuilder();
+    Filter filter = builder.attribute(FOO_ATTRIBUTE).before().date(new Date());
+    String cql = ECQL.toCQL(filter);
+    // will throw an exception if the generated CQL was not valid
+    ECQL.toFilter(cql);
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
- Removes the object wrapping of the Date literal in BEFORE and AFTER filters. This change makes BEFORE and AFTER fall in line with the BETWEEN case.

I'm treating the Geotools library as the authority here.

I'm putting this up to test integration tests in CI. If it fails I may not pursue this change since this code is touched by many parts of the system.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@ahoffer @figliold @jhunzik 

#### Select relevant component teams: 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@emmberk
@pklinef

#### How should this be tested?
CI

#### What are the relevant tickets?
Fixes: #5469

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
