### PR TITLE
[2.19.x] DDF-5474 Escapes user-input jsonp parameter on GeoCoderEndpoint.getLocation calls

### DIFF
--- a/catalog/spatial/geocoding/spatial-geocoding-endpoint/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-endpoint/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>spatial-geocoding-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons-text.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -45,6 +50,9 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            commons-text
+                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/catalog/spatial/geocoding/spatial-geocoding-endpoint/src/main/java/org/codice/ddf/spatial/geocoder/endpoint/GeoCoderEndpoint.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-endpoint/src/main/java/org/codice/ddf/spatial/geocoder/endpoint/GeoCoderEndpoint.java
@@ -18,6 +18,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import org.apache.commons.text.StringEscapeUtils;
 import org.codice.ddf.spatial.geocoding.GeoCoderService;
 import org.codice.ddf.spatial.geocoding.GeoEntryQueryException;
 import org.slf4j.Logger;
@@ -40,8 +41,8 @@ public class GeoCoderEndpoint {
 
     String jsonString = geoCoderService.getLocation(jsonp, query);
     if (jsonString != null) {
-      return Response.ok(jsonp + "(" + jsonString + ")").build();
-
+      return Response.ok(String.format("%s(%s)", StringEscapeUtils.escapeHtml4(jsonp), jsonString))
+          .build();
     } else {
       return Response.status(Response.Status.BAD_REQUEST).build();
     }


### PR DESCRIPTION
#### What does this PR do?
Cherry pick of #5475 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@bakejeyner @garrettfreibott 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@blen-desta
@brjeter

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Cherry-pick; CI sufficient.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5474 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
