### PR TITLE
DDF-5593 prevent a query from running when geo string is in wrong format

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -27,7 +27,10 @@ const LoadingView = require('../loading/loading.view.js')
 const wreqr = require('../../js/wreqr.js')
 const user = require('../singletons/user-instance.js')
 import ExtensionPoints from '../../extension-points'
-import { validate } from '../../react-component/utils/validation'
+import {
+  validate,
+  validateFilters,
+} from '../../react-component/utils/validation'
 
 const { createAction } = require('imperio')
 
@@ -233,7 +236,14 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    if (!validate(queryContentView.validate())) {
+    const filters = queryContentView.queryAdvanced
+      ? queryContentView.queryAdvanced.currentView.getFilters().filters
+      : typeof queryContentView.constructFilter === 'function'
+        ? queryContentView.constructFilter().filters
+        : []
+    if (
+      !validate(queryContentView.validate().concat(validateFilters(filters)))
+    ) {
       return
     }
     queryContentView.save()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -27,7 +27,7 @@ const LoadingView = require('../loading/loading.view.js')
 const wreqr = require('../../js/wreqr.js')
 const user = require('../singletons/user-instance.js')
 import ExtensionPoints from '../../extension-points'
-import { validate } from '../../react-component/utils/validation'
+import { showErrorMessages } from '../../react-component/utils/validation'
 
 const { createAction } = require('imperio')
 
@@ -233,7 +233,9 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    if (!validate(queryContentView.validate())) {
+    const errorMessages = queryContentView.getErrorMessages()
+    if (errorMessages.length !== 0) {
+      showErrorMessages(errorMessages)
       return
     }
     queryContentView.save()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -27,10 +27,7 @@ const LoadingView = require('../loading/loading.view.js')
 const wreqr = require('../../js/wreqr.js')
 const user = require('../singletons/user-instance.js')
 import ExtensionPoints from '../../extension-points'
-import {
-  validate,
-  validateFilters,
-} from '../../react-component/utils/validation'
+import { validate } from '../../react-component/utils/validation'
 
 const { createAction } = require('imperio')
 
@@ -236,14 +233,7 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    const filters = queryContentView.queryAdvanced
-      ? queryContentView.queryAdvanced.currentView.getFilters().filters
-      : typeof queryContentView.constructFilter === 'function'
-        ? queryContentView.constructFilter().filters
-        : []
-    if (
-      !validate(queryContentView.validate().concat(validateFilters(filters)))
-    ) {
+    if (!validate(queryContentView.validate())) {
       return
     }
     queryContentView.save()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-adhoc/query-adhoc.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-adhoc/query-adhoc.view.js
@@ -210,7 +210,7 @@ module.exports = Marionette.LayoutView.extend({
     this.$el.find('form')[0].submit()
     this.saveToModel()
   },
-  validate() {
+  getErrorMessages() {
     return []
   },
   setDefaultTitle() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -22,7 +22,7 @@ const cql = require('../../js/cql.js')
 const store = require('../../js/store.js')
 const QuerySettingsView = require('../query-settings/query-settings.view.js')
 const properties = require('../../js/properties.js')
-import { validateFilters } from '../../react-component/utils/validation'
+import { getFilterErrors } from '../../react-component/utils/validation'
 
 import query from '../../react-component/utils/query'
 
@@ -194,11 +194,11 @@ module.exports = Marionette.LayoutView.extend({
       this.options.onSave()
     }
   },
-  validate() {
+  getErrorMessages() {
     return this.querySettings.currentView
-      .validate()
+      .getErrorMessages()
       .concat(
-        validateFilters(
+        getFilterErrors(
           this.queryAdvanced.currentView.getFilters().filters || []
         )
       )

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -22,6 +22,7 @@ const cql = require('../../js/cql.js')
 const store = require('../../js/store.js')
 const QuerySettingsView = require('../query-settings/query-settings.view.js')
 const properties = require('../../js/properties.js')
+import { validateFilters } from '../../react-component/utils/validation'
 
 import query from '../../react-component/utils/query'
 
@@ -194,7 +195,13 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
   validate() {
-    return this.querySettings.currentView.validate()
+    return this.querySettings.currentView
+      .validate()
+      .concat(
+        validateFilters(
+          this.queryAdvanced.currentView.getFilters().filters || []
+        )
+      )
   },
   setDefaultTitle() {
     this.model.set('title', this.model.get('cql'))

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -439,7 +439,7 @@ module.exports = Marionette.LayoutView.extend({
   getErrorMessages() {
     return this.basicSettings.currentView
       .getErrorMessages()
-      .concat(getFilterErrors(this.constructFilter()))
+      .concat(getFilterErrors(this.constructFilter().filters))
   },
   constructFilter() {
     const filters = []

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -29,7 +29,7 @@ const sources = require('../singletons/sources-instance.js')
 const CQLUtils = require('../../js/CQLUtils.js')
 const QuerySettingsView = require('../query-settings/query-settings.view.js')
 const QueryTimeView = require('../query-time/query-time.view.js')
-import { validateFilters } from '../../react-component/utils/validation'
+import { getFilterErrors } from '../../react-component/utils/validation'
 
 function isNested(filter) {
   let nested = false
@@ -436,10 +436,10 @@ module.exports = Marionette.LayoutView.extend({
       cql: generatedCQL,
     })
   },
-  validate() {
+  getErrorMessages() {
     return this.basicSettings.currentView
-      .validate()
-      .concat(validateFilters(this.constructFilter()))
+      .getErrorMessages()
+      .concat(getFilterErrors(this.constructFilter()))
   },
   constructFilter() {
     const filters = []

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -29,6 +29,7 @@ const sources = require('../singletons/sources-instance.js')
 const CQLUtils = require('../../js/CQLUtils.js')
 const QuerySettingsView = require('../query-settings/query-settings.view.js')
 const QueryTimeView = require('../query-time/query-time.view.js')
+import { validateFilters } from '../../react-component/utils/validation'
 
 function isNested(filter) {
   let nested = false
@@ -436,7 +437,9 @@ module.exports = Marionette.LayoutView.extend({
     })
   },
   validate() {
-    return this.basicSettings.currentView.validate()
+    return this.basicSettings.currentView
+      .validate()
+      .concat(validateFilters(this.constructFilter()))
   },
   constructFilter() {
     const filters = []

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
@@ -147,6 +147,7 @@ module.exports = Marionette.LayoutView.extend({
     const errorMessages = queryContentView.getErrorMessages()
     if (errorMessages.length !== 0) {
       showErrorMessages(errorMessages)
+      return
     }
     queryContentView.save()
     this.queryTitle.currentView.save()
@@ -164,6 +165,7 @@ module.exports = Marionette.LayoutView.extend({
     const errorMessages = queryContentView.getErrorMessages()
     if (errorMessages.length !== 0) {
       showErrorMessages(errorMessages)
+      return
     }
     queryContentView.save()
     this.queryTitle.currentView.save()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
@@ -21,7 +21,7 @@ const QueryAdvanced = require('../query-advanced/query-advanced.view.js')
 const QueryTitle = require('../query-title/query-title.view.js')
 const store = require('../../js/store.js')
 import ExtensionPoints from '../../extension-points'
-import { validate } from '../../react-component/utils/validation'
+import { showErrorMessages } from '../../react-component/utils/validation'
 
 module.exports = Marionette.LayoutView.extend({
   template,
@@ -144,8 +144,9 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    if (!validate(queryContentView.validate())) {
-      return
+    const errorMessages = queryContentView.getErrorMessages()
+    if (errorMessages.length !== 0) {
+      showErrorMessages(errorMessages)
     }
     queryContentView.save()
     this.queryTitle.currentView.save()
@@ -160,8 +161,9 @@ module.exports = Marionette.LayoutView.extend({
     const queryContentView = this.queryView
       ? this.queryView
       : this.queryContent.currentView
-    if (!validate(queryContentView.validate())) {
-      return
+    const errorMessages = queryContentView.getErrorMessages()
+    if (errorMessages.length !== 0) {
+      showErrorMessages(errorMessages)
     }
     queryContentView.save()
     this.queryTitle.currentView.save()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -31,7 +31,7 @@ const plugin = require('plugins/query-settings')
 const ResultForm = require('../result-form/result-form.js')
 import * as React from 'react'
 import RadioComponent from '../../react-component/input-wrappers/radio'
-import { validate } from '../../react-component/utils/validation'
+import { showErrorMessages } from '../../react-component/utils/validation'
 
 module.exports = plugin(
   Marionette.LayoutView.extend({
@@ -268,11 +268,13 @@ module.exports = plugin(
     saveToModel() {
       this.model.set(this.toJSON())
     },
-    validate() {
+    getErrorMessages() {
       return []
     },
     save() {
-      if (!validate(this.validate())) {
+      const errorMessages = getErrorMessages()
+      if (errorMessages.length !== 0) {
+        showErrorMessages(errorMessages)
         return
       }
       this.saveToModel()
@@ -280,7 +282,7 @@ module.exports = plugin(
       this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
     },
     run() {
-      if (!validate(this.validate())) {
+      if (showErrorMessages().length !== 0) {
         return
       }
       this.saveToModel()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -272,7 +272,7 @@ module.exports = plugin(
       return []
     },
     save() {
-      const errorMessages = getErrorMessages()
+      const errorMessages = this.getErrorMessages()
       if (errorMessages.length !== 0) {
         showErrorMessages(errorMessages)
         return
@@ -282,7 +282,7 @@ module.exports = plugin(
       this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
     },
     run() {
-      const errorMessages = getErrorMessages()
+      const errorMessages = this.getErrorMessages()
       if (errorMessages.length !== 0) {
         showErrorMessages(errorMessages)
         return

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -282,7 +282,9 @@ module.exports = plugin(
       this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
     },
     run() {
-      if (showErrorMessages().length !== 0) {
+      const errorMessages = getErrorMessages()
+      if (errorMessages.length !== 0) {
+        showErrorMessages(errorMessages)
         return
       }
       this.saveToModel()

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -75,7 +75,7 @@ class BaseLine extends React.Component {
               type="number"
               label="Buffer width"
               min={0.000001}
-              value={props[widthKey]}
+              value={String(props[widthKey])}
               onChange={cursor(widthKey)}
             />
           </Units>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -12,4 +12,4 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-export { validate, validateFilters } from './validation'
+export { showErrorMessages, getFilterErrors } from './validation'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -12,4 +12,4 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-export { validate } from './validation'
+export { validate, validateFilters } from './validation'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -37,3 +37,33 @@ export function validate(errors: any) {
   announcement.announce(searchErrorMessage)
   return false
 }
+
+export function validateFilters(filters: any) {
+  const errors: any[] = []
+  for (let i = 0; i < filters.length; i++) {
+    const filter = filters[i]
+    const geometry = filter.geojson && filter.geojson.geometry
+    if (
+      geometry &&
+      geometry.type === 'Polygon' &&
+      geometry.coordinates[0].length < 4
+    ) {
+      errors.push({
+        title: 'Invalid geometry filter',
+        body:
+          'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]',
+      })
+    }
+    if (
+      geometry &&
+      geometry.type === 'LineString' &&
+      geometry.coordinates.length < 2
+    ) {
+      errors.push({
+        title: 'Invalid geometry filter',
+        body: 'Line coordinates must be in the form [[x,y],[x,y], ... ]',
+      })
+    }
+  }
+  return errors
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -18,7 +18,7 @@ const announcement = require('../../../component/announcement/index.jsx')
 
 export function showErrorMessages(errors: any) {
   if (errors.length === 0) {
-    throw new Error("errors should not be empty")
+    return
   }
   let searchErrorMessage = JSON.parse(JSON.stringify(InvalidSearchFormMessage))
   if (errors.length > 1) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -16,9 +16,9 @@
 import { InvalidSearchFormMessage } from '../../../component/announcement/CommonMessages'
 const announcement = require('../../../component/announcement/index.jsx')
 
-export function validate(errors: any) {
+export function showErrorMessages(errors: any) {
   if (errors.length === 0) {
-    return true
+    throw new Error("errors should not be empty")
   }
   let searchErrorMessage = JSON.parse(JSON.stringify(InvalidSearchFormMessage))
   if (errors.length > 1) {
@@ -35,10 +35,9 @@ export function validate(errors: any) {
     searchErrorMessage.message = error.body
   }
   announcement.announce(searchErrorMessage)
-  return false
 }
 
-export function validateFilters(filters: any) {
+export function getFilterErrors(filters: any) {
   const errors: any[] = []
   for (let i = 0; i < filters.length; i++) {
     const filter = filters[i]


### PR DESCRIPTION
Rebased @hayleynorton 's PR: 
https://github.com/codice/ddf/pull/5636

__________________

ABBREVIATED REVIEW
Link to original PR: #5594

What does this PR do?
~~Note: only review the last commit; this PR is built off #5609~~ #5609 has been merged, so only one commit in this PR

This PR provides the user with an error message containing guidance for the correct geo string format and prevents the search from being run or saved until corrected. It also changes the value passed to the buffer input to a string to prevent a large console error due to prop types not matching.

Who is reviewing it?
@andrewzimmer
@zta6
@cassandrabailey293

Select relevant component teams:
@codice/ui

Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@Bdthomson

How should this be tested?
Open the dev console
Start an anyGeo Advanced Search and select Line or Polygon
Verify that you no longer see the error pictured in the first screenshot below in the console
Paste a WKT string (or any string not in the correct format; could also leave blank) into the geo field
Click Search twice
Verify that you see the error pictured in the second (if searching with Polygon) or third (if searching with Line) screenshot below
Enter a geo string in the correct format and verify that you can successfully search
Verify the same as above but with the opposite geo type as before
Verify steps 4 - 8 with Basic Search
