### PR TITLE
DDF-5747 Fix input field widths in add new cert/key menu

### DIFF
--- a/ui/packages/admin-security-certificate-ui/src/main/webapp/less/styles.less
+++ b/ui/packages/admin-security-certificate-ui/src/main/webapp/less/styles.less
@@ -98,6 +98,12 @@ table.align-middle {
   }
 }
 
+input {
+  &.form-control {
+    width: 100%;
+  }
+}
+
 .IframeModalDOM {
   padding-top: 30px;
   padding-bottom: 30px;


### PR DESCRIPTION
## What does this PR do?
Fixes an issue where the input fields when adding a new cert/key in the security app don't resize to fit when the window width is decreased.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@aaronilovici 
@rfding 
@josephthweatt 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdthomson
@djblue 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Open the Admin Console and navigate to the `Security` app
2. Click on the `+` icon to open the menu for adding a new cert/key
3. Resize the window width and verify that the input fields don't run off the page

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5747 

#### Screenshots
<!--(if appropriate)-->
<img width="594" alt="Screen Shot 2020-01-08 at 2 11 54 PM" src="https://user-images.githubusercontent.com/10703203/72068731-becf1a80-32b3-11ea-82c0-1842b12005db.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
