### PR TITLE
DDF-5535 improve DynamicSchemaResolver so that is pre-populates its cache with all metacard types

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
@@ -32,7 +32,6 @@ import ddf.catalog.data.MetacardCreationException;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
-import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.data.types.Validation;
 import ddf.catalog.source.solr.json.MetacardTypeMapperFactory;
@@ -51,12 +50,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -99,26 +99,25 @@ import org.slf4j.LoggerFactory;
  */
 public class DynamicSchemaResolver {
 
-  public static final String LUX_XML_FIELD_NAME = "lux_xml";
+  private static final String LUX_XML_FIELD_NAME = "lux_xml";
 
-  public static final String SCORE_FIELD_NAME = "score";
+  private static final String SCORE_FIELD_NAME = "score";
 
-  public static final int TOKEN_MAXIMUM_BYTES = 32766;
+  private static final int TOKEN_MAXIMUM_BYTES = 32766;
 
-  public static final String PHONETICS_FEATURE = "phonetics";
+  static final String PHONETICS_FEATURE = "phonetics";
 
-  protected static final char FIRST_CHAR_OF_SUFFIX = '_';
+  static final char FIRST_CHAR_OF_SUFFIX = '_';
 
-  protected static final String COULD_NOT_READ_METACARD_TYPE_MESSAGE =
-      "Could not read MetacardType.";
+  private static final String COULD_NOT_READ_METACARD_TYPE_MESSAGE = "Could not read MetacardType.";
 
-  protected static final String FIELDS_KEY = "fields";
+  private static final String FIELDS_KEY = "fields";
 
-  protected static final String COULD_NOT_SERIALIZE_OBJECT_MESSAGE = "Could not serialize object";
+  private static final String COULD_NOT_SERIALIZE_OBJECT_MESSAGE = "Could not serialize object";
 
-  protected static final XMLInputFactory XML_INPUT_FACTORY;
+  private static final XMLInputFactory XML_INPUT_FACTORY;
 
-  protected static final int FIVE_MEGABYTES = 5 * 1024 * 1024;
+  static final int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
   private static final String METADATA_SIZE_LIMIT = "metadata.size.limit";
 
@@ -164,19 +163,28 @@ public class DynamicSchemaResolver {
     }
   }
 
-  protected Set<String> fieldsCache = new HashSet<>();
+  Set<String> fieldsCache = new HashSet<>();
 
-  protected Set<String> anyTextFieldsCache = new HashSet<>();
+  private Set<String> anyTextFieldsCache = new HashSet<>();
 
-  protected SchemaFields schemaFields;
+  private SchemaFields schemaFields;
 
-  protected Cache<String, MetacardType> metacardTypesCache =
+  private Cache<String, MetacardType> metacardTypesCache =
       CacheBuilder.newBuilder().maximumSize(4096).initialCapacity(64).build();
 
-  protected Cache<String, byte[]> metacardTypeNameToSerialCache =
+  private Cache<String, byte[]> metacardTypeNameToSerialCache =
       CacheBuilder.newBuilder().maximumSize(4096).initialCapacity(64).build();
 
   private Processor processor = new Processor(new Config());
