### PR TITLE
DDF-5561 crypter deletes file on stream close

### DIFF
--- a/platform/security/encryption/platform-security-encryption-crypter/src/main/java/ddf/security/encryption/crypter/Crypter.java
+++ b/platform/security/encryption/platform-security-encryption-crypter/src/main/java/ddf/security/encryption/crypter/Crypter.java
@@ -29,13 +29,13 @@ import com.google.crypto.tink.streamingaead.StreamingAeadFactory;
 import com.google.crypto.tink.streamingaead.StreamingAeadKeyTemplates;
 import ddf.security.SecurityConstants;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.security.AccessController;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedAction;
@@ -249,7 +249,8 @@ public class Crypter {
         availableBytes = getAvailableBytesLessThanChunkSize(plainInputStream);
       }
       encryptedOutputStream.close(); // need to close it here in order for it to flush
-      return new FileInputStream(tmpFile);
+      return Files.newInputStream(
+          Paths.get(tmpFile.getAbsolutePath()), StandardOpenOption.DELETE_ON_CLOSE);
     } catch (GeneralSecurityException | IOException e) {
       throw new CrypterException("Problem encrypting.", e);
     } finally {


### PR DESCRIPTION
#### What does this PR do?
**Crypter.encrypt()** returns a IOStream that deletes files on stream close.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@aaronilovici 
@bakejeyner 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@ahoffer 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. build DDF and go to the Search UI
2. Ingest a file in the search ui
3. Check the directory **data/tmp**, verify that there are no files starting with "encryption"



#### What are the relevant tickets?
Fixes: #5561 


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
