### PR TITLE
[2.19.x] DDF-5627 G-7443 Add an endpoint to validate different aspects of a query

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -508,6 +508,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.codice.ddf.validator</groupId>
+            <artifactId>catalog-validator-unsupportedattributes</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.transformer</groupId>
             <artifactId>catalog-transformer-overlay</artifactId>
             <version>${project.version}</version>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -550,6 +550,15 @@
         </bundle>
     </feature>
 
+    <feature name="catalog-validator-unsupportedattributes"
+      version="${project.version}"
+      description="Unsupported Attributes Query Validator">
+        <feature>catalog-core-api</feature>
+        <bundle>
+            mvn:org.codice.ddf.validator/catalog-validator-unsupportedattributes/${project.version}
+        </bundle>
+    </feature>
+
     <feature name="catalog-transformer-overlay" version="${project.version}"
              description="Transforms a metacard into a geographically aligned image suitable for overlaying on a map">
         <bundle>mvn:ddf.catalog.transformer/catalog-transformer-overlay/${project.version}</bundle>
@@ -685,6 +694,7 @@
         <feature>catalog-validator-metacardduplication</feature>
         <feature>catalog-validator-metacardlocation</feature>
         <feature>catalog-validator-metacardframecenter</feature>
+        <feature>catalog-validator-unsupportedattributes</feature>
         <feature>catalog-transformer-overlay</feature>
         <feature>catalog-transformer-preview</feature>
         <feature>catalog-client-info</feature>

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/violation/QueryValidationViolationImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/violation/QueryValidationViolationImpl.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.violation;
+
+import ddf.catalog.validation.violation.QueryValidationViolation;
+import java.util.Map;
+import java.util.Objects;
+
+public class QueryValidationViolationImpl implements QueryValidationViolation {
+
+  private Severity severity;
+
+  private String message;
+
+  private Map<String, Object> extraData;
+
+  public QueryValidationViolationImpl(
+      final Severity severity, final String message, final Map<String, Object> extraData) {
+    this.severity = severity;
+    this.message = message;
+    this.extraData = extraData;
+  }
+
+  @Override
+  public Severity getSeverity() {
+    return severity;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public Map<String, Object> getExtraData() {
+    return extraData;
+  }
+
+  @Override
+  public String toString() {
+    return "QueryValidationViolationImpl{"
+        + "severity="
+        + severity
+        + ", message='"
+        + message
+        + '\''
+        + ", extraData="
+        + extraData
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QueryValidationViolationImpl that = (QueryValidationViolationImpl) o;
+    return severity == that.severity
+        && Objects.equals(message, that.message)
+        && Objects.equals(extraData, that.extraData);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(severity, message, extraData);
+  }
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/QueryValidator.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/QueryValidator.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation;
+
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.validation.violation.QueryValidationViolation;
+import java.util.Set;
+
+/**
+ * A {@code QueryRequest} may be structurally valid but be semantically incorrect. For example, a
+ * {@code QueryRequest} might include a valid {@code Filter} but the specified source may not
+ * support it. A {@code QueryValidator} inspects a {@link QueryRequest} for these types of
+ * violations.
+ *
+ * <p><b> This code is experimental. While this interface is functional and tested, it may change or
+ * be removed in a future version of the library. </b>
+ */
+public interface QueryValidator {
+
+  /**
+   * Returns the unique identifier corresponding to this validator instance. This is used as a
+   * marker to determine which violations were created by each validator instance.
+   *
+   * @return the id of this validator
+   */
+  String getValidatorId();
+
+  /**
+   * Validates a {@link QueryRequest} for semantic correctness.
+   *
+   * @param request - the {@link QueryRequest} to validate
+   * @return a {@code Set} of violations found in the {@code request}.
+   */
+  Set<QueryValidationViolation> validate(QueryRequest request);
+}

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/violation/QueryValidationViolation.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/violation/QueryValidationViolation.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.violation;
+
+import java.util.Map;
+
+/**
+ * Describes a violation of a constraint on query.
+ *
+ * <p><b> This code is experimental. While this interface is functional and tested, it may change or
+ * be removed in a future version of the library. </b>
+ */
+public interface QueryValidationViolation {
+  /**
+   * Describes the severity of a validation violation. An error is a violation severe enough to
+   * cause validation to fail, and a warning is a less severe violation unrelated to validation
+   * failure.
+   */
+  enum Severity {
+    WARNING,
+    ERROR
+  }
+
+  /**
+   * Returns the severity of the violation. Cannot return null.
+   *
+   * @return the severity
+   */
+  Severity getSeverity();
+
+  /**
+   * Returns a message describing the violation. Cannot return null.
+   *
+   * @return the message
+   */
+  String getMessage();
+
+  /**
+   * Returns supplemental information about the violation. This is structured data that is more
+   * easily parsable than the message. Cannot return null.
+   *
+   * @return a map of supplemental information
+   */
+  Map<String, Object> getExtraData();
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/QueryApplication.java
@@ -40,6 +40,7 @@ import org.codice.ddf.catalog.ui.query.suggestion.DmsCoordinateProcessor;
 import org.codice.ddf.catalog.ui.query.suggestion.LatLonCoordinateProcessor;
 import org.codice.ddf.catalog.ui.query.suggestion.MgrsCoordinateProcessor;
 import org.codice.ddf.catalog.ui.query.suggestion.UtmUpsCoordinateProcessor;
+import org.codice.ddf.catalog.ui.query.validate.CqlValidationHandler;
 import org.codice.ddf.catalog.ui.util.EndpointUtil;
 import org.codice.ddf.catalog.ui.ws.JsonRpc;
 import org.codice.ddf.spatial.geocoding.Suggestion;
@@ -85,10 +86,13 @@ public class QueryApplication implements SparkApplication, Function {
 
   private CqlTransformHandler cqlTransformHandler;
 
+  private CqlValidationHandler cqlValidationHandler;
+
   private EndpointUtil util;
 
   public QueryApplication(
       CqlTransformHandler cqlTransformHandler,
+      CqlValidationHandler cqlValidationHandler,
       LatLonCoordinateProcessor latLonCoordinateProcessor,
       DmsCoordinateProcessor dmsCoordinateProcessor,
       MgrsCoordinateProcessor mgrsCoordinateProcessor,
@@ -98,6 +102,7 @@ public class QueryApplication implements SparkApplication, Function {
     this.mgrsCoordinateProcessor = mgrsCoordinateProcessor;
     this.utmUpsCoordinateProcessor = utmUpsCoordinateProcessor;
     this.cqlTransformHandler = cqlTransformHandler;
+    this.cqlValidationHandler = cqlValidationHandler;
   }
 
   @Override
@@ -121,6 +126,8 @@ public class QueryApplication implements SparkApplication, Function {
         });
 
     post("/cql/transform/:transformerId", cqlTransformHandler, GSON::toJson);
+
+    post("/cql/validator/:validatorId", cqlValidationHandler, GSON::toJson);
 
     get(
         "/geofeature/suggestions",

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/validate/CqlRequestParser.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/validate/CqlRequestParser.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.validate;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryRequest;
+import java.io.IOException;
+import java.util.Date;
+import org.codice.ddf.catalog.ui.query.cql.CqlRequest;
+import org.codice.ddf.catalog.ui.util.EndpointUtil;
+import org.codice.gsonsupport.GsonTypeAdapters.DateLongFormatTypeAdapter;
+import org.codice.gsonsupport.GsonTypeAdapters.LongDoubleTypeAdapter;
+import spark.Request;
+
+public class CqlRequestParser {
+
+  private static final Gson GSON =
+      new GsonBuilder()
+          .disableHtmlEscaping()
+          .serializeNulls()
+          .registerTypeAdapterFactory(LongDoubleTypeAdapter.FACTORY)
+          .registerTypeAdapter(Date.class, new DateLongFormatTypeAdapter())
+          .create();
+
+  private CatalogFramework catalogFramework;
+
+  private FilterBuilder filterBuilder;
+
+  private EndpointUtil endpointUtil;
+
+  public CqlRequestParser(
+      CatalogFramework catalogFramework, FilterBuilder filterBuilder, EndpointUtil endpointUtil) {
+    this.catalogFramework = catalogFramework;
+    this.filterBuilder = filterBuilder;
+    this.endpointUtil = endpointUtil;
+  }
+
+  public QueryRequest parse(Request request) throws IOException {
+    CqlRequest cqlRequest = GSON.fromJson(endpointUtil.safeGetBody(request), CqlRequest.class);
+    return cqlRequest.createQueryRequest(catalogFramework.getId(), filterBuilder);
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/validate/CqlValidationHandler.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/validate/CqlValidationHandler.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.validate;
+
+import com.google.common.collect.ImmutableMap;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.validation.QueryValidator;
+import ddf.catalog.validation.violation.QueryValidationViolation;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+public class CqlValidationHandler implements Route {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CqlValidationHandler.class);
+
+  private QueryValidators queryValidators;
+
+  private CqlRequestParser parser;
+
+  public CqlValidationHandler(QueryValidators queryValidators, CqlRequestParser parser) {
+    this.queryValidators = queryValidators;
+    this.parser = parser;
+  }
+
+  @Override
+  public Object handle(Request request, Response response) throws Exception {
+    String validatorId = request.params(":validatorId");
+
+    QueryValidator validator = queryValidators.get(validatorId);
+    if (validator == null) {
+      LOGGER.debug(
+          "No query validator could be found with id \"{}\". Skipping validation.", validatorId);
+      response.status(404);
+      return ImmutableMap.of(
+          "error",
+          "No validator matching id " + validatorId,
+          "validationViolations",
+          Collections.emptyList());
+    }
+
+    QueryRequest queryRequest = parser.parse(request);
+    Set<QueryValidationViolation> violations = validator.validate(queryRequest);
+
+    List<Map<String, Object>> violationResponses =
+        violations
+            .stream()
+            .map(v -> constructViolationResponse(v, validatorId))
+            .collect(Collectors.toList());
+    return ImmutableMap.of("validationViolations", violationResponses);
+  }
+
+  private Map<String, Object> constructViolationResponse(
+      QueryValidationViolation violation, String type) {
+    return ImmutableMap.of(
+        "type",
+        type,
+        "severity",
+        violation.getSeverity(),
+        "message",
+        violation.getMessage(),
+        "extraData",
+        violation.getExtraData());
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/validate/QueryValidators.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/validate/QueryValidators.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.validate;
+
+import ddf.catalog.validation.QueryValidator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A collection of {@code QueryValidator} instances that have been registered in the system. These
+ * instances can be fetched by their unique id (see {@code QueryValidator#getValidatorId}).
+ */
+public class QueryValidators {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryValidators.class);
+
+  private Map<String, QueryValidator> validators = new ConcurrentHashMap<>();
+
+  /**
+   * Gets a registered {@code QueryValidator} instance by it's id.
+   *
+   * @return a {@code QueryValidator} instance whose id matches {@code id}, otherwise null.
+   */
+  public QueryValidator get(String id) {
+    return validators.getOrDefault(id, null);
+  }
+
+  /**
+   * Adds a new {@code QueryValidator} to the {@code validators} map. Called by blueprint when a new
+   * {@code QueryValidator} is registered as a service.
+   *
+   * @param queryValidator the new {@code QueryValidator} to be registered.
+   */
+  public void bind(QueryValidator queryValidator) {
+    if (queryValidator != null) {
+      LOGGER.trace("Adding query validator with id \"{}\"", queryValidator.getValidatorId());
+      validators.put(queryValidator.getValidatorId(), queryValidator);
+    }
+  }
+
+  /**
+   * Removes an existing {@code QueryValidator} from the {@code validators} map. Called by blueprint
+   * when an existing {@code QueryValidator} service is removed.
+   *
+   * @param queryValidator the {@code QueryValidator} to be removed from the collection.
+   */
+  public void unbind(QueryValidator queryValidator) {
+    if (queryValidator != null) {
+      LOGGER.trace("Removing query validator with id \"{}\"", queryValidator);
+      validators.remove(queryValidator.getValidatorId());
+    }
+  }
+}

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -284,6 +284,25 @@ Implementation details
         <argument ref="endpointUtil"/>
     </bean>
 
+    <bean id="queryValidators" class="org.codice.ddf.catalog.ui.query.validate.QueryValidators"/>
+
+    <reference-list interface="ddf.catalog.validation.QueryValidator"
+      availability="optional">
+        <reference-listener ref="queryValidators" bind-method="bind" unbind-method="unbind"/>
+    </reference-list>
+
+    <bean id="cqlRequestParser" class="org.codice.ddf.catalog.ui.query.validate.CqlRequestParser">
+        <argument ref="catalogFramework"/>
+        <argument ref="filterBuilder"/>
+        <argument ref="endpointUtil"/>
+    </bean>
+
+    <bean id="cqlValidationHandler"
+      class="org.codice.ddf.catalog.ui.query.validate.CqlValidationHandler">
+        <argument ref="queryValidators"/>
+        <argument ref="cqlRequestParser"/>
+    </bean>
+
     <bean id="latLonProcessor"
           class="org.codice.ddf.catalog.ui.query.suggestion.LatLonCoordinateProcessor"/>
 
@@ -304,6 +323,7 @@ Implementation details
         <property name="featureService" ref="featureService"/>
         <property name="endpointUtil" ref="endpointUtil"/>
         <argument ref="cqlTransformHandler"/>
+        <argument ref="cqlValidationHandler"/>
         <argument ref="latLonProcessor"/>
         <argument ref="dmsProcessor"/>
         <argument ref="mgrsProcessor"/>

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/validate/CqlValidationHandlerTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/query/validate/CqlValidationHandlerTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.catalog.ui.query.validate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.validation.QueryValidator;
+import ddf.catalog.validation.impl.violation.QueryValidationViolationImpl;
+import ddf.catalog.validation.violation.QueryValidationViolation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+import spark.Request;
+import spark.Response;
+
+public class CqlValidationHandlerTest {
+
+  private CqlValidationHandler cqlValidationHandler;
+
+  private CqlRequestParser parser = mock(CqlRequestParser.class);
+
+  private QueryValidators queryValidators = mock(QueryValidators.class);
+
+  private FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+
+  @Test
+  public void testHandleUnknownValidatorId() throws Exception {
+    when(queryValidators.get(any())).thenReturn(null);
+    QueryRequest queryRequest =
+        createQueryRequest(filterBuilder.attribute("attr").is().text("val"), "src");
+    when(parser.parse(any())).thenReturn(queryRequest);
+    Request request = mock(Request.class);
+    when(request.params(":validatorId")).thenReturn("invalidId");
+    Response response = mock(Response.class);
+
+    cqlValidationHandler = new CqlValidationHandler(queryValidators, parser);
+    Object objResponse = cqlValidationHandler.handle(request, response);
+
+    verify(response).status(404);
+    Map<String, Object> jsonResponse = (Map<String, Object>) objResponse;
+    assertThat(jsonResponse.get("error"), is("No validator matching id invalidId"));
+    assertThat((List<Object>) jsonResponse.get("validationViolations"), hasSize(0));
+  }
+
+  @Test
+  public void testHandleOneValidatorOneViolation() throws Exception {
+    QueryValidationViolation violation =
+        new QueryValidationViolationImpl(
+            QueryValidationViolation.Severity.ERROR,
+            "there was an error",
+            ImmutableMap.of("k", "v"));
+    QueryValidator validator = mock(QueryValidator.class);
+    when(validator.validate(any())).thenReturn(ImmutableSet.of(violation));
+    when(validator.getValidatorId()).thenReturn("id");
+    when(queryValidators.get("id")).thenReturn(validator);
+    QueryRequest queryRequest = mock(QueryRequest.class);
+    when(parser.parse(any())).thenReturn(queryRequest);
+    Request request = mock(Request.class);
+    when(request.params(":validatorId")).thenReturn("id");
+    Response response = mock(Response.class);
+
+    cqlValidationHandler = new CqlValidationHandler(queryValidators, parser);
+    Object objResponse = cqlValidationHandler.handle(request, response);
+
+    Map<String, Object> jsonResponse = (Map<String, Object>) objResponse;
+    List<Object> violations = (List<Object>) jsonResponse.get("validationViolations");
+    assertThat(violations, hasSize(1));
+    assertViolation(
+        (Map<String, Object>) violations.get(0),
+        QueryValidationViolation.Severity.ERROR,
+        "there was an error",
+        ImmutableMap.of("k", "v"),
+        "id");
+  }
+
+  @Test
+  public void testHandleOneValidatorTwoViolations() throws Exception {
+    QueryValidationViolation violation1 =
+        new QueryValidationViolationImpl(
+            QueryValidationViolation.Severity.ERROR, "ONE", ImmutableMap.of("k1", "v1"));
+    QueryValidationViolation violation2 =
+        new QueryValidationViolationImpl(
+            QueryValidationViolation.Severity.WARNING, "TWO", ImmutableMap.of("k2", "v2"));
+    QueryValidator validator = mock(QueryValidator.class);
+    when(validator.validate(any())).thenReturn(ImmutableSet.of(violation1, violation2));
+    when(validator.getValidatorId()).thenReturn("id");
+    when(queryValidators.get("id")).thenReturn(validator);
+    QueryRequest queryRequest = mock(QueryRequest.class);
+    when(parser.parse(any())).thenReturn(queryRequest);
+    Request request = mock(Request.class);
+    when(request.params(":validatorId")).thenReturn("id");
+    Response response = mock(Response.class);
+
+    cqlValidationHandler = new CqlValidationHandler(queryValidators, parser);
+    Object objResponse = cqlValidationHandler.handle(request, response);
+
+    Map<String, Object> jsonResponse = (Map<String, Object>) objResponse;
+    List<Object> violations = (List<Object>) jsonResponse.get("validationViolations");
+    assertThat(violations, hasSize(2));
+    assertViolation(
+        (Map<String, Object>) violations.get(0),
+        QueryValidationViolation.Severity.ERROR,
+        "ONE",
+        ImmutableMap.of("k1", "v1"),
+        "id");
+    assertViolation(
+        (Map<String, Object>) violations.get(1),
+        QueryValidationViolation.Severity.WARNING,
+        "TWO",
+        ImmutableMap.of("k2", "v2"),
+        "id");
+  }
+
+  private void assertViolation(
+      Map<String, Object> actualViolation,
+      QueryValidationViolation.Severity severity,
+      String message,
+      Map<String, Object> extras,
+      String validatorId) {
+    assertThat(actualViolation.get("severity"), is(severity));
+    assertThat(actualViolation.get("message"), is(message));
+    assertThat(actualViolation.get("extraData"), is(extras));
+    assertThat(actualViolation.get("type"), is(validatorId));
+  }
+
+  private QueryRequest createQueryRequest(Filter filter, String... sourceIds) {
+    return new QueryRequestImpl(new QueryImpl(filter), Arrays.asList(sourceIds));
+  }
+}

--- a/catalog/ui/search-ui-app/src/main/resources/etc/IntrigueBundle.properties
+++ b/catalog/ui/search-ui-app/src/main/resources/etc/IntrigueBundle.properties
@@ -7,3 +7,4 @@ sources.polling.error.message=Unable to query server for list of active sources
 search.sources.selected.none.message=No sources are currently selected. Edit the search and select at least one source.
 form.title=Form
 forms.title=Forms
+validation.attribute.unsupported=The field "{attribute}" is not supported by the {sources} Source(s)

--- a/catalog/validator/catalog-validator-unsupportedattributes/pom.xml
+++ b/catalog/validator/catalog-validator-unsupportedattributes/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>validator</artifactId>
+    <groupId>org.codice.ddf.validator</groupId>
+    <version>2.22.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>DDF :: Catalog :: Validator :: Query :: Unsupported Attributes</name>
+  <artifactId>catalog-validator-unsupportedattributes</artifactId>
+  <packaging>bundle</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codice.thirdparty</groupId>
+      <artifactId>gt-opengis</artifactId>
+      <version>${opengis.bundle.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.platform.util</groupId>
+      <artifactId>platform-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.platform</groupId>
+      <artifactId>resource-bundle-locator</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>filter-proxy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Embed-Dependency>
+              catalog-core-api-impl,
+              platform-util,
+            </Embed-Dependency>
+0          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <haltOnFailure>true</haltOnFailure>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.91</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.94</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>COMPLEXITY</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.83</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/catalog/validator/catalog-validator-unsupportedattributes/pom.xml
+++ b/catalog/validator/catalog-validator-unsupportedattributes/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>validator</artifactId>
     <groupId>org.codice.ddf.validator</groupId>
-    <version>2.22.0-SNAPSHOT</version>
+    <version>2.19.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/validator/catalog-validator-unsupportedattributes/src/main/java/org/codice/ddf/validator/query/unsupportedattributes/AttributeExtractor.java
+++ b/catalog/validator/catalog-validator-unsupportedattributes/src/main/java/org/codice/ddf/validator/query/unsupportedattributes/AttributeExtractor.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.validator.query.unsupportedattributes;
+
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.impl.SimpleFilterDelegate;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.opengis.filter.Filter;
+
+public class AttributeExtractor {
+
+  private FilterAdapter filterAdapter;
+
+  public AttributeExtractor(FilterAdapter filterAdapter) {
+    this.filterAdapter = filterAdapter;
+  }
+
+  public Set<String> extractAttributes(Filter filter) throws UnsupportedQueryException {
+    AttributeFilterDelegate filterDelegate = new AttributeFilterDelegate();
+    filterAdapter.adapt(filter, filterDelegate);
+    return filterDelegate.getAttributes();
+  }
+
+  private class AttributeFilterDelegate extends SimpleFilterDelegate<Boolean> {
+
+    private Set<String> attributesInFilter = new HashSet<>();
+
+    @Override
+    public <S> Boolean defaultOperation(
+        Object property, S literal, Class<S> literalClass, Enum operation) {
+      return Boolean.TRUE;
+    }
+
+    @Override
+    public <S> Boolean comparisonOperation(
+        String propertyName,
+        S literal,
+        Class<S> literalClass,
+        ComparisonPropertyOperation comparisonPropertyOperation) {
+      attributesInFilter.add(propertyName);
+      return Boolean.TRUE;
+    }
+
+    @Override
+    public <S> Boolean spatialOperation(
+        String propertyName,
+        S wkt,
+        Class<S> wktClass,
+        SpatialPropertyOperation spatialPropertyOperation) {
+      attributesInFilter.add(propertyName);
+      return Boolean.TRUE;
+    }
+
+    @Override
+    public <S> Boolean temporalOperation(
+        String propertyName,
+        S literal,
+        Class<S> literalClass,
+        TemporalPropertyOperation temporalPropertyOperation) {
+      attributesInFilter.add(propertyName);
+      return Boolean.TRUE;
+    }
+
+    @Override
+    public Boolean and(List<Boolean> operands) {
+      return Boolean.TRUE;
+    }
+
+    @Override
+    public Boolean or(List<Boolean> operands) {
+      return Boolean.TRUE;
+    }
+
+    @Override
+    public Boolean not(Boolean operand) {
+      return Boolean.TRUE;
+    }
+
+    public Set<String> getAttributes() {
+      return this.attributesInFilter;
+    }
+  }
+}

--- a/catalog/validator/catalog-validator-unsupportedattributes/src/main/java/org/codice/ddf/validator/query/unsupportedattributes/MessageFormatSupplier.java
+++ b/catalog/validator/catalog-validator-unsupportedattributes/src/main/java/org/codice/ddf/validator/query/unsupportedattributes/MessageFormatSupplier.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.validator.query.unsupportedattributes;
+
+import ddf.platform.resource.bundle.locator.ResourceBundleLocator;
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MessageFormatSupplier implements Supplier<String> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MessageFormatSupplier.class);
+
+  private static final String INTRIGUE_BASE_NAME = "IntrigueBundle";
+
+  private static final String DEFAULT_MESSAGE_FORMAT =
+      "The field \"{attribute}\" is not supported by the {sources} Source(s)";
+
+  private ResourceBundleLocator resourceBundleLocator;
+
+  public MessageFormatSupplier(ResourceBundleLocator resourceBundleLocator) {
+    this.resourceBundleLocator = resourceBundleLocator;
+  }
+
+  @Override
+  public String get() {
+    return AccessController.doPrivileged(
+        (PrivilegedAction<String>)
+            () -> {
+              try {
+                return resourceBundleLocator
+                    .getBundle(INTRIGUE_BASE_NAME)
+                    .getString("validation.attribute.unsupported");
+              } catch (IOException e) {
+                LOGGER.debug(
+                    "Failed getting {} resource bundle, using default \"{}\"",
+                    INTRIGUE_BASE_NAME,
+                    DEFAULT_MESSAGE_FORMAT);
+                return DEFAULT_MESSAGE_FORMAT;
+              }
+            });
+  }
+}

--- a/catalog/validator/catalog-validator-unsupportedattributes/src/main/java/org/codice/ddf/validator/query/unsupportedattributes/UnsupportedAttributeQueryValidator.java
+++ b/catalog/validator/catalog-validator-unsupportedattributes/src/main/java/org/codice/ddf/validator/query/unsupportedattributes/UnsupportedAttributeQueryValidator.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.validator.query.unsupportedattributes;
+
+import com.google.common.collect.ImmutableMap;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.source.SourceAttributeRestriction;
+import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.validation.QueryValidator;
+import ddf.catalog.validation.impl.violation.QueryValidationViolationImpl;
+import ddf.catalog.validation.violation.QueryValidationViolation;
+import ddf.catalog.validation.violation.QueryValidationViolation.Severity;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UnsupportedAttributeQueryValidator implements QueryValidator {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(UnsupportedAttributeQueryValidator.class);
+
+  private AttributeExtractor attributeExtractor;
+
+  private Supplier<String> messageFormatSupplier;
+
+  private Map<String, Set<String>> sourceIdToSupportedAttributesMap = new ConcurrentHashMap<>();
+
+  public UnsupportedAttributeQueryValidator(
+      AttributeExtractor attributeExtractor, Supplier<String> messageFormatSupplier) {
+    this.attributeExtractor = attributeExtractor;
+    this.messageFormatSupplier = messageFormatSupplier;
+  }
+
+  @Override
+  public String getValidatorId() {
+    return "unsupportedAttribute";
+  }
+
+  @Override
+  public Set<QueryValidationViolation> validate(QueryRequest request) {
+    Set<String> queryAttributes = getAttributes(request);
+    Set<String> sourceIds =
+        request.getSourceIds() != null ? request.getSourceIds() : Collections.emptySet();
+
+    return queryAttributes
+        .stream()
+        .map(attr -> getViolation(attr, sourceIds))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toSet());
+  }
+
+  private Set<String> getAttributes(QueryRequest request) {
+    try {
+      return attributeExtractor.extractAttributes(request.getQuery());
+    } catch (UnsupportedQueryException e) {
+      LOGGER.debug(
+          "Skipping validation: Failed to aggregate all attributes from query {}",
+          request.getQuery(),
+          e);
+      return Collections.emptySet();
+    }
+  }
+
+  private Optional<QueryValidationViolation> getViolation(String attribute, Set<String> sourceIds) {
+    Set<String> sourcesThatDontSupportAttribute = new HashSet<>();
+    for (String sourceId : sourceIds) {
+      if (!sourceIdToSupportedAttributesMap.containsKey(sourceId)) {
+        LOGGER.debug("Source {} supports querying by all attributes", sourceId);
+        continue;
+      }
+      Set<String> supportedAttributes = sourceIdToSupportedAttributesMap.get(sourceId);
+      if (!supportedAttributes.contains(attribute)) {
+        LOGGER.debug(
+            "Source \"{}\" does not support querying by attribute {}", sourceId, attribute);
+        sourcesThatDontSupportAttribute.add(sourceId);
+      } else {
+        LOGGER.debug("Source \"{}\" supports querying by attribute {}", sourceId, attribute);
+      }
+    }
+
+    if (sourcesThatDontSupportAttribute.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new QueryValidationViolationImpl(
+            Severity.ERROR,
+            createMessage(attribute, sourcesThatDontSupportAttribute),
+            createExtras(attribute, sourcesThatDontSupportAttribute)));
+  }
+
+  private Map<String, Object> createExtras(String invalidAttribute, Set<String> sourceIds) {
+    return ImmutableMap.of("attribute", invalidAttribute, "sources", sourceIds);
+  }
+
+  private String createMessage(String invalidAttribute, Set<String> sourceIds) {
+    String messageFormat = messageFormatSupplier.get();
+    return messageFormat
+        .replace("{attribute}", invalidAttribute)
+        .replace("{sources}", prettyPrintSources(sourceIds));
+  }
+
+  private String prettyPrintSources(Set<String> sourceIds) {
+    List<String> sourceIdsList = sourceIds.stream().sorted().collect(Collectors.toList());
+    if (sourceIds.size() == 1) {
+      return sourceIdsList.get(0);
+    } else if (sourceIds.size() == 2) {
+      return String.format("%s and %s", sourceIdsList.get(0), sourceIdsList.get(1));
+    } else {
+      String allSourcesExceptLast =
+          String.join(", ", sourceIdsList.subList(0, sourceIdsList.size() - 1));
+      String lastSource = sourceIdsList.get(sourceIdsList.size() - 1);
+      return String.format("%s, and %s", allSourcesExceptLast, lastSource);
+    }
+  }
+
+  /**
+   * Adds a new {@code SourceAttributeRestriction} to the {@code sourceIdToSupportedAttributesMap}
+   * map. Called by blueprint when a new {@code SourceAttributeRestriction} is registered as a
+   * service.
+   *
+   * @param sourceAttributeRestriction the new {@code SourceAttributeRestriction} to be registered.
+   */
+  public void bind(SourceAttributeRestriction sourceAttributeRestriction) {
+    if (sourceAttributeRestriction != null) {
+      String sourceId = sourceAttributeRestriction.getSource().getId();
+      LOGGER.trace("Binding new SourceAttributeRestriction instance with id {}", sourceId);
+      sourceIdToSupportedAttributesMap.put(
+          sourceId, sourceAttributeRestriction.getSupportedAttributes());
+    }
+  }
+
+  /**
+   * Removes an existing {@code SourceAttributeRestriction} from the {@code
+   * sourceIdToSupportedAttributesMap} map. Called by blueprint when an existing {@code
+   * SourceAttributeRestriction} service is removed.
+   *
+   * @param sourceAttributeRestriction the {@code SourceAttributeRestriction} to be removed from the
+   *     collection.
+   */
+  public void unbind(SourceAttributeRestriction sourceAttributeRestriction) {
+    if (sourceAttributeRestriction != null) {
+      String sourceId = sourceAttributeRestriction.getSource().getId();
+      LOGGER.trace("Unbinding SourceAttributeRestriction instance with id {}", sourceId);
+      sourceIdToSupportedAttributesMap.remove(sourceId);
+    }
+  }
+}

--- a/catalog/validator/catalog-validator-unsupportedattributes/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/validator/catalog-validator-unsupportedattributes/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+  <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
+
+  <bean id="attributeExtractor" class="org.codice.ddf.validator.query.unsupportedattributes.AttributeExtractor">
+    <argument ref="filterAdapter"/>
+  </bean>
+
+  <reference id="resourceBundleLocator"
+    interface="ddf.platform.resource.bundle.locator.ResourceBundleLocator"/>
+
+  <bean id="messageFormatSupplier" class="org.codice.ddf.validator.query.unsupportedattributes.MessageFormatSupplier">
+    <argument ref="resourceBundleLocator"/>
+  </bean>
+
+  <bean id="unsupportedAttributeQueryValidator" class="org.codice.ddf.validator.query.unsupportedattributes.UnsupportedAttributeQueryValidator">
+    <argument ref="attributeExtractor"/>
+    <argument ref="messageFormatSupplier"/>
+  </bean>
+
+  <reference-list interface="ddf.catalog.source.SourceAttributeRestriction"
+    availability="optional">
+    <reference-listener ref="unsupportedAttributeQueryValidator" bind-method="bind" unbind-method="unbind"/>
+  </reference-list>
+
+  <service  ref="unsupportedAttributeQueryValidator" interface="ddf.catalog.validation.QueryValidator"/>
+
+</blueprint>

--- a/catalog/validator/catalog-validator-unsupportedattributes/src/test/java/org/codice/ddf/validator/query/unsupportedattributes/AttributeExtractorTest.java
+++ b/catalog/validator/catalog-validator-unsupportedattributes/src/test/java/org/codice/ddf/validator/query/unsupportedattributes/AttributeExtractorTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.validator.query.unsupportedattributes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableSet;
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.util.Date;
+import java.util.Set;
+import org.junit.Test;
+import org.opengis.filter.Filter;
+
+public class AttributeExtractorTest {
+
+  private FilterAdapter filterAdapter = new GeotoolsFilterAdapterImpl();
+
+  private FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+
+  private AttributeExtractor attributeExtractor = new AttributeExtractor(filterAdapter);
+
+  @Test
+  public void testExtractAttributesComparisonFilter() throws UnsupportedQueryException {
+    Filter filter = filterBuilder.attribute("attr").is().text("text");
+    Set<String> attributes = attributeExtractor.extractAttributes(filter);
+
+    assertThat(attributes, is(ImmutableSet.of("attr")));
+  }
+
+  @Test
+  public void testExtractAttributesTemporalFilter() throws UnsupportedQueryException {
+    Filter filter = filterBuilder.attribute("attr").before().date(new Date(1562112000L));
+    Set<String> attributes = attributeExtractor.extractAttributes(filter);
+
+    assertThat(attributes, is(ImmutableSet.of("attr")));
+  }
+
+  @Test
+  public void testExtractAttributesSpatialFilter() throws UnsupportedQueryException {
+    Filter filter =
+        filterBuilder.attribute("attr").within().wkt("POLYGON((51 11,42 0,41 10,51 11))");
+    Set<String> attributes = attributeExtractor.extractAttributes(filter);
+
+    assertThat(attributes, is(ImmutableSet.of("attr")));
+  }
+
+  @Test
+  public void testExtractAttributesAndFilter() throws UnsupportedQueryException {
+    Filter filter =
+        filterBuilder.allOf(
+            filterBuilder.attribute("attr-1").is().text("text-1"),
+            filterBuilder.attribute("attr-2").is().text("text-2"));
+    Set<String> attributes = attributeExtractor.extractAttributes(filter);
+
+    assertThat(attributes, is(ImmutableSet.of("attr-1", "attr-2")));
+  }
+
+  @Test
+  public void testExtractAttributesOrFilter() throws UnsupportedQueryException {
+    Filter filter =
+        filterBuilder.anyOf(
+            filterBuilder.attribute("attr-1").is().text("text-1"),
+            filterBuilder.attribute("attr-2").is().text("text-2"));
+    Set<String> attributes = attributeExtractor.extractAttributes(filter);
+
+    assertThat(attributes, is(ImmutableSet.of("attr-1", "attr-2")));
+  }
+
+  @Test
+  public void testExtractAttributesNotFilter() throws UnsupportedQueryException {
+    Filter filter = filterBuilder.not(filterBuilder.attribute("attr").is().text("text"));
+    Set<String> attributes = attributeExtractor.extractAttributes(filter);
+
+    assertThat(attributes, is(ImmutableSet.of("attr")));
+  }
+}

--- a/catalog/validator/catalog-validator-unsupportedattributes/src/test/java/org/codice/ddf/validator/query/unsupportedattributes/UnsupportedAttributeQueryValidatorTest.java
+++ b/catalog/validator/catalog-validator-unsupportedattributes/src/test/java/org/codice/ddf/validator/query/unsupportedattributes/UnsupportedAttributeQueryValidatorTest.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.validator.query.unsupportedattributes;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.source.Source;
+import ddf.catalog.source.SourceAttributeRestriction;
+import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.validation.impl.violation.QueryValidationViolationImpl;
+import ddf.catalog.validation.violation.QueryValidationViolation;
+import ddf.catalog.validation.violation.QueryValidationViolation.Severity;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class UnsupportedAttributeQueryValidatorTest {
+
+  private UnsupportedAttributeQueryValidator validator;
+
+  private AttributeExtractor attributeExtractor = Mockito.mock(AttributeExtractor.class);
+
+  private Supplier<String> messageFormatSupplier = (Supplier<String>) Mockito.mock(Supplier.class);
+
+  @Before
+  public void setup() {
+    Mockito.when(messageFormatSupplier.get())
+        .thenReturn("The field \"{attribute}\" is not supported by the {sources} Source(s)");
+  }
+
+  @Test
+  public void testGetValidatorId() {
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    assertThat(validator.getValidatorId(), is("unsupportedAttribute"));
+  }
+
+  @Test
+  public void testValidateNoViolationsIfNoRestrictionsRegistered()
+      throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any())).thenReturn(ImmutableSet.of("attr-1"));
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+
+    QueryRequest request = mockQueryRequest("src-1");
+    Set<QueryValidationViolation> violations = validator.validate(request);
+
+    assertThat(violations, hasSize(0));
+  }
+
+  @Test
+  public void testValidateSingleValidAttribute() throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any())).thenReturn(ImmutableSet.of("attr"));
+    QueryRequest request = mockQueryRequest("src-1");
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.bind(mockRestriction("src-1", ImmutableSet.of("attr")));
+
+    Set<QueryValidationViolation> violations = validator.validate(request);
+
+    assertThat(violations, hasSize(0));
+  }
+
+  @Test
+  public void testValidateSingleInvalidAttribute() throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any())).thenReturn(ImmutableSet.of("attr-2"));
+    QueryRequest request = mockQueryRequest("src-1");
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.bind(mockRestriction("src-1", ImmutableSet.of("attr-1")));
+
+    Set<QueryValidationViolation> violations = validator.validate(request);
+
+    QueryValidationViolation violation =
+        makeViolation(
+            "The field \"attr-2\" is not supported by the src-1 Source(s)", "attr-2", "src-1");
+    assertThat(violations, hasSize(1));
+    assertThat(violations, hasItem(violation));
+  }
+
+  @Test
+  public void testValidateNoViolationsIfSourceDoesNotHaveRestriction()
+      throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any())).thenReturn(ImmutableSet.of("attr-2"));
+    QueryRequest request = mockQueryRequest("src-1");
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.bind(mockRestriction("src-2", ImmutableSet.of("attr-2")));
+
+    Set<QueryValidationViolation> violations = validator.validate(request);
+
+    assertThat(violations, hasSize(0));
+  }
+
+  @Test
+  public void testValidateNoViolationsIfFailedToGetAttributesFromQuery()
+      throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any()))
+        .thenThrow(UnsupportedQueryException.class);
+    QueryRequest request = mockQueryRequest("src-1");
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.bind(mockRestriction("src-1", ImmutableSet.of("attr-1")));
+
+    Set<QueryValidationViolation> violations = validator.validate(request);
+
+    assertThat(violations, hasSize(0));
+  }
+
+  @Test
+  public void testValidateMultipleInvalidAttributes() throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any()))
+        .thenReturn(ImmutableSet.of("attr-2", "attr-3"));
+    QueryRequest request = mockQueryRequest("src-1");
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.bind(mockRestriction("src-1", ImmutableSet.of("attr-1")));
+
+    Set<QueryValidationViolation> violations = validator.validate(request);
+
+    QueryValidationViolation violation1 =
+        makeViolation(
+            "The field \"attr-2\" is not supported by the src-1 Source(s)", "attr-2", "src-1");
+    QueryValidationViolation violation2 =
+        makeViolation(
+            "The field \"attr-3\" is not supported by the src-1 Source(s)", "attr-3", "src-1");
+    assertThat(violations, hasSize(2));
+    assertThat(violations, hasItems(violation1, violation2));
+  }
+
+  @Test
+  public void testValidateTwoSourcesProduceCorrectMessage() throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any())).thenReturn(ImmutableSet.of("attr-2"));
+    QueryRequest request = mockQueryRequest("src-1", "src-2");
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.bind(mockRestriction("src-1", ImmutableSet.of("attr-1")));
+    validator.bind(mockRestriction("src-2", ImmutableSet.of("attr-1")));
+
+    Set<QueryValidationViolation> violations = validator.validate(request);
+
+    QueryValidationViolation violation =
+        makeViolation(
+            "The field \"attr-2\" is not supported by the src-1 and src-2 Source(s)",
+            "attr-2",
+            "src-1",
+            "src-2");
+    assertThat(violations, hasSize(1));
+    assertThat(violations, hasItem(violation));
+  }
+
+  @Test
+  public void testValidateThreeSourcesProduceCorrectMessage() throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any())).thenReturn(ImmutableSet.of("attr-2"));
+    QueryRequest request = mockQueryRequest("src-1", "src-2", "src-3");
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.bind(mockRestriction("src-1", ImmutableSet.of("attr-1")));
+    validator.bind(mockRestriction("src-2", ImmutableSet.of("attr-1")));
+    validator.bind(mockRestriction("src-3", ImmutableSet.of("attr-1")));
+
+    Set<QueryValidationViolation> violations = validator.validate(request);
+
+    QueryValidationViolation violation =
+        makeViolation(
+            "The field \"attr-2\" is not supported by the src-1, src-2, and src-3 Source(s)",
+            "attr-2",
+            "src-1",
+            "src-2",
+            "src-3");
+    assertThat(violations, hasSize(1));
+    assertThat(violations, hasItem(violation));
+  }
+
+  @Test
+  public void testBindNullSourceAttributeRestrictionDoesNotErrorOut() {
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.bind(null);
+  }
+
+  @Test
+  public void testUnbindNullSourceAttributeRestrictionDoesNotErrorOut() {
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+    validator.unbind(null);
+  }
+
+  @Test
+  public void testUnbind() throws UnsupportedQueryException {
+    Mockito.when(attributeExtractor.extractAttributes(any())).thenReturn(ImmutableSet.of("attr-2"));
+    QueryRequest request = mockQueryRequest("src-1");
+    validator = new UnsupportedAttributeQueryValidator(attributeExtractor, messageFormatSupplier);
+
+    // There is one violation because a SourceAttributeViolation was bound
+    validator.bind(mockRestriction("src-1", ImmutableSet.of("attr-1")));
+    Set<QueryValidationViolation> violations = validator.validate(request);
+    assertThat(violations, hasSize(1));
+
+    // There are no violations because the SourceAttributeViolation was unbound
+    validator.unbind(mockRestriction("src-1", ImmutableSet.of("attr-1")));
+    Set<QueryValidationViolation> violationsAfterUnbind = validator.validate(request);
+    assertThat(violationsAfterUnbind, hasSize(0));
+  }
+
+  private QueryRequest mockQueryRequest(String... sourceIds) {
+    QueryRequest request = Mockito.mock(QueryRequest.class);
+    Mockito.when(request.getSourceIds()).thenReturn(ImmutableSet.copyOf(sourceIds));
+    return request;
+  }
+
+  private SourceAttributeRestriction mockRestriction(
+      String sourceId, Set<String> supportedAttributes) {
+    Source source = Mockito.mock(Source.class);
+    Mockito.when(source.getId()).thenReturn(sourceId);
+    SourceAttributeRestriction restriction = Mockito.mock(SourceAttributeRestriction.class);
+    Mockito.when(restriction.getSource()).thenReturn(source);
+    Mockito.when(restriction.getSupportedAttributes()).thenReturn(supportedAttributes);
+    return restriction;
+  }
+
+  private QueryValidationViolation makeViolation(
+      String message, String attribute, String... sources) {
+    Map<String, Object> extraData =
+        ImmutableMap.of("attribute", attribute, "sources", ImmutableSet.copyOf(sources));
+    return new QueryValidationViolationImpl(Severity.ERROR, message, extraData);
+  }
+}

