### PR TITLE
DDF-5734 Allow notifications to specify the number of results they found

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/security/app/UserApplication.java
@@ -278,6 +278,7 @@ public class UserApplication implements SparkApplication {
         .put("serverGenerated", persistentItem.getOrDefault("serverGenerated", "true"))
         .put("when", persistentItem.getOrDefault("when", DateTime.now().toInstant().getMillis()))
         .put("unseen", Boolean.parseBoolean((String) persistentItem.getOrDefault("unseen", "true")))
+        .put("count", persistentItem.getOrDefault("count", -1))
         .build();
   }
 
@@ -311,6 +312,7 @@ public class UserApplication implements SparkApplication {
     item.addProperty("queryId", alert.getOrDefault("queryId", ""));
     item.addProperty("serverGenerated", alert.getOrDefault("serverGenerated", false));
     item.addProperty("unseen", alert.getOrDefault("unseen", true));
+    item.addProperty("count", alert.getOrDefault("count", -1));
     if (alert.containsKey("metacardIds")) {
       item.addProperty("metacardIds", ImmutableSet.copyOf((List<String>) alert.get("metacardIds")));
     } else {
@@ -342,6 +344,8 @@ public class UserApplication implements SparkApplication {
       persistentStore.delete(
           PersistenceType.NOTIFICATION_TYPE.toString(),
           ECQL.toCQL(filterBuilder.anyOf(idsToDelete)));
+      persistentStore.delete(
+          PersistenceType.RESULTS_TYPE.toString(), ECQL.toCQL(filterBuilder.anyOf(idsToDelete)));
     } catch (PersistenceException e) {
       LOGGER.debug(
           "PersistenceException while trying to delete persisted notifications with ids {} ",

--- a/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentStore.java
+++ b/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentStore.java
@@ -32,8 +32,8 @@ public interface PersistentStore {
     SUBSCRIPTION_TYPE("subscriptions"),
     EVENT_SUBSCRIPTIONS_TYPE("event_subscriptions"),
     ALERT_TYPE("alerts"),
-    DECANTER_TYPE("decanter");
-
+    DECANTER_TYPE("decanter"),
+    RESULTS_TYPE("result_cache");
     private String type;
 
     PersistenceType(final String type) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.hbs
@@ -25,6 +25,12 @@
     <div class="details-amount details-detail">
         {{amount}} new items found
     </div>
+    {{#if overCount}}
+    <div class="details-overflow details-detail">
+        Only the first 1000 will be shown.
+    </div>
+    {{/if}}
+</div>
 </div>
 <button class="alert-delete is-negative">
     <span class="fa fa-minus">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.less
@@ -4,7 +4,7 @@
   white-space: nowrap;
   position: relative;
   cursor: pointer;
-  height: 4 * @minimumButtonSize;
+  min-height: 4 * @minimumButtonSize;
   animation: new-alert-item @coreTransitionTime 1 ease-in-out;
 
   .alert-details,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/alert-item/alert-item.view.js
@@ -78,7 +78,11 @@ module.exports = Marionette.ItemView.extend({
       query = workspace.get('queries').get(modelJSON.queryId)
     }
     return {
-      amount: modelJSON.metacardIds.length,
+      amount:
+        modelJSON.count && modelJSON.count > -1
+          ? modelJSON.count
+          : modelJSON.metacardIds.length,
+      overCount: modelJSON.count > 1000,
       when: Common.getMomentDate(modelJSON.when),
       queryName: query ? query.get('title') : 'Unknown Search',
       workspaceName: workspace ? workspace.get('title') : 'Unknown Workspace',


### PR DESCRIPTION
#### What does this PR do?
Checks for a count property on an alert. If it exists and is greater than negative 1, it will use that property instead of count the number of associated metacards. If `count` is more than 1000, it will tell the user their results have been truncated. 

Also, it enables deleting from the `result-cache` core. 
#### Who is reviewing it? 
@nsuvarna 
@bennuttle 
@lavoywj 
@jrnorth 
@leo-sakh 
#### Select relevant component teams: 
<!--
@codice/solr 
@codice/ui 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@gordocanchola 
@jrnorth

#### How should this be tested?
Ensure notifications work in DDF as expected. DDF does not specify the count property, so this should not affect how scheduled queries behave. 
1. Build DDF and install the standard profile
2. Ingest some data, and scheduled a query one it
3. Check that you can view the results of the query
4. Verify that you can delete the query
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5734 
G-3176
#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
