### PR TITLE
DDF-5606 Standardized references to 'resources' in documentation

### DIFF
--- a/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-api.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-api.adoc
@@ -83,7 +83,6 @@ If no sort policy is defined for a particular search, the temporal policy will a
 
 The ${branding} is used to catalog resources.
 A Resource is a URI-addressable entity that is represented by a Metacard.
-Resources may also be known as products or data.
 Resources may exist either locally or on a remote data store.
 
 .Examples of Resources
@@ -101,30 +100,16 @@ Resources may exist either locally or on a remote data store.
 * ${branding} REST
 
 The Query Service Endpoint, the Catalog Framework, and the `CatalogProvider` are key
-components for processing a retrieve product request.
-The Endpoint bundle contains a Web service that exposes the interface to retrieve products, also referred to as Resources.
+components for processing a retrieve resource request.
+The Endpoint bundle contains a Web service that exposes the interface to retrieve resources.
 The Endpoint calls the `CatalogFramework` to execute the operations of its specification.
-The `CatalogFramework` relies on the Sources to execute the actual product retrieval.
-Optional PreResource and PostResource Catalog Plugins may be invoked by the `CatalogFramework` to modify the product retrieval request/response prior to the Catalog Provider processing the request and providing the response.
-It is possible to retrieve products from specific remote Sources by specifying the site name(s) in the request.
+The `CatalogFramework` relies on the Sources to execute the actual resource retrieval.
+Optional `PreResource` and `PostResource` Catalog Plugins may be invoked by the `CatalogFramework` to modify the resource retrieval request/response prior to the Catalog Provider processing the request and providing the response.
+It is possible to retrieve resources from specific remote Sources by specifying the site name(s) in the request.
 
 .Product Caching
-[NOTE]
-====
-Existing ${branding} clients are able to leverage product caching due to the product cache being implemented in the ${branding}.
-Enabling the product cache is an administrator function.
-
 Product Caching is enabled by default.
-====
-
-To configure product caching:
-
-. Navigate to the *${admin-console}*.
-. Select ${ddf-catalog}.
-. Select *Configuration*.
-. Select *Resource Download Settings*.
-
-See <<{reference-prefix}ddf.catalog.resource.download.ReliableResourceDownloadManager,Resource Download Settings configurations>> for all possible configurations.
+Existing ${branding} clients are able to leverage product caching due to the product cache being implemented in the ${branding}.
 
 .Product Retrieval Request
 [ditaa,product_retrieval_request,png]
@@ -165,11 +150,11 @@ See <<{reference-prefix}ddf.catalog.resource.download.ReliableResourceDownloadMa
 
 ===== Notifications and Activities
 
-${branding} can send/receive notifications of "Activities" occuring in the system.
+${branding} can send/receive notifications of "Activities" occurring in the system.
 
 ====== Notifications
 
-Currently, the notifications provide information about product retrieval only.
+Currently, the notifications provide information about resource retrieval only.
 
 ====== Activities
 

