### PR TITLE
DDF-5549 Removing the upload icon in the list menu if uploads are not enabled

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-item/list-item.hbs
@@ -45,9 +45,11 @@
             <button class="list-edit is-button" title="Edits the list." data-help="Edits the list.">
                 <span class="fa fa-pencil"></span>
             </button>
-            <button class="list-add is-button" title="Add items to the list." data-help="Import or manually add new items to the list.">
-                <span class="fa fa-upload"></span>
-            </button>
+            {{#if uploadEnabled}}
+                <button class="list-add is-button" title="Add items to the list." data-help="Import or manually add new items to the list.">
+                    <span class="fa fa-upload"></span>
+                </button>
+            {{/if}}
             <button class="list-actions is-button" title="Shows a list of actions to take on the list." data-help="Shows a list of actions to take on the list.">
                 <span class="fa fa-ellipsis-v"></span>
             </button>

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/List.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/List.js
@@ -16,6 +16,7 @@ const Backbone = require('backbone')
 const Query = require('./Query')
 const cql = require('../cql.js')
 const Common = require('../Common.js')
+const properties = require('../properties')
 const _ = require('lodash')
 require('backbone-associations')
 
@@ -73,6 +74,7 @@ module.exports = Backbone.AssociatedModel.extend(
         'list.icon': 'folder',
         'list.bookmarks': [],
         query: undefined,
+        uploadEnabled: properties.isUploadEnabled(),
       }
     },
     relations: [


### PR DESCRIPTION
#### What does this PR do?
This PR removes the upload button from the List menu if `Search UI -> Configuration -> Catalog UI search -> Show Uploader` is checked.

This work was done by @mdang8 for the UC hackathon.

#### Who is reviewing it? 
@josephthweatt 
@mdang8 
@rfding

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann
@clockard

#### How should this be tested?
- Navigate to `Search UI -> Configuration -> Catalog UI search -> Show Uploader`
- Ensure the box is unchecked
- Navigate to `Intrigue -> Lists`
- Verify the upload icon is present
- Navigate to `Search UI -> Configuration -> Catalog UI search -> Show Uploader`
- Ensure the box is *checked*
- Navigate to `Intrigue -> Lists`
- Verify the upload icon is *not* present

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5549

#### Screenshots
List menu with button unchecked:
<img width="597" alt="Screen Shot 2019-11-04 at 3 52 44 PM" src="https://user-images.githubusercontent.com/19710619/68157902-91b16500-ff1c-11e9-81af-19662b614f2f.png">

List menu with button checked:
<img width="620" alt="Screen Shot 2019-11-04 at 3 53 25 PM" src="https://user-images.githubusercontent.com/19710619/68157934-a68df880-ff1c-11e9-9915-301b20a68332.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
