### PR TITLE
[2.20.x] DDF-5455 Improve GML parsing performance

### DIFF
--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-handlebars/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-handlebars/pom.xml
@@ -195,7 +195,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.85</minimum>
+                                            <minimum>0.86</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-handlebars/src/main/java/org/codice/ddf/spatial/ogc/wfs/transformer/handlebars/HandlebarsWfsFeatureTransformer.java
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-handlebars/src/main/java/org/codice/ddf/spatial/ogc/wfs/transformer/handlebars/HandlebarsWfsFeatureTransformer.java
@@ -79,7 +79,6 @@ import org.codice.ddf.spatial.ogc.wfs.featuretransformer.WfsMetadata;
 import org.codice.ddf.transformer.xml.streaming.Gml3ToWkt;
 import org.codice.ddf.transformer.xml.streaming.impl.Gml3ToWktImpl;
 import org.codice.gsonsupport.GsonTypeAdapters.LongDoubleTypeAdapter;
-import org.geotools.xml.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
@@ -529,19 +528,16 @@ public class HandlebarsWfsFeatureTransformer implements FeatureTransformer<Featu
   }
 
   private String getWktFromGeometry(String geometry, String coordinateOrder) {
-    String wkt = getWktFromGml(geometry, new org.geotools.gml3.GMLConfiguration(), coordinateOrder);
+    String wkt = getWktFromGml(geometry, Gml3ToWktImpl.newGml3ToWkt(), coordinateOrder);
     if (StringUtils.isNotBlank(wkt)) {
       return wkt;
     }
     LOGGER.debug("Error converting gml to wkt using gml3 configuration. Trying gml2.");
-    return getWktFromGml(geometry, new org.geotools.gml2.GMLConfiguration(), coordinateOrder);
+    return getWktFromGml(geometry, Gml3ToWktImpl.newGml2ToWkt(), coordinateOrder);
   }
 
   private String getWktFromGml(
-      final String geometry,
-      final Configuration gmlConfiguration,
-      final String featureCoordinateOrder) {
-    final Gml3ToWkt gml3ToWkt = new Gml3ToWktImpl(gmlConfiguration);
+      final String geometry, final Gml3ToWkt gml3ToWkt, final String featureCoordinateOrder) {
     try (final InputStream gmlStream =
         new ByteArrayInputStream(geometry.getBytes(StandardCharsets.UTF_8))) {
       final Object gmlObject = gml3ToWkt.parseXml(gmlStream);
@@ -556,11 +552,7 @@ public class HandlebarsWfsFeatureTransformer implements FeatureTransformer<Featu
         return null;
       }
     } catch (Exception e) {
-      LOGGER.debug(
-          "Error converting gml to wkt using configuration {}. GML: {}.",
-          gmlConfiguration,
-          geometry,
-          e);
+      LOGGER.debug("Error converting GML '{}' to WKT.", geometry, e);
       return null;
     }
   }

--- a/catalog/transformer/catalog-transformer-streaming-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/transformer/catalog-transformer-streaming-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -74,14 +74,10 @@
     </cm:managed-service-factory>
 
 
-    <bean id="gml3Configuration" class="org.geotools.gml3.GMLConfiguration"/>
-    <bean id="gml3_2Configuration" class="org.geotools.gml3.v3_2.GMLConfiguration"/>
-    <bean id="gml3ToWkt" class="org.codice.ddf.transformer.xml.streaming.impl.Gml3ToWktImpl">
-        <argument ref="gml3Configuration"/>
-    </bean>
-    <bean id="gml3_2ToWkt" class="org.codice.ddf.transformer.xml.streaming.impl.Gml3ToWktImpl">
-        <argument ref="gml3_2Configuration"/>
-    </bean>
+    <bean id="gml3ToWkt" class="org.codice.ddf.transformer.xml.streaming.impl.Gml3ToWktImpl"
+        factory-method="newGml3ToWkt"/>
+    <bean id="gml3_2ToWkt" class="org.codice.ddf.transformer.xml.streaming.impl.Gml3ToWktImpl"
+        factory-method="newGml32ToWkt"/>
 
     <service id="Gml3ToWkt" ref="gml3ToWkt"
              interface="org.codice.ddf.transformer.xml.streaming.Gml3ToWkt">

--- a/catalog/transformer/catalog-transformer-streaming-impl/src/test/java/org/codice/ddf/transformer/xml/streaming/impl/Gml3ToWktImplTest.java
+++ b/catalog/transformer/catalog-transformer-streaming-impl/src/test/java/org/codice/ddf/transformer/xml/streaming/impl/Gml3ToWktImplTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import ddf.catalog.validation.ValidationException;
 import java.io.InputStream;
 import org.codice.ddf.transformer.xml.streaming.Gml3ToWkt;
