### PR TITLE
DDF-5575 Fixes goldenlayout pref saving

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/golden-layout/golden-layout.view.js
@@ -216,6 +216,9 @@ module.exports = Marionette.LayoutView.extend({
     })
   },
   updateSize() {
+    if (this.isDestroyed) {
+      return
+    }
     this.goldenLayout.updateSize()
   },
   showWidgetDropdown() {
@@ -284,6 +287,9 @@ module.exports = Marionette.LayoutView.extend({
       })
   },
   handleGoldenLayoutStateChange(event) {
+    if (this.isDestroyed) {
+      return
+    }
     this.detectIfGoldenLayoutMaximised()
     this.detectIfGoldenLayoutEmpty()
     //https://github.com/deepstreamIO/golden-layout/issues/253


### PR DESCRIPTION
#### What does this PR do?
 - If the view for the goldenlayout ends up being destroyed, it's still possible for the debounced handleStateChange function to be called.  If it is, we need to abort the call, otherwise the goldenlayout pref will be reset to have no visuals open, which can be very confusing.

#### How should this be tested?
Not sure if this is possible upstream honestly.  We don't destroy any golden-layout views.  

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5575 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