+
+  /**
+   * As metacard types are added via {@link #addMetacardType(MetacardType)}, this map keeps track of
+   * the number of times metacard attributes are added to the {@link #fieldsCache} and {@link
+   * #anyTextFieldsCache}. The count is decremented when {@link #removeMetacardType(MetacardType)}
+   * is called. When the count reaches zero, the attribute is removed from {@link #fieldsCache} and
+   * {@link #anyTextFieldsCache}.
+   */
+  private Map<String, AtomicInteger> countedFieldsCache = new HashMap<>();
 
   public DynamicSchemaResolver(
       List<String> additionalFields, Function<TinyTree, TinyBinary> tinyBinaryFunction) {
@@ -195,29 +203,77 @@ public class DynamicSchemaResolver {
     fieldsCache.add(Metacard.TAGS + SchemaFields.TEXT_SUFFIX);
 
     anyTextFieldsCache.add(Metacard.METADATA + SchemaFields.TEXT_SUFFIX);
-    Set<String> basicTextAttributes =
-        MetacardImpl.BASIC_METACARD
-            .getAttributeDescriptors()
-            .stream()
-            .filter(descriptor -> BasicTypes.STRING_TYPE.equals(descriptor.getType()))
-            .map(stringDescriptor -> stringDescriptor.getName() + SchemaFields.TEXT_SUFFIX)
-            .collect(Collectors.toSet());
-    anyTextFieldsCache.addAll(basicTextAttributes);
+
     fieldsCache.add(Validation.VALIDATION_ERRORS + SchemaFields.TEXT_SUFFIX);
     fieldsCache.add(Validation.VALIDATION_WARNINGS + SchemaFields.TEXT_SUFFIX);
 
     fieldsCache.add(SchemaFields.METACARD_TYPE_FIELD_NAME);
     fieldsCache.add(SchemaFields.METACARD_TYPE_OBJECT_FIELD_NAME);
 
-    for (String field : additionalFields) {
-      if (StringUtils.isNotBlank(field)) {
-        fieldsCache.add(field);
-      }
-    }
+    addAdditionalFields(this, additionalFields);
   }
 
   public DynamicSchemaResolver() {
     this(Collections.emptyList());
+  }
+
+  public static void addAdditionalFields(
+      DynamicSchemaResolver dynamicSchemaResolver, List<String> additionalFields) {
+    additionalFields
+        .stream()
+        .filter(StringUtils::isNotBlank)
+        .forEach(field -> dynamicSchemaResolver.fieldsCache.add(field));
+  }
+
+  @SuppressWarnings("WeakerAccess" /* access needed by blueprint */)
+  public void addMetacardType(MetacardType metacardType) {
+
+    metacardType
+        .getAttributeDescriptors()
+        .forEach(
+            attribute -> {
+              countedFieldsCache
+                  .computeIfAbsent(attribute.getName(), key -> new AtomicInteger(0))
+                  .incrementAndGet();
+              addToFieldsCache(attribute);
+            });
+
+    metacardType
+        .getAttributeDescriptors()
+        .stream()
+        .filter(descriptor -> BasicTypes.STRING_TYPE.equals(descriptor.getType()))
+        .map(stringDescriptor -> stringDescriptor.getName() + SchemaFields.TEXT_SUFFIX)
+        .forEach(fieldName -> anyTextFieldsCache.add(fieldName));
+  }
+
+  @SuppressWarnings("WeakerAccess" /* access needed by blueprint */)
+  public void removeMetacardType(MetacardType metacardType) {
+
+    metacardType
+        .getAttributeDescriptors()
+        .stream()
+        .map(AttributeDescriptor::getName)
+        .filter(attributeName -> countedFieldsCache.containsKey(attributeName))
+        .forEach(attributeName -> countedFieldsCache.get(attributeName).decrementAndGet());
+
+    List<String> attributeNamesToBeRemoved =
+        countedFieldsCache
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getValue().get() == 0)
+            .map(Entry::getKey)
+            .collect(Collectors.toList());
+
+    attributeNamesToBeRemoved.forEach(
+        attributeName -> {
+          for (AttributeFormat format : AttributeFormat.values()) {
+            String fullFieldName = attributeName + schemaFields.getFieldSuffix(format);
+            fieldsCache.remove(fullFieldName);
+          }
+
+          anyTextFieldsCache.remove(attributeName + SchemaFields.TEXT_SUFFIX);
+          countedFieldsCache.remove(attributeName);
+        });
   }
 
   /**
@@ -229,7 +285,7 @@ public class DynamicSchemaResolver {
    * @throws SolrException if a Solr exception occurs
    * @throws IOException if an I/O exception occurs
    */
