### PR TITLE
DDF-2824 fix for duplicate anchors in documentation

### DIFF
--- a/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-api.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-api.adoc
@@ -152,11 +152,7 @@ Existing ${branding} clients are able to leverage product caching due to the pro
 
 ${branding} can send/receive notifications of "Activities" occurring in the system.
 
-====== Notifications
-
 Currently, the notifications provide information about resource retrieval only.
-
-====== Activities
 
 Activity events include the status and progress of actions that are being performed by the user, such as searches and downloads.
 

--- a/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-framework-camel-component.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-framework-camel-component.adoc
@@ -12,10 +12,7 @@ The Catalog Framework Camel Component supports creating, updating, and deleting 
 catalog:framework
 ----
 
-===== Message Headers
-
-====== Catalog Framework Producer
-
+.Catalog Framework Producer Message Headers
 [cols="1,5" options="header"]
 |===
 |Header
@@ -27,9 +24,8 @@ catalog:framework
 
 ===== Sending Messages to Catalog Framework Endpoint
 
-====== Catalog Framework Producer
-
-In Producer mode, the component provides the ability to provide different inputs and have the Catalog framework perform different operations based upon the header values.  
+.Catalog Framework Producer
+In Producer mode, the component provides the ability to supply different inputs and have the Catalog Framework perform different operations based upon the header values.  
 
 For the CREATE and UPDATE operation, the message body can contain a list of metacards or a single metacard object. 
 
@@ -68,8 +64,7 @@ FrameworkProducerException will be thrown causing the route to fail
 with a CamelExecutionException.
 ====
 
-====== Samples
-
+.Example Route
 This example demonstrates:
 
 . Reading in some sample data from the file system.

--- a/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-framework-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-framework-intro.adoc
@@ -163,15 +163,6 @@ Optional PreQuery and PostQuery Catalog Plugins may be invoked by the `CatalogFr
 If a `CatalogProvider` is not configured and no other remote Sources are configured, a fault will be returned.
 It is possible to have only remote Sources configured and no local `CatalogProvider` configured and be able to execute queries to specific remote Sources by specifying the site name(s) in the query request.
 
-===== Product Retrieval
-
-The Query Service Endpoint, the Catalog Framework, and the `CatalogProvider` are key components for processing a resource retrieval request.
-The Endpoint bundle contains a Web service that exposes the interface to retrieve resources.
-The Endpoint calls the `CatalogFramework` to execute the operations of its specification.
-The `CatalogFramework` relies on the Sources to execute the actual product retrieval.
-Optional `PreResource` and `PostResource` Catalog Plugins may be invoked by the `CatalogFramework` to modify the product retrieval request/response prior to the Catalog Provider processing the request and providing the response. 
-It is possible to retrieve products from specific remote Sources by specifying the site name(s) in the request.
-
 ===== Product Caching
 
 The Catalog Framework optionally provides caching of products, so future requests to retrieve the same product will be serviced much quicker.

--- a/distribution/docs/src/main/resources/content/_architectures/_plugins/catalog-metrics-plugin.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_plugins/catalog-metrics-plugin.adoc
@@ -8,7 +8,7 @@
 The Catalog Metrics Plugin captures metrics on catalog operations.
 These metrics can be viewed and analyzed using the <<_metrics_reporting_application,Metrics Reporting Application>> in the ${admin-console}.
 
-===== Related Components to the Source Metrics Plugin
+===== Related Components to the Catalog Metrics Plugin
 
 * <<_source_metrics_plugin,Source Metrics Plugin>>.
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-sts-claims-handlers.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-sts-claims-handlers.adoc
@@ -735,6 +735,7 @@ This is used to prove that the client can possess the SAML assertion returned by
 
 ==== X.509 PublicKey SAML Security Token Sample
 
+.X.509 PublicKey SAML Security Token Request
 The STS that comes with ${branding} requires the following to be in the RequestSecurityToken request in order to issue a valid SAML assertion.
 See the request block below for an example of how these components should be populated.
 
@@ -823,8 +824,7 @@ hwtE3xo6qQRRWlO3/clC4RnTev1crFVJQVBF3yfpRu8udJ2SOGdqU0vjUSu1h7aMkYJMHIu08Whj
 </soapenv:Envelope>
 ----
 
-==== X.509 PublicKey SAML Security Token Sample
-
+.X.509 PublicKey SAML Security Token Response
 This is the response from the STS containing the SAML assertion to be used in subsequent requests to QCRUD endpoints.
 
 The `saml2:Assertion` block contains the entire SAML assertion.

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/managed-service-factories.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/managed-service-factories.adoc
@@ -5,8 +5,6 @@
 :summary: Configuring Managed Service Factory bundles.
 :order: 20
 
-==== Configuring Managed Service Factory Bundles
-
 Services that are created using a Managed Service Factory can be configured using `.config` files as well.
 These configuration files, however, follow a different naming convention than `.cfg` files.
 The filenames must start with the Managed Service Factory PID, be followed by a dash and a unique identifier, and have a `.config` extension.
@@ -18,7 +16,7 @@ Also, a new service will be created and configured every time a configuration fi
 
 Any `service.factoryPid` and `service.pid` values in these `.config` files will be overridden by the values parsed from the file name, so `.config` files should not contain these properties.
 
-===== File Format
+==== File Format
 
 The basic syntax of the `.config` configuration files is similar to the older `.cfg` files but introduces support for lists and types other than simple strings.
 The type associated with a property must match the type attribute used in the corresponding `metatype.xml` file when applicable.


### PR DESCRIPTION
#### What does this PR do?

Updates documentation to avoid having section headings with duplicate titles.

#### Select relevant component teams: 
@codice/docs 
#### Ask 2 committers to review/merge the PR and tag them here.
@ahoffer
@lessarderic
@mcalcote
@shaundmorris

#### How should this be tested?

review content updates

#### Any background context you want to provide?
Section headers are automatically made into anchors for ease of linking. Duplicate anchors could cause a link to not point to the intended section of the documentation.

#### Screenshots

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
