### PR TITLE
DDF-2824 cleaned up stray backticks in documentation

### DIFF
--- a/distribution/docs/src/main/resources/content/_architectures/_migrationApi/migration-api.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_migrationApi/migration-api.adoc
@@ -232,15 +232,15 @@ The `errors()` method provides access to all recorded error messages so far. +
 The `warnings()` method provides access to all recorded warning messages so far. +
 The `infos()` method provides access to all recorded informational messages so far. +
 The `wasSuccessful()` method provides a quick check to see if the report is successful. A successful report might have warnings recorded but cannot have errors recorded. +
-The `wasSuccessful(Runnable code) method allows code to be executed. It will return true if no new errors are recorded as a result of executing the provided code. +
-The `wasIOSuccessful(ThrowingRunnable<IOException> code) method allows code to be executed which can throw I/O exceptions which are automatically recorded as errors. It will return true if no new errors are recorded as a result of executing the provided code. +
+The `wasSuccessful(Runnable code)` method allows code to be executed. It will return true if no new errors are recorded as a result of executing the provided code. +
+The `wasIOSuccessful(ThrowingRunnable<IOException> code)` method allows code to be executed which can throw I/O exceptions which are automatically recorded as errors. It will return true if no new errors are recorded as a result of executing the provided code. +
 The `hasInfos()` method will return true if at least one information message has been recorded so far. +
 The `hasWarnings()` method will return true if at least one warning message has been recorded so far. +
 The `hasErrors()` method will return true if at least one error message has been recorded so far. +
-The `verifyCompletion() method will verify if the report is successful and if not, it will throw back the first recorded exception and attach as suppressed exceptions all other recorded exceptions.
+The `verifyCompletion()` method will verify if the report is successful and if not, it will throw back the first recorded exception and attach as suppressed exceptions all other recorded exceptions.
 
 ==== `MigrationMessage`
-The `org.codice.ddf.migration.MigrationException is defined as a base class for all recordable messages during migration operations. It defines the following methods:
+The `org.codice.ddf.migration.MigrationException` is defined as a base class for all recordable messages during migration operations. It defines the following methods:
 
 - `String getMessage()`
 

--- a/distribution/docs/src/main/resources/content/_architectures/_resources/retrieving-resources-options.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_resources/retrieving-resources-options.adoc
@@ -18,7 +18,7 @@ properties.put("RESOURCE_OPTION", "OptionA");
 ResourceRequestById resourceRequest = new ResourceRequestById("0123456789abcdef0123456789abcdef", properties);
 ----
 
-Depending on the support that the `ResourceReader` or `Source` provides for options, the `properties``Map` will be checked for the `RESOURCE_OPTION` entry. 
+Depending on the support that the `ResourceReader` or `Source` provides for options, the `properties` `Map` will be checked for the `RESOURCE_OPTION` entry. 
 If that entry is found, the option will be handled. 
 If the `ResourceReader` or `Source` does not support options, that entry will be ignored.
 

--- a/distribution/docs/src/main/resources/content/_architectures/_resources/retrieving-resources.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_resources/retrieving-resources.adoc
@@ -6,7 +6,7 @@
 :summary: Retrieving Resources.
 
 When a client attempts to retrieve a resource, it must provide a metacard ID or URI corresponding to a unique resource. 
-As mentioned above, the resource URI is obtained from a `Metacard`'s `getResourceUri` method. 
+As mentioned above, the resource URI is obtained from a ``Metacard``'s `getResourceUri` method. 
 The `CatalogFramework` has three methods that can be used by clients to obtain a resource: `getEnterpriseResource`, `getResource`, and `getLocalResource`.
 The `getEnterpriseResource` method invokes the `retrieveResource` method on a local `ResourceReader` as well as all the `Federated` and `Connected` Sources inthe ${branding} enterprise. 
 The second method, `getResource`, takes in a source ID as a parameter and only invokes `retrieveResource` on the specified `Source`. 
