### PR TITLE
[2.21.x] DDF-5572 Render map marker labels with custom text notation on 2D and 3D maps

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -135,6 +135,10 @@ public class ConfigurationApplication implements SparkApplication {
 
   private Boolean metacardPreviewEnabled = true;
 
+  private Boolean customTextNotationEnabled = false;
+
+  private String customTextNotationAttribute = "title";
+
   private Boolean spellcheckEnabled = false;
 
   private Boolean phoneticsEnabled = false;
@@ -564,6 +568,8 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("isHistoricalSearchDisabled", !historicalSearchEnabled);
     config.put("isArchiveSearchDisabled", !archiveSearchEnabled);
     config.put("isMetacardPreviewDisabled", !metacardPreviewEnabled);
+    config.put("isCustomTextNotationEnabled", customTextNotationEnabled);
+    config.put("customTextNotationAttribute", customTextNotationAttribute);
     config.put("isSpellcheckEnabled", spellcheckEnabled);
     config.put("isPhoneticsEnabled", phoneticsEnabled);
     config.put(
@@ -1134,6 +1140,22 @@ public class ConfigurationApplication implements SparkApplication {
 
   public void setMetacardPreviewEnabled(Boolean metacardPreviewEnabled) {
     this.metacardPreviewEnabled = metacardPreviewEnabled;
+  }
+
+  public Boolean getCustomTextNotationEnabled() {
+    return customTextNotationEnabled;
+  }
+
+  public void setCustomTextNotationEnabled(Boolean customTextNotationEnabled) {
+    this.customTextNotationEnabled = customTextNotationEnabled;
+  }
+
+  public String getCustomTextNotationAttribute() {
+    return customTextNotationAttribute;
+  }
+
+  public void setCustomTextNotationAttribute(String customTextNotationAttribute) {
+    this.customTextNotationAttribute = customTextNotationAttribute;
   }
 
   public Boolean getSpellcheckEnabled() {

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -222,6 +222,20 @@
             type="Boolean"
             default="false"/>
 
+        <AD id="customTextNotationEnabled"
+          name="Show Custom Text Notations"
+          description="Toggle the display of custom text notations next to metacard map markers."
+          type="Boolean"
+          default="false"
+          required="false"/>
+
+        <AD id="customTextNotationAttribute"
+          name="Custom Text Notation Attribute"
+          description="Set the metacard attribute to display next to the map markers. The default is 'title'."
+          type="String"
+          default="title"
+          required="false"/>
+
         <AD id="basicSearchTemporalSelectionDefault"
             name="Basic Search Temporal Selections"
             description="Enable Basic Search Temporal Selections."

--- a/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
+++ b/catalog/ui/search-ui-app/src/main/resources/etc/org.codice.ddf.catalog.ui.config
@@ -53,6 +53,7 @@ localCatalogEnabled=B"true"
 historicalSearchEnabled=B"true"
 archiveSearchEnabled=B"true"
 unknownErrorBoxEnabled=B"true"
+customTextNotationAttribute="title"
 basicSearchTemporalSelectionDefault=[ \
   "created", \
   "effective", \

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -650,8 +650,9 @@ module.exports = function CesiumMap(
       return billboardRef
     },
     /*
-     * Draws a label containing the text in the given options.
-     */
+          Adds a label utilizing the passed in point and options.
+          Options are a view to an id and text.
+        */
     addLabel(point, options) {
       const pointObject = convertPointCoordinate(point)
       const cartographicPosition = Cesium.Cartographic.fromDegrees(
@@ -875,7 +876,7 @@ module.exports = function CesiumMap(
             label =>
               label.position.x === geometry.position.x &&
               label.position.y === geometry.position.y &&
-              label.show === true
+              label.show
           )
           if (labelWithSamePosition !== undefined) {
             labelWithSamePosition.show = false
@@ -889,7 +890,7 @@ module.exports = function CesiumMap(
             label =>
               label.position.x === geometry.position.x &&
               label.position.y === geometry.position.y &&
-              label.show === true
+              label.show
           )
           if (
             labelWithSamePosition === undefined ||
@@ -945,11 +946,11 @@ module.exports = function CesiumMap(
           label =>
             label.position.x === geometry.position.x &&
             label.position.y === geometry.position.y &&
-            (label.isSelected === true || label.show === true)
+            (label.isSelected || label.show)
         )
         if (
           labelWithSamePosition === undefined ||
-          geometry.id == labelWithSamePosition.id
+          geometry.id === labelWithSamePosition.id
         ) {
           geometry.show = true
         }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -939,7 +939,7 @@ module.exports = function CesiumMap(
     showGeometry(geometry) {
       if (geometry.constructor === Cesium.Billboard) {
         geometry.show = true
-      } else if (showLabels && geometry.constructor === Cesium.Label) {
+      } else if (geometry.constructor === Cesium.Label) {
         // only show one label at one location
         const labelWithSamePosition = _.find(
           mapModel.get('labels'),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -294,9 +294,8 @@ module.exports = function CesiumMap(
     findSelected = false,
   }) {
     const labelWithSamePosition = findOverlappingLabel(findSelected, geometry)
-    if (isSelected && labelWithSamePosition !== undefined) {
+    if (isSelected && labelWithSamePosition) {
       labelWithSamePosition.show = false
-      labelWithSamePosition.isSelected = false
     }
     geometry.show =
       isSelected ||
@@ -973,6 +972,9 @@ module.exports = function CesiumMap(
       //unminified cesium chokes if you feed a geometry with id as an Array
       if (geometry.constructor === Cesium.Entity) {
         map.entities.remove(geometry)
+      }
+      if (geometry.constructor === Cesium.Label) {
+        mapModel.clearLabels()
       }
       map.scene.requestRender()
     },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/geometry.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/geometry.view.js
@@ -19,6 +19,7 @@ const _ = require('underscore')
 const _debounce = require('lodash/debounce')
 const wkx = require('wkx')
 const metacardDefinitions = require('../../singletons/metacard-definitions.js')
+const properties = require('../../../js/properties')
 
 const GeometryView = Marionette.ItemView.extend({
   template: false,
@@ -134,6 +135,20 @@ const GeometryView = Marionette.ItemView.extend({
         view: this,
       })
     )
+    // adds an additional map element to the geometry for the label
+    if (properties.isCustomTextNotationEnabled) {
+      const attribute = this.model
+        .get('metacard')
+        .get('properties')
+        .get(properties.customTextNotationAttribute)
+      // use an empty string if there is no metacard attribute set
+      this.geometry.push(
+        this.options.map.addLabel(point, {
+          id: `${this.model.id}-label`,
+          text: attribute !== undefined ? attribute : '',
+        })
+      )
+    }
   },
   handleLine(line) {
     this.geometry.push(

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -80,10 +80,8 @@ module.exports = Backbone.AssociatedModel.extend({
       labels: [...this.get('labels'), label],
     })
   },
-  clearLabels() {
-    this.set({
-      labels: [],
-    })
+  removeLabel(label) {
+    _.remove(this.get('labels'), e => e === label)
   },
   /*
    * Sets the line to the given new line. This represents the line on the map

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -46,6 +46,7 @@ module.exports = Backbone.AssociatedModel.extend({
     measurementState: 'NONE',
     currentDistance: 0,
     points: [],
+    labels: [],
     line: undefined,
   },
   /*
@@ -72,6 +73,11 @@ module.exports = Backbone.AssociatedModel.extend({
   addPoint(point) {
     this.set({
       points: [...this.get('points'), point],
+    })
+  },
+  addLabel(label) {
+    this.set({
+      labels: [...this.get('labels'), label],
     })
   },
   /*

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -15,6 +15,7 @@
 
 import wrapNum from '../../../react-component/utils/wrap-num/wrap-num.tsx'
 
+const _ = require('underscore')
 const Backbone = require('backbone')
 const MetacardModel = require('../../../js/model/Metacard.js')
 const mtgeo = require('mt-geo')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -80,6 +80,11 @@ module.exports = Backbone.AssociatedModel.extend({
       labels: [...this.get('labels'), label],
     })
   },
+  clearLabels() {
+    this.set({
+      labels: [],
+    })
+  },
   /*
    * Sets the line to the given new line. This represents the line on the map
    * being used for the ruler measurement.

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.model.js
@@ -15,7 +15,7 @@
 
 import wrapNum from '../../../react-component/utils/wrap-num/wrap-num.tsx'
 
-const _ = require('underscore')
+const _ = require('lodash')
 const Backbone = require('backbone')
 const MetacardModel = require('../../../js/model/Metacard.js')
 const mtgeo = require('mt-geo')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -196,9 +196,8 @@ module.exports = function OpenlayersMap(
       findSelected,
       geometryInstance
     )
-    if (isSelected && labelWithSamePosition !== undefined) {
+    if (isSelected && labelWithSamePosition) {
       labelWithSamePosition.setVisible(false)
-      labelWithSamePosition.set('isSelected', false)
     }
     const visible =
       isSelected ||
@@ -802,6 +801,10 @@ module.exports = function OpenlayersMap(
     },
     removeGeometry(geometry) {
       map.removeLayer(geometry)
+      const feature = geometry.getSource().getFeatures()[0]
+      if (feature.getProperties().isLabel) {
+        mapModel.clearLabels()
+      }
     },
     showPolygonShape(locationModel) {
       const polygon = new DrawPolygon.PolygonView({


### PR DESCRIPTION
#### What does this PR do?
Backport of #5638 and #5768 

Adds an option and input field to the Search UI preferences to enable "custom text notation". Custom text notation allows for a user to enter a metacard attribute to display as a text label next to metacard map markers in Intrigue. title is the default attribute used.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@aaronilovici 
@josephthweatt 
@mdang8 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@vinamartin 
@andrewkfiedler 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Open the Admin console and navigate to `Search UI -> Configuration -> Catalog UI Search`
2. Scroll down to `Show Custom Text Notations` and click the checkbox to enable it
3. Ingest some metacards in Intrigue, ensuring there are metacards that overlap with different titles
4. Open the 2D map and run a * search
5. Verify the metacard map markers have a label next to each one and that there are no overlapping labels
6. Scroll in and out to change appearances of labels
7. Select different overlapping metacards and verify that only the selected metacard's label shows up (no overlapping labels)
8. Turn on clustering and verify that clusters do not have labels
9. Turn off clustering and verify that unclustered metacards do not have overlapping labels
10. Re-run the search and verify the labels still display as intended
11. Repeat steps 4-10 in the 3D map

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5572, #5508, #5767 

#### Screenshots
<!--(if appropriate)-->
![image](https://user-images.githubusercontent.com/6109231/73222200-a9ba0e80-4130-11ea-80b8-00440412a758.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
