### PR TITLE
DDF-5757 Fix the DefinitionParser-generated required attributes metacard validators

### DIFF
--- a/catalog/core/catalog-core-definitionparser/src/main/java/ddf/catalog/definition/impl/DefinitionParser.java
+++ b/catalog/core/catalog-core-definitionparser/src/main/java/ddf/catalog/definition/impl/DefinitionParser.java
@@ -436,7 +436,8 @@ public class DefinitionParser {
     for (Map<String, List<MetacardValidatorDefinition>> mvdMap : metacardValidatorDefinitions) {
       for (Entry<String, List<MetacardValidatorDefinition>> row : mvdMap.entrySet()) {
         try {
-          List<MetacardValidator> metacardValidators = getMetacardValidators(row.getValue().get(0));
+          List<MetacardValidator> metacardValidators =
+              getMetacardValidators(row.getKey(), row.getValue().get(0));
           metacardValidators.forEach(
               metacardValidator ->
                   staged.add(
@@ -447,7 +448,6 @@ public class DefinitionParser {
                         changeset.metacardValidatorServices.add(registration);
                         return registration != null;
                       }));
-
         } catch (IllegalStateException ise) {
           LOGGER.error(
               "Could not register metacard validator for definition: {} {}",
@@ -524,7 +524,7 @@ public class DefinitionParser {
   }
 
   private List<MetacardValidator> getMetacardValidators(
-      MetacardValidatorDefinition validatorDefinition) {
+      String metacardTypeName, MetacardValidatorDefinition validatorDefinition) {
 
     if (!REQUIRED_ATTRIBUTE_VALIDATOR_PROPERTY.equals(validatorDefinition.validator)) {
       throw new IllegalStateException(
@@ -538,8 +538,7 @@ public class DefinitionParser {
 
     return ImmutableList.of(
         new RequiredAttributesMetacardValidator(
-            validatorDefinition.validator,
-            ImmutableSet.copyOf(validatorDefinition.requiredattributes)));
+            metacardTypeName, ImmutableSet.copyOf(validatorDefinition.requiredattributes)));
   }
 
   private ValidatorWrapper getValidator(String key, Outer.Validator validator) {

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/json-definition-files.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/json-definition-files.adoc
@@ -11,6 +11,7 @@ The following may be defined in a JSON definition file:
 - <<{developing-prefix}attribute_type_definition_file,Attribute Types>>
 - <<{developing-prefix}metacard_type_definition_file,Metacard Types>>
 - <<{developing-prefix}global_attribute_validators_file,Global Attribute Validators>>
+- <<{developing-prefix}metacard_validator_definition,Metacard Validators>>
 - <<{developing-prefix}default_attribute_values,Default Attribute Values>>
 - <<{developing-prefix}attribute_injection_definition,Attribute Injections>>
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/metacard-type.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/metacard-type.adoc
@@ -5,7 +5,7 @@
 :summary: Creating a custom Metacard Type.
 :order: 01
 
-Create custome Metacard types with Metacard Type definition files.
+Create custom Metacard types with Metacard Type definition files.
 
 ==== Metacard Type Definition File
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/metacard-validators.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/metacard-validators.adoc
@@ -1,0 +1,65 @@
+:title: Developing Metacard Validators
+:type: developingComponent
+:status: published
+:link: _developing_metacard_validators
+:summary: Creating a custom metacard validator.
+:order: 02
+
+==== Metacard Validator Definition
+
+Metacard Validator definitions are similar to the Validators definitions. To define Metacard
+Validators, your definition file must have a `metacardvalidators` key in the root object.
+
+[source,json]
+----
+{
+    "metacardvalidators": {...}
+}
+----
+
+The value of `metacardvalidators` is a list of maps, where each map contains a key that is the name
+of the metacard type the corresponding validators will apply to. Its value is a list of maps of the
+validator configuration parameters that specify which validators to configure for the given metacard
+type.
+
+[source,json]
+----
+{
+    "metacardvalidators": [{
+        "metacard.type" : [{
+            "validator": "requiredattributes",
+            "key": "value"
+        }]
+      }]
+}
+----
+
+[IMPORTANT]
+====
+The configuration for the metacard validator must always contain a `validator` key that specifies
+the type of validator to create. Additional key/value pairs may be required to configure the
+validator.
+====
+
+The `validator` key must have a value of one of the following:
+
+- `requiredattributes` (checks that metacards of the specified type contain certain attributes)
+* Must add the key `requiredattributes` whose value is a list of strings naming the required
+attributes
+
+Examples:
+[source, json]
+----
+{
+  "metacardvalidators": [{
+    "fallback.common": [{
+        "validator": "requiredattributes",
+        "requiredattributes": [
+          "id",
+          "title",
+          "attr"
+        ]
+    }]
+  }]
+}
+----


### PR DESCRIPTION
#### What does this PR do?
* Fixes the `DefinitionParser` so that the required attributes metacard validators it generates have the correct metacard type names.
* Re-adds the metacard validators section to the JSON definition file section of the documentation.

#### Who is reviewing it? 
@bennuttle 
@leo-sakh 
@nsuvarna 
@aj-brooks 
@lavoywj 

#### Select relevant component teams: 
@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@rzwiefel

#### How should this be tested?
1. Create a definition JSON file containing a `requiredattributes` validator in the `metacardvalidators` section.
2. Drop the file into `etc/definitions`.
3. Ingest an _invalid_ metacard of the type the validator is configured for (i.e. the metacard should be missing at least one of the attributes required by the validator).
4. Verify the metacard is marked as invalid and that the validation errors say it is missing required attributes.

#### What are the relevant tickets?
Fixes: #5757

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.