### PR TITLE
[2.19.x] DDF-5610 Added support for negative coordinate values in WKT conversion

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -18,7 +18,7 @@ const { Units } = require('./common')
 const TextField = require('../text-field')
 import styled from 'styled-components'
 
-const coordinatePairRegex = /\d{1,3}(\.\d*)?\s\d{1,3}(\.\d*)?/g
+const coordinatePairRegex = /-?\d{1,3}(\.\d*)?\s-?\d{1,3}(\.\d*)?/g
 
 const Invalid = styled.div`
   background-color: ${props => props.theme.negativeColor};


### PR DESCRIPTION
#### What does this PR do?
Adds support for negative values when automatically converting WKT strings to the correct format in search geos
#### Who is reviewing it? 
@andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@Bdthomson 
#### How should this be tested?
Copy and paste WKT strings with negative coordinate values into the Polygon and Line geo filter fields. Verify that they're being immediately converted into the correct format.

Example polygon: 
`POLYGON ((-45.69035002266293 -20.676851, -45.6903113 20.6255905, 45.623261 -20.625589597640413, 45.623261 20.676851, 45.69035002266293 20.676851))`

Example line:
`LINESTRING (45.4806 20.644323,45.620127 20.727819)`

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
