### PR TITLE
DDF-5360 Adds the ability to go through OAuth to download a resource

### DIFF
--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -47,6 +47,11 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -47,11 +47,6 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpclient.version}</version>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/OAuthPluginException.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/OAuthPluginException.java
@@ -13,10 +13,7 @@
  */
 package ddf.catalog.plugin;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.util.Map;
-import org.apache.http.client.utils.URIBuilder;
 
 /** Exception thrown when an user doesn't have the appropriate OAuth tokens to federate */
 public class OAuthPluginException extends RuntimeException {
@@ -47,23 +44,17 @@ public class OAuthPluginException extends RuntimeException {
   }
 
   public OAuthPluginException(
-      String sourceId, String baseUrl, Map<String, String> parameters, ErrorType errorType) {
+      String sourceId,
+      String url,
+      String baseUrl,
+      Map<String, String> parameters,
+      ErrorType errorType) {
     super();
     this.sourceId = sourceId;
+    this.url = url;
     this.baseUrl = baseUrl;
     this.parameters = parameters;
-    this.url = buildUrl(baseUrl, parameters);
     this.errorType = errorType;
-  }
-
-  private String buildUrl(String baseUrl, Map<String, String> parameters) {
-    try {
-      URIBuilder uriBuilder = new URIBuilder(baseUrl);
-      parameters.forEach(uriBuilder::addParameter);
-      return uriBuilder.build().toURL().toString();
-    } catch (URISyntaxException | MalformedURLException e) {
-      return null;
-    }
   }
 
   public String getSourceId() {

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/OAuthPluginException.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/plugin/OAuthPluginException.java
@@ -13,6 +13,11 @@
  */
 package ddf.catalog.plugin;
 
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.util.Map;
+import org.apache.http.client.utils.URIBuilder;
+
 /** Exception thrown when an user doesn't have the appropriate OAuth tokens to federate */
 public class OAuthPluginException extends RuntimeException {
 
@@ -21,6 +26,10 @@ public class OAuthPluginException extends RuntimeException {
   private final ErrorType errorType;
 
   private final String url;
+
+  private final String baseUrl;
+
+  private final Map<String, String> parameters;
 
   public enum ErrorType {
     NO_AUTH(401),
@@ -37,15 +46,36 @@ public class OAuthPluginException extends RuntimeException {
     }
   }
 
-  public OAuthPluginException(String sourceId, String url, ErrorType errorType) {
+  public OAuthPluginException(
+      String sourceId, String baseUrl, Map<String, String> parameters, ErrorType errorType) {
     super();
     this.sourceId = sourceId;
-    this.url = url;
+    this.baseUrl = baseUrl;
+    this.parameters = parameters;
+    this.url = buildUrl(baseUrl, parameters);
     this.errorType = errorType;
+  }
+
+  private String buildUrl(String baseUrl, Map<String, String> parameters) {
+    try {
+      URIBuilder uriBuilder = new URIBuilder(baseUrl);
+      parameters.forEach(uriBuilder::addParameter);
+      return uriBuilder.build().toURL().toString();
+    } catch (URISyntaxException | MalformedURLException e) {
+      return null;
+    }
   }
 
   public String getSourceId() {
     return sourceId;
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public Map<String, String> getParameters() {
+    return parameters;
   }
 
   public String getUrl() {

--- a/catalog/core/catalog-core-urlresourcereader/pom.xml
+++ b/catalog/core/catalog-core-urlresourcereader/pom.xml
@@ -154,17 +154,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.64</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -91,6 +91,16 @@ public class URLResourceReader implements ResourceReader {
   @SuppressWarnings("squid:S2068" /* Password property key */)
   private static final String PASSWORD = "password";
 
+  static final String ID_PROPERTY = "id";
+
+  static final String OAUTH_DISCOVERY_URL = "oauthDiscoveryUrl";
+
+  static final String OAUTH_CLIENT_ID = "oauthClientId";
+
+  static final String OAUTH_CLIENT_SECRET = "oauthClientSecret";
+
+  static final String OAUTH_FLOW = "oauthFlow";
+
   private static final Set<String> QUALIFIER_SET =
       ImmutableSet.of(URL_HTTP_SCHEME, URL_HTTPS_SCHEME, URL_FILE_SCHEME);
 
@@ -598,6 +608,26 @@ public class URLResourceReader implements ResourceReader {
               null,
               (String) properties.get(USERNAME),
               (String) properties.get(PASSWORD));
+    } else if (properties.get(ID_PROPERTY) != null
+        && properties.get(OAUTH_DISCOVERY_URL) != null
+        && properties.get(OAUTH_CLIENT_ID) != null
+        && properties.get(OAUTH_CLIENT_SECRET) != null
+        && properties.get(OAUTH_FLOW) != null) {
+      factory =
+          clientFactoryFactory.getSecureCxfClientFactory(
+              uri,
+              WebClient.class,
+              null,
+              null,
+              false,
+              getFollowRedirects(),
+              null,
+              null,
+              (String) properties.get(ID_PROPERTY),
+              (String) properties.get(OAUTH_DISCOVERY_URL),
+              (String) properties.get(OAUTH_CLIENT_ID),
+              (String) properties.get(OAUTH_CLIENT_SECRET),
+              (String) properties.get(OAUTH_FLOW));
     } else {
       factory =
           clientFactoryFactory.getSecureCxfClientFactory(

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchSource.java
@@ -123,6 +123,16 @@ public class OpenSearchSource implements OAuthFederatedSource, ConfiguredService
   @SuppressWarnings("squid:S2068" /*Key for the requestProperties map, not a hardcoded password*/)
   protected static final String PASSWORD_PROPERTY = "password";
 
+  private static final String ID_PROPERTY = "id";
+
+  private static final String OAUTH_DISCOVERY_URL = "oauthDiscoveryUrl";
+
+  private static final String OAUTH_CLIENT_ID = "oauthClientId";
+
+  private static final String OAUTH_CLIENT_SECRET = "oauthClientSecret";
+
+  private static final String OAUTH_FLOW = "oauthFlow";
+
   private static final int MIN_DISTANCE_TOLERANCE_IN_METERS = 1;
 
   private static final int MIN_NUM_POINT_RADIUS_VERTICES = 4;
@@ -920,6 +930,17 @@ public class OpenSearchSource implements OAuthFederatedSource, ConfiguredService
       if (StringUtils.isNotBlank(username)) {
         requestProperties.put(USERNAME_PROPERTY, username);
         requestProperties.put(PASSWORD_PROPERTY, password);
+      }
+
+      if (OAUTH_AUTH_TYPE.equals(authenticationType)
+          && StringUtils.isNotBlank(oauthDiscoveryUrl)
+          && StringUtils.isNotBlank(oauthClientId)
+          && StringUtils.isNotBlank(oauthClientSecret)) {
+        requestProperties.put(ID_PROPERTY, shortname);
+        requestProperties.put(OAUTH_DISCOVERY_URL, oauthDiscoveryUrl);
+        requestProperties.put(OAUTH_CLIENT_ID, oauthClientId);
+        requestProperties.put(OAUTH_CLIENT_SECRET, oauthClientSecret);
+        requestProperties.put(OAUTH_FLOW, oauthFlow);
       }
       return resourceReader.retrieveResource(restClient.getCurrentURI(), requestProperties);
     }

--- a/catalog/plugin/catalog-plugin-oauth/src/main/java/org/codice/ddf/catalog/plugin/oauth/OAuthPlugin.java
+++ b/catalog/plugin/catalog-plugin-oauth/src/main/java/org/codice/ddf/catalog/plugin/oauth/OAuthPlugin.java
@@ -47,7 +47,6 @@ import ddf.security.Subject;
 import ddf.security.SubjectUtils;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -66,7 +65,6 @@ import org.apache.cxf.rs.security.oauth2.common.AccessTokenGrant;
 import org.apache.cxf.rs.security.oauth2.common.ClientAccessToken;
 import org.apache.cxf.rs.security.oauth2.grants.refresh.RefreshTokenGrant;
 import org.apache.cxf.rs.security.oauth2.provider.OAuthServiceException;
-import org.apache.http.client.utils.URIBuilder;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.security.oidc.validator.OidcTokenValidator;
 import org.codice.ddf.security.oidc.validator.OidcValidationException;
@@ -307,19 +305,12 @@ public class OAuthPlugin implements PreFederatedQueryPlugin {
         "Unable to process query. The user needs to authorize to query the {} source.",
         oauthSource.getId());
 
-    try {
-      URIBuilder uriBuilder = new URIBuilder(AUTHORIZE_SOURCE_ENDPOINT);
-      uriBuilder.addParameter(USER_ID, userId);
-      uriBuilder.addParameter(SOURCE_ID, oauthSource.getId());
-      uriBuilder.addParameter(DISCOVERY_URL, oauthSource.getOauthDiscoveryUrl());
-
-      String url = uriBuilder.build().toURL().toString();
-      throw new OAuthPluginException(oauthSource.getId(), url, AUTH_SOURCE);
-
-    } catch (URISyntaxException | MalformedURLException e) {
-      LOGGER.warn("Unable to construct authorization URL.");
-      throw new StopProcessingException("Unable to construct authorization URL. " + e.getMessage());
-    }
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(USER_ID, userId);
+    parameters.put(SOURCE_ID, oauthSource.getId());
+    parameters.put(DISCOVERY_URL, oauthSource.getOauthDiscoveryUrl());
+    throw new OAuthPluginException(
+        oauthSource.getId(), AUTHORIZE_SOURCE_ENDPOINT, parameters, AUTH_SOURCE);
   }
 
   /**
@@ -443,21 +434,17 @@ public class OAuthPlugin implements PreFederatedQueryPlugin {
     stateMap.put(EXPIRES_AT, Instant.now().plus(STATE_EXP, ChronoUnit.MINUTES).getEpochSecond());
     tokenStorage.getStateMap().put(state, stateMap);
 
-    try {
-      URIBuilder uriBuilder = new URIBuilder(metadata.getAuthorizationEndpointURI());
-      uriBuilder.addParameter(RESPONSE_TYPE, CODE_FLOW);
-      uriBuilder.addParameter(CLIENT_ID_PARAM, oauthSource.getOauthClientId());
-      uriBuilder.addParameter(SCOPE, OPENID_SCOPE);
-      uriBuilder.addParameter(REDIRECT_URI, OAUTH_REDIRECT_URL);
-      uriBuilder.addParameter(STATE, state);
-
-      String redirectUrl = uriBuilder.build().toURL().toString();
-      return new OAuthPluginException(oauthSource.getId(), redirectUrl, NO_AUTH);
-
-    } catch (URISyntaxException | IOException e) {
-      LOGGER.debug("Unable to construct redirect URL.");
-      throw new StopProcessingException("Unable to construct redirect URL. " + e.getMessage());
-    }
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(RESPONSE_TYPE, CODE_FLOW);
+    parameters.put(CLIENT_ID_PARAM, oauthSource.getOauthClientId());
+    parameters.put(SCOPE, OPENID_SCOPE);
+    parameters.put(REDIRECT_URI, OAUTH_REDIRECT_URL);
+    parameters.put(STATE, state);
+    return new OAuthPluginException(
+        oauthSource.getId(),
+        metadata.getAuthorizationEndpointURI().toString(),
+        parameters,
+        NO_AUTH);
   }
 
   @VisibleForTesting

--- a/catalog/plugin/catalog-plugin-oauth/src/test/java/org/codice/ddf/catalog/plugin/oauth/OAuthPluginTest.java
+++ b/catalog/plugin/catalog-plugin-oauth/src/test/java/org/codice/ddf/catalog/plugin/oauth/OAuthPluginTest.java
@@ -383,8 +383,7 @@ public class OAuthPluginTest {
 
     String url = e.getUrl();
     Map<String, String> urlParams =
-        URLEncodedUtils.parse(
-                new URI(url.substring(0, url.indexOf("&state"))), StandardCharsets.UTF_8)
+        URLEncodedUtils.parse(new URI(url), StandardCharsets.UTF_8)
             .stream()
             .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
     assertEquals(urlParams.get("response_type"), "code");

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -263,7 +263,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.41</minimum>
+                                            <minimum>0.40</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -15,6 +15,7 @@ package org.codice.ddf.endpoints.rest;
 
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.plugin.OAuthPluginException;
 import ddf.catalog.resource.DataUsageLimitExceededException;
 import ddf.catalog.resource.Resource;
 import java.io.InputStream;
@@ -249,7 +250,8 @@ public class RESTEndpoint implements RESTService {
           .entity("<pre>" + e.getMessage() + "</pre>")
           .type(MediaType.TEXT_HTML)
           .build();
-
+    } catch (OAuthPluginException e) {
+      return Response.status(Status.SEE_OTHER).header(HttpHeaders.LOCATION, e.getUrl()).build();
     } catch (UnsupportedEncodingException e) {
       String exceptionMessage = "Unknown error occurred while processing request: ";
       LOGGER.info(exceptionMessage, e);

--- a/catalog/rest/catalog-rest-service/pom.xml
+++ b/catalog/rest/catalog-rest-service/pom.xml
@@ -126,6 +126,11 @@
             <artifactId>catalog-rest-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -956,6 +956,18 @@ public abstract class AbstractCswSource extends MaskableImpl
         requestProperties.put(USERNAME_PROPERTY, username);
         requestProperties.put(PASSWORD_PROPERTY, password);
       }
+
+      if (OAUTH_AUTH_TYPE.equals(cswSourceConfiguration.getAuthenticationType())
+          && StringUtils.isNotBlank(cswSourceConfiguration.getOauthDiscoveryUrl())
+          && StringUtils.isNotBlank(cswSourceConfiguration.getOauthClientId())
+          && StringUtils.isNotBlank(cswSourceConfiguration.getOauthClientSecret())) {
+
+        requestProperties.put(ID_PROPERTY, cswSourceConfiguration.getId());
+        requestProperties.put(OAUTH_DISCOVERY_URL, cswSourceConfiguration.getOauthDiscoveryUrl());
+        requestProperties.put(OAUTH_CLIENT_ID, cswSourceConfiguration.getOauthClientId());
+        requestProperties.put(OAUTH_CLIENT_SECRET, cswSourceConfiguration.getOauthClientSecret());
+        requestProperties.put(OAUTH_FLOW, cswSourceConfiguration.getOauthFlow());
+      }
     }
 
     if (canRetrieveResourceById()) {

--- a/platform/security/rest/security-rest-clientapi/src/main/java/org/codice/ddf/cxf/client/SecureCxfClientFactory.java
+++ b/platform/security/rest/security-rest-clientapi/src/main/java/org/codice/ddf/cxf/client/SecureCxfClientFactory.java
@@ -43,6 +43,13 @@ public interface SecureCxfClientFactory<T> {
   WebClient getWebClient();
 
   /**
+   * Returns the WebClient
+   *
+   * @return
+   */
+  WebClient getWebSystemClient();
+
+  /**
    * Adds subject to a new client and returns
    *
    * @param subject

--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/client/impl/SecureCxfClientFactoryImpl.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/client/impl/SecureCxfClientFactoryImpl.java
@@ -563,6 +563,10 @@ public class SecureCxfClientFactoryImpl<T> implements SecureCxfClientFactory<T> 
     return getWebClientForSubject(null);
   }
 
+  public WebClient getWebSystemClient() {
+    return getWebClient(getClientForSystemSubject(null));
+  }
+
   /**
    * Clients produced by this method will be secured with two-way ssl and the provided security
    * subject.

--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/oauth/OAuthOutInterceptor.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/oauth/OAuthOutInterceptor.java
@@ -44,6 +44,7 @@ public class OAuthOutInterceptor extends AbstractPhaseInterceptor<Message> {
     }
 
     LOGGER.debug("Setting access token to the authorization header.");
+    headers.remove(OAUTH);
     headers.put(AUTHORIZATION, authorizationHeader);
   }
 }

--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/oauth/OAuthSecurityImpl.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/oauth/OAuthSecurityImpl.java
@@ -78,11 +78,13 @@ public class OAuthSecurityImpl implements OAuthSecurity {
   private static final String REFRESH_TOKEN = "refresh_token";
   private static final String ACCESS_TOKEN = "access_token";
   private static final String GRANT_TYPE = "grant_type";
+  private static final String OPENID_SCOPE = "openid";
   private static final String ID_TOKEN = "id_token";
   private static final String USERNAME = "username";
   private static final String PASSWORD = "password";
   private static final String BEARER = "Bearer ";
   private static final String BASIC = "Basic ";
+  private static final String SCOPE = "scope";
   private static final String EXP = "exp";
   private static final String IAT = "iat";
 
@@ -323,6 +325,7 @@ public class OAuthSecurityImpl implements OAuthSecurity {
     webClient.accept(APPLICATION_JSON);
 
     Form formParam = new Form(GRANT_TYPE, grantType);
+    formParam.param(SCOPE, OPENID_SCOPE);
     queryParameters.forEach(formParam::param);
     javax.ws.rs.core.Response response = webClient.form(formParam);
 


### PR DESCRIPTION
Needs: https://github.com/codice/ddf-ui/pull/83

#### What does this PR do?
Adds the ability to go through OAuth to download a resource.

#### Who is reviewing it? 
@SmithJosh @bakejeyner 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@garrettfreibott
@stustison

#### How should this be tested?
- Verify downloading a resource from an OAuth protected source works. Download using
  - the download button
  - the inspector tab
  - the action tab
- Delete the user's tokens and try downloading a resource (should be prompted to log in).
- Verify querying with OAuth still works

#### What are the relevant tickets?
#5360 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
