### PR TITLE
[DDF-5567][DDF-5526] Notifications specify the source they query; results are selectable.  

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/CqlRequest.java
@@ -79,6 +79,16 @@ public class CqlRequest {
 
   private Boolean phonetics;
 
+  public String getCacheId() {
+    return cacheId;
+  }
+
+  public void setCacheId(String cacheId) {
+    this.cacheId = cacheId;
+  }
+
+  private String cacheId;
+
   private List<Sort> sorts = Collections.emptyList();
 
   private Set<String> facets = Collections.emptySet();
@@ -266,6 +276,10 @@ public class CqlRequest {
 
     if (phonetics != null) {
       queryRequest.getProperties().put("phonetics", phonetics);
+    }
+
+    if (cacheId != null) {
+      queryRequest.getProperties().put("cacheId", cacheId);
     }
 
     return queryRequest;

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
@@ -316,6 +316,11 @@ public class UserApplication implements SparkApplication {
     } else {
       item.addProperty("metacardIds", Collections.emptySet());
     }
+    if (alert.containsKey("src")) {
+      item.addProperty("src", ImmutableSet.copyOf((List<String>) alert.get("src")));
+    } else {
+      item.addProperty("src", Collections.emptySet());
+    }
     try {
       persistentStore.add(PersistenceType.NOTIFICATION_TYPE.toString(), item);
     } catch (PersistenceException e) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
@@ -99,7 +99,13 @@ module.exports = new (Backbone.AssociatedModel.extend({
                 property: '"id"',
               }),
           }),
-          federation: 'enterprise',
+          federation:
+            alert.get('src') && alert.get('src').length > 0
+              ? 'selected'
+              : 'enterprise',
+          src: alert.get('src'),
+          cacheId: alertId,
+          id: alert.get('queryId'),
         })
         if (this.get('currentQuery')) {
           this.get('currentQuery').cancelCurrentSearches()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert/alert.js
@@ -158,6 +158,9 @@ module.exports = new (Backbone.AssociatedModel.extend({
   addSelectedResult(metacard) {
     this.getSelectedResults().add(metacard)
   },
+  setSelectedResults(metacards) {
+    this.set('selectedResults', metacards)
+  },
   removeSelectedResult(metacard) {
     this.getSelectedResults().remove(metacard)
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -271,7 +271,8 @@ Query.Model = PartialAssociatedModel.extend({
       'sorts',
       'id',
       'spellcheck',
-      'phonetics'
+      'phonetics',
+      'cacheId'
     )
   },
   isOutdated() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/multi-select-actions/container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/multi-select-actions/container.tsx
@@ -49,7 +49,12 @@ class MultiSelectActions extends React.Component<Props, State> {
   }
 
   render() {
-    return <MultiSelectActionsPresentation isDisabled={this.state.isDisabled} />
+    return (
+      <MultiSelectActionsPresentation
+        selectionInterface={this.props.selectionInterface}
+        isDisabled={this.state.isDisabled}
+      />
+    )
   }
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/multi-select-actions/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/multi-select-actions/presentation.tsx
@@ -21,6 +21,7 @@ import ExtensionPoints from '../../extension-points'
 
 type Props = {
   isDisabled: boolean
+  selectionInterface: any
 }
 
 const Root = styled.div`


### PR DESCRIPTION
#### What does this PR do?

Queries will only be created for sources that notifications specify. If no sources are specified, an enterprise query will be performed as before. Additionally, the notification Id itself is attached to these queries to help identify how they were generated.

Also,
We pass the selection interface as a prop to the multi select component, so it can access whatever the current selection interface is in a given environment. The ability to select all alert results is also added.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 

@codice/ui 


#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@jrnorth



#### How should this be tested?
Ingest some data, and schedule a query. In the network request tab, a query should be generated for each available source, and the notification Id should be attached as the cacheId. Use the top checkbox to select all results, and verify that each of them have a checkmark added to them. 

#### Any background context you want to provide?
https://github.com/codice/ddf/pull/5568
https://github.com/codice/ddf/pull/5527

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
