### PR TITLE
[2.18.x] DDF-5513 Fix anyGeo bounding box not updating correctly

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -175,7 +175,6 @@ const Polygon = {
 const BoundingBox = {
   'json->location': json => {
     const {
-      geometry: { coordinates },
       properties: { north, east, south, west },
     } = json
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -179,11 +179,8 @@ const BoundingBox = {
       properties: { north, east, south, west },
     } = json
 
-    const [polygon] = coordinates
-
     return {
       mode: 'bbox',
-      polygon,
       north,
       east,
       south,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
@@ -161,13 +161,6 @@ describe('serialize/deserialize polygon', () => {
 describe('serialize/deserialize bbox', () => {
   const deserializedBbox = {
     mode: 'bbox',
-    polygon: [
-      [-122.144963, 51.08591],
-      [-108.169324, 51.08591],
-      [-108.169324, 12.374553],
-      [-122.144963, 12.374553],
-      [-122.144963, 51.08591],
-    ],
     north: 51.08591,
     east: -108.169324,
     south: 12.374553,


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where updating a bounding box in an anyGeo search didn't the bounding box in the query. 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@willwill96 
@hayleynorton 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@bdthomson

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Ingest multiple pieces of data with location information. 
2. Create an anyGeo bounding box search that will return some of the ingested data
3. Run the search
4. Edit the search, draw a new bounding box that should return a different piece of data
5. re-run the search
6. verify that the search returns results within the new, updated bounding box.
7. Test anyGeo querying with other geo types and make sure they still function correctly. 
8. Test some basic AOI functionality with bounding boxes and make sure that they still function correctly. 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5513 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