@@ -33,16 +33,16 @@ Resource resource = resourceResponse.getResource(); //actual Resource object con
 `${ddf-branding}.catalog.resource.ResourceReader` instances can be discovered via the OSGi Service Registry.
 The system can contain multiple `ResourceReaders`. 
 The `CatalogFramework` determines which one to call based on the scheme of the resource's URI and what schemes the `ResourceReader` supports. 
-The supported schemes are obtained by a `ResourceReader`'s `getSupportedSchemes` method. 
+The supported schemes are obtained by a ``ResourceReader``'s `getSupportedSchemes` method. 
 As an example, one `ResourceReader` may know how to handle file-based URIs with the scheme `file`, whereas another `ResourceReader` may support HTTP-based URIs with the scheme `http`.
 
 The `ResourceReader` or `Source` is responsible for locating the resource, reading its bytes, adding the binary data to a `Resource` implementation, then returning that `Resource` in a `ResourceResponse`. 
-The `ResourceReader` or `Source` is also responsible for determining the `Resource`'s name and mime type, which it sends back in the `Resource` implementation.
+The `ResourceReader` or `Source` is also responsible for determining the ``Resource``'s name and mime type, which it sends back in the `Resource` implementation.
 
 ===== BinaryContent
 
 `BinaryContent` is an object used as a container to store translated or transformed ${branding} components. 
-`Resource` extends `BinaryContent` and includes a `getName` method.  `
-BinaryContent` has methods to get the `InputStream`, `byte` array, MIME type, and size of the represented binary data.
+`Resource` extends `BinaryContent` and includes a `getName` method. 
+`BinaryContent` has methods to get the `InputStream`, `byte` array, MIME type, and size of the represented binary data.
 An implementation of `BinaryContent` (`BinaryContentImpl`) can be found in the Catalog API in the `${ddf-branding}.catalog.data` package.
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-catalog-frameworks.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-catalog-frameworks.adoc
@@ -88,7 +88,7 @@ public ResourceResponse getEnterpriseResource(ResourceRequest request) throwsIOE
 public ResourceResponse getLocalResource(ResourceRequest request) throws IOException, ResourceNotFoundException, ResourceNotSupportedException;
 public ResourceResponse getResource(ResourceRequest request, String resourceSiteName) throws IOException, ResourceNotFoundException, ResourceNotSupportedException;
 ----
-Resource requests process `PreResourcePlugin`s before execution and `PostResourcePlugin`s after execution.
+Resource requests process ``PreResourcePlugin``s before execution and ``PostResourcePlugin``s after execution.
 
 ====== Source Methods
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-filters.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-filters.adoc
@@ -218,7 +218,7 @@ GeoTools 8 includes implementations of the `FilterVisitor` interface.
 The `DefaultFilterVisitor`, as an example, provides only business logic to visit every node in the `Filter` tree.
 The `DefaultFilterVisitor` methods are meant to be overwritten with the correct business logic. 
 The simplest approach when using `FilterVisitor` instances is to build the appropriate query syntax for a target language as each part of the `Filter` is visited.
