### PR TITLE
DDF-5674 G-5334 Enable PropertyIsLike special character customization for the WFS 1.1.0 source

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -164,6 +164,12 @@ public class WfsSource extends AbstractWfsSource {
 
   private static final String SRS_NAME_KEY = "srsName";
 
+  private static final String WILDCARD_CHAR_KEY = "wildcardChar";
+
+  private static final String SINGLE_CHAR_KEY = "singleChar";
+
+  private static final String ESCAPE_CHAR_KEY = "escapeChar";
+
   private static final Properties DESCRIBABLE_PROPERTIES = new Properties();
 
   private static final String SOURCE_MSG = " Source '";
@@ -225,6 +231,12 @@ public class WfsSource extends AbstractWfsSource {
   private String srsName;
 
   private boolean allowRedirects;
+
+  private Character wildcardChar;
+
+  private Character singleChar;
+
+  private Character escapeChar;
 
   private WfsMetadata<FeatureTypeType> wfsMetadata;
 
@@ -310,6 +322,9 @@ public class WfsSource extends AbstractWfsSource {
     setConnectionTimeout((Integer) configuration.get(CONNECTION_TIMEOUT_KEY));
     setReceiveTimeout((Integer) configuration.get(RECEIVE_TIMEOUT_KEY));
     setSrsName((String) configuration.get(SRS_NAME_KEY));
+    setWildcardChar((Character) configuration.get(WILDCARD_CHAR_KEY));
+    setSingleChar((Character) configuration.get(SINGLE_CHAR_KEY));
+    setEscapeChar((Character) configuration.get(ESCAPE_CHAR_KEY));
 
     createClientFactory();
     configureWfsFeatures();
@@ -527,7 +542,13 @@ public class WfsSource extends AbstractWfsSource {
           this.featureTypeFilters.put(
               featureMetacardType.getFeatureType(),
               new WfsFilterDelegate(
-                  featureMetacardType, metacardMapper, supportedGeo, getCoordinateStrategy()));
+                  featureMetacardType,
+                  metacardMapper,
+                  supportedGeo,
+                  getCoordinateStrategy(),
+                  wildcardChar,
+                  singleChar,
+                  escapeChar));
 
           mcTypeRegs.put(ftSimpleName, featureMetacardType);
 
@@ -1065,6 +1086,18 @@ public class WfsSource extends AbstractWfsSource {
 
   public void setCoordinateOrder(String coordinateOrder) {
     this.coordinateOrder = coordinateOrder;
+  }
+
+  public void setWildcardChar(final Character wildcardChar) {
+    this.wildcardChar = wildcardChar;
+  }
+
+  public void setSingleChar(final Character singleChar) {
+    this.singleChar = singleChar;
+  }
+
+  public void setEscapeChar(final Character escapeChar) {
+    this.escapeChar = escapeChar;
   }
 
   @Override

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -72,7 +72,7 @@
             <Option label="Overlaps" value="Overlaps"/>
             <Option label="Touches" value="Touches"/>
             <Option label="Within" value="Within"/>
-		</AD>
+        </AD>
         <AD description="Amount of time to attempt to establish a connection before timing out, in milliseconds."
             name="Connection Timeout" id="connectionTimeout"
             required="true" type="Integer" default="30000"/>
@@ -82,6 +82,12 @@
         <AD description="SRS Name to use in outbound GetFeature requests. The SRS Name parameter is used to assert the specific CRS transformation to be applied to the geometries of the features returned in a response document."
             name="SRS Name" id="srsName"
             required="false" type="String" default="EPSG:4326"/>
+        <AD description="Wildcard character to use in PropertyIsLike filters."
+          name="Wildcard Character" id="wildcardChar" required="false" type="Char" default="*"/>
+        <AD description="Single-character wildcard character to use in PropertyIsLike filters."
+          name="Single-Character Wildcard Character" id="singleChar" required="false" type="Char" default="?"/>
+        <AD description="Escape character to use in PropertyIsLike filters."
+          name="Escape Character" id="escapeChar" required="false" type="Char" default="\\"/>
     </OCD>
 
     <Designate pid="Wfs_v110_Federated_Source" factoryPid="Wfs_v110_Federated_Source">

--- a/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/WfsConstants.java
+++ b/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/WfsConstants.java
@@ -22,8 +22,6 @@ public class WfsConstants {
   /* XML Encoded Filter Constants */
   public static final String ESCAPE = "!";
 
-  public static final String SINGLE_CHAR = "#";
-
   public static final String WILD_CARD = "*";
 
   public static final String METERS = "METERS";


### PR DESCRIPTION
#### What does this PR do?
Allows the WFS 1.1.0 source to customize the `wildCard`, `singleChar`, and `escapeChar` characters used for `PropertyIsLike` queries.

#### Who is reviewing it? 
@leo-sakh 
@bennuttle 
@lavoywj 
@nsuvarna 
@aj-brooks 
@AzGoalie 

#### Select relevant component teams: 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8

#### How should this be tested?
1. Create a WFS 1.1.0 source with the URL http://services.azgs.az.gov/ArcGIS/services/aasggeothermal/CAWellLogs/MapServer/WFSServer
2. Change the `Wildcard Character`, `Single-Character Wildcard Character`, and `Escape Character` from their default values.
3. `log:set info org.apache.cxf` (so you can see the outgoing WFS queries)
4. Open Intrigue and run some queries using the wildcard character `*`, the single-character wildcard character `?` and the escape character `\` (these are the special characters Intrigue understands and will be translated to the characters you specified on the query to the WFS server).
5. Check the logs for your WFS query and verify each `PropertyIsLike` element has the correct `wildCard`, `singleChar`, and `escapeChar` attributes (the ones you specified in step 2).
6. Verify the special characters in the `Literal` (query) of each `PropertyIsLike` were correctly translated to the characters you specified in step 2.

#### What are the relevant tickets?
Fixes: #5674 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.