-import org.geotools.gml3.GMLConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +42,7 @@ public class Gml3ToWktImplTest {
 
   @Before
   public void setUp() {
-    gtw = new Gml3ToWktImpl(new GMLConfiguration());
+    gtw = Gml3ToWktImpl.newGml3ToWkt();
   }
 
   @Test

--- a/catalog/transformer/catalog-transformer-streaming-impl/src/test/java/org/codice/ddf/transformer/xml/streaming/impl/XmlInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-streaming-impl/src/test/java/org/codice/ddf/transformer/xml/streaming/impl/XmlInputTransformerTest.java
@@ -44,7 +44,6 @@ import org.codice.ddf.transformer.xml.streaming.SaxEventHandler;
 import org.codice.ddf.transformer.xml.streaming.SaxEventHandlerFactory;
 import org.codice.ddf.transformer.xml.streaming.lib.SaxEventHandlerDelegate;
 import org.codice.ddf.transformer.xml.streaming.lib.XmlInputTransformer;
-import org.geotools.gml3.GMLConfiguration;
 import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.ErrorHandler;
@@ -57,7 +56,7 @@ public class XmlInputTransformerTest {
 
   static GmlHandler gmlHandler;
 
-  static Gml3ToWkt gml3ToWkt = new Gml3ToWktImpl(new GMLConfiguration());
+  static Gml3ToWkt gml3ToWkt = Gml3ToWktImpl.newGml3ToWkt();
 
   static SaxEventHandlerDelegate saxEventHandlerDelegate;
 


### PR DESCRIPTION
### Backport of #5456 

#### What does this PR do?
`Gml3ToWktImpl` now uses a `SAXParser` with GeoTools' `GMLParserDelegate` instead of GeoTools' `Parser` class. The `Parser` class creates a new `SAXParserFactory` on every parse() call which results in bad performance when batches of GML are parsed. Now, `Gml3ToWktImpl` creates a single `SAXParserFactory` and uses it to create `SAXParser`s (which is expected to be thread safe according to the JAXP 1.6 spec, section 4.14) which use GeoTools' `GMLParserDelegate` to handle the GML, so `Gml3ToWktImpl`'s functionality should remain unchanged.

As stated in the issue (#5455), the WFS 1.1.0 source is where this issue was discovered so I ran some JMeter load tests (100 requests, 5 concurrent users) against DDF's `/cql` endpoint with queries to a WFS 1.1.0 source with and without this change applied.

Test 1: a public WFS server (http://services.azgs.az.gov/ArcGIS/services/aasggeothermal/AZWellLogs/MapServer/WFSServer) with one full page of results (250).
**Before**
![WFSTestSlowAZ](https://user-images.githubusercontent.com/4495447/66672927-5b7e0f80-ec14-11e9-98ab-7cc1b09cf01a.jpg)
**After**
![WFSTestFastAZ](https://user-images.githubusercontent.com/4495447/66673084-b31c7b00-ec14-11e9-945f-9e6ec4b51709.jpg)

Test 2: a local GeoServer instance with 90 results.
**Before**
![WfsTestSlowGeoServer](https://user-images.githubusercontent.com/4495447/66673263-0bec1380-ec15-11e9-9bd1-7442b38bdff1.jpg)
**After**
![WfsTestFastGeoServer](https://user-images.githubusercontent.com/4495447/66673275-10b0c780-ec15-11e9-91bb-aff286eef51d.jpg)

I tried some JMH benchmarks and they didn't show a significant performance increase, but I believe that's due to the different classloaders used in the OSGi environment and the test environment.

#### Who is reviewing it? 
@lavoywj 
@leo-sakh 
@bennuttle 

#### Select relevant component teams: 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@lambeaux
@bdeining 

#### How should this be tested?
1. In the Admin UI, open the Spatial app.
2. Click `WFS Feature to Metacard Templated Mapping`.
a. For `Feature Type`, enter `{http://stategeothermaldata.org/uri-gin/aasg/xmlschema/welllog/0.8}AZWellLogs`.
b. For `Attribute Mappings`, enter `{"attributeName":"location","featureName":"Shape","template":"{{Shape}}"}`
c. Click `Save changes`.
3. On the Sources tab, create a WFS 1.1.0 source with the URL http://services.azgs.az.gov/ArcGIS/services/aasggeothermal/AZWellLogs/MapServer/WFSServer (leave everything else as-is).
4. Open Intrigue and run a * query against the source. Verify the results show up on the map in Arizona. The shapes should be points.
5. Set up a local GeoServer instance:
a. Download [GeoServer](http://geoserver.org/).
b. Unzip it and run `java -jar start.jar`.
c. Follow the instructions [here](https://docs.geoserver.org/latest/en/user/gettingstarted/shapefile-quickstart/index.html) to set up GeoServer with some sample data.
i. Don't use `nyc_roads` as your data source (skip the `Data preparation` step).
ii. In the `Create a store` step, use `<geoserver_install_location>/data_dir/data/nyc/poly_landmarks.shp` as the shapefile location. You can also name the data store something other than 'NYC Roads' but it doesn't really matter.
6. Open the Admin UI and create another `WFS Feature to Metacard Templated Mapping`:
a. For `Feature Type`, enter `{http://geoserver.org/nyc}poly_landmarks`.
b. For `Attribute Mappings`, enter `{"attributeName":"location","featureName":"the_geom","template":"{{the_geom}}"}`.
c. Click `Save changes`.
7. Create another WFS 1.1.0 source with the URL http://localhost:8080/geoserver/ows
a. Set `Coordinate Order` to `Lon/Lat` and leave everything else as-is.
8. Open Intrigue and run a * query against the source. Verify the results show up on the map around New York City. The shapes in this result should be more complex (e.g. polygons, multipolygons).
9. Compare the query performance against the master branch. Build DDF master and run the same setup steps above. Disable Web Sockets in the Search UI configuration on both instances so you can see the `/cql` requests in your browser's network tools. Compare the response times for queries against both WFS sources and verify that they are significantly faster with this change.

#### What are the relevant tickets?
Fixes: #5455 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.