### PR TITLE
DDF-5505 Allow editing of DMS decimals

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
@@ -52,7 +52,7 @@ const MaskedCoordinate = props => {
 const DmsLatitude = props => {
   return (
     <MaskedCoordinate
-      placeholder="dd°mm'ss.s&quot;"
+      placeholder="dd°mm'ss.sss&quot;"
       mask={latitudeDMSMask}
       {...props}
     />
@@ -62,7 +62,7 @@ const DmsLatitude = props => {
 const DmsLongitude = props => {
   return (
     <MaskedCoordinate
-      placeholder="ddd°mm'ss.s&quot;"
+      placeholder="ddd°mm'ss.sss&quot;"
       mask={longitudeDMSMask}
       {...props}
     />

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/masks.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/masks.js
@@ -14,23 +14,19 @@
  **/
 /* This is a collection of masking functions for the various coordinate inputs */
 
+const decimalMask = ['.', /\d/, /\d/, /\d/, '"']
+
 const latitudeDMSMask = function(rawValue) {
   const baseMask = [/\d/, /\d/, '°', /\d/, /\d/, "'", /\d/, /\d/]
 
   const pattern = new RegExp(
-    "^[0-9_]{2,3}[°*][0-9_]{2,3}[`'’]([0-9_]{2,3}(?:[.][0-9]*)?).*"
+    "^[0-9_]{2,3}[°*][0-9_]{2,3}[`'’]([0-9_]{2,3}(?:[.][0-9]{0,3})?)\"?"
   )
   const match = rawValue.match(pattern)
   if (match) {
     const seconds = match[1]
-    const intDecimalPair = seconds.split('.')
-    if (intDecimalPair.length > 1) {
-      const decimalPlaces = intDecimalPair[1].length
-      const array = new Array(decimalPlaces + 2)
-      array[0] = /\./
-      array.fill(/\d/, 1, decimalPlaces + 1)
-      array[decimalPlaces + 1] = '"'
-      return baseMask.concat(array)
+    if (seconds.includes('.')) {
+      return baseMask.concat(decimalMask)
     }
   }
   return baseMask.concat('"')
@@ -40,19 +36,13 @@ const longitudeDMSMask = function(rawValue) {
   const baseMask = [/\d/, /\d/, /\d/, '°', /\d/, /\d/, "'", /\d/, /\d/]
 
   const pattern = new RegExp(
-    "^[0-9_]{3,4}[°*][0-9_]{2,3}[`'’]([0-9_]{2,3}(?:[.][0-9]*)?).*"
+    "^[0-9_]{3,4}[°*][0-9_]{2,3}[`'’]([0-9_]{2,3}(?:[.][0-9]{0,3})?)\"?"
   )
   const match = rawValue.match(pattern)
   if (match) {
     const seconds = match[1]
-    const intDecimalPair = seconds.split('.')
-    if (intDecimalPair.length > 1) {
-      const decimalPlaces = intDecimalPair[1].length
-      const array = new Array(decimalPlaces + 2)
-      array[0] = /\./
-      array.fill(/\d/, 1, decimalPlaces + 1)
-      array[decimalPlaces + 1] = '"'
-      return baseMask.concat(array)
+    if (seconds.includes('.')) {
+      return baseMask.concat(decimalMask)
     }
   }
   return baseMask.concat('"')


### PR DESCRIPTION
#### What does this PR do?
Allows for the editing/manual entry of DMS decimals. 
Allows three places of decimal precision, which is equivalent to the 6 digits of precision that we along in the Decimal Degrees format. 

#### Who is reviewing it? 
@andrewzimmer 
@hayleynorton 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@djblue
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Verify that when performing an anyGeo search with a Bounding Box or Pt. Rad geo you are able to manually enter decimals in the DMS coordinate input boxes. Also verify that converting back and forth between DMS and other coordinate formats works properly. Verify that there is never more than 3 digits of decimal precision displayed to the user.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5505 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
