### PR TITLE
DDF-5542 Make AttributeImpl accept lists of any type that implements Serializable

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/AttributeImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/AttributeImpl.java
@@ -73,7 +73,7 @@ public class AttributeImpl implements Attribute {
    * @param name - the name of this {@link Attribute}
    * @param values - the value of this {@link Attribute}
    */
-  public AttributeImpl(String name, List<Serializable> values) {
+  public AttributeImpl(String name, List<? extends Serializable> values) {
     /*
      * If any defensive logic is added to this constructor, then that logic should be reflected
      * in the deserialization (readObject()) of this object so that the integrity of a

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/AttributeImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/AttributeImpl.java
@@ -68,6 +68,15 @@ public class AttributeImpl implements Attribute {
   }
 
   /**
+   * Static factory method to avoid ambiguous constructor references when passing a value that
+   * implements both {@link List} and {@link Serializable}, such as an {@link java.util.ArrayList}.
+   * See {@link #AttributeImpl(String, Serializable)}.
+   */
+  public static AttributeImpl fromSingleValue(String name, Serializable value) {
+    return new AttributeImpl(name, value);
+  }
+
+  /**
    * Multivalued Constructor
    *
    * @param name - the name of this {@link Attribute}
@@ -82,6 +91,15 @@ public class AttributeImpl implements Attribute {
      */
     this.name = name;
     this.values = new LinkedList<>(values);
+  }
+
+  /**
+   * Static factory method to avoid ambiguous constructor references when passing a value that
+   * implements both {@link List} and {@link Serializable}, such as an {@link java.util.ArrayList}.
+   * See {@link #AttributeImpl(String, List)}.
+   */
+  public static AttributeImpl fromMultipleValues(String name, List<? extends Serializable> values) {
+    return new AttributeImpl(name, values);
   }
 
   /** Copy Constructor */

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPlugin.java
@@ -177,7 +177,7 @@ public class MetacardValidityMarkerPlugin implements PreIngestPlugin {
     }
 
     tags.add(valid);
-    metacard.setAttribute(new AttributeImpl(Metacard.TAGS, new ArrayList<String>(tags)));
+    metacard.setAttribute(new AttributeImpl(Metacard.TAGS, (List<String>) new ArrayList<>(tags)));
 
     metacard.setAttribute(
         new AttributeImpl(

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPlugin.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/main/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPlugin.java
@@ -177,7 +177,7 @@ public class MetacardValidityMarkerPlugin implements PreIngestPlugin {
     }
 
     tags.add(valid);
-    metacard.setAttribute(new AttributeImpl(Metacard.TAGS, (List<String>) new ArrayList<>(tags)));
+    metacard.setAttribute(AttributeImpl.fromMultipleValues(Metacard.TAGS, new ArrayList<>(tags)));
 
     metacard.setAttribute(
         new AttributeImpl(

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
@@ -176,9 +176,9 @@ public class MetacardValidityMarkerPluginTest {
     CreateRequest request = getMockCreateRequest();
     Metacard m1 = request.getMetacards().get(0);
 
-    Set<String> tags = m1.getTags();
+    List<String> tags = new ArrayList<>(m1.getTags());
     tags.add(INVALID_TAG);
-    m1.setAttribute(new AttributeImpl(Metacard.TAGS, new ArrayList<String>(tags)));
+    m1.setAttribute(new AttributeImpl(Metacard.TAGS, tags));
 
     CreateRequest filteredRequest = plugin.process(request);
     assertThat(filteredRequest.getMetacards().get(0).getTags(), hasItem(VALID_TAG));
@@ -192,9 +192,9 @@ public class MetacardValidityMarkerPluginTest {
     CreateRequest request = getMockCreateRequest();
     Metacard m1 = request.getMetacards().get(0);
 
-    Set<String> tags = m1.getTags();
+    List<String> tags = new ArrayList<>(m1.getTags());
     tags.add(VALID_TAG);
-    m1.setAttribute(new AttributeImpl(Metacard.TAGS, new ArrayList<String>(tags)));
+    m1.setAttribute(new AttributeImpl(Metacard.TAGS, tags));
 
     CreateRequest filteredRequest = plugin.process(request);
     assertThat(filteredRequest.getMetacards().get(0).getTags(), hasItem(INVALID_TAG));

--- a/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
+++ b/catalog/plugin/catalog-plugin-metacard-validation/src/test/java/ddf/catalog/metacard/validation/MetacardValidityMarkerPluginTest.java
@@ -176,9 +176,9 @@ public class MetacardValidityMarkerPluginTest {
     CreateRequest request = getMockCreateRequest();
     Metacard m1 = request.getMetacards().get(0);
 
-    List<String> tags = new ArrayList<>(m1.getTags());
+    Set<String> tags = m1.getTags();
     tags.add(INVALID_TAG);
-    m1.setAttribute(new AttributeImpl(Metacard.TAGS, tags));
+    m1.setAttribute(AttributeImpl.fromMultipleValues(Metacard.TAGS, new ArrayList<>(tags)));
 
     CreateRequest filteredRequest = plugin.process(request);
     assertThat(filteredRequest.getMetacards().get(0).getTags(), hasItem(VALID_TAG));
@@ -192,9 +192,9 @@ public class MetacardValidityMarkerPluginTest {
     CreateRequest request = getMockCreateRequest();
     Metacard m1 = request.getMetacards().get(0);
 
-    List<String> tags = new ArrayList<>(m1.getTags());
+    Set<String> tags = m1.getTags();
     tags.add(VALID_TAG);
-    m1.setAttribute(new AttributeImpl(Metacard.TAGS, tags));
+    m1.setAttribute(AttributeImpl.fromMultipleValues(Metacard.TAGS, new ArrayList<>(tags)));
 
     CreateRequest filteredRequest = plugin.process(request);
     assertThat(filteredRequest.getMetacards().get(0).getTags(), hasItem(INVALID_TAG));

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/associations/Associated.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/associations/Associated.java
@@ -146,7 +146,7 @@ public class Associated {
       /*Mutable*/ Map<String, Metacard> changedMetacards) {
     String id = edge.parent.get(Metacard.ID).toString();
     Metacard target = changedMetacards.getOrDefault(id, metacards.get(id));
-    ArrayList<String> values =
+    List<String> values =
         Optional.of(target)
             .map(m -> m.getAttribute(edge.relation))
             .map(Attribute::getValues)
@@ -161,7 +161,7 @@ public class Associated {
       Edge edge, Map<String, Metacard> metacards, Map<String, Metacard> changedMetacards) {
     String id = edge.parent.get(Metacard.ID).toString();
     Metacard target = changedMetacards.getOrDefault(id, metacards.get(id));
-    ArrayList<String> values =
+    List<String> values =
         Optional.of(target)
             .map(m -> m.getAttribute(edge.relation))
             .map(Attribute::getValues)

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/associations/Associated.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/associations/Associated.java
@@ -146,14 +146,14 @@ public class Associated {
       /*Mutable*/ Map<String, Metacard> changedMetacards) {
     String id = edge.parent.get(Metacard.ID).toString();
     Metacard target = changedMetacards.getOrDefault(id, metacards.get(id));
-    List<String> values =
+    ArrayList<String> values =
         Optional.of(target)
             .map(m -> m.getAttribute(edge.relation))
             .map(Attribute::getValues)
             .map(util::getStringList)
             .orElseGet(ArrayList::new);
     values.remove(edge.child.get(Metacard.ID).toString());
-    target.setAttribute(new AttributeImpl(edge.relation, values));
+    target.setAttribute(AttributeImpl.fromMultipleValues(edge.relation, values));
     changedMetacards.put(id, target);
   }
 
@@ -161,14 +161,14 @@ public class Associated {
       Edge edge, Map<String, Metacard> metacards, Map<String, Metacard> changedMetacards) {
     String id = edge.parent.get(Metacard.ID).toString();
     Metacard target = changedMetacards.getOrDefault(id, metacards.get(id));
-    List<String> values =
+    ArrayList<String> values =
         Optional.of(target)
             .map(m -> m.getAttribute(edge.relation))
             .map(Attribute::getValues)
             .map(util::getStringList)
             .orElseGet(ArrayList::new);
     values.add(edge.child.get(Metacard.ID).toString());
-    target.setAttribute(new AttributeImpl(edge.relation, values));
+    target.setAttribute(AttributeImpl.fromMultipleValues(edge.relation, values));
     changedMetacards.put(id, target);
   }
 

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -338,7 +338,7 @@ public class EndpointUtilTest {
 
       if (attribute != null) {
         when(metacardMock.getAttribute(attribute))
-            .thenReturn(new AttributeImpl(attribute, new ArrayList<String>()));
+            .thenReturn(new AttributeImpl(attribute, Collections.emptyList()));
       }
       resultMockList.add(resultMock);
     }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/util/EndpointUtilTest.java
@@ -338,7 +338,7 @@ public class EndpointUtilTest {
 
       if (attribute != null) {
         when(metacardMock.getAttribute(attribute))
-            .thenReturn(new AttributeImpl(attribute, Collections.emptyList()));
+            .thenReturn(AttributeImpl.fromMultipleValues(attribute, new ArrayList<>()));
       }
       resultMockList.add(resultMock);
     }


### PR DESCRIPTION
#### What does this PR do?
Makes `AttributeImpl`'s multi-value constructor accept lists of any type that implements `Serializable`. This will allow developers to write code like the following:
```java
List<String> values = ...
Attribute attribute = new AttributeImpl("myAttribute", values);
```

#### Who is reviewing it? 
@leo-sakh 
@bennuttle 
@nsuvarna 
@aj-brooks 
@lavoywj 

#### Select relevant component teams: 
@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.
@rzwiefel 
@Lambeaux 

#### How should this be tested?
Full build.

#### What are the relevant tickets?
Fixes: #5542

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.