### PR TITLE
DDF-5554 password protected pptx files get ingested and removed in tmp

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/MetacardFactory.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/MetacardFactory.java
@@ -73,7 +73,7 @@ public class MetacardFactory {
       try (InputStream transformerStream =
           com.google.common.io.Files.asByteSource(tmpContentPath.toFile()).openStream()) {
         generatedMetacard = candidate.transform(transformerStream);
-      } catch (CatalogTransformerException | IOException e) {
+      } catch (RuntimeException | CatalogTransformerException | IOException e) {
         List<String> stackTraces = Arrays.asList(ExceptionUtils.getRootCauseStackTrace(e));
         stackTraceList.add(String.format("Transformer [%s] could not create metacard.", candidate));
         stackTraceList.addAll(stackTraces);

--- a/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/MetacardFactorySpec.groovy
+++ b/catalog/core/catalog-core-standardframework/src/test/groovy/ddf/catalog/impl/operations/MetacardFactorySpec.groovy
@@ -98,7 +98,6 @@ class MetacardFactorySpec extends Specification {
         metacardFactory.generateMetacard('application/xml-runtime-bad', 'idError', 'fileName', path)
 
         then:
-        !thrown(RuntimeException)
         thrown(MetacardCreationException)
     }
 

--- a/catalog/transformer/catalog-transformer-pptx/src/main/java/ddf/catalog/transformer/input/pptx/PptxInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-pptx/src/main/java/ddf/catalog/transformer/input/pptx/PptxInputTransformer.java
@@ -165,6 +165,8 @@ public class PptxInputTransformer implements InputTransformer {
         LOGGER.debug("Cannot transform old style (OLE2) ppt : id = {}", metacard.getId());
       }
 
+    } catch (NoClassDefFoundError e) {
+      LOGGER.warn("Cannot extract thumbnail: ", e);
     } finally {
       Thread.currentThread().setContextClassLoader(originalContextClassLoader);
     }


### PR DESCRIPTION
#### What does this PR do?
Allows Pptx files with password protection to be ingested by DDF. Also removes the temp file of the pptx file from **data/tmp**

#### Who is reviewing it? 
@aaronilovici 
@rfding 

#### Ask 2 committers to review/merge the PR and tag them here.
@brjeter
@clockard

#### How should this be tested?
1. Build this branch and start DDF
2. Create a password protected powerpoint: https://support.office.com/en-us/article/password-protection-for-presentations-in-powerpoint-33dfadad-f231-4bd1-8bf6-d15e1671da41
3. Ingest this powerpoint
4. Check that the powerpoint exists in the catalog, and that there is no temporary pptx file in the directory **data/tmp/**


#### What are the relevant tickets?
Fixes: #5554 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