--- a/catalog/validator/pom.xml
+++ b/catalog/validator/pom.xml
@@ -30,5 +30,6 @@
         <module>catalog-validator-metacardwkt</module>
         <module>catalog-validator-metacardlocation</module>
         <module>catalog-validator-metacardframecenter</module>
+        <module>catalog-validator-unsupportedattributes</module>
     </modules>
 </project>

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -619,7 +619,7 @@ grant codeBase "file:/landing-page" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}i18n${/}LandingPageBundle${/}-", "read";
 }
 
-grant codeBase "file:/catalog-ui-search" {
+grant codeBase "file:/catalog-ui-search/catalog-validator-unsupportedattributes" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}i18n${/}IntrigueBundle", "read";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}i18n${/}IntrigueBundle${/}-", "read";
 }


### PR DESCRIPTION
# Backport of https://github.com/codice/ddf/pull/5628

#### What does this PR do?
Adds a new framework for validating queries **before they are ran**. The idea is that as a user creates/modifies a query in the UI, it will be sent to the backend for validation in real-time.

 It works by exposing a new `cql/validator/:id` POST endpoint that accepts a CQL query body just like the `/cql` endpoint. The `:id` parameter is the id of the validator that you want to run. The response contains a set of validation warnings or errors.

New validators are added by implementing the `QueryValidator` interface. Currently, the only validator in the system is the `UnsupportedAttributesQueryValidator` with id `unsupportedAttribute`. This validator aggregates all instances of the `SourceAttributeRestriction` interface and uses them to determine if there are any attributes in the query that are not supported by the currently selected sources.

