### PR TITLE
[2.19.x] DDF-5466 Fix LDAP after Karaf upgrade (#5467)

### DIFF
--- a/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/SslLdapLoginModule.java
+++ b/platform/security/sts/security-sts-ldaplogin/src/main/java/ddf/ldap/ldaplogin/SslLdapLoginModule.java
@@ -339,22 +339,12 @@ public class SslLdapLoginModule extends AbstractKarafLoginModule {
         return false;
       }
 
+      succeeded = true;
+      commitSucceeded = true;
       return true;
     } finally {
       ldapConnectionPool.returnObject(connection);
     }
-  }
-
-  @Override
-  public boolean abort() throws LoginException {
-    return true;
-  }
-
-  @Override
-  public boolean logout() throws LoginException {
-    subject.getPrincipals().removeAll(principals);
-    principals.clear();
-    return true;
   }
 
   protected BundleContext getContext() {


### PR DESCRIPTION
#### What does this PR do?
The Karaf upgrade from 4.2.2 to 4.2.6 added some flags in their LDAP authentication module. As such, we need to set said flags accordingly in our `SslLdapLoginModule` in order for LDAP authentication to work properly.

Also, the `logout()` and `abort()` methods overrides are no longer necessary and are removed from the `SslLdapLoginModule`.

#### Who is reviewing it? 
@blen-desta 
@garrettfreibott 
@stustison 
@tyler30clemens 

#### Select relevant component teams: 
@codice/security

#### How should this be tested?
Test steps described in issue #5466.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5466

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
