### PR TITLE
[2.19.x] DDF-5610 Automatically convert WKT strings to correct format in polygon and line geo filters

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/announcement.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/announcement.less
@@ -43,7 +43,7 @@
   }
 
   .announcement-title {
-    text-align: center;
+    text-align: left;
     .is-bold();
     font-size: @largeFontSize;
     height: @minimumButtonSize;
@@ -58,7 +58,8 @@
   .announcement-message {
     max-height: 168px;
     overflow: auto;
-    text-align: center;
+    text-align: left;
+    margin: 0 @minimumButtonSize;
   }
 
   .announcement-action {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -27,7 +27,10 @@ const LoadingView = require('../loading/loading.view.js')
 const wreqr = require('../../js/wreqr.js')
 const user = require('../singletons/user-instance.js')
 import ExtensionPoints from '../../extension-points'
-import { validate } from '../../react-component/utils/validation'
+import {
+  validate,
+  validateFilters,
+} from '../../react-component/utils/validation'
 
 const { createAction } = require('imperio')
 
@@ -233,7 +236,14 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    if (!validate(queryContentView.validate())) {
+    const filters = queryContentView.queryAdvanced
+      ? queryContentView.queryAdvanced.currentView.getFilters().filters
+      : typeof queryContentView.constructFilter === 'function'
+        ? queryContentView.constructFilter().filters
+        : []
+    if (
+      !validate(queryContentView.validate().concat(validateFilters(filters)))
+    ) {
       return
     }
     queryContentView.save()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -25,10 +25,9 @@ const QueryConfirmationView = require('../confirmation/query/confirmation.query.
 const SearchForm = require('../search-form/search-form')
 const LoadingView = require('../loading/loading.view.js')
 const wreqr = require('../../js/wreqr.js')
-const announcement = require('../announcement/index.jsx')
 const user = require('../singletons/user-instance.js')
-import { InvalidSearchFormMessage } from 'component/announcement/CommonMessages'
 import ExtensionPoints from '../../extension-points'
+import { validate } from '../../react-component/utils/validation'
 
 const { createAction } = require('imperio')
 
@@ -234,8 +233,7 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    if (!queryContentView.isValid()) {
-      announcement.announce(InvalidSearchFormMessage)
+    if (!validate(queryContentView.validate())) {
       return
     }
     queryContentView.save()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -193,8 +193,8 @@ module.exports = Marionette.LayoutView.extend({
       this.options.onSave()
     }
   },
-  isValid() {
-    return this.querySettings.currentView.isValid()
+  validate() {
+    return this.querySettings.currentView.validate()
   },
   setDefaultTitle() {
     this.model.set('title', this.model.get('cql'))

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -435,8 +435,8 @@ module.exports = Marionette.LayoutView.extend({
       cql: generatedCQL,
     })
   },
-  isValid() {
-    return this.basicSettings.currentView.isValid()
+  validate() {
+    return this.basicSettings.currentView.validate()
   },
   constructFilter() {
     const filters = []

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
@@ -20,9 +20,8 @@ const CustomElements = require('../../js/CustomElements.js')
 const QueryAdvanced = require('../query-advanced/query-advanced.view.js')
 const QueryTitle = require('../query-title/query-title.view.js')
 const store = require('../../js/store.js')
-const announcement = require('../announcement/index.jsx')
-import { InvalidSearchFormMessage } from 'component/announcement/CommonMessages'
 import ExtensionPoints from '../../extension-points'
+import { validate } from '../../react-component/utils/validation'
 
 module.exports = Marionette.LayoutView.extend({
   template,
@@ -145,8 +144,7 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    if (!queryContentView.isValid()) {
-      announcement.announce(InvalidSearchFormMessage)
+    if (!validate(queryContentView.validate())) {
       return
     }
     queryContentView.save()
@@ -162,8 +160,7 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    if (!queryContentView.isValid()) {
-      announcement.announce(InvalidSearchFormMessage)
+    if (!validate(queryContentView.validate())) {
       return
     }
     queryContentView.save()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -28,11 +28,10 @@ const SortItemCollectionView = require('../sort/sort.view.js')
 const Common = require('../../js/Common.js')
 const properties = require('../../js/properties.js')
 const plugin = require('plugins/query-settings')
-const announcement = require('../announcement/index.jsx')
 const ResultForm = require('../result-form/result-form.js')
-import { InvalidSearchFormMessage } from 'component/announcement/CommonMessages'
 import * as React from 'react'
 import RadioComponent from '../../react-component/input-wrappers/radio'
+import { validate } from '../../react-component/utils/validation'
 
 module.exports = plugin(
   Marionette.LayoutView.extend({
@@ -269,12 +268,11 @@ module.exports = plugin(
     saveToModel() {
       this.model.set(this.toJSON())
     },
-    isValid() {
-      return this.settingsSortField.currentView.collection.models.length !== 0
+    validate() {
+      return []
     },
     save() {
-      if (!this.isValid()) {
-        announcement.announce(InvalidSearchFormMessage)
+      if (!validate(this.validate())) {
         return
       }
       this.saveToModel()
@@ -282,8 +280,7 @@ module.exports = plugin(
       this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
     },
     run() {
-      if (!this.isValid()) {
-        announcement.announce(InvalidSearchFormMessage)
+      if (!validate(this.validate())) {
         return
       }
       this.saveToModel()

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -18,6 +18,8 @@ const { Units } = require('./common')
 const TextField = require('../text-field')
 import styled from 'styled-components'
 
+const coordinatePairRegex = /\d{1,3}(\.\d*)?\s\d{1,3}(\.\d*)?/g
+
 const Invalid = styled.div`
   background-color: ${props => props.theme.negativeColor};
   height: 100%;
@@ -57,6 +59,14 @@ class BaseLine extends React.Component {
             label={label}
             value={this.state.value}
             onChange={value => {
+              value = value.trim()
+              if (value.includes('MULTI')) {
+                value = this.convertMultiWkt(value.includes('POLYGON'), value)
+              } else if (value.includes('POLYGON') && value.endsWith('))')) {
+                value = this.convertWkt(value, 4)
+              } else if (value.includes('LINESTRING') && value.endsWith(')')) {
+                value = this.convertWkt(value, 2)
+              }
               this.setState({ value })
               const fn = cursor(geometryKey)
               try {
@@ -108,31 +118,51 @@ class BaseLine extends React.Component {
       return false
     }
   }
+  validatePoint(point) {
+    if (
+      point.length !== 2 ||
+      (Number.isNaN(Number.parseFloat(point[0])) &&
+        Number.isNaN(Number.parseFloat(point[1])))
+    ) {
+      return JSON.stringify(point) + ' is not a valid point.'
+    } else if (
+      point[0] > 180 ||
+      point[0] < -180 ||
+      point[1] > 90 ||
+      point[1] < -90
+    ) {
+      return JSON.stringify(point) + ' is not a valid point.'
+    }
+    return ''
+  }
   validateListOfPoints(coordinates) {
     let message = ''
-    if (this.props.mode === 'poly' && coordinates.length < 4) {
-      message = 'Minimum of 4 points needed for polygon'
-    } else if (this.props.mode === 'line' && coordinates.length < 2) {
-      message = 'Minimum of 2 points needed for line'
+    const isLine = this.props.mode.includes('line')
+    let numPoints = isLine ? 2 : 4
+    if (!this.props.mode.includes('multi')) {
+      if (coordinates.some(coords => coords.length > 2)) {
+        message = ''
+      } else if (coordinates.length < numPoints) {
+        message = `Minimum of ${numPoints} points needed for ${
+          isLine ? 'Line' : 'Polygon'
+        }`
+      }
     }
-    coordinates.forEach(point => {
-      if (
-        point.length !== 2 ||
-        (Number.isNaN(Number.parseFloat(point[0])) &&
-          Number.isNaN(Number.parseFloat(point[1])))
-      ) {
-        message = JSON.stringify(point) + ' is not a valid point.'
+    for (let i = 0; i < coordinates.length; i++) {
+      if (coordinates[i].length > 2) {
+        coordinates[i].forEach(coordinate => {
+          if (this.validatePoint(coordinate)) {
+            message = this.validatePoint(coordinate)
+          }
+        })
       } else {
-        if (
-          point[0] > 180 ||
-          point[0] < -180 ||
-          point[1] > 90 ||
-          point[1] < -90
-        ) {
-          message = JSON.stringify(point) + ' is not a valid point.'
+        if (this.props.mode.includes('multi')) {
+          message = `Switch to ${isLine ? 'Line' : 'Polygon'}`
+        } else if (this.validatePoint(coordinates[i])) {
+          message = this.validatePoint(coordinates[i])
         }
       }
-    })
+    }
     if (message !== '') {
       this.invalidMessage = message
       throw 'Invalid coordinates.'
@@ -149,6 +179,36 @@ class BaseLine extends React.Component {
     } catch (e) {
       return false
     }
+  }
+  convertWkt(value, numCoords) {
+    const coordinatePairs = value.match(coordinatePairRegex)
+    if (!coordinatePairs || coordinatePairs.length < numCoords) {
+      return value
+    }
+    const coordinates = coordinatePairs.map(coord => coord.replace(' ', ','))
+    return `[[${coordinates.join('],[')}]]`
+  }
+  convertMultiWkt(isPolygon, value) {
+    if (isPolygon && !value.endsWith(')))')) {
+      return value
+    } else if (!value.endsWith('))')) {
+      return value
+    }
+    const splitter = isPolygon ? '))' : ')'
+    const numPoints = isPolygon ? 4 : 2
+    let shapes = value
+      .split(splitter)
+      .map(shape => shape.match(coordinatePairRegex))
+    shapes = shapes
+      .filter(shape => shape !== null && shape.length >= numPoints)
+      .map(shape =>
+        shape.map(coordinatePair => coordinatePair.replace(' ', ','))
+      )
+    return shapes.length === 0
+      ? value
+      : shapes.length === 1
+        ? `[[${shapes[0].join('],[')}]]`
+        : `[${shapes.map(shapeCoords => `[[${shapeCoords.join('],[')}]]`)}]`
   }
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -75,7 +75,7 @@ class BaseLine extends React.Component {
               type="number"
               label="Buffer width"
               min={0.000001}
-              value={props[widthKey]}
+              value={`${props[widthKey]}`}
               onChange={cursor(widthKey)}
             />
           </Units>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -12,11 +12,4 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-const properties = require('../../js/properties.js')
-
-export const InvalidSearchFormMessage: any = {
-  title: `Validation Issues: Search ${properties.i18n['form.title'] ||
-    'Form'} cannot be run.`,
-  message: [],
-  type: 'error',
-}
+export { validate } from './validation'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -12,4 +12,4 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-export { validate } from './validation'
+export { validate, validateFilters } from './validation'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -37,3 +37,33 @@ export function validate(errors: any) {
   announcement.announce(searchErrorMessage)
   return false
 }
+
+export function validateFilters(filters: any) {
+  const errors: any[] = []
+  for (let i = 0; i < filters.length; i++) {
+    const filter = filters[i]
+    const geometry = filter.geojson && filter.geojson.geometry
+    if (
+      geometry &&
+      geometry.type === 'Polygon' &&
+      geometry.coordinates[0].length < 4
+    ) {
+      errors.push({
+        title: 'Invalid geometry filter',
+        body:
+          'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]',
+      })
+    }
+    if (
+      geometry &&
+      geometry.type === 'LineString' &&
+      geometry.coordinates.length < 2
+    ) {
+      errors.push({
+        title: 'Invalid geometry filter',
+        body: 'Line coordinates must be in the form [[x,y],[x,y], ... ]',
+      })
+    }
+  }
+  return errors
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+import { InvalidSearchFormMessage } from '../../../component/announcement/CommonMessages'
+const announcement = require('../../../component/announcement/index.jsx')
+
+export function validate(errors: any) {
+  if (errors.length === 0) {
+    return true
+  }
+  let searchErrorMessage = JSON.parse(JSON.stringify(InvalidSearchFormMessage))
+  if (errors.length > 1) {
+    let msg = searchErrorMessage.message
+    searchErrorMessage.title =
+      'Your search cannot be run due to multiple errors'
+    const formattedErrors = errors.map(
+      (error: any) => `\u2022 ${error.title}: ${error.body}`
+    )
+    searchErrorMessage.message = msg.concat(formattedErrors)
+  } else {
+    const error = errors[0]
+    searchErrorMessage.title = error.title
+    searchErrorMessage.message = error.body
+  }
+  announcement.announce(searchErrorMessage)
+  return false
+}


### PR DESCRIPTION
#### What does this PR do?

_Only review the last commit; this PR is based on https://github.com/codice/ddf/pull/5571 and https://github.com/codice/ddf/pull/5594_

Converts WKT strings to the correct format automatically instead of relying on error messages to inform the user of the correct format and making them convert it themselves.
#### Who is reviewing it? 
@zta6 @cassandrabailey293 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@Bdthomson 
#### How should this be tested?
Copy and paste WKT strings into the Polygon and Line geo filter fields. Verify that they're being immediately converted into the correct format, the shapes are still showing up on the map and you can successfully execute the search without any error messages.

Note about multipolygons: each polygon in a multipolygon must have at least 4 coordinate pairs (first and last should be the same). Test with multipolygons where at least one polygon isn't valid and verify that the invalid polygon is simply removed from the multipolygon; the rest of the shapes should still convert and be visible on the map. Also test with a multipolygon where none of the polygons are valid. No conversion should occur and you should still get an error.

Example multipolygon: 
`MULTIPOLYGON (((45.574810133283215 20.62558894559107, 45.5194086 20.6255882, 45.51939284236649 20.66286978112815, 45.574810133283215 20.62558894559107)), ((45.59837085736602 20.762588148838585, 45.64061788382024 20.762594644045915, 45.69038779816324 20.72685765983166, 45.69032921329696 20.649303862907075, 45.613123 20.715271, 45.635361148168556 20.715827143471095, 45.59837085736602 20.762588148838585)))`

Example polygon: 
`POLYGON ((45.69035002266293 20.676851, 45.6903113 20.6255905, 45.623261 20.625589597640413, 45.623261 20.676851, 45.69035002266293 20.676851))`

Example line:
`LINESTRING (45.4806 20.644323,45.620127 20.727819)`
#### Any background context you want to provide?
_Only review the last commit; this PR is based on https://github.com/codice/ddf/pull/5571 and https://github.com/codice/ddf/pull/5594_
#### What are the relevant tickets?
Fixes: #5610
G-7587 
#### Screenshots
Before:
![before](https://user-images.githubusercontent.com/39737329/69277387-7477ca00-0b9d-11ea-8307-014f1045a8d3.gif)
After:
![after1-min](https://user-images.githubusercontent.com/39737329/69277727-fff15b00-0b9d-11ea-84a7-b4aa1f970edf.gif)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
