### PR TITLE
DDF-5716 G-7628 Add support for specifying UTM coords with the hemisphere notation in the gazetteer 

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
@@ -13,18 +13,21 @@
  */
 package org.codice.ddf.catalog.ui.query.suggestion;
 
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.codice.ddf.spatial.geocoding.Suggestion;
 import org.codice.usng4j.CoordinateSystemTranslator;
 import org.codice.usng4j.DecimalDegreesCoordinate;
+import org.codice.usng4j.NSIndicator;
 import org.codice.usng4j.UsngCoordinate;
 import org.codice.usng4j.UtmUpsCoordinate;
 import org.slf4j.Logger;
@@ -76,42 +79,166 @@ public class UtmUpsCoordinateProcessor {
    */
   public void enhanceResults(final List<Suggestion> results, final String query) {
     LOGGER.trace("(UTM/UPS) Adding result for query [{}]", query);
-    final LiteralSuggestion literal = getUtmUpsSuggestion(query);
-    if (literal != null && literal.hasGeo()) {
-      LOGGER.trace("Adding the UTM/UPS suggestion to results [{}]", literal);
-      results.add(0, literal);
-    }
+    final List<LiteralSuggestion> literals = getUtmUpsSuggestions(query);
+    literals
+        .stream()
+        .filter(Objects::nonNull)
+        .filter(LiteralSuggestion::hasGeo)
+        .forEach(
+            literal -> {
+              LOGGER.trace("Adding the UTM/UPS suggestion to results [{}]", literal);
+              results.add(0, literal);
+            });
     LOGGER.trace("(UTM/UPS) Done");
   }
 
   @Nullable
-  private LiteralSuggestion getUtmUpsSuggestion(final String query) {
+  private List<LiteralSuggestion> getUtmUpsSuggestions(final String query) {
     final Matcher matcher = PATTERN_UTM_OR_UPS_COORDINATE.matcher(query);
-    final StringBuilder nameBuilder = new StringBuilder("UTM/UPS:");
-    final List<UtmUpsCoordinate> utmUpsCoords = new ArrayList<>();
+    final List<String> utmUpsMatches = new ArrayList<>();
     while (matcher.find()) {
       final String group = matcher.group();
       LOGGER.trace("Match found [{}]", group);
-      final String utmOrUpsText = normalizeCoordinate(group);
-      final UtmUpsCoordinate utmUps = parseUtmUpsString(utmOrUpsText);
-      if (utmUps != null) {
-        nameBuilder.append(" [ ").append(utmUps.toString()).append(" ]");
-        utmUpsCoords.add(utmUps);
-      }
+      utmUpsMatches.add(capitalizeLatBand(group));
     }
-    if (utmUpsCoords.isEmpty()) {
+
+    if (utmUpsMatches.isEmpty()) {
       LOGGER.trace("No valid UTM or UPS strings could be inferred from query [{}]", query);
-      return null;
+      return Collections.emptyList();
     }
+
+    return utmUpsMatches.size() == 1
+        ? suggestionsForSinglePoint(utmUpsMatches.get(0))
+        : Collections.singletonList(suggestionForMultiplePoints(utmUpsMatches));
+  }
+
+  /**
+   * Generates a list of {@code LiteralSuggestion}s based on the given {@code utmUpsCoord} string.
+   * This method is only used to generate suggestions when the user enters a single UTM/UPS
+   * coordinate. The following suggestions are returned depending on the information provided in the
+   * coordinate:
+   *
+   * <ul>
+   *   <li>If the {@code utmUpsCoord} does not have a latitude band, then two suggestions are
+   *       returned - one for each hemisphere - and the hemisphere is denoted by a "N" or "S"
+   *       suffix. Example: "18 631054mE 4776851mN" -> "UTM/UPS: [ 18N 631054mE 4776851mN N ]",
+   *       "UTM/UPS: [ 18S 631054mE 4776851mN S ]"
+   *   <li>If the {@code utmpUpsCoord} has an S latitude band, then two suggestions are also
+   *       returned: one for the S latitude band coordinate and another for the Southern hemisphere
+   *       coordinate. This is because the "S" is ambiguous - it can either refer to the latitude
+   *       band or the Southern hemisphere. Example: "15S 533427mE 3796272mN" -> "UTM/UPS: [ 15S
+   *       533427mE 3796272mN ]", "UTM/UPS: [ 15S 533427mE 3796272mN S ]"
+   *   <li>If the {@code utmUpsCoord} has an N latitude band, then two suggestions are returned: one
+   *       for the N latitude band and another for the Northern hemisphere. The "N" isn't ambiguous
+   *       in this case, but the Northern hemisphere suggestion is included for consistency and to
+   *       teach users about the N/S hemisphere syntax. Example: "9N 365103mE 659568mN" -> "UTM/UPS:
+   *       [ 9N 365103mE 659568mN ]", "UTM/UPS: [ 9N 365103mE 659568mN N ]"
+   *   <li>Otherwise, one suggestion is returned. Example: "20M 48831mE09437282mN" -> "UTM/UPS: [
+   *       20M 48831mE09437282mN ]"
+   * </ul>
+   *
+   * @param utmUpsCoord the user-provided gazetteer query text. It must match the {@code
+   *     PATTERN_UTM_OR_UPS_COORDINATE} pattern.
+   * @return a list of either one or two {@LiteralSuggestion}s, depending on the latitude band of
+   *     {@code utmUps}
+   */
+  private List<LiteralSuggestion> suggestionsForSinglePoint(String utmUpsCoord) {
+    //    if (!hasNSIndicator(utmUpsCoord)) {
+    final Character latBand = getLatBand(utmUpsCoord);
+    if (latBand == null) {
+      // A coordinate without an NS indicator and a lat band is invalid so show two suggestions,
+      // one for the northern hemisphere and another for the southern hemisphere.
+      return Stream.of(parseUtmUpsString(utmUpsCoord + " S"), parseUtmUpsString(utmUpsCoord + " N"))
+          .filter(Objects::nonNull)
+          .map(this::suggestion)
+          .collect(toList());
+    } else if (latBand.equals('N')) {
+      // If the coordinate has a N lat band, include the northern hemisphere suggestion for
+      // convenience
+      return Stream.of(
+              parseUtmUpsString(removeLatBand(utmUpsCoord) + " N"), parseUtmUpsString(utmUpsCoord))
+          .filter(Objects::nonNull)
+          .map(this::suggestion)
+          .collect(toList());
+    } else if (latBand.equals('S')) {
+      // Similarly, if the coordinate has an S lat band, include the southern hemisphere
+      // suggestion for convenience
+      return Stream.of(
+              parseUtmUpsString(removeLatBand(utmUpsCoord) + " S"), parseUtmUpsString(utmUpsCoord))
+          .filter(Objects::nonNull)
+          .map(this::suggestion)
+          .collect(toList());
+    } else {
+      return Stream.of(parseUtmUpsString(utmUpsCoord))
+          .filter(Objects::nonNull)
+          .map(this::suggestion)
+          .collect(toList());
+    }
+  }
+
+  private LiteralSuggestion suggestion(UtmUpsCoordinate utmUps) {
     return new LiteralSuggestion(
         LITERAL_SUGGESTION_ID,
-        nameBuilder.toString(),
+        makeSuggestionText(utmUps),
+        Collections.singletonList(latLonFromUtmUtps(utmUps)));
+  }
+
+  /**
+   * Generates one {@code LiteralSuggestion} by combining the latitude/longitude values of each
+   * UTM/UPS coordinate in the {@code utmUpsCoords} list. This method is used to generate a
+   * suggestion when the user enters multiple UTM/UPS coordinates. No additional suggestions are
+   * made for each point for simplicity since the map will pan to the extent or bounding box of all
+   * the points. As a result, the N/S characters of each coordinate are always treated as latitude
+   * bands and a coordinate is considered invalid if a latitude band is not included. Example: "12S
+   * 241451mE 4101052mN 13R 37090mE 63394439mN" -> "UTM/UPS: [ 12S 241451mE 4101052mN ] [ 13R
+   * 37090mE 63394439mN ]"
+   *
+   * @param utmUpsCoords a list of strings matching the {@code PATTERN_UTM_OR_UPS_COORDINATE}
+   *     pattern, created from the user-provided gazetteer query text.
+   * @return a singleton list with one {@code LiteralSuggestion} with the combined list of
+   *     latitude/longitude values.
+   */
+  private LiteralSuggestion suggestionForMultiplePoints(final List<String> utmUpsCoords) {
+    List<UtmUpsCoordinate> utmUpsList =
         utmUpsCoords
             .stream()
-            .map(this::toLatLon)
+            .map(this::parseUtmUpsString)
             .filter(Objects::nonNull)
-            .map(d -> new LatLon(d.getLat(), d.getLon()))
-            .collect(Collectors.toList()));
+            .collect(toList());
+    List<LatLon> latLonList =
+        utmUpsList.stream().map(this::latLonFromUtmUtps).filter(Objects::nonNull).collect(toList());
+    String suggestionText = makeSuggestionText(utmUpsList);
+
+    return new LiteralSuggestion(LITERAL_SUGGESTION_ID, suggestionText, latLonList);
+  }
+
+  private static String makeSuggestionText(UtmUpsCoordinate utmUps) {
+    final StringBuilder nameBuilder = new StringBuilder("UTM/UPS: [ ").append(utmUps.toString());
+    if (utmUps.getLatitudeBand() == null) {
+      if (utmUps.getNSIndicator() == NSIndicator.SOUTH) {
+        nameBuilder.append(" S");
+      } else {
+        nameBuilder.append(" N");
+      }
+    }
+    return nameBuilder.append(" ]").toString();
+  }
+
+  private static String makeSuggestionText(List<UtmUpsCoordinate> utmUpsList) {
+    final StringBuilder nameBuilder = new StringBuilder("UTM/UPS:");
+    for (UtmUpsCoordinate utmUps : utmUpsList) {
+      nameBuilder.append(" [ ").append(utmUps.toString()).append(" ]");
+    }
+    return nameBuilder.toString();
+  }
+
+  @Nullable
+  private LatLon latLonFromUtmUtps(UtmUpsCoordinate utmUps) {
+    DecimalDegreesCoordinate d = toLatLon(utmUps);
+    if (d == null) {
+      return null;
+    }
+    return new LatLon(d.getLat(), d.getLon());
   }
 
   /**
@@ -147,19 +274,15 @@ public class UtmUpsCoordinateProcessor {
    * @param utmOrUps the UTM string to transform.
    * @return a UTM string with a single piece of data that defines hemisphere.
    */
-  private static String normalizeCoordinate(final String utmOrUps) {
+  private static String capitalizeLatBand(final String utmOrUps) {
     if (!PATTERN_UTM_COORDINATE.matcher(utmOrUps).matches()) {
       LOGGER.trace("No transform necessary, coordinate [{}] was not UTM", utmOrUps);
       return utmOrUps; // Must be UPS, do nothing
     }
     final Character latBand = getLatBand(utmOrUps);
     if (latBand == null) {
-      final String withDefaultNorthLatBand = useDefaultNorthLatBand(utmOrUps);
-      LOGGER.trace(
-          "No lat band found on input [{}], setting it to default for north hemisphere [{}]",
-          utmOrUps,
-          withDefaultNorthLatBand);
-      return withDefaultNorthLatBand;
+      LOGGER.trace("No lat band found on input [{}], skipping conversion to upper case", utmOrUps);
+      return utmOrUps;
     }
     if (Character.isLowerCase(latBand)) {
       final String asUpperCase = setLatBand(utmOrUps, Character.toUpperCase(latBand));
@@ -192,18 +315,6 @@ public class UtmUpsCoordinateProcessor {
   }
 
   /**
-   * Convenience method for setting the lat band to the default north lat band. The provided input
-   * <b>must</b> match {@link #PATTERN_UTM_COORDINATE}.
-   *
-   * @param input the UTM input with no lat band, or a lat band to replace.
-   * @return the provided input UTM string with a lat band that directs calculations to the northern
-   *     hemisphere.
-   */
-  private static String useDefaultNorthLatBand(final String input) {
-    return setLatBand(input, 'N');
-  }
-
-  /**
    * Private utility method for updating a UTM string in-place with a new latitude band. The
    * provided input <b>must</b> match {@link #PATTERN_UTM_COORDINATE}.
    *
@@ -222,6 +333,25 @@ public class UtmUpsCoordinateProcessor {
     return input
         .substring(0, indexOfFirstWhiteSpaceOrLatBand)
         .concat(Character.toString(newLatBand))
+        .concat(input.substring(indexOfFirstWhiteSpace));
+  }
+
+  /**
+   * Private utility method for removing the latitude band in a UTM string in-place. The provided
+   * input <b>must</b> match {@link #PATTERN_UTM_COORDINATE}.
+   *
+   * @param input UTM string input; must match {@link #PATTERN_UTM_COORDINATE}.
+   * @return a new UTM string with the latitude band removed, regardless if the original UTM {@code
+   *     input} had a lat band or not.
+   */
+  private static String removeLatBand(final String input) {
+    final int indexOfFirstWhiteSpace = input.indexOf(SPACE_CHAR);
+    final int indexOfFirstWhiteSpaceOrLatBand =
+        Character.isLetter(input.charAt(indexOfFirstWhiteSpace - 1))
+            ? indexOfFirstWhiteSpace - 1 // Use lat band index instead
+            : indexOfFirstWhiteSpace;
+    return input
+        .substring(0, indexOfFirstWhiteSpaceOrLatBand)
         .concat(input.substring(indexOfFirstWhiteSpace));
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
@@ -214,7 +214,6 @@ public class UtmUpsCoordinateProcessor {
   private static String makeSuggestionText(UtmUpsCoordinate utmUps) {
     final StringBuilder nameBuilder = new StringBuilder();
     if (utmUps.isUTM()) {
-      // TODO add (hemisphere) / (latitude bands)
       nameBuilder.append("UTM: [ ").append(utmUps.toString()).append(" ]");
       if (utmUps.getLatitudeBand() == null) {
         if (utmUps.getNSIndicator() == NSIndicator.SOUTH) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
@@ -212,15 +212,21 @@ public class UtmUpsCoordinateProcessor {
   }
 
   private static String makeSuggestionText(UtmUpsCoordinate utmUps) {
-    final StringBuilder nameBuilder = new StringBuilder("UTM/UPS: [ ").append(utmUps.toString());
-    if (utmUps.getLatitudeBand() == null) {
-      if (utmUps.getNSIndicator() == NSIndicator.SOUTH) {
-        nameBuilder.append(" S");
-      } else {
-        nameBuilder.append(" N");
+    final StringBuilder nameBuilder = new StringBuilder();
+    if (utmUps.isUTM()) {
+      // TODO add (hemisphere) / (latitude bands)
+      nameBuilder.append("UTM: [ ").append(utmUps.toString()).append(" ]");
+      if (utmUps.getLatitudeBand() == null) {
+        if (utmUps.getNSIndicator() == NSIndicator.SOUTH) {
+          nameBuilder.append(" (Southern)");
+        } else {
+          nameBuilder.append(" (Northern)");
+        }
       }
+    } else {
+      nameBuilder.append("UPS: [ ").append(utmUps.toString()).append(" ]");
     }
-    return nameBuilder.append(" ]").toString();
+    return nameBuilder.toString();
   }
 
   private static String makeSuggestionText(List<UtmUpsCoordinate> utmUpsList) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
@@ -230,7 +230,16 @@ public class UtmUpsCoordinateProcessor {
   }
 
   private static String makeSuggestionText(List<UtmUpsCoordinate> utmUpsList) {
-    final StringBuilder nameBuilder = new StringBuilder("UTM/UPS:");
+    final StringBuilder nameBuilder = new StringBuilder();
+    long numberOfUtmCoords = utmUpsList.stream().filter(UtmUpsCoordinate::isUTM).count();
+    int total = utmUpsList.size();
+    if (numberOfUtmCoords == total) {
+      nameBuilder.append("UTM:");
+    } else if (numberOfUtmCoords == 0) {
+      nameBuilder.append("UPS:");
+    } else {
+      nameBuilder.append("UTM/UPS:");
+    }
     for (UtmUpsCoordinate utmUps : utmUpsList) {
       nameBuilder.append(" [ ").append(utmUps.toString()).append(" ]");
     }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
@@ -112,7 +112,7 @@ public class UtmUpsCoordinateProcessor {
   }
 
   /**
-   * Generates a list of {@code LiteralSuggestion}s based on the given {@code utmUpsCoord} string.
+   * Generates a list of {@link LiteralSuggestion}s based on the given {@code utmUpsCoord} string.
    * This method is only used to generate suggestions when the user enters a single UTM/UPS
    * coordinate. The following suggestions are returned depending on the information provided in the
    * coordinate:
@@ -138,8 +138,8 @@ public class UtmUpsCoordinateProcessor {
    *
    * @param utmUpsCoord the user-provided gazetteer query text. It must match the {@code
    *     PATTERN_UTM_OR_UPS_COORDINATE} pattern.
-   * @return a list of either one or two {@LiteralSuggestion}s, depending on the latitude band of
-   *     {@code utmUps}
+   * @return a list of either one or two {@link LiteralSuggestion}s, depending on the latitude band
+   *     of {@code utmUpsCoord}
    */
   private List<LiteralSuggestion> suggestionsForSinglePoint(String utmUpsCoord) {
     final Character latBand = getLatBand(utmUpsCoord);
@@ -182,7 +182,7 @@ public class UtmUpsCoordinateProcessor {
   }
 
   /**
-   * Generates one {@code LiteralSuggestion} by combining the latitude/longitude values of each
+   * Generates one {@link LiteralSuggestion} by combining the latitude/longitude values of each
    * UTM/UPS coordinate in the {@code utmUpsCoords} list. This method is used to generate a
    * suggestion when the user enters multiple UTM/UPS coordinates. No additional suggestions are
    * made for each point for simplicity since the map will pan to the extent or bounding box of all
@@ -193,7 +193,7 @@ public class UtmUpsCoordinateProcessor {
    *
    * @param utmUpsCoords a list of strings matching the {@code PATTERN_UTM_OR_UPS_COORDINATE}
    *     pattern, created from the user-provided gazetteer query text.
-   * @return a singleton list with one {@code LiteralSuggestion} with the combined list of
+   * @return a singleton list with one {@link LiteralSuggestion} with the combined list of
    *     latitude/longitude values.
    */
   private LiteralSuggestion suggestionForMultiplePoints(final List<String> utmUpsCoords) {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
@@ -92,7 +92,6 @@ public class UtmUpsCoordinateProcessor {
     LOGGER.trace("(UTM/UPS) Done");
   }
 
-  @Nullable
   private List<LiteralSuggestion> getUtmUpsSuggestions(final String query) {
     final Matcher matcher = PATTERN_UTM_OR_UPS_COORDINATE.matcher(query);
     final List<String> utmUpsMatches = new ArrayList<>();

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessor.java
@@ -143,7 +143,6 @@ public class UtmUpsCoordinateProcessor {
    *     {@code utmUps}
    */
   private List<LiteralSuggestion> suggestionsForSinglePoint(String utmUpsCoord) {
-    //    if (!hasNSIndicator(utmUpsCoord)) {
     final Character latBand = getLatBand(utmUpsCoord);
     if (latBand == null) {
       // A coordinate without an NS indicator and a lat band is invalid so show two suggestions,

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessorTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessorTest.java
@@ -14,65 +14,46 @@
 package org.codice.ddf.catalog.ui.query.suggestion;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import org.codice.ddf.spatial.geocoding.Suggestion;
 import org.codice.usng4j.CoordinateSystemTranslator;
-import org.codice.usng4j.DecimalDegreesCoordinate;
-import org.codice.usng4j.UtmUpsCoordinate;
-import org.junit.Before;
+import org.codice.usng4j.impl.CoordinateSystemTranslatorImpl;
 import org.junit.Test;
 
 public class UtmUpsCoordinateProcessorTest {
-  private CoordinateSystemTranslator translatorMock;
 
-  private UtmUpsCoordinateProcessor processor;
+  private CoordinateSystemTranslator translator = new CoordinateSystemTranslatorImpl();
 
-  @Before
-  public void setup() {
-    translatorMock = mock(CoordinateSystemTranslator.class);
-    processor = new UtmUpsCoordinateProcessor(translatorMock);
+  private UtmUpsCoordinateProcessor processor = new UtmUpsCoordinateProcessor(translator);
+
+  @Test
+  public void testUtmStringNorthernHemisphere() {
+    assertSuggestion(
+        "17R 522908mE 2853543mN", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
-  public void testUtmStringNorthernHemisphere() throws Exception {
-    setupMocks("13N 234789mE 234789mN", 1.0, 2.0);
+  public void testUtmStringNorthernHemisphereWithMultipleSpaces() {
     assertSuggestion(
-        "13N 234789mE 234789mN",
-        "UTM/UPS: [ 13N 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
-  }
-
-  @Test
-  public void testUtmStringNorthernHemisphereWithMultipleSpaces() throws Exception {
-    setupMocks("13N   234789mE   234789mN", 1.0, 2.0);
-    assertSuggestion(
-        "13N   234789mE   234789mN",
-        "UTM/UPS: [ 13N   234789mE   234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "17R   522908mE   2853543mN", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
   public void testUtmStringNorthernHemisphereWithTabs() {
-    assertSuggestionDoesNotExist(String.format("%s\t%s\t%s", "13N", "234789mE", "234789mN"));
+    assertSuggestionDoesNotExist(String.format("%s\t%s\t%s", "17R", "522908mE", "2853543mN"));
   }
 
   @Test
-  public void testUtmStringSouthernHemisphere() throws Exception {
-    setupMocks("13M 234789mE 234789mN", 1.0, 2.0);
+  public void testUtmStringSouthernHemisphere() {
     assertSuggestion(
-        "13M 234789mE 234789mN",
-        "UTM/UPS: [ 13M 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "13M 604276mE 9805713mN", "UTM/UPS: [ 13M 604276mE 9805713mN ]", -1.757537, -104.062500);
   }
 
   @Test
@@ -81,12 +62,9 @@ public class UtmUpsCoordinateProcessorTest {
   }
 
   @Test
-  public void testUtmStringZoneTooBig() throws Exception {
-    setupMocks("1N 234789mE 234789mN", 1.0, 2.0);
+  public void testUtmStringZoneTooBig() {
     assertSuggestion(
-        "61N 234789mE 234789mN",
-        "UTM/UPS: [ 1N 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "61P 508378mE 967744mN", "UTM/UPS: [ 1P 508378mE 967744mN ]", 8.754795, -176.923828);
   }
 
   @Test
@@ -95,12 +73,21 @@ public class UtmUpsCoordinateProcessorTest {
   }
 
   @Test
-  public void testUtmStringWithoutLatBand() throws Exception {
-    setupMocks("13N 234789mE 234789mN", 1.0, 2.0);
+  public void testUtmStringWithoutLatBand() {
+    List<Suggestion> list = new ArrayList<>();
+    processor.enhanceResults(list, "13 234789mE 234789mN");
+    assertThat(list, hasSize(2));
+
     assertSuggestion(
-        "13 234789mE 234789mN",
-        "UTM/UPS: [ 13N 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        (LiteralSuggestion) list.get(0),
+        "UTM/UPS: [ 13 234789mE 234789mN N ]",
+        2.122350,
+        -107.384318);
+    assertSuggestion(
+        (LiteralSuggestion) list.get(1),
+        "UTM/UPS: [ 13 234789mE 234789mN S ]",
+        -86.716923,
+        -164.055897);
   }
 
   @Test
@@ -109,39 +96,63 @@ public class UtmUpsCoordinateProcessorTest {
   }
 
   @Test
-  public void testUtmStringWithNorthernHemisphereIndicator() throws Exception {
-    setupMocks("13N 234789mE 234789mN", 1.0, 2.0);
+  public void testUtmStringWithNLatitudeBand() {
+    List<Suggestion> list = new ArrayList<>();
+    processor.enhanceResults(list, "13N 234789mE 234789mN");
+    assertThat(list, hasSize(2));
+
     assertSuggestion(
-        "13N 234789mE 234789mN N",
+        (LiteralSuggestion) list.get(0),
         "UTM/UPS: [ 13N 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        2.122350,
+        -107.384318);
+    assertSuggestion(
+        (LiteralSuggestion) list.get(1),
+        "UTM/UPS: [ 13 234789mE 234789mN N ]",
+        2.122350,
+        -107.384318);
   }
 
   @Test
-  public void testUtmStringWithSouthernHemisphereIndicator() throws Exception {
-    setupMocks("13N 234789mE 234789mN", 1.0, 2.0);
+  public void testUtmStringWithSLatitudeBand() {
+    List<Suggestion> list = new ArrayList<>();
+    processor.enhanceResults(list, "19S 634900mE 4004219mN");
+    assertThat(list, hasSize(2));
+
     assertSuggestion(
-        "13N 234789mE 234789mN S",
-        "UTM/UPS: [ 13N 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        (LiteralSuggestion) list.get(0),
+        "UTM/UPS: [ 19S 634900mE 4004219mN ]",
+        36.173357,
+        -67.500000);
+    assertSuggestion(
+        (LiteralSuggestion) list.get(1),
+        "UTM/UPS: [ 19 634900mE 4004219mN S ]",
+        -54.092504,
+        -66.937300);
   }
 
   @Test
-  public void testUtmStringWithInvalidNSIndicator() throws Exception {
-    setupMocks("13N 234789mE 234789mN", 1.0, 2.0);
+  public void testUtmStringWithNorthernHemisphereIndicator() {
     assertSuggestion(
-        "13N 234789mE 234789mN R",
-        "UTM/UPS: [ 13N 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "17R 522908mE 2853543mN N", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
-  public void testUtmStringWithLowerCaseLatBand() throws Exception {
-    setupMocks("13M 234789mE 234789mN", 1.0, 2.0);
+  public void testUtmStringWithSouthernHemisphereIndicator() {
     assertSuggestion(
-        "13m 234789mE 234789mN",
-        "UTM/UPS: [ 13M 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "17R 522908mE 2853543mN S", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
+  }
+
+  @Test
+  public void testUtmStringWithInvalidNSIndicator() {
+    assertSuggestion(
+        "17R 522908mE 2853543mN R", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
+  }
+
+  @Test
+  public void testUtmStringWithLowerCaseLatBand() {
+    assertSuggestion(
+        "17r 522908mE 2853543mN", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
@@ -150,149 +161,125 @@ public class UtmUpsCoordinateProcessorTest {
   }
 
   @Test
-  public void testUpsString() throws Exception {
-    setupMocks("A 2347891mE 2347891mN", 1.0, 2.0);
+  public void testUpsString() {
     assertSuggestion(
-        "A 2347891mE 2347891mN",
-        "UTM/UPS: [ A 2347891mE 2347891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "A 2347891mE 2347891mN", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
-  public void testUpsStringWithoutEastingUnits() throws Exception {
-    setupMocks("A 2347891 2347891mN", 1.0, 2.0);
-    assertSuggestion(
-        "A 2347891 2347891mN",
-        "UTM/UPS: [ A 2347891 2347891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+  public void testUpsStringWithoutEastingUnits() {
+    assertSuggestion("A 2347891 2347891mN", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
-  public void testUpsStringWithoutNorthingUnits() throws Exception {
-    setupMocks("A 2347891mE 2347891", 1.0, 2.0);
-    assertSuggestion(
-        "A 2347891mE 2347891",
-        "UTM/UPS: [ A 2347891mE 2347891 ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+  public void testUpsStringWithoutNorthingUnits() {
+    assertSuggestion("A 2347891mE 2347891", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
-  public void testUpsStringWithRedundantZoneZero() throws Exception {
-    setupMocks("0A 2347891mE 2347891mN", 1.0, 2.0);
+  public void testUpsStringWithRedundantZoneZero() {
     assertSuggestion(
-        "0A 2347891mE 2347891mN",
-        "UTM/UPS: [ 0A 2347891mE 2347891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "0A 2347891mE 2347891mN", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
-  public void testUpsStringDisregardsNorthIndicator() throws Exception {
-    setupMocks("A 2347891mE 2347891mN", 1.0, 2.0);
+  public void testUpsStringDisregardsNorthIndicator() {
     assertSuggestion(
-        "A 2347891mE 2347891mN N",
-        "UTM/UPS: [ A 2347891mE 2347891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "A 2347891mE 2347891mN N", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
-  public void testUpsStringDisregardsSouthIndicator() throws Exception {
-    setupMocks("A 2347891mE 2347891mN", 1.0, 2.0);
+  public void testUpsStringDisregardsSouthIndicator() {
     assertSuggestion(
-        "A 2347891mE 2347891mN S",
-        "UTM/UPS: [ A 2347891mE 2347891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0)));
+        "A 2347891mE 2347891mN S", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
-  public void testUtmFollowedByUtm() throws Exception {
-    setupMocks("13N 234789mE 234789mN", 1.0, 2.0);
-    setupMocks("22X 234789mE 234789mN", 3.0, 4.0);
+  public void testUtmFollowedByUtm() {
     assertSuggestion(
-        "13N 234789mE 234789mN 22X 234789mE 234789mN",
-        "UTM/UPS: [ 13N 234789mE 234789mN ] [ 22X 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0), new LatLon(3.0, 4.0)));
+        "13N 234789mE 234789mN 22X 234789mE 8592442mN",
+        "UTM/UPS: [ 13N 234789mE 234789mN ] [ 22X 234789mE 8592442mN ]",
+        2.122350,
+        -107.384318,
+        77.190666,
+        -61.773164);
   }
 
   @Test
-  public void testUtmWithoutUnitLabelFollowedByUtm() throws Exception {
-    setupMocks("13N 234789mE 234789", 1.0, 2.0);
-    setupMocks("22X 234789mE 234789mN", 3.0, 4.0);
+  public void testUtmWithoutUnitLabelFollowedByUtm() {
     assertSuggestion(
-        "13N 234789mE 234789 22X 234789mE 234789mN",
-        "UTM/UPS: [ 13N 234789mE 234789 ] [ 22X 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0), new LatLon(3.0, 4.0)));
+        "13N 234789mE 234789 22X 234789mE 8592442mN",
+        "UTM/UPS: [ 13N 234789mE 234789mN ] [ 22X 234789mE 8592442mN ]",
+        2.122350,
+        -107.384318,
+        77.190666,
+        -61.773164);
   }
 
   @Test
-  public void testUpsFollowedByUps() throws Exception {
-    setupMocks("A 2347891mE 2347891mN", 1.0, 2.0);
-    setupMocks("B 1077891mE 1077891mN", 3.0, 4.0);
+  public void testUpsFollowedByUps() {
     assertSuggestion(
         "A 2347891mE 2347891mN B 1077891mE 1077891mN",
         "UTM/UPS: [ A 2347891mE 2347891mN ] [ B 1077891mE 1077891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0), new LatLon(3.0, 4.0)));
+        -85.570691,
+        45.0,
+        -78.293449,
+        -135.0);
   }
 
   @Test
-  public void testUpsWithoutUnitLabelFollowedByUps() throws Exception {
-    setupMocks("A 2347891mE 2347891", 1.0, 2.0);
-    setupMocks("B 1077891mE 1077891mN", 3.0, 4.0);
+  public void testUpsWithoutUnitLabelFollowedByUps() {
     assertSuggestion(
         "A 2347891mE 2347891 B 1077891mE 1077891mN",
-        "UTM/UPS: [ A 2347891mE 2347891 ] [ B 1077891mE 1077891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0), new LatLon(3.0, 4.0)));
+        "UTM/UPS: [ A 2347891mE 2347891mN ] [ B 1077891mE 1077891mN ]",
+        -85.570691,
+        45.0,
+        -78.293449,
+        -135.0);
   }
 
   @Test
-  public void testUtmFollowedByUps() throws Exception {
-    setupMocks("13N 234789mE 234789mN", 1.0, 2.0);
-    setupMocks("B 1077891mE 1077891mN", 3.0, 4.0);
+  public void testUtmFollowedByUps() {
     assertSuggestion(
         "13N 234789mE 234789mN B 1077891mE 1077891mN",
         "UTM/UPS: [ 13N 234789mE 234789mN ] [ B 1077891mE 1077891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0), new LatLon(3.0, 4.0)));
+        2.122350,
+        -107.384318,
+        -78.293449,
+        -135.0);
   }
 
   @Test
-  public void testUtmWithoutUnitLabelFollowedByUps() throws Exception {
-    setupMocks("13N 234789mE 234789", 1.0, 2.0);
-    setupMocks("B 1077891mE 1077891mN", 3.0, 4.0);
+  public void testUtmWithoutUnitLabelFollowedByUps() {
     assertSuggestion(
         "13N 234789mE 234789 B 1077891mE 1077891mN",
-        "UTM/UPS: [ 13N 234789mE 234789 ] [ B 1077891mE 1077891mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0), new LatLon(3.0, 4.0)));
+        "UTM/UPS: [ 13N 234789mE 234789mN ] [ B 1077891mE 1077891mN ]",
+        2.122350,
+        -107.384318,
+        -78.293449,
+        -135.0);
   }
 
   @Test
-  public void testUpsFollowedByUtm() throws Exception {
-    setupMocks("B 1077891mE 1077891mN", 1.0, 2.0);
-    setupMocks("13N 234789mE 234789mN", 3.0, 4.0);
+  public void testUpsFollowedByUtm() {
     assertSuggestion(
         "B 1077891mE 1077891mN 13N 234789mE 234789mN",
         "UTM/UPS: [ B 1077891mE 1077891mN ] [ 13N 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0), new LatLon(3.0, 4.0)));
+        -78.293449,
+        -135.0,
+        2.122350,
+        -107.384318);
   }
 
   @Test
-  public void testUpsWithoutUnitLabelFollowedByUtm() throws Exception {
-    setupMocks("B 1077891mE 1077891", 1.0, 2.0);
-    setupMocks("13N 234789mE 234789mN", 3.0, 4.0);
+  public void testUpsWithoutUnitLabelFollowedByUtm() {
     assertSuggestion(
         "B 1077891mE 1077891 13N 234789mE 234789mN",
-        "UTM/UPS: [ B 1077891mE 1077891 ] [ 13N 234789mE 234789mN ]",
-        ImmutableList.of(new LatLon(1.0, 2.0), new LatLon(3.0, 4.0)));
-  }
-
-  private void setupMocks(String expectedCoordString, Double expectedLat, Double expectedLon)
-      throws Exception {
-    UtmUpsCoordinate mockUtmUps = mock(UtmUpsCoordinate.class);
-    doReturn(mockUtmUps).when(translatorMock).parseUtmUpsString(expectedCoordString);
-    doReturn(expectedCoordString).when(mockUtmUps).toString();
-
-    DecimalDegreesCoordinate ddc = mock(DecimalDegreesCoordinate.class);
-    doReturn(expectedLat).when(ddc).getLat();
-    doReturn(expectedLon).when(ddc).getLon();
-    doReturn(ddc).when(translatorMock).toLatLon(mockUtmUps);
+        "UTM/UPS: [ B 1077891mE 1077891mN ] [ 13N 234789mE 234789mN ]",
+        -78.293449,
+        -135.0,
+        2.122350,
+        -107.384318);
   }
 
   private void assertSuggestionDoesNotExist(String query) {
@@ -301,16 +288,27 @@ public class UtmUpsCoordinateProcessorTest {
     assertThat(list, is(empty()));
   }
 
-  private void assertSuggestion(String query, String expectedName, List<LatLon> expectedGeo) {
+  private void assertSuggestion(String query, String expectedName, double... expectedLatLons) {
     List<Suggestion> list = new LinkedList<>();
     processor.enhanceResults(list, query);
-    assertThat(list, is(not(empty())));
     assertThat(list, hasSize(1));
 
     LiteralSuggestion literalSuggestion = (LiteralSuggestion) list.get(0);
-    assertThat(literalSuggestion.getId(), is("LITERAL-UTM-UPS"));
-    assertThat(literalSuggestion.getName(), is(expectedName));
-    assertThat(literalSuggestion.hasGeo(), is(true));
-    assertThat(literalSuggestion.getGeo(), is(equalTo(expectedGeo)));
+    assertSuggestion(literalSuggestion, expectedName, expectedLatLons);
+  }
+
+  private void assertSuggestion(
+      LiteralSuggestion actualSuggestion, String expectedName, double... expectedLatLons) {
+    assertThat(actualSuggestion.getId(), is("LITERAL-UTM-UPS"));
+    assertThat(actualSuggestion.getName(), is(expectedName));
+    assertThat(actualSuggestion.hasGeo(), is(true));
+    assertThat(expectedLatLons.length % 2, is(0));
+    assertThat(expectedLatLons.length / 2, is(actualSuggestion.getGeo().size()));
+    int i = 0;
+    for (LatLon latLon : actualSuggestion.getGeo()) {
+      assertThat(latLon.getLat(), is(closeTo(expectedLatLons[i], 0.00001)));
+      assertThat(latLon.getLon(), is(closeTo(expectedLatLons[i + 1], 0.00001)));
+      i += 2;
+    }
   }
 }

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessorTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessorTest.java
@@ -36,13 +36,13 @@ public class UtmUpsCoordinateProcessorTest {
   @Test
   public void testUtmStringNorthernHemisphere() {
     assertSuggestion(
-        "17R 522908mE 2853543mN", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
+        "17R 522908mE 2853543mN", "UTM: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
   public void testUtmStringNorthernHemisphereWithMultipleSpaces() {
     assertSuggestion(
-        "17R   522908mE   2853543mN", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
+        "17R   522908mE   2853543mN", "UTM: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
@@ -53,7 +53,7 @@ public class UtmUpsCoordinateProcessorTest {
   @Test
   public void testUtmStringSouthernHemisphere() {
     assertSuggestion(
-        "13M 604276mE 9805713mN", "UTM/UPS: [ 13M 604276mE 9805713mN ]", -1.757537, -104.062500);
+        "13M 604276mE 9805713mN", "UTM: [ 13M 604276mE 9805713mN ]", -1.757537, -104.062500);
   }
 
   @Test
@@ -64,7 +64,7 @@ public class UtmUpsCoordinateProcessorTest {
   @Test
   public void testUtmStringZoneTooBig() {
     assertSuggestion(
-        "61P 508378mE 967744mN", "UTM/UPS: [ 1P 508378mE 967744mN ]", 8.754795, -176.923828);
+        "61P 508378mE 967744mN", "UTM: [ 1P 508378mE 967744mN ]", 8.754795, -176.923828);
   }
 
   @Test
@@ -80,12 +80,12 @@ public class UtmUpsCoordinateProcessorTest {
 
     assertSuggestion(
         (LiteralSuggestion) list.get(0),
-        "UTM/UPS: [ 13 234789mE 234789mN N ]",
+        "UTM: [ 13 234789mE 234789mN ] (Northern)",
         2.122350,
         -107.384318);
     assertSuggestion(
         (LiteralSuggestion) list.get(1),
-        "UTM/UPS: [ 13 234789mE 234789mN S ]",
+        "UTM: [ 13 234789mE 234789mN ] (Southern)",
         -86.716923,
         -164.055897);
   }
@@ -102,13 +102,10 @@ public class UtmUpsCoordinateProcessorTest {
     assertThat(list, hasSize(2));
 
     assertSuggestion(
-        (LiteralSuggestion) list.get(0),
-        "UTM/UPS: [ 13N 234789mE 234789mN ]",
-        2.122350,
-        -107.384318);
+        (LiteralSuggestion) list.get(0), "UTM: [ 13N 234789mE 234789mN ]", 2.122350, -107.384318);
     assertSuggestion(
         (LiteralSuggestion) list.get(1),
-        "UTM/UPS: [ 13 234789mE 234789mN N ]",
+        "UTM: [ 13 234789mE 234789mN ] (Northern)",
         2.122350,
         -107.384318);
   }
@@ -120,13 +117,10 @@ public class UtmUpsCoordinateProcessorTest {
     assertThat(list, hasSize(2));
 
     assertSuggestion(
-        (LiteralSuggestion) list.get(0),
-        "UTM/UPS: [ 19S 634900mE 4004219mN ]",
-        36.173357,
-        -67.500000);
+        (LiteralSuggestion) list.get(0), "UTM: [ 19S 634900mE 4004219mN ]", 36.173357, -67.500000);
     assertSuggestion(
         (LiteralSuggestion) list.get(1),
-        "UTM/UPS: [ 19 634900mE 4004219mN S ]",
+        "UTM: [ 19 634900mE 4004219mN ] (Southern)",
         -54.092504,
         -66.937300);
   }
@@ -134,25 +128,25 @@ public class UtmUpsCoordinateProcessorTest {
   @Test
   public void testUtmStringWithNorthernHemisphereIndicator() {
     assertSuggestion(
-        "17R 522908mE 2853543mN N", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
+        "17R 522908mE 2853543mN N", "UTM: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
   public void testUtmStringWithSouthernHemisphereIndicator() {
     assertSuggestion(
-        "17R 522908mE 2853543mN S", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
+        "17R 522908mE 2853543mN S", "UTM: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
   public void testUtmStringWithInvalidNSIndicator() {
     assertSuggestion(
-        "17R 522908mE 2853543mN R", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
+        "17R 522908mE 2853543mN R", "UTM: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
   public void testUtmStringWithLowerCaseLatBand() {
     assertSuggestion(
-        "17r 522908mE 2853543mN", "UTM/UPS: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
+        "17r 522908mE 2853543mN", "UTM: [ 17R 522908mE 2853543mN ]", 25.799891, -80.771484);
   }
 
   @Test
@@ -162,36 +156,32 @@ public class UtmUpsCoordinateProcessorTest {
 
   @Test
   public void testUpsString() {
-    assertSuggestion(
-        "A 2347891mE 2347891mN", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
+    assertSuggestion("A 2347891mE 2347891mN", "UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
   public void testUpsStringWithoutEastingUnits() {
-    assertSuggestion("A 2347891 2347891mN", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
+    assertSuggestion("A 2347891 2347891mN", "UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
   public void testUpsStringWithoutNorthingUnits() {
-    assertSuggestion("A 2347891mE 2347891", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
+    assertSuggestion("A 2347891mE 2347891", "UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
   public void testUpsStringWithRedundantZoneZero() {
-    assertSuggestion(
-        "0A 2347891mE 2347891mN", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
+    assertSuggestion("0A 2347891mE 2347891mN", "UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
   public void testUpsStringDisregardsNorthIndicator() {
-    assertSuggestion(
-        "A 2347891mE 2347891mN N", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
+    assertSuggestion("A 2347891mE 2347891mN N", "UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test
   public void testUpsStringDisregardsSouthIndicator() {
-    assertSuggestion(
-        "A 2347891mE 2347891mN S", "UTM/UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
+    assertSuggestion("A 2347891mE 2347891mN S", "UPS: [ A 2347891mE 2347891mN ]", -85.570691, 45.0);
   }
 
   @Test

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessorTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/suggestion/UtmUpsCoordinateProcessorTest.java
@@ -188,7 +188,7 @@ public class UtmUpsCoordinateProcessorTest {
   public void testUtmFollowedByUtm() {
     assertSuggestion(
         "13N 234789mE 234789mN 22X 234789mE 8592442mN",
-        "UTM/UPS: [ 13N 234789mE 234789mN ] [ 22X 234789mE 8592442mN ]",
+        "UTM: [ 13N 234789mE 234789mN ] [ 22X 234789mE 8592442mN ]",
         2.122350,
         -107.384318,
         77.190666,
@@ -199,7 +199,7 @@ public class UtmUpsCoordinateProcessorTest {
   public void testUtmWithoutUnitLabelFollowedByUtm() {
     assertSuggestion(
         "13N 234789mE 234789 22X 234789mE 8592442mN",
-        "UTM/UPS: [ 13N 234789mE 234789mN ] [ 22X 234789mE 8592442mN ]",
+        "UTM: [ 13N 234789mE 234789mN ] [ 22X 234789mE 8592442mN ]",
         2.122350,
         -107.384318,
         77.190666,
@@ -210,7 +210,7 @@ public class UtmUpsCoordinateProcessorTest {
   public void testUpsFollowedByUps() {
     assertSuggestion(
         "A 2347891mE 2347891mN B 1077891mE 1077891mN",
-        "UTM/UPS: [ A 2347891mE 2347891mN ] [ B 1077891mE 1077891mN ]",
+        "UPS: [ A 2347891mE 2347891mN ] [ B 1077891mE 1077891mN ]",
         -85.570691,
         45.0,
         -78.293449,
@@ -221,7 +221,7 @@ public class UtmUpsCoordinateProcessorTest {
   public void testUpsWithoutUnitLabelFollowedByUps() {
     assertSuggestion(
         "A 2347891mE 2347891 B 1077891mE 1077891mN",
-        "UTM/UPS: [ A 2347891mE 2347891mN ] [ B 1077891mE 1077891mN ]",
+        "UPS: [ A 2347891mE 2347891mN ] [ B 1077891mE 1077891mN ]",
         -85.570691,
         45.0,
         -78.293449,


### PR DESCRIPTION
#### What does this PR do?
When a user enters a UTM coordinate in the gazetteer search box with no latitude band, `N` is used as the default. This behavior makes is appear as if we support specifying the Northern or Southern hemisphere in place of the latitude band since the gazetteer correctly pans to the Northern hemisphere point. However, this is only a side-effect of how we are parsing the coordinates. In reality, `N` does not directly correspond to the Northern hemisphere. Instead, if the latitude band does not actually correspond with the northing value, then the invalid latitude band is used to *indirectly* determine which hemisphere to use with C-M latitude bands corresponding to the Southern hemisphere and N-X latitude bands corresponding the the Northern hemisphere. As a result, the default behavior of adding the `N` latitude band happens to correctly takes the user to the Northern hemisphere coordinate. But when they try to use the `S` latitude band as the Southern hemisphere equivalent, they are taken to the same coordinate as the `N` latitude band because `S` also falls between N-X.

This PR allows users to use the `S` latitude band by showing two suggestions for that case:
1. the usual coordinate with the `S` latitude band, and
2. the Southern hemisphere alternative

For consistency and to teach the users about this feature, two suggestions are also shown for coordinates with the `N` latitude band even though both actually point to the same location.

In addition, if no latitude band is entered then both the Northern hemisphere and Southern hemisphere suggestions are shown.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@brianfelix @brhumphe @kentmorrissey @mazarag2 @Lambeaux 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Start solr by running `docker-compose up` in distribution/docker/solrcloud
2. Start DDF and install the standard profile (`profile:install standard`)
3. In the admin UI, go to "Catalog UI Search" and unselect "Use Online Gazetteer"
4. In the gazetteer search box in Intrigue, test these cases. Make sure the suggestions are shown as expected and the map pans to the correct location. You can use this tool (https://mappingsupport.com/p2/coordinates-utm-gissurfer-maps.html) to determine if the locations are correct and get new coordinates to test (right clicking on that map shows the UTM coordinates for that point).

| Gazetteer Query        | UTM suggestion(s)           | Location |
| ------------- |-------------|-------------|
| 17R 461652mE 2993043mN      | UTM: [ 17R 461652mE 2993043mN ] | Florida
| 19G 577867mE 5117939mN      | UTM: [ 19G 577867mE 5117939mN ]      | Argentina
| 34 678879 6697434 | UTM: [ 34  678879mE 6697434mN N ], UTM: [ 34  678879mE 6697434mN N ]      | Finland, South Africa
| 53S 571222mE 7287229mN | UTM: [ 53 570673mE 7181387mN N ], UTM: [ 53 570673mE 7181387mN N ]      | Russia, Australia
| 20N 235789mE 756626mN | UTM: [ 20N 235789mE 756626mN ], UTM: [ 20 235789mE 756626mN N ] | Both go to Venezuela      | 
| 10U 432103mE 5412830mN 19R 430147mE 2862469mN | UTM: [ 10U 432103mE 5412830mN 19R ] [ 430147mE 2862469mN ]      | The extent of the US

5. Enter combinations of UTM and UPS coordinates
     - Verify if only UTM coordinates are entered, the suggestion prefix is `UTM`
     - Verify if only UPS coordinates are entered, the suggestion prefix is `UPS`
     - Verify if a mix of UTM and UPS coordinates are entered, the suggestion prefix is `UTM/UPS`
5. Try any other coordinates / combinations of coordinates
6. Try some malformed coordinates (i.e. no zone, no latitude band, no units, multiple spaces, etc)

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5716 

#### Screenshots
S latitude band and Southern hemisphere suggestions
<img width="537" alt="single-UTM-point" src="https://user-images.githubusercontent.com/8922441/71222086-4cf34a80-228c-11ea-8dc7-01e664b91e27.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