--- a/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-framework-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-framework-intro.adoc
@@ -165,8 +165,8 @@ It is possible to have only remote Sources configured and no local `CatalogProvi
 
 ===== Product Retrieval
 
-The Query Service Endpoint, the Catalog Framework, and the `CatalogProvider` are key components for processing a retrieve product request.
-The Endpoint bundle contains a Web service that exposes the interface to retrieve products, also referred to as Resources.
+The Query Service Endpoint, the Catalog Framework, and the `CatalogProvider` are key components for processing a resource retrieval request.
+The Endpoint bundle contains a Web service that exposes the interface to retrieve resources.
 The Endpoint calls the `CatalogFramework` to execute the operations of its specification.
 The `CatalogFramework` relies on the Sources to execute the actual product retrieval.
 Optional `PreResource` and `PostResource` Catalog Plugins may be invoked by the `CatalogFramework` to modify the product retrieval request/response prior to the Catalog Provider processing the request and providing the response. 

--- a/distribution/docs/src/main/resources/content/_architectures/_data/data-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_data/data-intro.adoc
@@ -38,7 +38,7 @@ A `Metacard` is a container for metadata. 
 === Metacards
 
 A metacard is a single instance of metadata in the Catalog (an instance of a metacard type) which
-generally contains general information about the product, such as the title of the product, the product's geo-location, the date the product was created and/or modified, the owner or producer, and/or the security classification. 
+generally contains general information about the resource, such as the title of the resource, the resource's geo-location, the date the resource was created and/or modified, the owner or producer, and/or the security classification. 
 
 ==== Metacard Type
 

--- a/distribution/docs/src/main/resources/content/_architectures/_plugins/filter-plugin.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_plugins/filter-plugin.adoc
@@ -17,7 +17,7 @@ The PDP that is being used returns a decision, and the metacard will either be f
 How a metacard gets filtered is left up to any number of FilterStrategy implementations that might be installed.
 Each FilterStrategy will return a result to the filter plugin that says whether or not it was able to process the metacard, along with the metacard or response itself.
 This allows a metacard or entire response to be partially filtered to allow some data to pass back to the requester.
-This could also include filtering any products sent back to a requester.
+This could also include filtering any resources sent back to a requester.
 
 The security attributes populated on the metacard are completely dependent on the type of the metacard.
 Each type of metacard must have its own `PolicyPlugin` that reads the metadata being returned and then returns the appropriate attributes.

--- a/distribution/docs/src/main/resources/content/_architectures/_plugins/metacard-resource-size-plugin.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_plugins/metacard-resource-size-plugin.adoc
@@ -5,7 +5,7 @@
 :plugintypes: postquery
 :summary: Updates the resource size attribute of a metacard.
 
-This post-query plugin updates the resource size attribute of each metacard in the query results if there is a cached file for the product and it has a size greater than zero; otherwise, the resource size is unmodified and the original result is returned.
+This post-query plugin updates the resource size attribute of each metacard in the query results if there is a cached file for the resource and it has a size greater than zero; otherwise, the resource size is unmodified and the original result is returned.
 
 Use this post-query plugin as a convenience to return query results with accurate resource sizes for cached products. 
 

--- a/distribution/docs/src/main/resources/content/_architectures/_plugins/metacard-validity-marker.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_plugins/metacard-validity-marker.adoc
@@ -11,7 +11,7 @@ The plugin runs each metacard in the `CreateRequest` and `UpdateRequest` against
 
 [NOTE]
 ====
-This plugin can make it seem like ingested products are not successfully ingested if a user does not have permissions to access invalid metacards.
+This plugin can make it seem like ingested resources are not successfully ingested if a user does not have permissions to access invalid metacards.
 If an ingest did not fail, there are no errors in the ingest log, but the expected results do not show up after a query,
 verify either that the ingested data is valid or that the <<_metacard_validity_filter_plugin,Metacard Validity Filter Plugin>> is configured to show warnings and/or errors.
 ====

--- a/distribution/docs/src/main/resources/content/_architectures/_resources/resource-components-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_resources/resource-components-intro.adoc
@@ -9,7 +9,6 @@
 Resource components are used when working with resources
 
 A resource is a URI-addressable entity that is represented by a metacard.
-Resources may also be known as *products* or *data*.
 
 Resources may exist either locally or on a remote data store.
 

--- a/distribution/docs/src/main/resources/content/_architectures/_resources/resource-writers-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_resources/resource-writers-intro.adoc
@@ -6,10 +6,10 @@
 :order: 03
 :summary: Resource Writers.
 
-A resource writer stores a resource and produces a URI that can be used to retrieve the resource at a later time.
+A resource writer stores a resource and produces a URI that can be used for retrieval.
 The resource URI uniquely locates and identifies the resource.
 Resource writers can interact with an underlying data store and store the resource in the proper place.
 Each implementation can do this differently, providing flexibility in the data stores used to persist the resources.
 
-Resource Writers should be used within the Content Framework if and when implementing a custom Storage Provider to store the product.
-The default Storage Provider that comes with the ${branding} writes the products to the file system.
+Resource Writers should be used within the Content Framework if and when implementing a custom Storage Provider to store data.
+The default Storage Provider that comes with the ${branding} writes the resources to the file system.

--- a/distribution/docs/src/main/resources/content/_architectures/_resources/url-resource-reader.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_resources/url-resource-reader.adoc
@@ -11,9 +11,9 @@ The `URLResourceReader` will connect to the provided Resource URL and read the
 
 [WARNING]
 ====
-When a resource linked using a file-based URL is in the product cache, the `URLResourceReader`&#8217;s rootResourceDirectories is not checked when downloading the product.
+When a resource linked using a file-based URL is in the product cache, the ``URLResourceReader``'s `rootResourceDirectories` is not checked when downloading.
 It is downloaded from the product cache which bypasses the `URLResourceReader`.
-For example, if path `/my/valid/path` is configured in the `URLResourceReader`&#8217;s rootResourceDirectories and one downloads the product with resource-uri `file:///my/valid/path/product.txt` and then one removes `/my/valid/path` from the `URLResourceReader`&#8217;s `rootResourceDirectories` configuration, the product will still be accessible via the product cache.
+For example, if path `/my/valid/path` is configured in the ``URLResourceReader``'s `rootResourceDirectories` and one downloads the product with resource-uri `file:///my/valid/path/product.txt` and then one removes `/my/valid/path` from the ``URLResourceReader``'s `rootResourceDirectories` configuration, the product will still be accessible via the product cache.
 ====
 
 ===== Installing the URL Resource Reader
