### PR TITLE
DDF-5683 Pass federation to metacard view

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/metacard/metacard.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/metacard/metacard.js
@@ -73,6 +73,7 @@ module.exports = new (Backbone.AssociatedModel.extend({
   handleRoute() {
     if (router.toJSON().name === 'openMetacard') {
       const metacardId = router.toJSON().args[0]
+      const federation = router.toJSON().args[1]
       const queryForMetacard = new Query.Model({
         cql: cql.write({
           type: 'AND',
@@ -89,7 +90,7 @@ module.exports = new (Backbone.AssociatedModel.extend({
             },
           ],
         }),
-        federation: 'enterprise',
+        federation: federation,
       })
       if (this.get('currentQuery')) {
         this.get('currentQuery').cancelCurrentSearches()

--- a/ui/packages/catalog-ui-search/src/main/webapp/extension-points/routes/definitions/base/openMetacard.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/extension-points/routes/definitions/base/openMetacard.js
@@ -15,7 +15,7 @@
 // eslint-disable-next-line no-extra-semi
 ;({
   openMetacard: {
-    patterns: ['metacards/:id'],
+    patterns: ['metacards/:id/:federation'],
     component: 'component/metacard/metacard.view',
     menu: {
       component: 'component/metacard-menu/metacard-menu.view',

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/expand-interaction.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/metacard-interactions/expand-interaction.tsx
@@ -48,8 +48,10 @@ const handleExpand = (props: Props) => {
 
   id = encodeURIComponent(id)
 
+  const federation = props.model.first().get('src') === 'Local Content Stores' ? 'local' : 'enterprise'
+
   wreqr.vent.trigger('router:navigate', {
-    fragment: 'metacards/' + id,
+    fragment: 'metacards/' + id + '/' + federation,
     options: {
       trigger: true,
     },


### PR DESCRIPTION
#### What does this PR do?
Fixes the expand metacard view by allowing it to run an enterprise _or_ local query depending on the metacard being searched for. 

#### Who is reviewing it? 
@bdeining 
@andrewzimmer 
@cassandrabailey293 
@willwill96 
@hayleynorton 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@bdthomson

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Ingest some data
Run a local query that returns some results
On one of the results click the ellipses 
Click 'expand metacard view' 
Verify that you are navigated to a view where the selected query result is the only metacard shown, Verify that it appears correctly in the table view. 

Start the mock server and repeat the above process with a query result from one of the mock sources. Open the dev console and watch the network tab for `cql` queries. You should see a query issued for each of the federated sources. You will not see the selected query result in the UI because the mock servers are not set up to respond to the queries issued. 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5683 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