-For instance, when given an incoming `Filter` object to be evaluated against a RDBMS, a `CatalogProvider instance could use a `FilterVisitor` to interpret each filter operation on the `Filter` object and translate those operations into SQL.
+For instance, when given an incoming `Filter` object to be evaluated against a RDBMS, a `CatalogProvider` instance could use a `FilterVisitor` to interpret each filter operation on the `Filter` object and translate those operations into SQL.
 The `FilterVisitor` may be needed to support `Filter` functionality not currently handled by the `FilterAdapter` and `FilterDelegate` reference implementation.
 
 ===== Interpreting a Filter to Create SQL
@@ -284,12 +284,12 @@ ft:query(//inventory:book/@subject,'science').
 . `FilterAdapter` visits the `OR` filter first.
 . `OR` filter visits its children in a loop. 
 . The first child in the loop that is encountered is the LHS `PropertyIsLike`.
-. The `FilterAdapter` will call the `FilterDelegate` `PropertyIsLike`method with the LHS property and literal.
+. The `FilterAdapter` will call the `FilterDelegate` `PropertyIsLike` method with the LHS property and literal.
 . The LHS `PropertyIsLike` delegate method builds the XQuery syntax that makes sense for this particular underlying object store. In this case, the _subject_ property is specific to this XML database, and the business logic maps the _subject_ property to its index at `//inventory:book/@subject` Note that `ft:query` in this instance is a custom XQuery module for this specific XML database that does full text searches.
 . The `FilterAdapter` then moves back to the `OR` filter, which visits its second child.
 . The `FilterAdapter` will call the `FilterDelegate` `PropertyIsLike` method with the RHS property and literal.
 . The RHS `PropertyIsLike` delegate method builds the XQuery syntax that makes sense for this particular underlying object store. In this case, the _subject_ property is specific to this XML database, and the business logic maps the _subject_ property to its index at `//inventory:book/@subject` Note that `ft:query` in this instance is a custom XQuery module for this specific XML database that does full text searches.
-. The `FilterAdapter` then moves back to its `OR Filter which is now done with its children.
+. The `FilterAdapter` then moves back to its `OR` Filter which is now done with its children.
 . It then collects the output of each child and sends the list of results to the `FilterDelegate OR` method.
 . The final result object will be returned from the `FilterAdapter` adapt method.
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-plugins.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-plugins.adoc
@@ -216,7 +216,7 @@ StopProcessingException;`
 Develop a custom Pre-Subscription Plugin.
 
 . Create a Java class that implements `PreSubscriptionPlugin`. +
-`public class SamplePreSubscriptionPlugin *implements* ddf.catalog.plugin.PreSubscriptionPlugin
+`public class SamplePreSubscriptionPlugin *implements* ddf.catalog.plugin.PreSubscriptionPlugin`
 
 . Implement the required method.
  * `public Subscription process(Subscription input) *throws* PluginExecutionException, StopProcessingException;`

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-query-options.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-query-options.adoc
@@ -68,7 +68,7 @@ A developer should consult a Source's documentation for the limitations, capabil
 
 ==== Commons-DDF Utilities
 
-The `commons-${ddf-branding}`bundle provides utilities and functionality commonly used across other ${branding} components, such as the endpoints and providers. 
+The `commons-${ddf-branding}` bundle provides utilities and functionality commonly used across other ${branding} components, such as the endpoints and providers. 
 
 ===== FuzzyFunction
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-registry-clients.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-registry-clients.adoc
@@ -6,7 +6,7 @@
 :summary: Creating a custom Registry Client.
 
 Registry Clients create Federated Sources using the OSGi Configuration Admin.
-Developers should reference an individual `Source`'s (Federated, Connected, or Catalog Provider) documentation for the Configuration properties (such as a Factory PID, addresses, intervals, etc) necessary to establish that `Source` in the framework. 
+Developers should reference an individual ``Source``'s (Federated, Connected, or Catalog Provider) documentation for the Configuration properties (such as a Factory PID, addresses, intervals, etc) necessary to establish that `Source` in the framework. 
 
 .Creating a Source Configuration
 [source,java,linenums]

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-sources.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-sources.adoc
@@ -50,8 +50,8 @@ Catalog Provider:: `ddf.catalog.source.CatalogProvider` _is used to communicate 
 Federated Source:: `ddf.catalog.source.FederatedSource` _is used to communicate with remote systems and only allows query operations._
 Connected Source:: `ddf.catalog.source.ConnectedSource` _is similar to a Federated Source with the following exceptions:_
 * _Queried on all local queries_
-* _`SiteName` is hidden (masked with the ${branding} sourceId) in query results_
-* _`SiteService` does not show this Source's information separate from ${branding}'s._
+* ``SiteName`` _is hidden (masked with the ${branding} sourceId) in query results_
+* ``SiteService`` _does not show this Source's information separate from ${branding}'s._
 Catalog Store:: `catalog.store.interface` _is used to store data._
 
 The procedure for implementing any of the source types follows a similar format:

--- a/distribution/docs/src/main/resources/content/_integrating/_endpoints/catalog-rest-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_endpoints/catalog-rest-endpoint.adoc
@@ -318,14 +318,14 @@ https://<FQDN>:<PORT>//sources/
 ----
 
 .Sources Error Responses
-[cols="2,2,3" options="header"]
+[cols="2,2m,3" options="header"]
 |===
 |Status Code
 |Error Message
 |Possible Causes
 
 |403
-a|<p>Problem accessing /ErrorServlet. Reason: <pre>    Forbidden</pre></p>`
+a|<p>Problem accessing /ErrorServlet. Reason: <pre>Forbidden</pre></p>
 |Connection error or service unavailable.
 
 |===