@@ -54,7 +54,7 @@ See <<{reference-prefix}ddf.catalog.resource.impl.URLResourceReader,URL Resource
 `URLResourceReader` will be used by the Catalog Framework to obtain a resource whose metacard is cataloged in the local data store.
 This particular `ResourceReader` will be chosen by the `CatalogFramework` if the requested resource's URL has a protocol of `http`, `https`, or `file`.  
 
-For example, requesting a resource with the following URL will make the Catalog Framework invoke the `URLResourceReader` to retrieve the product.
+For example, requesting a resource with the following URL will make the Catalog Framework invoke the `URLResourceReader` for retrieval.
 
 .Example
 [source,http]

--- a/distribution/docs/src/main/resources/content/_architectures/_transformers/kml-metacard-xformer.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_transformers/kml-metacard-xformer.adoc
@@ -7,7 +7,7 @@
 
 The KML Metacard Transformer is responsible for translating a metacard into a KML-formatted document.
 The KML will contain an HTML description that will display in the pop-up bubble in Google Earth.
-The HTML contains links to the full metadata view as well as the product.
+The HTML contains links to the full metadata view as well as the resource.
 
 ===== Installing the KML Metacard Transformer
 

--- a/distribution/docs/src/main/resources/content/_architectures/_transformers/kml-queryresp-xformer.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_transformers/kml-queryresp-xformer.adoc
@@ -7,7 +7,7 @@
 
 The KML Query Response Transformer translates a query response into a KML-formatted document.
 The KML will contain an HTML description for each metacard that will display in the pop-up bubble in Google Earth.
-The HTML contains links to the full metadata view as well as the product.
+The HTML contains links to the full metadata view as well as the resource.
 
 ===== Installing the KML Query Response Transformer
 

--- a/distribution/docs/src/main/resources/content/_architectures/_transformers/mime-type-mapper-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_transformers/mime-type-mapper-intro.adoc
@@ -6,7 +6,7 @@
 
 The MimeTypeMapper is the entry point in ${branding} for resolving file extensions to mime types, and vice versa.
 
-`MimeTypeMappers` are used by the `ResourceReader` to determine the file extension for a given mime type in aid of retrieving a product.
+`MimeTypeMappers` are used by the `ResourceReader` to determine the file extension for a given mime type in aid of retrieving a resource.
 `MimeTypeMappers` are also used by the `FileSystemProvider` in the Catalog Framework to read a file from the content file repository.
 
 The `MimeTypeMapper` maintains a list of all of the `MimeTypeResolvers` in ${branding}.

--- a/distribution/docs/src/main/resources/content/_architectures/_transformers/resource-metacard-xformer.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_transformers/resource-metacard-xformer.adoc
@@ -3,7 +3,7 @@
 :subtype: metacard
 :status: published
 :link: _resource_metacard_transformer
-:summary: Retrieves the resource bytes of a metacard by returning the product associated with the metacard.
+:summary: Retrieves the resource bytes of a metacard by returning the resource associated with the metacard.
 
 The Resource Metacard Transformer retrieves a resource associated with a metacard.
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-action-components.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-action-components.adoc
@@ -17,7 +17,7 @@ An action is a URL that, when invoked, provides a resource or executes intended 
 ==== Action Component Naming Convention
 
 For each Action, a title and description should be provided to describe what the action does.