-  public void addFieldsFromClient(SolrClient client) throws SolrServerException, IOException {
+  void addFieldsFromClient(SolrClient client) throws SolrServerException, IOException {
     if (client == null) {
       LOGGER.debug("Solr client is null, could not add fields to cache.");
       return;
@@ -271,7 +327,7 @@ public class DynamicSchemaResolver {
   }
 
   /** Adds the fields of the Metacard into the {@link SolrInputDocument} */
-  public void addFields(Metacard metacard, SolrInputDocument solrInputDocument)
+  void addFields(Metacard metacard, SolrInputDocument solrInputDocument)
       throws MetacardCreationException {
     MetacardType schema = metacard.getMetacardType();
 
@@ -304,11 +360,7 @@ public class DynamicSchemaResolver {
             List<Serializable> truncatedValues =
                 attributeValues
                     .stream()
-                    .map(
-                        value ->
-                            value != null
-                                ? truncateAsUTF8(value.toString(), TOKEN_MAXIMUM_BYTES)
-                                : value)
+                    .map(value -> value != null ? truncateAsUTF8(value.toString()) : value)
                     .collect(Collectors.toList());
             // *_txt
             solrInputDocument.addField(
@@ -401,7 +453,7 @@ public class DynamicSchemaResolver {
    * Truncation that takes multibyte UTF-8 characters and surrogate pairs into consideration.
    * https://stackoverflow.com/questions/119328/how-do-i-truncate-a-java-string-to-fit-in-a-given-number-of-bytes-once-utf-8-en
    */
-  private String truncateAsUTF8(String value, int maximumBytes) {
+  private String truncateAsUTF8(String value) {
     int b = 0;
     int skip;
     for (int i = 0; i < value.length(); i = i + 1 + skip) {
@@ -422,7 +474,7 @@ public class DynamicSchemaResolver {
         more = 3;
       }
 
-      if (b + more > maximumBytes) {
+      if (b + more > TOKEN_MAXIMUM_BYTES) {
         return value.substring(0, i);
       }
       b += more;
@@ -450,8 +502,7 @@ public class DynamicSchemaResolver {
     Point centerPoint;
     if (geometries.size() > 1) {
       GeometryCollection geoCollection =
-          GEOMETRY_FACTORY.createGeometryCollection(
-              geometries.toArray(new Geometry[geometries.size()]));
+          GEOMETRY_FACTORY.createGeometryCollection(geometries.toArray(new Geometry[0]));
 
       centerPoint = geoCollection.getCentroid();
     } else {
@@ -498,24 +549,23 @@ public class DynamicSchemaResolver {
     int lastIndexOfUndercore = solrFieldName.lastIndexOf(FIRST_CHAR_OF_SUFFIX);
 
     if (lastIndexOfUndercore != -1) {
-      suffix = solrFieldName.substring(lastIndexOfUndercore, solrFieldName.length());
+      suffix = solrFieldName.substring(lastIndexOfUndercore);
     }
 
     return schemaFields.getFormat(suffix);
   }
 
-  public List<Serializable> getDocValues(String solrFieldName, Collection<Object> docValues) {
+  List<Serializable> getDocValues(String solrFieldName, Collection<Object> docValues) {
     ArrayList<Serializable> values = new ArrayList<>();
-    Iterator<Object> iterator = docValues.iterator();
-    while (iterator.hasNext()) {
-      values.add(getDocValue(solrFieldName, iterator.next()));
+    for (Object docValue : docValues) {
+      values.add(getDocValue(solrFieldName, docValue));
     }
     return values;
   }
 
   @SuppressWarnings(
       "squid:S2093" /* try-with-resource will throw IOException with InputStream and we do not care to get that exception */)
-  public Serializable getDocValue(String solrFieldName, Object docValue) {
+  private Serializable getDocValue(String solrFieldName, Object docValue) {
 
     AttributeFormat format = getType(solrFieldName);
 
@@ -560,7 +610,7 @@ public class DynamicSchemaResolver {
    * @param solrFieldName Solr index field name
    * @return the original field name
    */
-  public String resolveFieldName(String solrFieldName) {
+  String resolveFieldName(String solrFieldName) {
     int lastIndexOfUndercore = solrFieldName.lastIndexOf(FIRST_CHAR_OF_SUFFIX);
 
     if (lastIndexOfUndercore != -1) {
@@ -569,7 +619,7 @@ public class DynamicSchemaResolver {
     return solrFieldName;
   }
 
-  public boolean isPrivateField(String solrFieldName) {
+  boolean isPrivateField(String solrFieldName) {
     return PRIVATE_SOLR_FIELDS.contains(solrFieldName);
   }
 
@@ -580,7 +630,7 @@ public class DynamicSchemaResolver {
    * @return a list of possible Solr field names that match the given field. If none are found, then
    *     an empty list is returned
    */
-  public List<String> getAnonymousField(String field) {
+  List<String> getAnonymousField(String field) {
     ArrayList<String> list = new ArrayList<>();
 
     for (AttributeFormat format : AttributeFormat.values()) {
@@ -605,7 +655,7 @@ public class DynamicSchemaResolver {
    * @return the proper schema field name. If a schema name cannot be found in cache, returns a
    *     schema field name that matches the dynamic field type formatting.
    */
-  public String getField(
+  String getField(
       String propertyName,
       AttributeFormat format,
       boolean isSearchedAsExactValue,
@@ -644,7 +694,7 @@ public class DynamicSchemaResolver {
     return fieldName;
   }
 
-  public String getFieldSuffix(AttributeFormat format) {
+  private String getFieldSuffix(AttributeFormat format) {
     return schemaFields.getFieldSuffix(format);
   }
 
@@ -674,7 +724,7 @@ public class DynamicSchemaResolver {
     return cachedMetacardType;
   }
 
-  public String getCaseSensitiveField(
+  String getCaseSensitiveField(
       String mappedPropertyName, Map<String, Serializable> enabledFeatures) {
     if (isPhoneticsEnabled(enabledFeatures)
         && mappedPropertyName.endsWith(SchemaFields.PHONETICS)) {
@@ -684,12 +734,11 @@ public class DynamicSchemaResolver {
     return mappedPropertyName + SchemaFields.HAS_CASE;
   }
 
-  protected String getSpecialIndexSuffix(AttributeFormat format) {
-    return getSpecialIndexSuffix(format, Collections.EMPTY_MAP);
+  private String getSpecialIndexSuffix(AttributeFormat format) {
+    return getSpecialIndexSuffix(format, Collections.emptyMap());
   }
 
-  protected String getSpecialIndexSuffix(
-      AttributeFormat format, Map<String, Serializable> enabledFeatures) {
+  String getSpecialIndexSuffix(AttributeFormat format, Map<String, Serializable> enabledFeatures) {
 
     switch (format) {
       case STRING:
@@ -719,37 +768,45 @@ public class DynamicSchemaResolver {
 
   private void addToFieldsCache(Set<AttributeDescriptor> descriptors) {
     for (AttributeDescriptor ad : descriptors) {
+      addToFieldsCache(ad);
+    }
+  }
 
-      AttributeFormat format = ad.getType().getAttributeFormat();
+  private void addToFieldsCache(AttributeDescriptor descriptor) {
 
-      fieldsCache.add(ad.getName() + schemaFields.getFieldSuffix(format));
+    AttributeFormat format = descriptor.getType().getAttributeFormat();
 
-      if (!getSpecialIndexSuffix(format).equals("")) {
-        fieldsCache.add(
-            ad.getName() + schemaFields.getFieldSuffix(format) + getSpecialIndexSuffix(format));
-      }
+    fieldsCache.add(descriptor.getName() + schemaFields.getFieldSuffix(format));
 
-      if (format.equals(AttributeFormat.STRING)) {
-        fieldsCache.add(
-            ad.getName()
-                + schemaFields.getFieldSuffix(format)
-                + getSpecialIndexSuffix(format)
-                + SchemaFields.HAS_CASE);
-        fieldsCache.add(
-            ad.getName() + schemaFields.getFieldSuffix(format) + SchemaFields.PHONETICS);
-        anyTextFieldsCache.add(ad.getName() + schemaFields.getFieldSuffix(format));
-      }
+    if (!getSpecialIndexSuffix(format).equals("")) {
+      fieldsCache.add(
+          descriptor.getName()
+              + schemaFields.getFieldSuffix(format)
+              + getSpecialIndexSuffix(format));
+    }
 
-      if (format.equals(AttributeFormat.XML)) {
-        fieldsCache.add(ad.getName() + SchemaFields.TEXT_SUFFIX + SchemaFields.TOKENIZED);
-        fieldsCache.add(
-            ad.getName()
-                + SchemaFields.TEXT_SUFFIX
-                + SchemaFields.TOKENIZED
-                + SchemaFields.HAS_CASE);
-        fieldsCache.add(
-            ad.getName() + schemaFields.getFieldSuffix(format) + getSpecialIndexSuffix(format));
-      }
+    if (format.equals(AttributeFormat.STRING)) {
+      fieldsCache.add(
+          descriptor.getName()
+              + schemaFields.getFieldSuffix(format)
+              + getSpecialIndexSuffix(format)
+              + SchemaFields.HAS_CASE);
+      fieldsCache.add(
+          descriptor.getName() + schemaFields.getFieldSuffix(format) + SchemaFields.PHONETICS);
+      anyTextFieldsCache.add(descriptor.getName() + schemaFields.getFieldSuffix(format));
+    }
+
+    if (format.equals(AttributeFormat.XML)) {
+      fieldsCache.add(descriptor.getName() + SchemaFields.TEXT_SUFFIX + SchemaFields.TOKENIZED);
+      fieldsCache.add(
+          descriptor.getName()
+              + SchemaFields.TEXT_SUFFIX
+              + SchemaFields.TOKENIZED
+              + SchemaFields.HAS_CASE);
+      fieldsCache.add(
+          descriptor.getName()
+              + schemaFields.getFieldSuffix(format)
+              + getSpecialIndexSuffix(format));
     }
   }
 
@@ -796,7 +853,7 @@ public class DynamicSchemaResolver {
    */
   @SuppressWarnings(
       "squid:S2093" /* try-with-resource will throw IOException with InputStream and we do not care to get that exception */)
-  protected List<String> parseTextFrom(List<Serializable> xmlDatas) {
+  private List<String> parseTextFrom(List<Serializable> xmlDatas) {
 
     StringBuilder builder = new StringBuilder();
     List<String> parsedTexts = new ArrayList<>();
@@ -874,14 +931,14 @@ public class DynamicSchemaResolver {
     return newAttributeDescriptors;
   }
 
-  public String getSortKey(String field) {
+  String getSortKey(String field) {
     if (field.endsWith(SchemaFields.GEO_SUFFIX)) {
       field = field + SchemaFields.SORT_SUFFIX;
     }
     return field;
   }
 
-  public Stream<String> anyTextFields() {
+  Stream<String> anyTextFields() {
     return anyTextFieldsCache.stream();
   }
 

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrCatalogProvider.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrCatalogProvider.java
@@ -129,19 +129,6 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
         new ProviderSolrMetacardClient(solrClient, adapter, solrFilterDelegateFactory, resolver);
   }
 
-  /**
-   * Convenience constructor that creates a new ddf.catalog.source.solr.DynamicSchemaResolver
-   *
-   * @param solrClient Solr client
-   * @param adapter injected implementation of FilterAdapter
-   */
-  public SolrCatalogProvider(
-      SolrClient solrClient,
-      FilterAdapter adapter,
-      SolrFilterDelegateFactory solrFilterDelegateFactory) {
-    this(solrClient, adapter, solrFilterDelegateFactory, new DynamicSchemaResolver());
-  }
-
   @Override
   public Set<ContentType> getContentTypes() {
     return client.getContentTypes();

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/DynamicSchemaResolverTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/DynamicSchemaResolverTest.java
@@ -156,9 +156,10 @@ public class DynamicSchemaResolverTest {
     when(mockMetacard.getMetacardType().getAttributeDescriptors()).thenReturn(attributeDescriptors);
     when(mockMetacard.getAttribute(name)).thenReturn(mockAttribute);
     SolrInputDocument solrInputDocument = new SolrInputDocument();
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver();
 
     // Perform Test
-    dynamicSchemaResolver.addFields(mockMetacard, solrInputDocument);
+    resolver.addFields(mockMetacard, solrInputDocument);
     assertThat(solrInputDocument.getFieldValue("lux_xml"), is(nullValue()));
   }
 
@@ -194,9 +195,10 @@ public class DynamicSchemaResolverTest {
     when(mockMetacard.getMetacardType().getAttributeDescriptors()).thenReturn(attributeDescriptors);
     when(mockMetacard.getAttribute(name)).thenReturn(mockAttribute);
     SolrInputDocument solrInputDocument = new SolrInputDocument();
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver();
 
     // Perform Test
-    dynamicSchemaResolver.addFields(mockMetacard, solrInputDocument);
+    resolver.addFields(mockMetacard, solrInputDocument);
     assertThat(solrInputDocument.getFieldValue("lux_xml"), is(notNullValue()));
   }
 
@@ -204,6 +206,7 @@ public class DynamicSchemaResolverTest {
   public void testAddFieldsRevertsTo5mbMetadataSizeLimitTooLarge() {
     long overflow = Integer.MAX_VALUE;
     System.setProperty("metadata.size.limit", String.valueOf(overflow + 1));
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver();
 
     int actual = DynamicSchemaResolver.getMetadataSizeLimit();
     assertThat(actual, equalTo(DynamicSchemaResolver.FIVE_MEGABYTES));
@@ -216,6 +219,7 @@ public class DynamicSchemaResolverTest {
   public void testAddFieldsRevertsTo5mbMetadataSizeLimitNotNumeric() {
     // Set
     System.setProperty("metadata.size.limit", "supercalifragilisticexpialidocious");
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver();
 
     int actual = DynamicSchemaResolver.getMetadataSizeLimit();
     assertThat(actual, equalTo(DynamicSchemaResolver.FIVE_MEGABYTES));

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/DynamicSchemaResolverTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/DynamicSchemaResolverTest.java
@@ -73,24 +73,11 @@ public class DynamicSchemaResolverTest {
 
   @Test
   public void testAddMetacardType() {
-
     assertThat(dynamicSchemaResolver.getAnonymousField(Metacard.TITLE), empty());
 
     dynamicSchemaResolver.addMetacardType(MetacardImpl.BASIC_METACARD);
 
     assertThat(dynamicSchemaResolver.getAnonymousField(Metacard.TITLE), hasSize(1));
-  }
-
-  @Test
-  public void testRemoveMetacardType() {
-
-    dynamicSchemaResolver.addMetacardType(MetacardImpl.BASIC_METACARD);
-
-    assertThat(dynamicSchemaResolver.getAnonymousField(Metacard.TITLE), hasSize(1));
-
-    dynamicSchemaResolver.removeMetacardType(MetacardImpl.BASIC_METACARD);
-
-    assertThat(dynamicSchemaResolver.getAnonymousField(Metacard.TITLE), empty());
   }
 
   /**

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderRealTimeQueryTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderRealTimeQueryTest.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.source.solr;
 
+import static ddf.catalog.data.impl.MetacardImpl.BASIC_METACARD;
 import static ddf.catalog.source.solr.provider.SolrProviderTestUtil.create;
 import static ddf.catalog.source.solr.provider.SolrProviderTestUtil.deleteAll;
 import static ddf.catalog.source.solr.provider.SolrProviderTestUtil.getFilterBuilder;
@@ -23,7 +24,6 @@ import static org.awaitility.Awaitility.await;
 import com.google.common.collect.Lists;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
-import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
 import ddf.catalog.operation.CreateResponse;
@@ -105,9 +105,15 @@ public class SolrProviderRealTimeQueryTest {
         solrClient.isAvailable(30L, TimeUnit.SECONDS),
         Matchers.equalTo(true));
 
+    DynamicSchemaResolver dynamicSchemaResolver = new DynamicSchemaResolver();
+    dynamicSchemaResolver.addMetacardType(BASIC_METACARD);
+
     provider =
         new SolrCatalogProvider(
-            solrClient, new GeotoolsFilterAdapterImpl(), new SolrFilterDelegateFactoryImpl());
+            solrClient,
+            new GeotoolsFilterAdapterImpl(),
+            new SolrFilterDelegateFactoryImpl(),
+            dynamicSchemaResolver);
 
     // Mask the id, this is something that the CatalogFramework would usually do
     provider.setId(MASKED_ID);
@@ -286,8 +292,7 @@ public class SolrProviderRealTimeQueryTest {
     deleteAll(provider);
 
     MetacardType nrtMetacardType =
-        new MetacardTypeImpl(
-            COMMIT_NRT_TYPE, MetacardImpl.BASIC_METACARD.getAttributeDescriptors());
+        new MetacardTypeImpl(COMMIT_NRT_TYPE, BASIC_METACARD.getAttributeDescriptors());
 
     MockMetacard nrtMetacard = new MockMetacard(Library.getFlagstaffRecord(), nrtMetacardType);
     nrtMetacard.setTitle(nrtTitle);

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
@@ -13,6 +13,7 @@
  */
 package ddf.catalog.source.solr;
 
+import static ddf.catalog.data.impl.MetacardImpl.BASIC_METACARD;
 import static ddf.catalog.source.solr.DynamicSchemaResolver.FIVE_MEGABYTES;
 
 import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
@@ -102,9 +103,15 @@ public class SolrProviderTest {
         solrClient.isAvailable(30L, TimeUnit.SECONDS),
         Matchers.equalTo(true));
 
+    DynamicSchemaResolver dynamicSchemaResolver = new DynamicSchemaResolver();
+    dynamicSchemaResolver.addMetacardType(BASIC_METACARD);
+
     provider =
         new SolrCatalogProvider(
-            solrClient, new GeotoolsFilterAdapterImpl(), new SolrFilterDelegateFactoryImpl());
+            solrClient,
+            new GeotoolsFilterAdapterImpl(),
+            new SolrFilterDelegateFactoryImpl(),
+            dynamicSchemaResolver);
 
     // Mask the id, this is something that the CatalogFramework would usually do
     provider.setId(MASKED_ID);

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderCreate.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderCreate.java
@@ -154,7 +154,7 @@ public class SolrProviderCreate {
   /** Testing that you cannot instantiate with a null Solr client. */
   @Test(expected = IllegalArgumentException.class)
   public void testSolrClientNull() {
-    new SolrCatalogProvider(null, null, null);
+    new SolrCatalogProvider(null, null, null, null);
   }
 
   /** Tests what happens when the whole request is null. */

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheSolrMetacardClient.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheSolrMetacardClient.java
@@ -40,12 +40,19 @@ class CacheSolrMetacardClient extends SolrMetacardClientImpl {
   public CacheSolrMetacardClient(
       SolrClient client,
       FilterAdapter catalogFilterAdapter,
-      SolrFilterDelegateFactory solrFilterDelegateFactory) {
+      SolrFilterDelegateFactory solrFilterDelegateFactory,
+      DynamicSchemaResolver dynamicSchemaResolver) {
     super(
         client,
         catalogFilterAdapter,
         solrFilterDelegateFactory,
-        new DynamicSchemaResolver(ADDITIONAL_FIELDS));
+        enhanceResolver(dynamicSchemaResolver));
+  }
+
+  private static DynamicSchemaResolver enhanceResolver(
+      DynamicSchemaResolver dynamicSchemaResolver) {
+    DynamicSchemaResolver.addAdditionalFields(dynamicSchemaResolver, ADDITIONAL_FIELDS);
+    return dynamicSchemaResolver;
   }
 
   @Override

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
@@ -28,6 +28,7 @@ import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.source.solr.DynamicSchemaResolver;
 import ddf.catalog.source.solr.SchemaFields;
 import ddf.catalog.source.solr.SolrFilterDelegateFactory;
 import ddf.catalog.source.solr.SolrMetacardClient;
@@ -106,8 +107,13 @@ public class SolrCache implements SolrCacheMBean {
   public SolrCache(
       FilterAdapter adapter,
       SolrClientFactory solrClientFactory,
-      SolrFilterDelegateFactory solrFilterDelegateFactory) {
-    this(adapter, solrClientFactory.newClient(METACARD_CACHE_CORE_NAME), solrFilterDelegateFactory);
+      SolrFilterDelegateFactory solrFilterDelegateFactory,
+      DynamicSchemaResolver dynamicSchemaResolver) {
+    this(
+        adapter,
+        solrClientFactory.newClient(METACARD_CACHE_CORE_NAME),
+        solrFilterDelegateFactory,
+        dynamicSchemaResolver);
   }
 
   @VisibleForTesting
@@ -132,8 +138,12 @@ public class SolrCache implements SolrCacheMBean {
   private SolrCache(
       FilterAdapter adapter,
       SolrClient client,
-      SolrFilterDelegateFactory solrFilterDelegateFactory) {
-    this(client, new CacheSolrMetacardClient(client, adapter, solrFilterDelegateFactory));
+      SolrFilterDelegateFactory solrFilterDelegateFactory,
+      DynamicSchemaResolver dynamicSchemaResolver) {
+    this(
+        client,
+        new CacheSolrMetacardClient(
+            client, adapter, solrFilterDelegateFactory, dynamicSchemaResolver));
   }
 
   public SourceResponse query(QueryRequest request) throws UnsupportedQueryException {

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/fedstrategy.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/fedstrategy.xml
@@ -38,7 +38,7 @@
     <bean id="dynamicSchemaResolver" class="ddf.catalog.source.solr.DynamicSchemaResolver"/>
 
     <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
-        <reference-listener bind-method="addMetacardType" unbind-method="removeMetacardType" ref="dynamicSchemaResolver"/>
+        <reference-listener bind-method="addMetacardType" ref="dynamicSchemaResolver"/>
     </reference-list>
 
     <bean id="solrCatalogCache" class="ddf.catalog.cache.solr.impl.SolrCache"

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/fedstrategy.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/fedstrategy.xml
@@ -35,6 +35,12 @@
 
     <reference id="solrClientFactory" interface="org.codice.solr.factory.SolrClientFactory"/>
 
+    <bean id="dynamicSchemaResolver" class="ddf.catalog.source.solr.DynamicSchemaResolver"/>
+
+    <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
+        <reference-listener bind-method="addMetacardType" unbind-method="removeMetacardType" ref="dynamicSchemaResolver"/>
+    </reference-list>
+
     <bean id="solrCatalogCache" class="ddf.catalog.cache.solr.impl.SolrCache"
           destroy-method="shutdown">
         <argument ref="filterAdapter"/>
@@ -42,6 +48,7 @@
         <argument>
             <bean class="ddf.catalog.source.solr.SolrFilterDelegateFactoryImpl"/>
         </argument>
+        <argument ref="dynamicSchemaResolver"/>
     </bean>
 
     <bean id="cacheQueryFactory" class="ddf.catalog.cache.solr.impl.CacheQueryFactory">

--- a/catalog/solr/catalog-solr-provider/src/main/java/ddf/catalog/solr/provider/SolrCatalogProvider.java
+++ b/catalog/solr/catalog-solr-provider/src/main/java/ddf/catalog/solr/provider/SolrCatalogProvider.java
@@ -14,6 +14,7 @@
 package ddf.catalog.solr.provider;
 
 import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.source.solr.DynamicSchemaResolver;
 import ddf.catalog.source.solr.RemoteSolrCatalogProvider;
 import ddf.catalog.source.solr.SolrFilterDelegateFactory;
 import org.codice.solr.factory.SolrClientFactory;
@@ -23,11 +24,12 @@ public class SolrCatalogProvider extends RemoteSolrCatalogProvider {
   public SolrCatalogProvider(
       FilterAdapter filterAdapter,
       SolrClientFactory clientFactory,
-      SolrFilterDelegateFactory solrFilterDelegateFactory) {
+      SolrFilterDelegateFactory solrFilterDelegateFactory,
+      DynamicSchemaResolver dynamicSchemaResolver) {
     super(
         filterAdapter,
         clientFactory.newClient(SOLR_CATALOG_CORE_NAME),
         solrFilterDelegateFactory,
-        null);
+        dynamicSchemaResolver);
   }
 }

--- a/catalog/solr/catalog-solr-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/solr/catalog-solr-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,6 +18,12 @@
 
 	<reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
 
+	<bean id="dynamicSchemaResolver" class="ddf.catalog.source.solr.DynamicSchemaResolver"/>
+
+	<reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
+		<reference-listener bind-method="addMetacardType" unbind-method="removeMetacardType" ref="dynamicSchemaResolver"/>
+	</reference-list>
+
 	<bean id="solrCatalogProvider" class="ddf.catalog.solr.provider.SolrCatalogProvider"
           destroy-method="shutdown">
 		<!-- Aries does not call my object on startup if set to component-managed. Therefore, we will use container-managed
@@ -29,6 +35,7 @@
 		<argument>
 			<bean class="ddf.catalog.source.solr.SolrFilterDelegateFactoryImpl"/>
 		</argument>
+		<argument ref="dynamicSchemaResolver"/>
 	</bean>
 
 	<service ref="solrCatalogProvider" interface="ddf.catalog.source.CatalogProvider"/>

--- a/catalog/solr/catalog-solr-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/solr/catalog-solr-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,7 @@
 	<bean id="dynamicSchemaResolver" class="ddf.catalog.source.solr.DynamicSchemaResolver"/>
 
 	<reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
-		<reference-listener bind-method="addMetacardType" unbind-method="removeMetacardType" ref="dynamicSchemaResolver"/>
+		<reference-listener bind-method="addMetacardType" ref="dynamicSchemaResolver"/>
 	</reference-list>
 
 	<bean id="solrCatalogProvider" class="ddf.catalog.solr.provider.SolrCatalogProvider"


### PR DESCRIPTION
#### What does this PR do?
Improve DynamicSchemaResolver so that is pre-populates its cache with all metacard types. This is done by creating a reference listener in blueprint for metacard types and adding/removing those types from the resolver.

#### Who is reviewing it? 
@pklinef 
@rzwiefel 
@derekwilhelm 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@bdthomson

#### How should this be tested?
The original problem can be reproduced by first installing a master build. Then, using the karaf console, run `catalog:search --cql '"security.access-groups" IS NULL'`. You should see an exception in the logs with the message `Anonymous Field Property does not exist. security.access-groups`.

With this PR, you should no longer see the exception.

#### Any background context you want to provide?

This is affecting downstream projects.

#### What are the relevant tickets?
Fixes: #5535 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