--- a/distribution/docs/src/main/resources/content/_integrating/_endpoints/csw-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_endpoints/csw-endpoint.adoc
@@ -373,7 +373,7 @@ To receive a response to a `GetRecords` query that conforms to the GMD specifica
 
 .Querying by UTM Coordinates
 UTM coordinates can be used when making a CSW GetRecords request using an `ogc:Filter`.
-UTM coordinates should use `EPSG:326XX`as the `srsName` where `XX` is the zone within the northern hemisphere.
+UTM coordinates should use `EPSG:326XX` as the `srsName` where `XX` is the zone within the northern hemisphere.
 UTM coordinates should use `EPSG:327XX` as the `srsName` where `XX` is the zone within the southern hemisphere.
 
 [NOTE]
@@ -1279,17 +1279,17 @@ The constraint can be either an OGC or CQL filter.
 ----
 
 .Delete Error Response Examples
-[cols="2,2,3" options="header"]
+[cols="2m,2,3" options="header"]
 |===
 |Status Code
 |Error Message
 |Possible Causes
 
-|`200 OK`
+|200 OK
 |`<csw:totalDeleted>0</csw:totalDeleted>`
 |No records matched filter criteria. Verify metacard ID.
 
-|`400 Bad Request
+|400 Bad Request
 |`<ows:Exception>` with details of error.
 |XML or CSW formatting error. Verify request.
 

--- a/distribution/docs/src/main/resources/content/_integrating/_endpoints/opensearch-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_endpoints/opensearch-endpoint.adoc
@@ -91,23 +91,23 @@ https://<FQDN>:<PORT>/services/catalog/query?q='cat OR dog'
 Queries can also specify a start and end time to narrow results.
 
 .OpenSearch Temporal Parameters
-[cols="4*", options="header"]
+[cols="1m,1m,2,2", options="header"]
 |===
 |OpenSearch Element
 |HTTPS Parameter
 |Possible Values
 |Comments
 
-|`start`
-|`dtstart`
-|RFC-3399-defined value:`YYYY-MM-DDTHH:mm:ssZ` or `yyyy-MM-dd'T'HH:mm:ss.SSSZZ`
+|start
+|dtstart
+|RFC-3399-defined value: `YYYY-MM-DDTHH:mm:ssZ` or `yyyy-MM-dd'T'HH:mm:ss.SSSZZ`
 |Specifies the beginning of the time slice of the search.
 
 Default value of "1970-01-01T00:00:00Z" is used when `dtend` is specified but `dtstart` is not specified.
 
-|`end`
-|`dtend`
-|RFC-3399-defined value:`YYYY-MM-DDTHH:mm:ssZ` or `yyyy-MM-dd'T'HH:mm:ss.SSSZZ`
+|end
+|dtend
+|RFC-3399-defined value: `YYYY-MM-DDTHH:mm:ssZ` or `yyyy-MM-dd'T'HH:mm:ss.SSSZZ`
 |Specifies the ending of the time slice of the search
 
 Current GMT date/time is used when `dtstart` is specified but `dtend` is not specified.
@@ -252,7 +252,7 @@ default: `300000` (5 minutes)
 
 |`selector`
 |`selector`
-|Comma-delimited list of XPath string selectors (e.g. `//namespace:example`, //example`)
+|Comma-delimited list of XPath string selectors (e.g. `//namespace:example`, `//example`)
 |Selectors to narrow the query.
 
 |===

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/hardening-solr.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/hardening-solr.adoc
@@ -73,7 +73,7 @@ command line utility `curl` to change the password from `admin` to `newpassword`
 +
 . Encrypt the password using the <<{integrating-prefix}encrypting_passwords,Encryption Service>>.
 The encryption command enciphers the password. It is safe to save the peristed password in a file.