-The recommended naming convention is to use the verb 'Get' when retrieving a portion of a metacard, such as the metadata or thumbnail, or when downloading a product.
+The recommended naming convention is to use the verb 'Get' when retrieving a portion of a metacard, such as the metadata or thumbnail, or when downloading a resource.
 The verb 'Export' or the expression 'Export as' is recommended when the metacard is being exported in a different format or presented after going some transformation.
 
 ===== Action Component Taxonomy

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-catalog-frameworks.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-catalog-frameworks.adoc
@@ -79,7 +79,7 @@ Query requests process  `PolicyPlugin`, `AccessPlugin`, and `PreQueryPlugin` i
 
 ====== Resource Methods
 
-Resource methods retrieve products from Sources.
+Resource methods retrieve data resources from Sources.
 
 .Example Resource Methods
 [source,java,linenums]

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-endpoints.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-endpoints.adoc
@@ -52,7 +52,7 @@ create, update, and delete. 
 |Get available `Source` information.
 
 |Resource
-|Retrieve products referenced in Metacards from Sources.
+|Retrieve resources referenced in Metacards from Sources.
 
 |Transform
 |Convert common Catalog Framework data types to and from other data formats.

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-resource-readers.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-resource-readers.adoc
@@ -5,7 +5,7 @@
 :order: 15
 :summary: Creating a custom Resource Reader.
 
-A `ResourceReader` is a class that retrieves a resource or product from a native/external source and returns it to ${branding}.
+A `ResourceReader` is a class that retrieves a resource from a native/external source and returns it to ${branding}.
 A simple example is that of a File `ResourceReader`.
 It takes a file from the local file system and passes it back to ${branding}.
 New implementations can be created in order to support obtaining Resources from various Resource data stores. 

--- a/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/federation-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/federation-intro.adoc
@@ -11,7 +11,7 @@ Federation is the ability of the ${branding} to query other data sources, includ
 By default, the ${branding} is able to federate using http://www.opensearch.org/Home[OpenSearch] and http://www.opengeospatial.org/standards/cat[CSW] protocols.
 The minimum configuration necessary to configure those federations is a query address.
 
-Federation enables constructing dynamic networks of data sources that can be queried individually or aggregated into specific configuration to enable a wider range of accessibility for data and data products.
+Federation enables constructing dynamic networks of data sources that can be queried individually or aggregated into specific configuration to enable a wider range of accessibility for data and data resources.
 
 Federation provides the capability to extend the ${branding} enterprise to include <<{managing-prefix}connecting_to_sources,Remote Sources>>, which may include other instances of ${branding}. 
 The Catalog handles all aspects of federated queries as they are sent to the Catalog Provider and Remote Sources, as they are processed, and as the query results are returned.

--- a/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/ingest-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/ingest-intro.adoc
@@ -7,7 +7,7 @@
 
 == {title}
 
-Ingest is the process of bringing data products, metadata, or both into the catalog to enable search, sharing, and discovery.
+Ingest is the process of bringing data resources, metadata, or both into the catalog to enable search, sharing, and discovery.
 Ingested files are <<{integrating-prefix}transformers,transformed>> into a neutral format that can be searched against as well as migrated to other formats and systems.
 See <<{managing-prefix}ingesting_data, Ingesting Data>> for the various methods of ingesting data.
 

--- a/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/metadata-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/metadata-intro.adoc
@@ -7,7 +7,7 @@
 
 == {title}
 
-In ${branding}, <<_introduction_to_resources,resources>> are the data products, files, reports, or documents of interest to users of the system.
+In ${branding}, <<_introduction_to_resources,resources>> are the files, reports, or documents of interest to users of the system.
 
 Metadata is information about those resources, organized into a schema to make search possible.
 The ${ddf-catalog} stores this metadata and allows access to it.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/catalog-filtering.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/catalog-filtering.adoc
@@ -7,7 +7,7 @@
 
 == {title}
 
