### PR TITLE
[2.19.x] Allow notifications to specify which sources they query

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
@@ -79,6 +79,16 @@ public class CqlRequest {
 
   private Boolean phonetics;
 
+  public String getCacheId() {
+    return cacheId;
+  }
+
+  public void setCacheId(String cacheId) {
+    this.cacheId = cacheId;
+  }
+
+  private String cacheId;
+
   private List<Sort> sorts = Collections.emptyList();
 
   private Set<String> facets = Collections.emptySet();
@@ -266,6 +276,10 @@ public class CqlRequest {
 
     if (phonetics != null) {
       queryRequest.getProperties().put("phonetics", phonetics);
+    }
+
+    if (cacheId != null) {
+      queryRequest.getProperties().put("cacheId", cacheId);
     }
 
     return queryRequest;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
@@ -316,6 +316,11 @@ public class UserApplication implements SparkApplication {
     } else {
       item.addProperty("metacardIds", Collections.emptySet());
     }
+    if (alert.containsKey("src")) {
+      item.addProperty("src", ImmutableSet.copyOf((List<String>) alert.get("src")));
+    } else {
+      item.addProperty("src", Collections.emptySet());
+    }
     try {
       persistentStore.add(PersistenceType.NOTIFICATION_TYPE.toString(), item);
     } catch (PersistenceException e) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
@@ -105,6 +105,7 @@ module.exports = new (Backbone.AssociatedModel.extend({
               : 'enterprise',
           src: alert.get('src'),
           cacheId: alertId,
+          id: alert.get('queryId'),
         })
         if (this.get('currentQuery')) {
           this.get('currentQuery').cancelCurrentSearches()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
@@ -99,7 +99,9 @@ module.exports = new (Backbone.AssociatedModel.extend({
                 property: '"id"',
               }),
           }),
-          federation: 'enterprise',
+          federation: alert.get('src') && alert.get('src').length > 0 ?  'selected' : 'enterprise',
+          src: alert.get('src'),
+          cacheId: alertId,
         })
         if (this.get('currentQuery')) {
           this.get('currentQuery').cancelCurrentSearches()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
@@ -99,7 +99,10 @@ module.exports = new (Backbone.AssociatedModel.extend({
                 property: '"id"',
               }),
           }),
-          federation: alert.get('src') && alert.get('src').length > 0 ?  'selected' : 'enterprise',
+          federation:
+            alert.get('src') && alert.get('src').length > 0
+              ? 'selected'
+              : 'enterprise',
           src: alert.get('src'),
           cacheId: alertId,
         })

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -271,7 +271,8 @@ Query.Model = PartialAssociatedModel.extend({
       'sorts',
       'id',
       'spellcheck',
-      'phonetics'
+      'phonetics',
+      'cacheId'
     )
   },
   isOutdated() {


### PR DESCRIPTION
#### What does this PR do?
Queries will only be created for sources that notifications specify. If no sources are specified, an enterprise query will be performed as before. Additionally, the notificationId itself is attached to these queries to help identify how they were generated.  
#### Who is reviewing it? 
@jrnorth 
@mojogitoverhere 
#### Select relevant component teams: 
@codice/core-apis 
@codice/ui 

#### How should this be tested?
Ingest some data, and schedule a query. In the network request tab, a query should be generated for each available source, and the notification Id should be attached as the `cacheId`
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5526 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