For example, a request to `/cql/validator/unsupportedAttribute` with the following body
```
{
    "srcs": ["OS"],
    "start": 1,
    "count": 250,
    "cql": "(\"ext.not-supported-by-os\" ILIKE 'some value')",
    "sorts": [
        {
            "attribute": "modified",
            "direction": "descending"
        }
    ],
    "id": "a65ffb0790194aeca46f37c9b1f14ccf",
    "spellcheck": false,
    "phonetics": false,
    "batchId": "106e57b9cff2461aa08486cc52064296"
}
```
... might produce a response like below.

```
{
    "validationViolations": [
        {
            "type": "unsupportedAttribute",
            "severity": "ERROR",
            "message": "The field \"ext.not-supported-by-os\" is not supported by the OS Source(s)",
            "extraData": {
                "attribute": "ext.not-supported-by-os",
                "sources": [
                    "OS"
                ]
            }
        }
    ]
}
```


Each validation violation is required to have a `type` (the id of the validator), a `severity`, and a `message`. The `message` field is user-friendly so that they can be shown directly to the user in the query view in Intrigue. The `extraData` field is optional and is used to return structured data about the violation so that no additional parsing is necessary to get key information (in this case, we won't need to parse the message to determine the name of the unsupported attribute or the sources that don't support it - they are supplied directly).