-Filtering is the process of evaluating security markings on data products, comparing them to the users permissions and protecting resources from inappropriate access.
+Filtering is the process of evaluating security markings on data resources, comparing them to the users permissions and protecting resources from inappropriate access.
 
 There are two options for processing filtering policies: internally, or through the use of a policy formatted in eXtensible Access Control Markup Language (XACML).
 The procedure for setting up a policy differs depending on whether that policy is to be used internally or by the external XACML processing engine.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/configuring-product-caching.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/configuring-product-caching.adoc
@@ -1,0 +1,18 @@
+:title: Configuring Product Caching
+:type: configuration
+:status: published
+:parent: Configuring Data Management
+:order: 026
+:summary: Enabling or disabling product caching.
+
+== {title}
+
+To configure product caching:
+
+. Navigate to the *${admin-console}*.
+. Select ${ddf-catalog}.
+. Select *Configuration*.
+. Select *Resource Download Settings*.
+. Select / Deselect *Enable Product Caching*.
+
+See <<{reference-prefix}ddf.catalog.resource.download.ReliableResourceDownloadManager,Resource Download Settings configurations>> for all possible configurations.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/content-directory-monitor.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/content-directory-monitor.adoc
@@ -46,7 +46,10 @@ If a CDM configuration is deleted, then the corresponding permissions that were 
 .Content Directory Monitor Permissions
 [IMPORTANT]
 ====
-When configuring a Content Directory Monitor, make sure to set permissions on the new directory to allow ${branding} to access it. Setting permissions should be done *before* configuring a CDM. Also, don't forget to add permissions for products outside of the monitored directory. See <<{managing-prefix}configuring_permissions_for_the_content_directory_monitor,Configuring Permissions for the Content Directory Monitor>> for in-depth instructions on configuring permissions.
+When configuring a Content Directory Monitor, make sure to set permissions on the new directory to allow ${branding} to access it.
+Setting permissions should be done *before* configuring a CDM.
+Also, don't forget to add permissions for resources outside of the monitored directory.
+See <<{managing-prefix}configuring_permissions_for_the_content_directory_monitor,Configuring Permissions for the Content Directory Monitor>> for in-depth instructions on configuring permissions.
 ====
 
 [NOTE]
@@ -57,7 +60,8 @@ If there's a metacard that points to a resource outside of the CDM, then you mus
 .Monitoring Directories In Place
 [WARNING]
 ====