-. Update property `solr.password` in the file ${home_directory}/etc/custom.system.properties` to
+. Update property `solr.password` in the file `${home_directory}/etc/custom.system.properties` to
 be the ouput from the encryption command. Be sure to include `ENC(` and `)` characters produced by
 the encryption comand. Note that the default password is not enclosed in `ENC()` because that
 is not necessary for cleartext. Cleartext is used by the system exactly as it appears.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/map-configuration-intrigue.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/map-configuration-intrigue.adoc
@@ -20,7 +20,7 @@ Equivalent addition and deletion of a map layer can be found in <<{managing-pref
 .. Example Imagery Provider Syntax: `{"type": "OSM", "url" "http://a.tile.openstreetmaps.org" "layers" ["layer1" "layer2"] "parameters" {"FORMAT" "image/png" "VERSION" "1.1.1"} "alpha" 0.5}`.
 ... "type": format of imagery provider.
 ... "url": location of server hosting the imagery provider.
-... "layers": names of individual layers. (enclose list in square brackets`[ ]`).
+... "layers": names of individual layers. (enclose list in square brackets `[ ]`).
 ... "parameters": (enclose in braces `{}`)
 .... "FORMAT": image type used by imagery provider.
 .... "VERSION": version of imagery provider to use.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/setting-internal-policies.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/setting-internal-policies.adoc
@@ -12,7 +12,7 @@
 . Click the *Configuration* tab.
 . Click on the *Security AuthZ Realm* configuration.
 . Add any attribute mappings necessary to map between subject attributes and the attributes to be asserted.
-.. For example, the above example would require two Match All mappings of `subjectAttribute1=assertedAttribute1` and `subjectAttribute2=assertedAttribute2``
+.. For example, the above example would require two Match All mappings of `subjectAttribute1=assertedAttribute1` and `subjectAttribute2=assertedAttribute2`
 .. Match One mappings would contain `subjectAttribute3=assertedAttribute3` and `subjectAttribute4=assertedAttribute4`.
 
 With the `security-pdp-authz` feature configured in this way, the above Metacard would be displayed to the user.

--- a/distribution/docs/src/main/resources/content/_managing/_securing/managing-crl.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_securing/managing-crl.adoc
@@ -81,7 +81,7 @@ The PKIHandler implements CRL revocation, so any web context that is configured 
 
 . After enabling revocation (see above), open the *Web Context Policy Manager*.
 . Add or modify a Web Context to use PKI in authentication. For example, enabling CRL for the search ui endpoint would require adding an authorization policy of `/search=PKI`
-. If guest access is also required, check the 'Allow Guest Access` box in the policy.
+. If guest access is also required, check the `Allow Guest Access` box in the policy.
 
 With guest access, a user with a revoked certificate will be given a 401 error, but users without a certificate will be able to access the web context as the guest user.
 


### PR DESCRIPTION
#### What does this PR do?

Backticks are used to monospace and set off terms in the documentation. These changes clear up typos or misapplications of monospace formatting. 

#### Select relevant component teams: 
@codice/docs 

#### Ask 2 committers to review/merge the PR and tag them here.
@ahoffer
@brjeter
@clockard
@lessarderic
@mcalcote
@ricklarsen - Documentation

#### How should this be tested?

build page and search for '`' in rendered html docs

#### What are the relevant tickets?

ddf-2824


#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