The approach is extensible to support other types of validation in the future.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@brianfelix @kentmorrissey @brhumphe @Lambeaux @mazarag2 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Install the standard profile
2. Create a new OpenSearch source (Catalog OpenSearch Federated Source) called `OS`
3. Download/extract this zip and import the json file into Postman
[Validation.postman_collection.json.zip](https://github.com/codice/ddf/files/4055684/Validation.postman_collection.json.zip)
4. Run the `CQL Validate` request and ensure no validation errors/warnings are shown (this is expected since there is no `SourceAttributeRestriction` implementation for the OpenSearch interface by default)

##### Test the `UnsupportedAttributesQueryValidator` with a `SourceAttributeRestriction` implementation for OpenSearch
1. Remove the `OS` source
2. Cherry-pick https://github.com/mojogitoverhere/ddf/commit/e97c92722e1c2cb787329eb295c722e80b3b5521, cd to catalog/opensearch/catalog-opensearch-source, and rebuild
3. Hot deploy the changes using `bundle:watch` or by dropping the catalog-opensearch-source-2.22.0-SNAPSHOT.jar into the deploy folder
4. Recreate the `OS` source
5. Run the `CQL Validate` request again and verify that no errors/warnings are returned still (since `title` is the only attribute supported by the OS source)
6. Change `title` in the `cql` field to another attribute like `subtitle` and rerun `CQL Validate`. Verify that an error like below is returned
```
{
    "validationViolations": [
        {
            "type": "unsupportedAttribute",
            "severity": "ERROR",
            "message": "The field \"ext.title\" is not supported by the OS Source(s)",
            "extraData": {
                "attribute": "ext.title",
                "sources": [
                    "OS"
                ]
            }
        }
    ]
}
```
7. Test different combinations of attributes (including operators like contains, equals, etc.) and cql queries. Instead of manually typing the cql string, I recommend running a query in Intrigue and copy/pasting the cql from the outgoing request in the network tab. You can also change the set of supported attributes here https://github.com/mojogitoverhere/ddf/commit/e97c92722e1c2cb787329eb295c722e80b3b5521#diff-1e3c7ae03e5895233d8e433f676aaac5R1169, rebuild, and redeploy for more testing.


#### What are the relevant tickets?
Fixes: #5627 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