-If monitoring a directory in place, then the <<{developing-prefix}url_resource_reader, URL Resource Reader>> must be configured prior to configuring the CDM to allow reading from the configured directory. This allows the ${ddf-catalog} to download the products.
+If monitoring a directory in place, then the <<{developing-prefix}url_resource_reader, URL Resource Reader>> must be configured prior to configuring the CDM to allow reading from the configured directory.
+This allows the ${ddf-catalog} to download the resources.
 ====
 
 Configure the CDM from the ${admin-console}:

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/environment-hardening.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/environment-hardening.adoc
@@ -41,7 +41,7 @@ a|Set OS File permissions under the `${home_directory}` directory (e.g. `/deploy
 ** Select the *${ddf-catalog}* application. +
 ** Select *Resource Download Settings*. +
 ** Uncheck the `Enable Product Caching` box. +
-* Install ${ddf-security} to ensure only the appropriate users are accessing the products. +
+* Install ${ddf-security} to ensure only the appropriate users are accessing the resources. +
 ** Navigate to the ${admin-console} +
 ** Select *Manage*. +
 ** Install the ${ddf-security} application, if applicable. +

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/uploading-and-editing.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/uploading-and-editing.adoc
@@ -3,18 +3,18 @@
 :status: published
 :parent: Configuring ${catalog-ui}
 :order: 02
-:summary: Configuring user ability to upload products and edit existing metadata in ${catalog-ui}.
+:summary: Configuring user ability to upload resources and edit existing metadata in ${catalog-ui}.
 
 == {title}
 
-${catalog-ui} lets the administrator control user access to ingest and metadata. The administrator
-can show or hide the uploader, letting them control whether users can ingest products. They
-can also choose whether or not users can edit existing metadata. By default, the uploader is
-available to users and editing is allowed.
+${catalog-ui} lets the administrator control user access to ingest and metadata.
+The administrator can show or hide the uploader, letting them control whether users can ingest resources.
+They can also choose whether or not users can edit existing metadata.
+By default, the uploader is available to users and editing is allowed.
 
 .Configuring The Uploader
-Choose to hide or show the uploader. Note that hiding the uploader will
-remove the users' ability to ingest.
+Choose to hide or show the uploader.
+Note that hiding the uploader will remove the users' ability to ingest.
 
 . Navigate to the *${admin-console}*.
 . Select the *${ddf-ui}* application.

--- a/distribution/docs/src/main/resources/content/_managing/_installing/high-availability-initial-setup-exceptions.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_installing/high-availability-initial-setup-exceptions.adoc
@@ -61,7 +61,7 @@ One way to accomplish this is to use the default <<{reference-prefix}org.codice.
 === High Availability Certificates
 
 Due to the nature of highly available environments, localhost is not suitable for use as a hostname to identify the ${branding} cluster.
-The default certificate that ships with the product uses localhost as the common name, so this certificate needs to be replaced.
+The default certificate uses localhost as the common name, so this certificate needs to be replaced.
 The following describes how to generate a certificate signed by the ${branding} Demo Certificate Authority that uses a proper hostname.
 
 [NOTE]

--- a/distribution/docs/src/main/resources/content/_managing/_running/ui-ingest.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/ui-ingest.adoc
@@ -11,7 +11,8 @@ Files can also be ingested directly from ${catalog-ui}.
 
 [WARNING]
 ====
-The ${catalog-ui} uploader is intended for the upload of products (such as images or documents), not metadata files (such as Metacard XML). A user will not be able to specify which input transformer is used to ingest the document.
+The ${catalog-ui} uploader is intended for the upload of resources (such as images or documents), not metadata files (such as Metacard XML).
+A user will not be able to specify which input transformer is used to ingest the document.
 ====
 
 See <<{using-prefix}uploading,Ingesting from ${catalog-ui}>> for details.

--- a/distribution/docs/src/main/resources/content/_metadataReference/associations-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataReference/associations-attributes-table.adoc
@@ -3,11 +3,11 @@
 :order: 01
 :parent: Catalog Taxonomy Definitions
 :status: published
-:summary: Attributes in this group represent associations between products.
+:summary: Attributes in this group represent associations between resources.
 
 == {title}
 
-.Associations: Attributes in this group represent associations between products. *Injected by default.*
+.Associations: Attributes in this group represent associations between resources. *Injected by default.*
 [cols="1,2,1,1,1" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_reference/_tables/catalog.ui.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/catalog.ui.adoc
@@ -386,7 +386,7 @@ a|* `1800`
 |Maximum Endpoint Upload Size
 |maximumUploadSize
 |Integer
-|The maximum size (in bytes) to allow per client when receiving a POST/PATCH/PUT. Note: This does not affect product upload size, just the maximum size allowed for calls from Intrigue.
+|The maximum size (in bytes) to allow per client when receiving a POST/PATCH/PUT. Note: This does not affect resource upload size, just the maximum size allowed for calls from Intrigue.
 |1048576
 |true
 

--- a/distribution/docs/src/main/resources/content/_using/ui-uploading.adoc
+++ b/distribution/docs/src/main/resources/content/_using/ui-uploading.adoc
@@ -11,7 +11,8 @@ Data can be ingested via ${catalog-ui}.
 
 [WARNING]
 ====
-The ${catalog-ui} uploader is intended for the upload of products (such as images or documents), not metadata files (such as Metacard XML). A user will not be able to specify which input transformer is used to ingest the document.
+The ${catalog-ui} uploader is intended for the upload of resources (such as images or documents), not metadata files (such as Metacard XML).
+A user will not be able to specify which input transformer is used to ingest the document.
 ====
 
 . Select the Menu icon (image:navigator-icon.png[]) in the upper left corner.
@@ -20,12 +21,12 @@ The ${catalog-ui} uploader is intended for the upload of products (such as image
 . After selecting the file(s) to be uploaded, select *Start* to begin uploading.
 
 Files are processed individually with a visual status indication of each upload.
-If there are any failures, the user is notified with a message on that specific product.
+If there are any failures, the user is notified with a message on that specific resource.
 More information about the uploads can be found in the ingest log.
 The default location of the log is `${home_directory}/data/log/ingest_error.log`.
 
 [NOTE]
 ====
-Uploaded products may be marked with Validation Warnings or Errors.
-Additional configuration may be needed to view these products in searches.
+Uploaded resources may be marked with Validation Warnings or Errors.
+Additional configuration may be needed to view these resources in searches.
 ====

--- a/distribution/docs/src/main/resources/content/_using/using-intrigue-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-intrigue-intro.adoc
@@ -18,13 +18,13 @@ To exit this mode, click the `?` again or press `escape`.
 .Glossary of Terms
 ====
 <<{using-prefix}advanced_query_builder,((Advanced Query Builder))>>:: Search tool for building complex queries beyond basic searches.
-<<{using-prefix}associations,((Associations))>>:: User-defined relationships between different data products.
+<<{using-prefix}associations,((Associations))>>:: User-defined relationships between different data resources.
 <<{using-prefix}using_the_attribute_editor,((Attribute Editor))>>:: Tool used to edit metadata attributes on uploads.
 <<{using-prefix}basic_search,((Basic Search Tool))>>:: Search tool for building simple searches.
 <<{using-prefix}inspector,((Inspector))>>:: Tool for viewing and editing metadata attributes.
 <<{using-prefix}using_lists,((Lists))>>:: User-defined collections of related results or products.
 <<{using-prefix}map_tools,((Map Tools Widget))>>:: Tool for customizing or navigating the map view.
-<<{using-prefix}viewing_metadata_quality,((Metadata Quality))>>:: A measure of the completeness or correctness of the metadata of a product.
+<<{using-prefix}viewing_metadata_quality,((Metadata Quality))>>:: A measure of the completeness or correctness of the metadata of a resource.
 <<{using-prefix}using_result_forms,((Result Forms))>>:: Customizable templates of the attributes shown when viewing searches.
 <<{using-prefix}using_search_forms,((Search Forms))>>:: Customizable templates of the attributes used in creating searches.
 <<{using-prefix}sources_view,((Sources View))>>:: View the health and status of all configured data sources

--- a/distribution/docs/src/main/resources/content/_using/using-simple-search-ui.adoc
+++ b/distribution/docs/src/main/resources/content/_using/using-simple-search-ui.adoc
@@ -28,7 +28,7 @@ Results per Page:: Select the number of results to be returned by a single query
 
 ==== Results
 
-The table of results shows the details of the results found, as well as a link to download the product if applicable.
+The table of results shows the details of the results found, as well as a link to download the resource if applicable.
 
 ===== Results  Summary
 
@@ -45,7 +45,7 @@ Source:: Displays where the metadata came from, which could be the local provide
 Location:: Displays the WKT Location of the metacard, if available.
 Time:: Shows the Received (Created) and Effective times of the metacard, if available.
 Thumbnail:: Shows the thumbnail of the metacard, if available.
-Download:: A download link to retrieve the product associated with the metacard, when applicable, if available.
+Download:: A download link to retrieve the resource associated with the metacard, when applicable, if available.
 
 ==== Result View
 

--- a/distribution/docs/src/main/resources/content/_using/viewing-results.adoc
+++ b/distribution/docs/src/main/resources/content/_using/viewing-results.adoc
@@ -25,7 +25,7 @@ image::search-results-options.png[search results options]
 === Search Result Options
 
 .Options for each individual search result
-* *Download*: Downloads the result's associated product directly to the local machine. This option is only available for results that have products.
+* *Download*: Downloads the result's associated resource directly to the local machine. This option is only available for results that have resources.
 * *Add to List* &#43;: Adds/removes the results to/from a list.
 * [[_hiding_a_result]]*Hide from Future Searches*: Adds to a list of results that will be hidden from future searches.
 * *Expand Metacard View*: Navigates to a view that only focuses on this particular result.


### PR DESCRIPTION
#### What does this PR do?

Changes, where possible, references to 'data products' to the more accurate 'data resources' or simply 'resources'

#### Select relevant component teams: 
@codice/data 
@codice/docs 

#### Ask 2 committers to review/merge the PR and tag them here.
@ahoffer
@brendan-hofmann
@brjeter
@clockard
@lessarderic
@mcalcote
@pklinef
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?

review content

#### Any background context you want to provide?

Tried not to change references where the actual code being referenced uses the term 'product' instead of 'resource'

#### What are the relevant tickets?
Fixes: #5606 


#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
