### PR TITLE
[2.19.x] Fixed Result Forms from hiding temporal attributes

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
@@ -84,15 +84,21 @@ const metacardStartingTypes = {
   },
 }
 
-// needed to handle erroneous or currently unknown attributes (they could be picked up after searching a source)
-properties.basicSearchTemporalSelectionDefault.forEach(proposedType => {
-  metacardStartingTypes[proposedType] = {
-    id: proposedType,
-    type: 'DATE',
-    alias: properties.attributeAliases[proposedType],
-    hidden: properties.isHidden(proposedType),
-  }
-})
+function metacardStartingTypesWithTemporal() {
+  // needed to handle erroneous or currently unknown attributes (they could be picked up after searching a source)
+  const metacardStartingTypeWithTemporal = { ...metacardStartingTypes }
+
+  properties.basicSearchTemporalSelectionDefault.forEach(proposedType => {
+    metacardStartingTypeWithTemporal[proposedType] = {
+      id: proposedType,
+      type: 'DATE',
+      alias: properties.attributeAliases[proposedType],
+      hidden: properties.isHidden(proposedType),
+    }
+  })
+
+  return metacardStartingTypeWithTemporal
+}
 
 module.exports = new (Backbone.Model.extend({
   initialize() {
@@ -218,7 +224,7 @@ module.exports = new (Backbone.Model.extend({
   },
   metacardDefinitions: [],
   sortedMetacardTypes: [],
-  metacardTypes: _.extendOwn({}, metacardStartingTypes),
+  metacardTypes: _.extendOwn({}, metacardStartingTypesWithTemporal()),
   validation: {},
   enums: properties.enums,
 }))()


### PR DESCRIPTION
#### What does this PR do?
Fixed Result Forms from hiding temporal attributes.  
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@cassandrabailey293 @andrewzimmer 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)

-->
@andrewkfiedler
@bdthomson
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Build / Install / Verify that temporal attributes are present in the result forms dropdown and verify basic search forms still work as expected.
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
