### PR TITLE
Fix 2D map labels disappearing in subsequent searches and clustering

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -650,8 +650,9 @@ module.exports = function CesiumMap(
       return billboardRef
     },
     /*
-     * Draws a label containing the text in the given options.
-     */
+          Adds a label utilizing the passed in point and options.
+          Options are a view to an id and text.
+        */
     addLabel(point, options) {
       const pointObject = convertPointCoordinate(point)
       const cartographicPosition = Cesium.Cartographic.fromDegrees(
@@ -875,7 +876,7 @@ module.exports = function CesiumMap(
             label =>
               label.position.x === geometry.position.x &&
               label.position.y === geometry.position.y &&
-              label.show === true
+              label.show
           )
           if (labelWithSamePosition !== undefined) {
             labelWithSamePosition.show = false
@@ -889,7 +890,7 @@ module.exports = function CesiumMap(
             label =>
               label.position.x === geometry.position.x &&
               label.position.y === geometry.position.y &&
-              label.show === true
+              label.show
           )
           if (
             labelWithSamePosition === undefined ||
@@ -945,11 +946,11 @@ module.exports = function CesiumMap(
           label =>
             label.position.x === geometry.position.x &&
             label.position.y === geometry.position.y &&
-            (label.isSelected === true || label.show === true)
+            (label.isSelected || label.show)
         )
         if (
           labelWithSamePosition === undefined ||
-          geometry.id == labelWithSamePosition.id
+          geometry.id === labelWithSamePosition.id
         ) {
           geometry.show = true
         }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -939,7 +939,7 @@ module.exports = function CesiumMap(
     showGeometry(geometry) {
       if (geometry.constructor === Cesium.Billboard) {
         geometry.show = true
-      } else if (showLabels && geometry.constructor === Cesium.Label) {
+      } else if (geometry.constructor === Cesium.Label) {
         // only show one label at one location
         const labelWithSamePosition = _.find(
           mapModel.get('labels'),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -294,9 +294,8 @@ module.exports = function CesiumMap(
     findSelected = false,
   }) {
     const labelWithSamePosition = findOverlappingLabel(findSelected, geometry)
-    if (isSelected && labelWithSamePosition !== undefined) {
+    if (isSelected && labelWithSamePosition) {
       labelWithSamePosition.show = false
-      labelWithSamePosition.isSelected = false
     }
     geometry.show =
       isSelected ||
@@ -973,6 +972,9 @@ module.exports = function CesiumMap(
       //unminified cesium chokes if you feed a geometry with id as an Array
       if (geometry.constructor === Cesium.Entity) {
         map.entities.remove(geometry)
+      }
+      if (geometry.constructor === Cesium.Label) {
+        mapModel.clearLabels()
       }
       map.scene.requestRender()
     },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -80,10 +80,8 @@ module.exports = Backbone.AssociatedModel.extend({
       labels: [...this.get('labels'), label],
     })
   },
-  clearLabels() {
-    this.set({
-      labels: [],
-    })
+  removeLabel(label) {
+    _.remove(this.get('labels'), e => e === label)
   },
   /*
    * Sets the line to the given new line. This represents the line on the map

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -80,6 +80,11 @@ module.exports = Backbone.AssociatedModel.extend({
       labels: [...this.get('labels'), label],
     })
   },
+  clearLabels() {
+    this.set({
+      labels: [],
+    })
+  },
   /*
    * Sets the line to the given new line. This represents the line on the map
    * being used for the ruler measurement.

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -196,9 +196,8 @@ module.exports = function OpenlayersMap(
       findSelected,
       geometryInstance
     )
-    if (isSelected && labelWithSamePosition !== undefined) {
+    if (isSelected && labelWithSamePosition) {
       labelWithSamePosition.setVisible(false)
-      labelWithSamePosition.set('isSelected', false)
     }
     const visible =
       isSelected ||
@@ -802,6 +801,10 @@ module.exports = function OpenlayersMap(
     },
     removeGeometry(geometry) {
       map.removeLayer(geometry)
+      const feature = geometry.getSource().getFeatures()[0]
+      if (feature.getProperties().isLabel) {
+        mapModel.clearLabels()
+      }
     },
     showPolygonShape(locationModel) {
       const polygon = new DrawPolygon.PolygonView({


### PR DESCRIPTION
#### What does this PR do?
Fixes 2D map labels

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@mdang8 
@josephthweatt 
@aaronilovici 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@vinamartin 
@andrewkfiedler 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Open the Admin console and navigate to `Search UI -> Configuration -> Catalog UI Search`
2. Scroll down to `Show Custom Text Notations` and click the checkbox to enable it
3. Ingest some metacards in Intrigue (make sure some overlap)
4. Open the 2D map and run a * search
5. Verify the metacard map markers have a label next to each one
6. Rerun the search
7. Verify the map labels are still there
8. Enable clustering
9. Verify the non-clustered map markers have labels

#### Any background context you want to provide?
Fixes functionality introduced in #5638 
The fix for the bug removed the benefit of 2D map labels not overlapping when zoomed out very far from the map. I also had to manually implement hiding logic for overlapping labels, but I think it is more important that the map labels continue to show up in subsequent searches. If there are any better ways to do this, please let me know.

#### What are the relevant tickets?
Fixes: #5767 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
