### PR TITLE
DDF-5802 Solr Split Catalog Provider

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -203,6 +203,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.catalog.solr</groupId>
+            <artifactId>catalog-solr-collection-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.schematron</groupId>
             <artifactId>catalog-schematron-plugin</artifactId>
             <version>${project.version}</version>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -36,6 +36,7 @@
         <feature>action-core-impl</feature>
         <bundle>mvn:ddf.platform.api/platform-api/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-api/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.solr/catalog-solr-collection-api/${project.version}</bundle>
         <bundle>mvn:ddf.mime.core/mime-core-api/${project.version}</bundle>
         <bundle>mvn:org.apache.tika/tika-core/${tika.version}</bundle>
         <bundle>mvn:org.codice.thirdparty/gt-opengis/${opengis.bundle.version}</bundle>

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/RemoteSolrCatalogProvider.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/RemoteSolrCatalogProvider.java
@@ -58,7 +58,7 @@ public abstract class RemoteSolrCatalogProvider extends MaskableImpl implements 
 
   protected static final String SOLR_CATALOG_CORE_NAME = "catalog";
 
-  private final SolrCatalogProvider provider;
+  private final SolrCatalogProviderImpl provider;
 
   /**
    * Constructor.
@@ -75,7 +75,7 @@ public abstract class RemoteSolrCatalogProvider extends MaskableImpl implements 
       SolrFilterDelegateFactory solrFilterDelegateFactory,
       @Nullable DynamicSchemaResolver resolver) {
     this.provider =
-        new SolrCatalogProvider(
+        new SolrCatalogProviderImpl(
             client,
             filterAdapter,
             solrFilterDelegateFactory,

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrCatalogProviderImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrCatalogProviderImpl.java
@@ -50,6 +50,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
@@ -68,9 +69,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** {@link CatalogProvider} implementation using Apache Solr */
-public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider {
+public class SolrCatalogProviderImpl extends MaskableImpl implements CatalogProvider {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SolrCatalogProvider.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SolrCatalogProviderImpl.class);
 
   private static final String COULD_NOT_COMPLETE_DELETE_REQUEST_MESSAGE =
       "Could not complete delete request.";
@@ -85,8 +86,7 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
 
   static {
     try (InputStream propertiesStream =
-        ddf.catalog.source.solr.SolrCatalogProvider.class.getResourceAsStream(
-            DESCRIBABLE_PROPERTIES_FILE)) {
+        SolrCatalogProviderImpl.class.getResourceAsStream(DESCRIBABLE_PROPERTIES_FILE)) {
       DESCRIBABLE_PROPERTIES.load(propertiesStream);
     } catch (IOException e) {
       LOGGER.info("Failed to load describable properties", e);
@@ -99,7 +99,7 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
 
   private final SolrMetacardClientImpl client;
 
-  private final FilterAdapter filterAdapter;
+  protected final FilterAdapter filterAdapter;
 
   /**
    * Constructor that creates a new instance and allows for a custom {@link DynamicSchemaResolver}
@@ -108,7 +108,7 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
    * @param adapter injected implementation of FilterAdapter
    * @param resolver Solr schema resolver
    */
-  public SolrCatalogProvider(
+  public SolrCatalogProviderImpl(
       SolrClient solrClient,
       FilterAdapter adapter,
       SolrFilterDelegateFactory solrFilterDelegateFactory,
@@ -122,7 +122,7 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
     this.resolver = resolver;
 
     LOGGER.debug(
-        "Constructing {} with Solr client [{}]", SolrCatalogProvider.class.getName(), solr);
+        "Constructing {} with Solr client [{}]", SolrCatalogProviderImpl.class.getName(), solr);
 
     solr.whenAvailable(this::addFieldsFromClientToResolver);
     this.client =
@@ -163,6 +163,16 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
     return isAvailable(); // then trigger an active ping
   }
 
+  public boolean isAvailable(long timeout, TimeUnit unit) {
+    try {
+      return solr.isAvailable(timeout, unit);
+    } catch (InterruptedException e) {
+      LOGGER.debug("Solr client is available interrupted exception {}", e);
+      Thread.currentThread().interrupt();
+    }
+    return false;
+  }
+
   @Override
   public String getDescription() {
     return DESCRIBABLE_PROPERTIES.getProperty("description");
@@ -191,7 +201,9 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
 
   @Override
   public SourceResponse query(QueryRequest request) throws UnsupportedQueryException {
+    long startTime = System.currentTimeMillis();
     SourceResponse response = client.query(request);
+    LOGGER.debug("Time elapsed for Query {} ms", System.currentTimeMillis() - startTime);
     return response;
   }
 
@@ -226,12 +238,17 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
       output.add(metacard);
     }
 
+    long startTime = System.currentTimeMillis();
     try {
       client.add(output, isForcedAutoCommit());
     } catch (SolrServerException | SolrException | IOException | MetacardCreationException e) {
       LOGGER.info("Solr could not ingest metacard(s) during create.", e);
-      throw new IngestException("Could not ingest metacard(s).");
+      throw new IngestException("Could not ingest metacard(s).", e);
     }
+    LOGGER.debug(
+        "Time elapsed to create {} metacards is {} ms",
+        metacards.size(),
+        System.currentTimeMillis() - startTime);
 
     return new CreateResponseImpl(request, request.getProperties(), output);
   }
@@ -498,7 +515,7 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
     return UUID.randomUUID().toString().replaceAll("-", "");
   }
 
-  public boolean isForcedAutoCommit() {
+  private boolean isForcedAutoCommit() {
     return ConfigurationStore.getInstance().isForceAutoCommit();
   }
 
@@ -530,7 +547,9 @@ public class SolrCatalogProvider extends MaskableImpl implements CatalogProvider
     @Override
     public MetacardImpl createMetacard(SolrDocument doc) throws MetacardCreationException {
       MetacardImpl metacard = super.createMetacard(doc);
-      metacard.setSourceId(getId());
+      if (metacard != null) {
+        metacard.setSourceId(getId());
+      }
       return metacard;
     }
   }

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -68,6 +68,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest.METHOD;
@@ -124,6 +125,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
 
   public static final String EXCLUDE_ATTRIBUTES = "excludeAttributes";
 
+  public static final String DO_REALTIME_GET = "doRealtimeGet";
+
   private static final String RESOURCE_ATTRIBUTE = "resource";
 
   private final SolrClient client;
@@ -168,15 +171,66 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       return new QueryResponseImpl(request, new ArrayList<>(), true, 0L);
     }
 
+    long totalHits = 0;
+    Map<String, Serializable> responseProps = new HashMap<>();
+    List<Result> results = new ArrayList<>();
+
     SolrFilterDelegate solrFilterDelegate =
         filterDelegateFactory.newInstance(resolver, request.getProperties());
     SolrQuery query = getSolrQuery(request, solrFilterDelegate);
 
-    Map<String, Serializable> responseProps = new HashMap<>();
+    boolean isFacetedQuery = handleFacetRequest(query, request);
+    query = handleSuggestionQuery(query, request);
+    boolean userSpellcheckIsOn = userSpellcheckIsOn(request);
 
+    try {
+      QueryResponse solrResponse;
+      Boolean doRealTimeGet =
+          (Boolean) request.getProperties().getOrDefault(DO_REALTIME_GET, false)
+              || filterAdapter.adapt(request.getQuery(), new RealTimeGetDelegate());
+
+      if (BooleanUtils.isTrue(doRealTimeGet)) {
+        LOGGER.debug("Performing real time query");
+        SolrQuery realTimeQuery = getRealTimeQuery(query, solrFilterDelegate.getIds());
+        solrResponse = client.query(realTimeQuery, METHOD.POST);
+      } else {
+        query.setParam("spellcheck", userSpellcheckIsOn);
+        solrResponse = client.query(query, METHOD.POST);
+      }
+
+      handleFacetResponse(solrResponse, responseProps, isFacetedQuery);
+      handleSuggestionResponse(solrResponse, responseProps);
+
+      SolrDocumentList docs = solrResponse.getResults();
+      docs = handleSpellcheck(solrResponse, responseProps, query, docs, userSpellcheckIsOn);
+      if (docs != null) {
+        addDocsToResults(docs, results);
+        totalHits = docs.getNumFound();
+      }
+    } catch (SolrServerException | IOException | SolrException e) {
+      throw new UnsupportedQueryException("Could not complete solr query.", e);
+    }
+
+    return new SourceResponseImpl(request, responseProps, results, totalHits);
+  }
+
+  private List<SolrDocument> getSolrDocs(Set<String> ids) throws UnsupportedQueryException {
+    List<SolrDocument> solrDocs = new ArrayList<>(ids.size());
+    List<List<String>> partitions = Lists.partition(new ArrayList<>(ids), GET_BY_ID_LIMIT);
+    for (List<String> partition : partitions) {
+      try {
+        SolrDocumentList page = client.getById(partition);
+        page.iterator().forEachRemaining(solrDocs::add);
+      } catch (SolrServerException | SolrException | IOException e) {
+        throw new UnsupportedQueryException("Could not complete solr query.", e);
+      }
+    }
+    return solrDocs;
+  }
+
+  private boolean handleFacetRequest(SolrQuery query, QueryRequest request) {
     boolean isFacetedQuery = false;
     Serializable textFacetPropRaw = request.getPropertyValue(EXPERIMENTAL_FACET_PROPERTIES_KEY);
-
     if (textFacetPropRaw instanceof TermFacetProperties) {
       TermFacetProperties textFacetProp = (TermFacetProperties) textFacetPropRaw;
       isFacetedQuery = true;
@@ -195,7 +249,10 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       query.setFacetLimit(textFacetProp.getFacetLimit());
       query.setFacetMinCount(textFacetProp.getMinFacetCount());
     }
+    return isFacetedQuery;
+  }
 
+  private SolrQuery handleSuggestionQuery(SolrQuery query, QueryRequest request) {
     Serializable suggestQuery = request.getPropertyValue(SUGGESTION_QUERY_KEY);
     Serializable suggestContext = request.getPropertyValue(SUGGESTION_CONTEXT_KEY);
     Serializable suggestDict = request.getPropertyValue(SUGGESTION_DICT_KEY);
@@ -215,92 +272,76 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       }
     }
 
-    long totalHits = 0;
-    List<Result> results = new ArrayList<>();
+    return query;
+  }
 
-    Boolean userSpellcheckIsOn = userSpellcheckIsOn(request);
-
-    try {
-      QueryResponse solrResponse;
-      Boolean doRealTimeGet = filterAdapter.adapt(request.getQuery(), new RealTimeGetDelegate());
-
-      if (doRealTimeGet) {
-        LOGGER.debug("Performing real time query");
-        SolrQuery realTimeQuery = getRealTimeQuery(query, solrFilterDelegate.getIds());
-        solrResponse = client.query(realTimeQuery, METHOD.POST);
-      } else {
-        query.setParam("spellcheck", userSpellcheckIsOn);
-        solrResponse = client.query(query, METHOD.POST);
+  private void handleFacetResponse(
+      QueryResponse solrResponse, Map<String, Serializable> responseProps, boolean isFacetedQuery) {
+    if (isFacetedQuery) {
+      List<FacetField> facetFields = solrResponse.getFacetFields();
+      if (CollectionUtils.isNotEmpty(facetFields)) {
+        List<FacetAttributeResult> facetedAttributeResults =
+            facetFields.stream().map(this::convertFacetField).collect(Collectors.toList());
+        responseProps.put(EXPERIMENTAL_FACET_RESULTS_KEY, (Serializable) facetedAttributeResults);
       }
+    }
+  }
 
-      SuggesterResponse suggesterResponse = solrResponse.getSuggesterResponse();
+  private void handleSuggestionResponse(
+      QueryResponse solrResponse, Map<String, Serializable> responseProps) {
+    SuggesterResponse suggesterResponse = solrResponse.getSuggesterResponse();
+    if (suggesterResponse != null) {
+      List<Map.Entry<String, String>> suggestionResults =
+          suggesterResponse
+              .getSuggestions()
+              .values()
+              .stream()
+              .flatMap(List::stream)
+              .map(
+                  suggestion ->
+                      new AbstractMap.SimpleImmutableEntry<>(
+                          suggestion.getPayload(), suggestion.getTerm()))
+              .collect(Collectors.toList());
 
-      if (suggesterResponse != null) {
-        List<Map.Entry<String, String>> suggestionResults =
-            suggesterResponse
-                .getSuggestions()
-                .entrySet()
-                .stream()
-                .map(Map.Entry::getValue)
-                .flatMap(List::stream)
-                .map(
-                    suggestion ->
-                        new AbstractMap.SimpleImmutableEntry<>(
-                            suggestion.getPayload(), suggestion.getTerm()))
-                .collect(Collectors.toList());
+      responseProps.put(SUGGESTION_RESULT_KEY, (Serializable) suggestionResults);
+    }
+  }
 
-        responseProps.put(SUGGESTION_RESULT_KEY, (Serializable) suggestionResults);
+  private SolrDocumentList handleSpellcheck(
+      QueryResponse solrResponse,
+      Map<String, Serializable> responseProps,
+      SolrQuery query,
+      SolrDocumentList originalDocs,
+      boolean userSpellcheckIsOn)
+      throws IOException, SolrServerException {
+
+    SolrDocumentList resultDocs = originalDocs;
+    responseProps.put(SPELLCHECK_KEY, userSpellcheckIsOn);
+    if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
+      Collation collation = getCollationToResend(query, solrResponse);
+      query.set("q", collation.getCollationQueryString());
+      query.set("spellcheck", false);
+      QueryResponse solrResponseRequery = client.query(query, METHOD.POST);
+      SolrDocumentList docs = solrResponseRequery.getResults();
+      if (docs != null && docs.size() > originalDocs.size()) {
+        resultDocs = docs;
+
+        Set<String> originals = new HashSet<>();
+        Set<String> corrections = new HashSet<>();
+        collation
+            .getMisspellingsAndCorrections()
+            .stream()
+            .forEach(
+                correction -> {
+                  originals.add(correction.getOriginal());
+                  corrections.add(correction.getCorrection());
+                });
+        responseProps.put(DID_YOU_MEAN_KEY, new ArrayList<>(originals));
+        responseProps.put(SHOWING_RESULTS_FOR_KEY, new ArrayList<>(corrections));
       }
-
-      SolrDocumentList docs = solrResponse.getResults();
-      int originalQueryResultsSize = 0;
-      if (docs != null) {
-        originalQueryResultsSize = docs.size();
-        totalHits = docs.getNumFound();
-        addDocsToResults(docs, results);
-
-        if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
-          Collation collation = getCollationToResend(query, solrResponse);
-          query.set("q", collation.getCollationQueryString());
-          query.set("spellcheck", false);
-          QueryResponse solrResponseRequery = client.query(query, METHOD.POST);
-          docs = solrResponseRequery.getResults();
-          if (docs != null && docs.size() > originalQueryResultsSize) {
-            results = new ArrayList<>();
-            totalHits = docs.getNumFound();
-            addDocsToResults(docs, results);
-
-            Set<String> originals = new HashSet<>();
-            Set<String> corrections = new HashSet<>();
-            collation
-                .getMisspellingsAndCorrections()
-                .stream()
-                .forEach(
-                    correction -> {
-                      originals.add(correction.getOriginal());
-                      corrections.add(correction.getCorrection());
-                    });
-            responseProps.put(DID_YOU_MEAN_KEY, new ArrayList<>(originals));
-            responseProps.put(SHOWING_RESULTS_FOR_KEY, new ArrayList<>(corrections));
-          }
-        }
-      }
-
-      if (isFacetedQuery) {
-        List<FacetField> facetFields = solrResponse.getFacetFields();
-        if (CollectionUtils.isNotEmpty(facetFields)) {
-          List<FacetAttributeResult> facetedAttributeResults =
-              facetFields.stream().map(this::convertFacetField).collect(Collectors.toList());
-          responseProps.put(EXPERIMENTAL_FACET_RESULTS_KEY, (Serializable) facetedAttributeResults);
-        }
-      }
-
-    } catch (SolrServerException | IOException | SolrException e) {
-      throw new UnsupportedQueryException("Could not complete solr query.", e);
     }
 
-    responseProps.put(SPELLCHECK_KEY, userSpellcheckIsOn);
-    return new SourceResponseImpl(request, responseProps, results, totalHits);
+    return resultDocs;
   }
 
   private Boolean userSpellcheckIsOn(QueryRequest request) {
@@ -381,24 +422,18 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
 
   @Override
   public List<Metacard> getIds(Set<String> ids) throws UnsupportedQueryException {
-    List<Metacard> metacards = new ArrayList<>(ids.size());
-    List<List<String>> partitions = Lists.partition(new ArrayList<>(ids), GET_BY_ID_LIMIT);
-    for (List<String> partition : partitions) {
-      try {
-        SolrDocumentList page = client.getById(partition);
-        metacards.addAll(createMetacards(page));
-      } catch (SolrServerException | SolrException | IOException e) {
-        throw new UnsupportedQueryException("Could not complete solr query.", e);
-      }
-    }
-    return metacards;
+    List<SolrDocument> solrDocs = getSolrDocs(ids);
+    return createMetacards(solrDocs);
   }
 
-  private List<Metacard> createMetacards(SolrDocumentList docs) throws UnsupportedQueryException {
+  private List<Metacard> createMetacards(List<SolrDocument> docs) throws UnsupportedQueryException {
     List<Metacard> results = new ArrayList<>(docs.size());
     for (SolrDocument doc : docs) {
       try {
-        results.add(createMetacard(doc));
+        Metacard metacard = createMetacard(doc);
+        if (metacard != null) {
+          results.add(metacard);
+        }
       } catch (MetacardCreationException e) {
         throw new UnsupportedQueryException("Could not create metacard(s).", e);
       }
@@ -525,7 +560,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     return postAdapt(request, solrFilterDelegate, query);
   }
 
-  private SolrQuery getRealTimeQuery(SolrQuery originalQuery, Collection<String> ids) {
+  protected SolrQuery getRealTimeQuery(SolrQuery originalQuery, Collection<String> ids) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("originalQuery: {}", getQueryParams(originalQuery));
     }
@@ -832,22 +867,23 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       CollectionUtils.transform(identifiers, Object::toString);
       client.deleteById((List<String>) identifiers);
     } else {
-      if (identifiers.size() < SolrCatalogProvider.MAX_BOOLEAN_CLAUSES) {
+      if (identifiers.size() < SolrCatalogProviderImpl.MAX_BOOLEAN_CLAUSES) {
         client.deleteByQuery(getIdentifierQuery(fieldName, identifiers));
       } else {
         int i;
-        for (i = SolrCatalogProvider.MAX_BOOLEAN_CLAUSES;
+        for (i = SolrCatalogProviderImpl.MAX_BOOLEAN_CLAUSES;
             i < identifiers.size();
-            i += SolrCatalogProvider.MAX_BOOLEAN_CLAUSES) {
+            i += SolrCatalogProviderImpl.MAX_BOOLEAN_CLAUSES) {
           client.deleteByQuery(
               getIdentifierQuery(
-                  fieldName, identifiers.subList(i - SolrCatalogProvider.MAX_BOOLEAN_CLAUSES, i)));
+                  fieldName,
+                  identifiers.subList(i - SolrCatalogProviderImpl.MAX_BOOLEAN_CLAUSES, i)));
         }
         client.deleteByQuery(
             getIdentifierQuery(
                 fieldName,
                 identifiers.subList(
-                    i - SolrCatalogProvider.MAX_BOOLEAN_CLAUSES, identifiers.size())));
+                    i - SolrCatalogProviderImpl.MAX_BOOLEAN_CLAUSES, identifiers.size())));
       }
     }
 

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrMetacardClientImplTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrMetacardClientImplTest.java
@@ -16,12 +16,15 @@ package ddf.catalog.source.solr;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardCreationException;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.Result;
@@ -53,6 +56,7 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SpellCheckResponse;
 import org.apache.solr.client.solrj.response.SpellCheckResponse.Collation;
+import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.codice.solr.client.solrj.SolrClient;
@@ -83,6 +87,11 @@ public class SolrMetacardClientImplTest {
         DynamicSchemaResolver dynamicSchemaResolver) {
       super(client, catalogFilterAdapter, solrFilterDelegateFactory, dynamicSchemaResolver);
     }
+
+    @Override
+    protected SolrQuery getRealTimeQuery(SolrQuery originalQuery, Collection<String> ids) {
+      return originalQuery;
+    }
   }
 
   @Before
@@ -103,6 +112,10 @@ public class SolrMetacardClientImplTest {
     when(solrFilterDelegateFactory.newInstance(
             dynamicSchemaResolver, Collections.singletonMap("spellcheck", new Boolean("true"))))
         .thenReturn(mock(SolrFilterDelegate.class));
+    when(solrFilterDelegateFactory.newInstance(
+            dynamicSchemaResolver,
+            Collections.singletonMap(SolrMetacardClientImpl.DO_REALTIME_GET, new Boolean("true"))))
+        .thenReturn(mock(SolrFilterDelegate.class));
 
     when(catalogFilterAdapter.adapt(any(), any()))
         .thenAnswer(
@@ -121,9 +134,56 @@ public class SolrMetacardClientImplTest {
   }
 
   @Test
+  public void testDeleteByIds() throws SolrServerException, IOException {
+    when(client.deleteById(anyList())).thenReturn(new UpdateResponse());
+    List<String> terms = Arrays.asList("1234");
+    clientImpl.deleteByIds(Metacard.ID, terms, false);
+  }
+
+  @Test
+  public void testDeleteEmpty() throws SolrServerException, IOException {
+    when(client.deleteById(anyList())).thenReturn(new UpdateResponse());
+    clientImpl.deleteByIds(Metacard.ID, null, false);
+  }
+
+  @Test
+  public void testDeleteSingle() throws SolrServerException, IOException {
+    when(client.deleteByQuery(anyString())).thenReturn(new UpdateResponse());
+    List<String> terms = Arrays.asList("title");
+    clientImpl.deleteByIds(Metacard.TITLE, terms, false);
+  }
+
+  @Test
+  public void testDeleteLargeSet() throws SolrServerException, IOException {
+    when(client.deleteByQuery(anyString())).thenReturn(new UpdateResponse());
+    List<String> terms = new ArrayList<>(SolrCatalogProviderImpl.MAX_BOOLEAN_CLAUSES + 1);
+    for (int i = 0; i < SolrCatalogProviderImpl.MAX_BOOLEAN_CLAUSES + 1; i++) {
+      terms.add("title");
+    }
+    clientImpl.deleteByIds(Metacard.TITLE, terms, false);
+  }
+
+  @Test
   public void testQueryOneResults() throws Exception {
     QueryRequest request = createQuery(builder.attribute("anyText").is().like().text("normal"));
 
+    List<String> names = Collections.singletonList("title");
+    List<String> values = Collections.singletonList("normal");
+
+    Map<String, String> attributes = createAttributes(names, values);
+
+    when(queryResponse.getResults()).thenReturn(createSolrDocumentList(attributes));
+    mockDynamicSchemsolverCalls(createAttributeDescriptor(names), attributes);
+
+    List<Result> results = clientImpl.query(request).getResults();
+    assertThat(results.size(), is(1));
+    assertThat(results.get(0).getMetacard().getAttribute("title").getValue(), is("normal"));
+  }
+
+  @Test
+  public void testRealTimeQuery() throws Exception {
+    QueryRequest request = createQuery(builder.attribute("anyText").is().like().text("normal"));
+    request.getProperties().put(SolrMetacardClientImpl.DO_REALTIME_GET, true);
     List<String> names = Collections.singletonList("title");
     List<String> values = Collections.singletonList("normal");
 

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderRealTimeQueryTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderRealTimeQueryTest.java
@@ -66,7 +66,7 @@ public class SolrProviderRealTimeQueryTest {
 
   private static MiniSolrCloudCluster miniSolrCloud;
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   public static final String MASKED_ID = "scp";
 
@@ -109,7 +109,7 @@ public class SolrProviderRealTimeQueryTest {
     dynamicSchemaResolver.addMetacardType(BASIC_METACARD);
 
     provider =
-        new SolrCatalogProvider(
+        new SolrCatalogProviderImpl(
             solrClient,
             new GeotoolsFilterAdapterImpl(),
             new SolrFilterDelegateFactoryImpl(),

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/SolrProviderTest.java
@@ -68,7 +68,7 @@ public class SolrProviderTest {
 
   private static SolrClient solrClient;
 
-  protected static SolrCatalogProvider provider = null;
+  protected static SolrCatalogProviderImpl provider = null;
 
   private static MiniSolrCloudCluster miniSolrCloud;
 
@@ -107,7 +107,7 @@ public class SolrProviderTest {
     dynamicSchemaResolver.addMetacardType(BASIC_METACARD);
 
     provider =
-        new SolrCatalogProvider(
+        new SolrCatalogProviderImpl(
             solrClient,
             new GeotoolsFilterAdapterImpl(),
             new SolrFilterDelegateFactoryImpl(),
@@ -136,7 +136,7 @@ public class SolrProviderTest {
     }
   }
 
-  public static SolrCatalogProvider getProvider() {
+  public static SolrCatalogProviderImpl getProvider() {
     return provider;
   }
 }

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderContentTypes.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderContentTypes.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.ContentTypeImpl;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,7 +50,7 @@ public class SolrProviderContentTypes {
 
   private static final String SAMPLE_CONTENT_VERSION_4 = "vers+4";
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderCreate.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderCreate.java
@@ -43,7 +43,7 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.source.solr.ConfigurationStore;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -63,7 +63,7 @@ import org.opengis.filter.FilterFactory;
 
 public class SolrProviderCreate {
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {
@@ -154,7 +154,7 @@ public class SolrProviderCreate {
   /** Testing that you cannot instantiate with a null Solr client. */
   @Test(expected = IllegalArgumentException.class)
   public void testSolrClientNull() {
-    new SolrCatalogProvider(null, null, null, null);
+    new SolrCatalogProviderImpl(null, null, null, null);
   }
 
   /** Tests what happens when the whole request is null. */

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderDelete.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderDelete.java
@@ -39,7 +39,7 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.source.solr.ConfigurationStore;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrMetacardClientImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.io.Serializable;
@@ -56,13 +56,13 @@ import org.opengis.filter.Filter;
 
 public class SolrProviderDelete {
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {
     provider = SolrProviderTest.getProvider();
   }
-  /** Testing that if records are properly deleted. */
+
   @Test
   public void testDeleteOperation() throws IngestException, UnsupportedQueryException {
 

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderExtensibleMetacards.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderExtensibleMetacards.java
@@ -35,7 +35,7 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.beans.XMLEncoder;
 import java.io.BufferedOutputStream;
@@ -89,7 +89,7 @@ public class SolrProviderExtensibleMetacards {
   private String objectField = "payload";
   private BevelBorder objectFieldValue = new BevelBorder(BevelBorder.RAISED);
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
@@ -56,7 +56,7 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrMetacardClientImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.io.Serializable;
@@ -96,7 +96,7 @@ public class SolrProviderQuery {
 
   private static final String DEFAULT_TEST_WILDCARD = "*";
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSorting.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSorting.java
@@ -33,7 +33,7 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -79,7 +79,7 @@ public class SolrProviderSorting {
   private static final int FACTOR = 5;
   private static final int NUMBERIC_METACARD_COUNT = 5;
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSource.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSource.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,7 +29,7 @@ public class SolrProviderSource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SolrProviderSource.class);
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSpatial.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSpatial.java
@@ -37,7 +37,7 @@ import ddf.catalog.operation.UpdateResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.solr.ConfigurationStore;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,7 +67,7 @@ public class SolrProviderSpatial {
 
   private final FilterFactory filterFactory = new FilterFactoryImpl();
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderTemporal.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderTemporal.java
@@ -30,7 +30,7 @@ import ddf.catalog.data.Result;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.util.Calendar;
 import java.util.Collections;
@@ -53,7 +53,7 @@ public class SolrProviderTemporal {
 
   private static final long MINUTES_IN_MILLISECONDS = 60000;
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderTestUtil.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderTestUtil.java
@@ -33,7 +33,7 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -70,12 +70,12 @@ public class SolrProviderTestUtil {
 
   private static final int A_LITTLE_WHILE = TIME_STEP_10SECONDS;
 
-  public static void deleteAll(SolrCatalogProvider provider)
+  public static void deleteAll(SolrCatalogProviderImpl provider)
       throws IngestException, UnsupportedQueryException {
     deleteAll(TEST_METHOD_NAME_INDEX, provider);
   }
 
-  public static void deleteAll(int methodNameIndex, SolrCatalogProvider provider)
+  public static void deleteAll(int methodNameIndex, SolrCatalogProviderImpl provider)
       throws IngestException, UnsupportedQueryException {
     messageBreak(Thread.currentThread().getStackTrace()[methodNameIndex].getMethodName() + "()");
 
@@ -92,7 +92,7 @@ public class SolrProviderTestUtil {
 
     LOGGER.info("Records found for deletion: {}", ids);
 
-    provider.delete(new DeleteRequestImpl(ids.toArray(new String[ids.size()])));
+    provider.delete(new DeleteRequestImpl(ids.toArray(new String[0])));
 
     LOGGER.info("Deletion complete. -----------");
   }
@@ -101,7 +101,7 @@ public class SolrProviderTestUtil {
     return new QueryRequestImpl(new QueryImpl(filter));
   }
 
-  public static void queryAndVerifyCount(int count, Filter filter, SolrCatalogProvider provider)
+  public static void queryAndVerifyCount(int count, Filter filter, SolrCatalogProviderImpl provider)
       throws UnsupportedQueryException {
     Query query = new QueryImpl(filter);
     QueryRequest request = new QueryRequestImpl(query);
@@ -110,33 +110,33 @@ public class SolrProviderTestUtil {
     assertEquals(count, response.getResults().size());
   }
 
-  public static DeleteResponse delete(String identifier, SolrCatalogProvider provider)
+  public static DeleteResponse delete(String identifier, SolrCatalogProviderImpl provider)
       throws IngestException {
     return delete(new String[] {identifier}, provider);
   }
 
-  public static DeleteResponse delete(String[] identifier, SolrCatalogProvider provider)
+  public static DeleteResponse delete(String[] identifier, SolrCatalogProviderImpl provider)
       throws IngestException {
     return provider.delete(new DeleteRequestImpl(identifier));
   }
 
-  public static UpdateResponse update(String id, Metacard metacard, SolrCatalogProvider provider)
-      throws IngestException {
+  public static UpdateResponse update(
+      String id, Metacard metacard, SolrCatalogProviderImpl provider) throws IngestException {
     String[] ids = {id};
     return update(ids, Collections.singletonList(metacard), provider);
   }
 
   public static UpdateResponse update(
-      String[] ids, List<Metacard> list, SolrCatalogProvider provider) throws IngestException {
+      String[] ids, List<Metacard> list, SolrCatalogProviderImpl provider) throws IngestException {
     return provider.update(new UpdateRequestImpl(ids, list));
   }
 
-  public static CreateResponse create(Metacard metacard, SolrCatalogProvider provider)
+  public static CreateResponse create(Metacard metacard, SolrCatalogProviderImpl provider)
       throws IngestException {
     return create(Collections.singletonList(metacard), provider);
   }
 
-  public static CreateResponse create(List<Metacard> metacards, SolrCatalogProvider provider)
+  public static CreateResponse create(List<Metacard> metacards, SolrCatalogProviderImpl provider)
       throws IngestException {
     return createIn(metacards, provider);
   }
@@ -145,7 +145,7 @@ public class SolrProviderTestUtil {
     return filterBuilder;
   }
 
-  public static void addMetacardWithModifiedDate(DateTime now, SolrCatalogProvider provider)
+  public static void addMetacardWithModifiedDate(DateTime now, SolrCatalogProviderImpl provider)
       throws IngestException {
     List<Metacard> list = new ArrayList<>();
     MockMetacard m = new MockMetacard(Library.getFlagstaffRecord());
@@ -154,8 +154,8 @@ public class SolrProviderTestUtil {
     create(list, provider);
   }
 
-  public static List<Result> getResultsForFilteredQuery(Filter filter, SolrCatalogProvider provider)
-      throws UnsupportedQueryException {
+  public static List<Result> getResultsForFilteredQuery(
+      Filter filter, SolrCatalogProviderImpl provider) throws UnsupportedQueryException {
     QueryImpl query = new QueryImpl(filter);
 
     SourceResponse sourceResponse = provider.query(new QueryRequestImpl(query));
@@ -192,8 +192,8 @@ public class SolrProviderTestUtil {
     return descriptors;
   }
 
-  private static CreateResponse createIn(List<Metacard> metacards, SolrCatalogProvider solrProvider)
-      throws IngestException {
+  private static CreateResponse createIn(
+      List<Metacard> metacards, SolrCatalogProviderImpl solrProvider) throws IngestException {
     return solrProvider.create(new CreateRequestImpl(metacards));
   }
 

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderUpdate.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderUpdate.java
@@ -42,7 +42,7 @@ import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.source.solr.ConfigurationStore;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.io.Serializable;
 import java.net.URI;
@@ -60,7 +60,7 @@ import org.junit.Test;
 
 public class SolrProviderUpdate {
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderXpath.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderXpath.java
@@ -29,7 +29,7 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.source.solr.ConfigurationStore;
-import ddf.catalog.source.solr.SolrCatalogProvider;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import ddf.catalog.source.solr.SolrProviderTest;
 import java.util.Arrays;
 import java.util.List;
@@ -40,7 +40,7 @@ import org.opengis.filter.Filter;
 
 public class SolrProviderXpath {
 
-  private static SolrCatalogProvider provider;
+  private static SolrCatalogProviderImpl provider;
 
   @BeforeClass
   public static void setUp() {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheSolrMetacardClient.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheSolrMetacardClient.java
@@ -59,8 +59,10 @@ class CacheSolrMetacardClient extends SolrMetacardClientImpl {
   public MetacardImpl createMetacard(SolrDocument doc) throws MetacardCreationException {
     MetacardImpl metacard = super.createMetacard(doc);
 
-    metacard.setSourceId(getMetacardSource(doc));
-    metacard.setId(getMetacardId(doc));
+    if (metacard != null) {
+      metacard.setSourceId(getMetacardSource(doc));
+      metacard.setId(getMetacardId(doc));
+    }
 
     return metacard;
   }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCacheSource.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCacheSource.java
@@ -21,6 +21,7 @@ import ddf.catalog.operation.impl.QueryResponseImpl;
 import ddf.catalog.source.SourceCache;
 import ddf.catalog.source.SourceMonitor;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -43,8 +44,7 @@ public class SolrCacheSource implements SourceCache {
 
   static {
     try (InputStream propertiesStream =
-        ddf.catalog.source.solr.SolrCatalogProvider.class.getResourceAsStream(
-            DESCRIBABLE_PROPERTIES_FILE)) {
+        SolrCatalogProviderImpl.class.getResourceAsStream(DESCRIBABLE_PROPERTIES_FILE)) {
       describableProperties.load(propertiesStream);
     } catch (IOException e) {
       LOGGER.info("IO exception loading describable properties", e);

--- a/catalog/migrate/workspace-query-separation/pom.xml
+++ b/catalog/migrate/workspace-query-separation/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>migrate</artifactId>
     <groupId>ddf.catalog</groupId>
-    <version>2.22.0-SNAPSHOT</version>
+    <version>2.24.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/solr/catalog-solr-collection-api/pom.xml
+++ b/catalog/solr/catalog-solr-collection-api/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>catalog-solr</artifactId>
+        <groupId>ddf.catalog.solr</groupId>
+        <version>2.24.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>catalog-solr-collection-api</artifactId>
+    <name>DDF :: Catalog :: Solr :: Collection :: API</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.solr</groupId>
+            <artifactId>solr-factory</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            ddf.catalog.solr.collection*
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/solr/catalog-solr-collection-api/src/main/java/ddf/catalog/solr/collection/SolrCollectionProvider.java
+++ b/catalog/solr/catalog-solr-collection-api/src/main/java/ddf/catalog/solr/collection/SolrCollectionProvider.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.solr.collection;
+
+import com.sun.istack.internal.Nullable;
+import ddf.catalog.data.Metacard;
+
+/** Provider to interface with a solr collection. */
+@FunctionalInterface
+public interface SolrCollectionProvider {
+
+  /**
+   * Gets the core name for a Metacard.
+   *
+   * @param metacard
+   * @return Core name
+   */
+  @Nullable
+  String getCollection(@Nullable Metacard metacard);
+}

--- a/catalog/solr/catalog-solr-collection-impl/pom.xml
+++ b/catalog/solr/catalog-solr-collection-impl/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>catalog-solr</artifactId>
+        <groupId>ddf.catalog.solr</groupId>
+        <version>2.24.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>catalog-solr-collection-impl</artifactId>
+    <name>DDF :: Catalog :: Solr :: Collection :: Implementation</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.platform.solr</groupId>
+            <artifactId>solr-factory</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.solr</groupId>
+            <artifactId>catalog-solr-collection-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            catalog-core-api-impl
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/solr/catalog-solr-collection-impl/src/main/java/ddf/catalog/solr/collection/impl/AbstractSolrCollectionProvider.java
+++ b/catalog/solr/catalog-solr-collection-impl/src/main/java/ddf/catalog/solr/collection/impl/AbstractSolrCollectionProvider.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.solr.collection.impl;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.solr.collection.SolrCollectionProvider;
+import ddf.catalog.util.impl.DescribableImpl;
+
+public abstract class AbstractSolrCollectionProvider extends DescribableImpl
+    implements SolrCollectionProvider {
+
+  protected abstract String getCollectionName();
+
+  protected abstract boolean matches(Metacard metacard);
+
+  @Override
+  public String getCollection(Metacard metacard) {
+    if (metacard == null) {
+      return null;
+    }
+
+    if (matches(metacard)) {
+      return getCollectionName();
+    }
+
+    return null;
+  }
+}

--- a/catalog/solr/catalog-solr-defaultcollectionprovider/pom.xml
+++ b/catalog/solr/catalog-solr-defaultcollectionprovider/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>catalog-solr</artifactId>
+    <groupId>ddf.catalog.solr</groupId>
+    <version>2.24.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>catalog-solr-defaultcollectionprovider</artifactId>
+  <name>DDF :: Catalog :: Solr :: Default Collection Provider</name>
+  <packaging>bundle</packaging>
+  <description>Provides the default collection name and configuration for storing a given Metacard record</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.solr</groupId>
+      <artifactId>catalog-solr-collection-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ddf.platform.solr</groupId>
+      <artifactId>solr-factory</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.solr</groupId>
+      <artifactId>catalog-solr-collection-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ddf.platform.util</groupId>
+      <artifactId>platform-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.platform.solr</groupId>
+      <artifactId>solr-schema</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}</directory>
+        <includes>
+          <include>solr-schema/**</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Embed-Dependency>
+              catalog-core-api-impl,
+              catalog-solr-collection-impl
+            </Embed-Dependency>
+            <Include-Resource>
+              {maven-resources},
+              target/classes/describable.properties
+            </Include-Resource>
+            <Export-Package />
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>ddf.platform.solr</groupId>
+                  <artifactId>solr-schema</artifactId>
+                  <outputDirectory>
+                    ${project.build.directory}/solr-schema
+                  </outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>check-artifact-size</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <ArtifactSizeEnforcerRule implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
+                  <maxArtifactSize>5_MB</maxArtifactSize>
+                </ArtifactSizeEnforcerRule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <haltOnFailure>true</haltOnFailure>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.99</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.99</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>COMPLEXITY</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.99</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/catalog/solr/catalog-solr-defaultcollectionprovider/src/main/java/ddf/catalog/solr/collectionprovider/DefaultSolrCollectionProvider.java
+++ b/catalog/solr/catalog-solr-defaultcollectionprovider/src/main/java/ddf/catalog/solr/collectionprovider/DefaultSolrCollectionProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.solr.collectionprovider;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.solr.collection.impl.AbstractSolrCollectionProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** This is the default collection provider and will always return `catalog_resource` */
+public class DefaultSolrCollectionProvider extends AbstractSolrCollectionProvider {
+  static final String DEFAULT_COLLECTION = "resource";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSolrCollectionProvider.class);
+
+  @Override
+  protected String getCollectionName() {
+    return DEFAULT_COLLECTION;
+  }
+
+  @Override
+  protected boolean matches(Metacard metacard) {
+    return true;
+  }
+
+  @Override
+  public String getCollection(Metacard metacard) {
+    LOGGER.trace("Returning Default Collection: {}", DEFAULT_COLLECTION);
+    return getCollectionName();
+  }
+}

--- a/catalog/solr/catalog-solr-defaultcollectionprovider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/solr/catalog-solr-defaultcollectionprovider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,25 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+		   xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+	<bean id="defaultSolrCollectionProvider" class="ddf.catalog.solr.collectionprovider.DefaultSolrCollectionProvider">
+		<cm:managed-properties persistent-id="ddf.catalog.solr.collectionprovider.DefaultSolrCollectionProvider"
+			update-strategy="container-managed"/>
+	</bean>
+
+	<!-- Publish so the ranking is last -->
+	<service ref="defaultSolrCollectionProvider" interface="ddf.catalog.solr.collection.SolrCollectionProvider" ranking="1"/>
+
+</blueprint>

--- a/catalog/solr/catalog-solr-defaultcollectionprovider/src/main/resources/describable.properties
+++ b/catalog/solr/catalog-solr-defaultcollectionprovider/src/main/resources/describable.properties
@@ -1,0 +1,4 @@
+version=${version}
+description=${description}
+organization=${organization.name}
+name=${artifactId}

--- a/catalog/solr/catalog-solr-defaultcollectionprovider/src/test/java/ddf/catalog/solr/collectionprovider/DefaultSolrCollectionProviderTest.java
+++ b/catalog/solr/catalog-solr-defaultcollectionprovider/src/test/java/ddf/catalog/solr/collectionprovider/DefaultSolrCollectionProviderTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.solr.collectionprovider;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Core;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class DefaultSolrCollectionProviderTest {
+
+  private DefaultSolrCollectionProvider indexProvider = new DefaultSolrCollectionProvider();
+
+  @Test
+  public void testGetCollection() throws Exception {
+    Metacard mockCard = getMockMetacard("workspace");
+    String collection = indexProvider.getCollection(mockCard);
+    MatcherAssert.assertThat(
+        collection, Matchers.is(DefaultSolrCollectionProvider.DEFAULT_COLLECTION));
+  }
+
+  @Test
+  public void testNotSupportedTag() {
+    Metacard mockCard = getMockMetacard("resource");
+    String collection = indexProvider.getCollection(mockCard);
+    MatcherAssert.assertThat(
+        collection, Matchers.is(DefaultSolrCollectionProvider.DEFAULT_COLLECTION));
+  }
+
+  @Test
+  public void testNoTags() {
+    Metacard mockCard = Mockito.mock(Metacard.class);
+    Mockito.when(mockCard.getAttribute(Core.METACARD_TAGS)).thenReturn(null);
+    String collection = indexProvider.getCollection(mockCard);
+    MatcherAssert.assertThat(
+        collection, Matchers.is(DefaultSolrCollectionProvider.DEFAULT_COLLECTION));
+  }
+
+  @Test
+  public void testNullMetacard() {
+    String collection = indexProvider.getCollection(null);
+    MatcherAssert.assertThat(
+        collection, Matchers.is(DefaultSolrCollectionProvider.DEFAULT_COLLECTION));
+  }
+
+  @Test
+  public void testMatches() {
+    boolean matches = indexProvider.matches(null);
+    MatcherAssert.assertThat(matches, Matchers.is(true));
+  }
+
+  @Test
+  public void testMetacardMatches() {
+    boolean matches = indexProvider.matches(getMockMetacard("anything"));
+    MatcherAssert.assertThat(matches, Matchers.is(true));
+  }
+
+  @Test
+  public void testGetCollectionName() {
+    String collectionName = indexProvider.getCollectionName();
+    MatcherAssert.assertThat(
+        collectionName, Matchers.is(DefaultSolrCollectionProvider.DEFAULT_COLLECTION));
+  }
+
+  private Metacard getMockMetacard(String tag) {
+    Metacard metacard = Mockito.mock(Metacard.class);
+    Attribute tagAttr = Mockito.mock(Attribute.class);
+    Mockito.when(tagAttr.getValues()).thenReturn(Collections.singletonList(tag));
+    Mockito.when(metacard.getAttribute(Core.METACARD_TAGS)).thenReturn(tagAttr);
+    return metacard;
+  }
+}

--- a/catalog/solr/catalog-split-provider/pom.xml
+++ b/catalog/solr/catalog-split-provider/pom.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>catalog-solr</artifactId>
+    <groupId>ddf.catalog.solr</groupId>
+    <version>2.24.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>catalog-split-provider</artifactId>
+  <name>DDF :: Catalog :: Split :: Provider</name>
+  <packaging>bundle</packaging>
+  <description>Split Catalog Provider that connects multiple collections</description>
+  <dependencies>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-solr</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.platform.util</groupId>
+      <artifactId>platform-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.solr</groupId>
+      <artifactId>catalog-solr-collection-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>catalog-core-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.solr</groupId>
+      <artifactId>solr-solrj</artifactId>
+      <version>${solr.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codice</groupId>
+      <artifactId>lux</artifactId>
+      <version>${lux.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.saxon</groupId>
+      <artifactId>Saxon-HE</artifactId>
+      <version>${lux.saxon.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ddf.catalog.core</groupId>
+      <artifactId>filter-proxy</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Embed-Dependency>
+              catalog-core-solr;scope=!test,
+              catalog-core-api-impl,
+              lux,
+              Saxon-HE
+            </Embed-Dependency>
+            <Include-Resource>
+              {maven-resources},
+              target/classes/describable.properties
+            </Include-Resource>
+            <Export-Package />
+            <Import-Package>
+              <!-- excluded packages coming from lux -->
+              !javax.xml.xquery,
+              !org.apache.lucene.*,
+              !org.apache.solr.*,
+
+              <!--packages required for solrj -->
+              org.apache.jute;version=${solr.zookeeper.version},
+              org.apache.solr.client.solrj;version=${solr.version},
+              org.apache.solr.client.solrj.beans;version=${solr.version},
+              org.apache.solr.client.solrj.cloud;version=${solr.version},
+              org.apache.solr.client.solrj.cloud.autoscaling;version=${solr.version},
+              org.apache.solr.client.solrj.impl;version=${solr.version},
+              org.apache.solr.client.solrj.request;version=${solr.version},
+              org.apache.solr.client.solrj.response;version=${solr.version},
+              org.apache.solr.common;version=${solr.version},
+              org.apache.solr.common.params;version=${solr.version},
+              org.apache.solr.common.util;version=${solr.version},
+              org.apache.zookeeper;version=${solr.zookeeper.version},
+              org.apache.zookeeper.client;version=${solr.zookeeper.version},
+              org.apache.zookeeper.data;version=${solr.zookeeper.version},
+              org.apache.zookeeper.proto;version=${solr.zookeeper.version},
+              com.fasterxml.jackson.*;version=${jackson.version},
+
+              <!-- used by  lux -->
+              org.apache.lucene.analysis.charfilter;version=${solr.version},
+              org.apache.lucene.analysis.core;version=${solr.version},
+              org.apache.lucene.analysis.miscellaneous;version=${solr.version},
+              org.apache.lucene.analysis.standard;version=${solr.version},
+              org.apache.lucene.analysis.tokenattributes;version=${solr.version},
+              org.apache.lucene.queryparser.classic;version=${solr.version},
+              org.apache.lucene.queryparser.ext;version=${solr.version},
+              org.apache.lucene.queryparser.xml;version=${solr.version},
+              org.apache.lucene.search.spans;version=${solr.version},
+              org.apache.lucene.store;version=${solr.version},
+              org.apache.lucene.util;version=${solr.version},
+              org.apache.solr.parser;version=${solr.version},
+
+              <!-- dependencies used by catalog-core-solr-->
+              org.locationtech.spatial4j.*;version=${solr.spatial4j.version},
+              org.locationtech.jts.*;version=${jts.spatial4j.version},
+              com.saxonica.config;resolution:=optional,
+              org.expath.pkg.saxon;resolution:=optional,
+              *
+
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>check-artifact-size</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <ArtifactSizeEnforcerRule implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
+                  <maxArtifactSize>4_MB</maxArtifactSize>
+                </ArtifactSizeEnforcerRule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <haltOnFailure>true</haltOnFailure>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.0</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.0</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>COMPLEXITY</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.0</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/catalog/solr/catalog-split-provider/src/main/java/ddf/catalog/solr/provider/SplitCatalogProvider.java
+++ b/catalog/solr/catalog-split-provider/src/main/java/ddf/catalog/solr/provider/SplitCatalogProvider.java
@@ -1,0 +1,608 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.solr.provider;
+
+import com.google.common.annotations.VisibleForTesting;
+import ddf.catalog.data.ContentType;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.ProcessingDetails;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.Request;
+import ddf.catalog.operation.Response;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.operation.Update;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.UpdateResponse;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.CreateResponseImpl;
+import ddf.catalog.operation.impl.DeleteResponseImpl;
+import ddf.catalog.operation.impl.SourceResponseImpl;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.operation.impl.UpdateResponseImpl;
+import ddf.catalog.solr.collection.SolrCollectionProvider;
+import ddf.catalog.source.CatalogProvider;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceMonitor;
+import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.source.solr.ConfigurationStore;
+import ddf.catalog.source.solr.DynamicSchemaResolver;
+import ddf.catalog.source.solr.RealTimeGetDelegate;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
+import ddf.catalog.source.solr.SolrFilterDelegateFactory;
+import ddf.catalog.source.solr.SolrMetacardClientImpl;
+import ddf.catalog.util.impl.MaskableImpl;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.Validate;
+import org.codice.solr.factory.SolrClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SplitCatalogProvider extends MaskableImpl implements CatalogProvider {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SplitCatalogProvider.class);
+
+  private static final String DESCRIBABLE_PROPERTIES_FILE = "/describable.properties";
+
+  private static final Properties DESCRIBABLE_PROPERTIES = new Properties();
+
+  static {
+    try (InputStream inputStream =
+        SplitCatalogProvider.class.getResourceAsStream(DESCRIBABLE_PROPERTIES_FILE)) {
+      DESCRIBABLE_PROPERTIES.load(inputStream);
+    } catch (IOException e) {
+      LOGGER.info("Did not load properties properly.", e);
+    }
+  }
+
+  protected static final String DEFAULT_COLLECTION = "default";
+
+  protected static final String DEFAULT_QUERY_ALIAS = "catalog";
+
+  protected static final String CATALOG_PREFIX_SEPARATOR = "_";
+
+  @VisibleForTesting static final String GET_HANDLER_WORKAROUND_PROP = "getHandlerWorkaround";
+
+  @VisibleForTesting static final String COLLECTION_ALIAS_PROP = "collectionAlias";
+
+  protected final Map<String, SolrCatalogProviderImpl> catalogProviders = new ConcurrentHashMap<>();
+
+  protected final SolrClientFactory clientFactory;
+
+  protected final FilterAdapter filterAdapter;
+
+  protected final SolrFilterDelegateFactory solrFilterDelegateFactory;
+
+  protected final DynamicSchemaResolver resolver;
+
+  protected final List<SolrCollectionProvider> solrCollectionProviders;
+
+  private IdQueryResultSorter sorter = new IdQueryResultSorter();
+
+  private boolean getHandlerWorkaround = true;
+
+  private String collectionAlias = DEFAULT_QUERY_ALIAS;
+
+  protected static final String COLLECTION_HINT = "collection-hint";
+
+  private static final String ALIAS_PROP = "alias";
+
+  /**
+   * Constructor that creates a new instance and allows for a custom {@link DynamicSchemaResolver}
+   *
+   * @param clientFactory Solr client factory
+   * @param adapter injected implementation of FilterAdapter
+   * @param resolver Solr schema resolver
+   * @param solrCollectionProviders collection provider list for each solr collection
+   */
+  public SplitCatalogProvider(
+      SolrClientFactory clientFactory,
+      FilterAdapter adapter,
+      SolrFilterDelegateFactory solrFilterDelegateFactory,
+      DynamicSchemaResolver resolver,
+      List<SolrCollectionProvider> solrCollectionProviders) {
+    Validate.notNull(clientFactory, "SolrClientFactory cannot be null.");
+    Validate.notNull(adapter, "FilterAdapter cannot be null");
+    Validate.notNull(solrFilterDelegateFactory, "SolrFilterDelegateFactory cannot be null");
+    Validate.notNull(resolver, "DynamicSchemaResolver cannot be null");
+    Validate.notEmpty(solrCollectionProviders, "CollectionProviders cannot be empty");
+
+    this.clientFactory = clientFactory;
+    this.filterAdapter = adapter;
+    this.solrFilterDelegateFactory = solrFilterDelegateFactory;
+    this.resolver = resolver;
+    this.solrCollectionProviders = solrCollectionProviders;
+
+    initProviders();
+  }
+
+  /**
+   * Convenience constructor that creates a new ddf.catalog.source.solr.DynamicSchemaResolver
+   *
+   * @param clientFactory Solr client factory
+   * @param adapter injected implementation of FilterAdapter
+   */
+  public SplitCatalogProvider(
+      SolrClientFactory clientFactory,
+      FilterAdapter adapter,
+      SolrFilterDelegateFactory solrFilterDelegateFactory,
+      List<SolrCollectionProvider> solrCollectionProviders) {
+    this(
+        clientFactory,
+        adapter,
+        solrFilterDelegateFactory,
+        new DynamicSchemaResolver(),
+        solrCollectionProviders);
+  }
+
+  protected SolrCatalogProviderImpl newProvider(String core) {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(ALIAS_PROP, getCollectionAlias());
+    return new SolrCatalogProviderImpl(
+        clientFactory.newClient(core, properties),
+        filterAdapter,
+        solrFilterDelegateFactory,
+        resolver);
+  }
+
+  @Override
+  public CreateResponse create(CreateRequest createRequest) throws IngestException {
+    LOGGER.trace("Create request received");
+    return (CreateResponse) executeRequest(createRequest);
+  }
+
+  @Override
+  public UpdateResponse update(UpdateRequest updateRequest) throws IngestException {
+    LOGGER.trace("Update request received");
+    return (UpdateResponse) executeRequest(updateRequest);
+  }
+
+  @Override
+  public DeleteResponse delete(DeleteRequest deleteRequest) throws IngestException {
+    /** Delete across all collections Assuming id uniqueness is preserved across all collection */
+    int numItems = deleteRequest.getAttributeValues().size();
+    List<DeleteResponse> responses = new ArrayList<>();
+    for (Map.Entry<String, SolrCatalogProviderImpl> entry : catalogProviders.entrySet()) {
+      responses.add(entry.getValue().delete(deleteRequest));
+      LOGGER.debug(
+          "Sending delete request for {} items to collection: {}", numItems, entry.getKey());
+    }
+    return responses.isEmpty()
+        ? new DeleteResponseImpl(deleteRequest, null, new ArrayList<>())
+        : responses.get(0);
+  }
+
+  @Override
+  public SourceResponse query(QueryRequest queryRequest) throws UnsupportedQueryException {
+    Boolean doRealTimeGet = filterAdapter.adapt(queryRequest.getQuery(), new RealTimeGetDelegate());
+
+    queryRequest.getProperties().put(SolrMetacardClientImpl.DO_REALTIME_GET, doRealTimeGet);
+
+    SourceResponse hintedResponse = handleHintedQuery(queryRequest);
+    if (hintedResponse != null) {
+      return hintedResponse;
+    }
+
+    SourceResponse getHandlerResponse = handleGetHandlerQuery(queryRequest);
+    if (getHandlerResponse != null) {
+      return getHandlerResponse;
+    }
+
+    if (BooleanUtils.isTrue(doRealTimeGet)) {
+      LOGGER.trace("NRT Query alias directly (/get)");
+    } else {
+      LOGGER.trace("Query the collection alias: {}", getCollectionAlias());
+    }
+
+    ensureDefaultCollectionExists();
+
+    return catalogProviders
+        .computeIfAbsent(getCollectionAlias(), this::newProvider)
+        .query(queryRequest);
+  }
+
+  private SourceResponse handleHintedQuery(QueryRequest queryRequest)
+      throws UnsupportedQueryException {
+    // Query the only provided collection hint
+    String hintCollection = (String) queryRequest.getPropertyValue(COLLECTION_HINT);
+    if (StringUtils.isNotBlank(hintCollection)) {
+      LOGGER.trace(
+          "Querying collection provided via property ({}): {}", COLLECTION_HINT, hintCollection);
+
+      SolrCatalogProviderImpl provider = catalogProviders.get(hintCollection);
+
+      if (provider == null) {
+        LOGGER.warn(
+            "Handling Hinted Query: unable to find catalog provider for {}", hintCollection);
+        return null;
+      }
+
+      return provider.query(queryRequest);
+    }
+    return null;
+  }
+
+  /**
+   * Solr doesn’t support querying the /get handler via the alias, so instances where we need the
+   * NRT information from Solr we have to get the collections in the alias and manually query the
+   * /get handler. In the case of ingesting/uploading a image and query by id using the getHandler
+   * via alias right away, the record is not found. To handle getHandlerWorkaround, need to handle
+   * real time query up front
+   */
+  private SourceResponse handleGetHandlerQuery(QueryRequest queryRequest)
+      throws UnsupportedQueryException {
+    if ((Boolean)
+            queryRequest.getProperties().getOrDefault(SolrMetacardClientImpl.DO_REALTIME_GET, false)
+        && getHandlerWorkaround) {
+      List<Result> results = new ArrayList<>();
+      long totalHits = 0;
+      LOGGER.trace("Using custom query for /get handler workaround");
+      for (SolrCatalogProviderImpl provider : getAliasProviderNonAlias().values()) {
+        long providerStart = System.currentTimeMillis();
+
+        SourceResponse response = provider.query(queryRequest);
+        results.addAll(response.getResults());
+        totalHits += response.getHits();
+
+        long total = System.currentTimeMillis() - providerStart;
+        LOGGER.trace("Provider took {} ms to respond", total);
+      }
+      List<Result> topResults =
+          getLimitedScoredResults(results, queryRequest.getQuery().getPageSize());
+
+      return new SourceResponseImpl(queryRequest, topResults, totalHits);
+    }
+    return null;
+  }
+
+  public void shutdown() {
+    LOGGER.debug("Closing down Solr client.");
+    this.catalogProviders.forEach((k, p) -> p.shutdown());
+  }
+
+  @Override
+  public void maskId(String id) {
+    super.maskId(id);
+    catalogProviders.forEach((k, p) -> p.maskId(id));
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return catalogProviders
+        .values()
+        .stream()
+        .map(p -> p.isAvailable())
+        .reduce(true, (a, b) -> a && b);
+  }
+
+  @Override
+  public boolean isAvailable(SourceMonitor callback) {
+    return catalogProviders
+        .values()
+        .stream()
+        .map(p -> p.isAvailable(callback))
+        .reduce(true, (a, b) -> a && b);
+  }
+
+  public void setGetHandlerWorkaround(boolean getHandlerWorkaround) {
+    this.getHandlerWorkaround = getHandlerWorkaround;
+  }
+
+  public void setCollectionAlias(String collectionAlias) {
+    LOGGER.info("Setting collection alias to: {}", collectionAlias);
+
+    if (StringUtils.isNotBlank(collectionAlias)) {
+      this.collectionAlias = collectionAlias;
+    }
+  }
+
+  public boolean isGetHandlerWorkaround() {
+    return getHandlerWorkaround;
+  }
+
+  public String getCollectionAlias() {
+    return collectionAlias;
+  }
+
+  private String getDefaultCollection() {
+    return getCatalogPrefix() + DEFAULT_COLLECTION;
+  }
+
+  /**
+   * Used to signal to the Solr client to commit on every transaction. Updates the underlying {@link
+   * ConfigurationStore} so that the property is propagated throughout the Solr Catalog Provider
+   * code.
+   *
+   * @param forceAutoCommit {@code true} to force auto-commits
+   */
+  public void setForceAutoCommit(boolean forceAutoCommit) {
+    ConfigurationStore.getInstance().setForceAutoCommit(forceAutoCommit);
+  }
+
+  public void refresh(Map<String, Object> configuration) {
+    if (configuration == null) {
+      LOGGER.debug("Null configuration");
+      return;
+    }
+
+    setGetHandlerWorkaround(
+        BooleanUtils.toBoolean((Boolean) configuration.get(GET_HANDLER_WORKAROUND_PROP)));
+
+    boolean reinitCollection = false;
+    String collectionAlias = (String) configuration.get(COLLECTION_ALIAS_PROP);
+    if (StringUtils.isNotBlank(collectionAlias)) {
+      setCollectionAlias(collectionAlias);
+      reinitCollection = true;
+    }
+
+    if (reinitCollection) {
+      catalogProviders.clear();
+      initProviders();
+    }
+  }
+
+  protected Response executeRequest(Request request) throws IngestException {
+    if (request instanceof CreateRequest) {
+      Map<String, Serializable> props = new HashMap<>();
+      List<Metacard> createdMetacards = new ArrayList<>();
+      Set<ProcessingDetails> errors = new HashSet<>();
+      Map<String, CreateRequest> requests = getCreateRequests((CreateRequest) request);
+      for (Map.Entry<String, CreateRequest> entry : requests.entrySet()) {
+        CreateResponse response =
+            catalogProviders
+                .computeIfAbsent(entry.getKey(), this::newProvider)
+                .create(entry.getValue());
+        props.putAll(response.getProperties());
+        createdMetacards.addAll(response.getCreatedMetacards());
+        errors.addAll(response.getProcessingErrors());
+      }
+
+      return new CreateResponseImpl((CreateRequest) request, props, createdMetacards, errors);
+    } else if (request instanceof UpdateRequest) {
+      Map<String, UpdateRequest> requests = getUpdateRequests((UpdateRequest) request);
+      Map<String, Serializable> props = new HashMap<>();
+      List<Metacard> updatedMetacards = new ArrayList<>();
+      List<Metacard> oldMetacards = new ArrayList<>();
+      Set<ProcessingDetails> errors = new HashSet<>();
+      for (Map.Entry<String, UpdateRequest> entry : requests.entrySet()) {
+        SolrCatalogProviderImpl provider =
+            catalogProviders.computeIfAbsent(entry.getKey(), this::newProvider);
+        UpdateResponse response = provider.update(entry.getValue());
+        if (response.getProperties() != null) {
+          props.putAll(response.getProperties());
+        }
+        for (Update update : response.getUpdatedMetacards()) {
+          updatedMetacards.add(update.getNewMetacard());
+          oldMetacards.add(update.getOldMetacard());
+        }
+        errors.addAll(response.getProcessingErrors());
+      }
+
+      return new UpdateResponseImpl(
+          (UpdateRequest) request, props, updatedMetacards, oldMetacards, errors);
+    }
+
+    return null;
+  }
+
+  /**
+   * From a list of tags extracted from a metacard, return the associate solr core assuming ...
+   *
+   * @param metacard The metacard used to determine collection
+   * @return the first associate solr core for those given tags
+   */
+  private String getCollection(Metacard metacard) {
+    LOGGER.trace("Getting collection for metacard: {}", metacard);
+    List<String> matchedCollections = new ArrayList<>();
+    for (SolrCollectionProvider provider : solrCollectionProviders) {
+      String collection = getCollectionName(provider.getCollection(metacard));
+      if (collection != null) {
+        matchedCollections.add(collection);
+        createCollectionIfRequired(collection, provider);
+      }
+    }
+
+    if (matchedCollections.isEmpty()) {
+      return getDefaultCollection();
+    }
+
+    if (matchedCollections.size() == 1) {
+      return matchedCollections.get(0);
+    }
+    // if there is more than once match, should not consider default collection
+    matchedCollections.remove(getDefaultCollection());
+
+    return matchedCollections.get(0);
+  }
+
+  /**
+   * Create solr remote collection and a local client connection reference
+   *
+   * @param collection
+   * @param provider
+   */
+  private void createCollectionIfRequired(String collection, SolrCollectionProvider provider) {
+    if (StringUtils.isBlank(collection)) {
+      return;
+    }
+
+    if (catalogProviders.containsKey(collection)) {
+      return;
+    }
+    catalogProviders.computeIfAbsent(collection, this::newProvider);
+  }
+
+  private Map<String, CreateRequest> getCreateRequests(CreateRequest createRequest) {
+    Map<String, CreateRequest> createRequests = new HashMap<>();
+    Map<String, List<Metacard>> collectionMetacardMap = new HashMap<>();
+    for (Metacard metacard : createRequest.getMetacards()) {
+      String collection = getCollection(metacard);
+      if (collectionMetacardMap.containsKey(collection)) {
+        List<Metacard> metacards = collectionMetacardMap.get(collection);
+        metacards.add(metacard);
+      } else {
+        List<Metacard> metacards = new ArrayList<>();
+        metacards.add(metacard);
+        collectionMetacardMap.put(collection, metacards);
+      }
+    }
+    for (Map.Entry<String, List<Metacard>> entry : collectionMetacardMap.entrySet()) {
+      CreateRequest request =
+          new CreateRequestImpl(
+              entry.getValue(), createRequest.getProperties(), createRequest.getStoreIds());
+      createRequests.put(entry.getKey(), request);
+    }
+
+    return createRequests;
+  }
+
+  private Map<String, UpdateRequest> getUpdateRequests(UpdateRequest updateRequest) {
+    Map<String, UpdateRequest> updateRequests = new HashMap<>();
+    Map<String, List<Entry<Serializable, Metacard>>> collectionMetacardMap = new HashMap<>();
+    for (Entry<Serializable, Metacard> entry : updateRequest.getUpdates()) {
+      String collection = getCollection(entry.getValue());
+      if (collectionMetacardMap.containsKey(collection)) {
+        List<Entry<Serializable, Metacard>> collectionEntries =
+            collectionMetacardMap.get(collection);
+        collectionEntries.add(entry);
+      } else {
+        List<Entry<Serializable, Metacard>> collectionEntries = new ArrayList<>();
+        collectionEntries.add(entry);
+        collectionMetacardMap.put(collection, collectionEntries);
+      }
+    }
+    for (Map.Entry<String, List<Entry<Serializable, Metacard>>> entry :
+        collectionMetacardMap.entrySet()) {
+      UpdateRequest request =
+          new UpdateRequestImpl(
+              entry.getValue(),
+              updateRequest.getAttributeName(),
+              updateRequest.getProperties(),
+              updateRequest.getStoreIds());
+      updateRequests.put(entry.getKey(), request);
+    }
+
+    return updateRequests;
+  }
+
+  private void ensureDefaultCollectionExists() {
+    for (SolrCollectionProvider provider : solrCollectionProviders) {
+      String collection = getCollectionName(provider.getCollection(null));
+      createCollectionIfRequired(collection, provider);
+    }
+  }
+
+  private Map<String, SolrCatalogProviderImpl> getAliasProviderNonAlias() {
+    Map<String, SolrCatalogProviderImpl> providers = new HashMap<>(catalogProviders.size());
+    for (Map.Entry<String, SolrCatalogProviderImpl> entry : catalogProviders.entrySet()) {
+      if (!entry.getKey().equals(getCollectionAlias())) {
+        providers.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return providers;
+  }
+
+  private String getCollectionName(String collection) {
+    if (StringUtils.isBlank(collection)) {
+      return null;
+    }
+    return getCatalogPrefix() + collection;
+  }
+
+  private void initProviders() {
+    // Always add default provider
+    ensureDefaultCollectionExists();
+    // create a client connection for alias
+    catalogProviders.computeIfAbsent(getCollectionAlias(), this::newProvider);
+  }
+
+  private List<Result> getLimitedScoredResults(List<Result> results, int num) {
+    results.sort(sorter);
+    return results.stream().limit(num).collect(Collectors.toList());
+  }
+
+  private String getCatalogPrefix() {
+    return getCollectionAlias() + CATALOG_PREFIX_SEPARATOR;
+  }
+
+  private static class IdQueryResultSorter implements Comparator<Result> {
+
+    @Override
+    public int compare(Result o1, Result o2) {
+      if (o1.getRelevanceScore() == null && o2.getRelevanceScore() == null) {
+        return 0;
+      } else if (o1.getRelevanceScore() == null && o2.getRelevanceScore() != null) {
+        return 1;
+      } else if (o1.getRelevanceScore() != null && o2.getRelevanceScore() == null) {
+        return -1;
+      } else
+        return Objects.requireNonNull(o1.getRelevanceScore()).compareTo(o2.getRelevanceScore());
+    }
+  }
+
+  /**
+   * Disables text path indexing for every subsequent update or insert.
+   *
+   * @param disableTextPath {@code true} to turn off text path indexing
+   */
+  public void setDisableTextPath(boolean disableTextPath) {
+    ConfigurationStore.getInstance().setDisableTextPath(disableTextPath);
+  }
+
+  @Override
+  public Set<ContentType> getContentTypes() {
+    return this.catalogProviders.values().stream().map(p -> p.getContentTypes()).findAny().get();
+  }
+
+  @Override
+  public String getDescription() {
+    return DESCRIBABLE_PROPERTIES.getProperty("description", "");
+  }
+
+  @Override
+  public String getOrganization() {
+    return DESCRIBABLE_PROPERTIES.getProperty("organization", "");
+  }
+
+  @Override
+  public String getTitle() {
+    return DESCRIBABLE_PROPERTIES.getProperty("name", "");
+  }
+
+  @Override
+  public String getVersion() {
+    return DESCRIBABLE_PROPERTIES.getProperty("version", "");
+  }
+}

--- a/catalog/solr/catalog-split-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/solr/catalog-split-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,53 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+		   xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+	<reference id="solrClientFactory" interface="org.codice.solr.factory.SolrClientFactory" />
+
+	<reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
+
+	<reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder" />
+
+	<bean id="dynamicSchemaResolver" class="ddf.catalog.source.solr.DynamicSchemaResolver"/>
+
+	<bean id="solrCollectionProviderList" class="org.codice.ddf.platform.util.SortedServiceList"/>
+
+	<reference-list id="solrCollectionProviders"
+		interface="ddf.catalog.solr.collection.SolrCollectionProvider"
+		availability="mandatory">
+		<reference-listener bind-method="bindPlugin"
+			unbind-method="unbindPlugin" ref="solrCollectionProviderList"/>
+	</reference-list>
+
+	<bean id="splitCatalogProvider" class="ddf.catalog.solr.provider.SplitCatalogProvider"
+		destroy-method="shutdown">
+		<!-- Aries does not call my object on startup if set to component-managed. Therefore, we will use container-managed
+		and have the setter call the update method. -->
+		<cm:managed-properties persistent-id="ddf.catalog.solr.provider.SplitCatalogProvider"
+			update-strategy="container-managed"/>
+		<argument ref="filterAdapter"/>
+		<argument ref="solrClientFactory" />
+		<argument>
+			<bean class="ddf.catalog.source.solr.SolrFilterDelegateFactoryImpl"/>
+		</argument>
+		<argument ref="dynamicSchemaResolver"/>
+		<argument ref="solrCollectionProviderList"/>
+		<property name="getHandlerWorkaround" value="true"/>
+		<property name="collectionAlias" value="catalog"/>
+	</bean>
+
+	<service ref="splitCatalogProvider" interface="ddf.catalog.source.CatalogProvider"/>
+
+</blueprint>

--- a/catalog/solr/catalog-split-provider/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/solr/catalog-split-provider/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Split Catalog Provider"
+      id="ddf.catalog.solr.provider.SplitCatalogProvider">
+        <AD
+          description="WARNING: Performance Impact. Only in special cases should auto-commit be forced. Forcing auto-commit makes the search results visible immediately."
+          name="Force Auto Commit" id="forceAutoCommit" required="true" type="Boolean"
+          default="false"/>
+        <AD
+          description="Disables the ability to make Text Path queries by disabling the Text Path index. Disabling Text Path indexing typically increases ingest performance."
+          name="Disable Text Path indexing" id="disableTextPath" required="true"
+          type="Boolean" default="false"/>
+        <AD description="Enable /get handler collection alias workaround"
+          name="/get handler workaround" id="getHandlerWorkaround"
+          type="Boolean" default="true"/>
+        <AD description="Alias to use for catalog collection. Default: catalog"
+          name="Catalog Collection Alias" id="collectionAlias"
+          type="String" default="catalog"/>
+    </OCD>
+
+    <Designate pid="ddf.catalog.solr.provider.SplitCatalogProvider">
+        <Object ocdref="ddf.catalog.solr.provider.SplitCatalogProvider"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/solr/catalog-split-provider/src/main/resources/describable.properties
+++ b/catalog/solr/catalog-split-provider/src/main/resources/describable.properties
@@ -1,0 +1,4 @@
+version=${version}
+description=${description}
+organization=${organization.name}
+name=${artifactId}

--- a/catalog/solr/catalog-split-provider/src/test/java/ddf/catalog/solr/provider/MockMetacard.java
+++ b/catalog/solr/catalog-split-provider/src/test/java/ddf/catalog/solr/provider/MockMetacard.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.solr.provider;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardImpl;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
+
+public class MockMetacard extends MetacardImpl {
+
+  public static final String DEFAULT_TITLE = "Flagstaff";
+
+  public static final String DEFAULT_VERSION = "mockVersion";
+
+  public static final String DEFAULT_TYPE = "simple";
+
+  public static final String DEFAULT_LOCATION = "POINT (1 0)";
+
+  public static final String DEFAULT_TAG = "resource";
+
+  public static final byte[] DEFAULT_THUMBNAIL = {-86};
+
+  private static final long serialVersionUID = -189776439741244547L;
+
+  public static String getFlagstaffRecord() {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
+        + "<rss version=\"2.0\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"\r\n"
+        + "    xmlns:wfw=\"http://wellformedweb.org/CommentAPI/\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\"\r\n"
+        + "    xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:sy=\"http://purl.org/rss/1.0/modules/syndication/\"\r\n"
+        + "    xmlns:slash=\"http://purl.org/rss/1.0/modules/slash/\" xmlns:itunes=\"http://www.itunes.com/dtds/podcast-1.0.dtd\"\r\n"
+        + "    xmlns:rawvoice=\"http://www.rawvoice.com/rawvoiceRssModule/\">\r\n"
+        + "\r\n"
+        + "    <channel>\r\n"
+        + "        <title>Flagstaff Chamber of Commerce</title>\r\n"
+        + "        <atom:link href=\"http://www.flagstaffchamber.com/feed/\" rel=\"self\"\r\n"
+        + "            type=\"application/rss+xml\" />\r\n"
+        + "        <link>http://www.flagstaffchamber.com</link>\r\n"
+        + "        <description></description>\r\n"
+        + "        <lastBuildDate>Mon, 16 Jul 2012 21:32:53 +0000</lastBuildDate>\r\n"
+        + "        <language>en</language>\r\n"
+        + "        <sy:updatePeriod>hourly</sy:updatePeriod>\r\n"
+        + "        <sy:updateFrequency>1</sy:updateFrequency>\r\n"
+        + "        <generator>http://wordpress.org/?v=3.1</generator>\r\n"
+        + "        <!-- podcast_generator=\"Blubrry PowerPress/2.0.4\" -->\r\n"
+        + "        <itunes:summary></itunes:summary>\r\n"
+        + "        <itunes:author>Flagstaff Chamber of Commerce</itunes:author>\r\n"
+        + "        <itunes:explicit>no</itunes:explicit>\r\n"
+        + "        <itunes:image\r\n"
+        + "            href=\"http://www.flagstaffchamber.com/wp-content/plugins/powerpress/itunes_default.jpg\" />\r\n"
+        + "        <itunes:subtitle></itunes:subtitle>\r\n"
+        + "        <image>\r\n"
+        + "            <title>Flagstaff Chamber of Commerce</title>\r\n"
+        + "            <url>http://www.flagstaffchamber.com/wp-content/plugins/powerpress/rss_default.jpg</url>\r\n"
+        + "            <link>http://www.flagstaffchamber.com</link>\r\n"
+        + "        </image>\r\n"
+        + "        <item>\r\n"
+        + "            <title>Arizona Cardinals NFL Training Camp Schedule, here in Airport FLG in AZ</title>\r\n"
+        + "            <link>http://www.flagstaffchamber.com/arizona-cardinals-nfl-training-camp-schedule/</link>\r\n"
+        + "            <comments>http://www.flagstaffchamber.com/arizona-cardinals-nfl-training-camp-schedule/#comments</comments>\r\n"
+        + "            <pubDate>Tue, 03 Jul 2012 23:16:58 +0000</pubDate>\r\n"
+        + "            <dc:creator>Flagstaff Chamber</dc:creator>\r\n"
+        + "            <category><![CDATA[Uncategorized]]></category>\r\n"
+        + "\r\n"
+        + "            <guid isPermaLink=\"false\">http://www.flagstaffchamber.com/?p=10160</guid>\r\n"
+        + "            <description><![CDATA[Join the Arizona Cardinals as they conduct their NFL Training Camp in Flagstaff from July 25 to August 21.]]></description>\r\n"
+        + "            <wfw:commentRss>http://www.flagstaffchamber.com/arizona-cardinals-nfl-training-camp-schedule/feed/\r\n"
+        + "            </wfw:commentRss>\r\n"
+        + "            <slash:comments>0</slash:comments>\r\n"
+        + "        </item>\r\n"
+        + "    </channel>\r\n"
+        + "</rss>\r\n"
+        + "\r\n"
+        + "\r\n"
+        + "<!-- Performance optimized by W3 Total Cache. Learn more: http://www.w3-edge.com/wordpress-plugins/ \r\n"
+        + "    Served from: flagstaffchamber.com @ 2012-07-17 08:28:04 -->";
+  }
+
+  public static String getTampaRecord() {
+    return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n"
+        + "<rss xmlns:atom=\"http://www.w3.org/2005/Atom\" version=\"2.0\">\r\n"
+        + "    <channel>\r\n"
+        + "        <title>www2.tbo.com - News</title>\r\n"
+        + "        <link>http://www2.tbo.com/news/</link>\r\n"
+        + "        <description></description>\r\n"
+        + "        <atom:link href=\"http://www2.tbo.com/feed/rss/news/\" rel=\"self\"></atom:link>\r\n"
+        + "        <language>en-us</language>\r\n"
+        + "        <copyright>Copyright (c) 2012, Media General Communications Holdings,\r\n"
+        + "            LLC. A Media General company.</copyright>\r\n"
+        + "        <lastBuildDate>Tue, 17 Jul 2012 13:03:04 -0400</lastBuildDate>\r\n"
+        + "        <item>\r\n"
+        + "            <title>Body of Staff Sgt. Ricardo Seija returns home</title>\r\n"
+        + "            <link>http://www2.tbo.com/news/news/2012/jul/17/7/body-of-staff-sgt-ricardo-seija-returns-home-ar-433878/</link>\r\n"
+        + "            <description>Body of Staff Sgt. Ricardo Seija returns home</description>\r\n"
+        + "            <pubDate>Tue, 17 Jul 2012 13:03:04 -0400</pubDate>\r\n"
+        + "            <guid>http://www2.tbo.com/news/news/2012/jul/17/7/body-of-staff-sgt-ricardo-seija-returns-home-ar-433878/</guid>\r\n"
+        + "            <enclosure\r\n"
+        + "                url=\"http://www2.tbo.com/mgmedia/image/100/100/217458/img-20120717-02368/\"\r\n"
+        + "                length=\"30000\" type=\"image/jpeg\"></enclosure>\r\n"
+        + "        </item>\r\n"
+        + "        <item>\r\n"
+        + "            <title>Sears steps down after years of government service</title>\r\n"
+        + "            <link>http://www2.tbo.com/news/plant-city/2012/jul/17/sears-steps-down-after-years-of-government-service-ar-429159/</link>\r\n"
+        + "            <description>Sears steps down after years of government service</description>\r\n"
+        + "            <pubDate>Tue, 17 Jul 2012 13:00:00 -0400</pubDate>\r\n"
+        + "            <guid>http://www2.tbo.com/news/plant-city/2012/jul/17/sears-steps-down-after-years-of-government-service-ar-429159/</guid>\r\n"
+        + "            <enclosure\r\n"
+        + "                url=\"http://www2.tbo.com/mgmedia/image/100/100/216697/pcsears18jpg/\"\r\n"
+        + "                length=\"30000\" type=\"image/jpeg\"></enclosure>\r\n"
+        + "        </item>\r\n"
+        + "        <item>\r\n"
+        + "            <title>Spirit Airlines to offer non-stop service from Tampa to\r\n"
+        + "                Chicago, Airport TPA in FL</title>\r\n"
+        + "            <link>http://www2.tbo.com/news/business/2012/jul/17/spirit-airlines-to-offer-non-stop-service-from-tam-ar-433900/</link>\r\n"
+        + "            <description>Spirit Airlines to offer non-stop service from Tampa to\r\n"
+        + "                Chicago</description>\r\n"
+        + "            <pubDate>Tue, 17 Jul 2012 12:48:10 -0400</pubDate>\r\n"
+        + "            <guid>http://www2.tbo.com/news/business/2012/jul/17/spirit-airlines-to-offer-non-stop-service-from-tam-ar-433900/</guid>\r\n"
+        + "        </item>\r\n"
+        + "        <item>\r\n"
+        + "            <title>More than workers</title>\r\n"
+        + "            <link>http://www2.tbo.com/news/opinion/2012/jul/17/naopino2-more-than-workers-ar-433254/</link>\r\n"
+        + "            <description>More than workers</description>\r\n"
+        + "            <pubDate>Tue, 17 Jul 2012 00:00:00 -0400</pubDate>\r\n"
+        + "            <guid>http://www2.tbo.com/news/opinion/2012/jul/17/naopino2-more-than-workers-ar-433254/</guid>\r\n"
+        + "            <enclosure\r\n"
+        + "                url=\"http://www2.tbo.com/mgmedia/image/100/100/217388/ed-school/\"\r\n"
+        + "                length=\"30000\" type=\"image/jpeg\"></enclosure>\r\n"
+        + "        </item>\r\n"
+        + "    </channel>\r\n"
+        + "</rss>";
+  }
+
+  public MockMetacard(String metadata, MetacardType type, Calendar calendar) {
+    super(type);
+    // make a simple metacard
+    this.setCreatedDate(calendar.getTime());
+    this.setEffectiveDate(calendar.getTime());
+    this.setExpirationDate(calendar.getTime());
+    this.setModifiedDate(calendar.getTime());
+    this.setMetadata(metadata);
+    this.setContentTypeName(DEFAULT_TYPE);
+    this.setContentTypeVersion(DEFAULT_VERSION);
+    this.setLocation(DEFAULT_LOCATION);
+    this.setThumbnail(DEFAULT_THUMBNAIL);
+    this.setTitle(DEFAULT_TITLE);
+    this.setSecurity(new HashMap<>());
+    this.setTags(Collections.singleton(DEFAULT_TAG));
+  }
+
+  public static Metacard createMetacard(String metadata, MetacardType type, Calendar calendar) {
+    MetacardImpl metacard = new MetacardImpl(type);
+
+    // make a simple metacard
+    metacard.setCreatedDate(calendar.getTime());
+    metacard.setEffectiveDate(calendar.getTime());
+    metacard.setExpirationDate(calendar.getTime());
+    metacard.setModifiedDate(calendar.getTime());
+    metacard.setMetadata(metadata);
+    metacard.setContentTypeName(DEFAULT_TYPE);
+    metacard.setContentTypeVersion(DEFAULT_VERSION);
+    metacard.setLocation(DEFAULT_LOCATION);
+    metacard.setThumbnail(DEFAULT_THUMBNAIL);
+    metacard.setTitle(DEFAULT_TITLE);
+    metacard.setSecurity(new HashMap<>());
+    metacard.setTags(Collections.singleton(DEFAULT_TAG));
+    return metacard;
+  }
+
+  public static Metacard createMetacard(String metadata, MetacardType type) {
+    return MockMetacard.createMetacard(metadata, type, Calendar.getInstance());
+  }
+
+  public static Metacard createMetacard(String metadata) {
+    return MockMetacard.createMetacard(metadata, MetacardImpl.BASIC_METACARD);
+  }
+}

--- a/catalog/solr/catalog-split-provider/src/test/java/ddf/catalog/solr/provider/SplitCatalogProviderTest.java
+++ b/catalog/solr/catalog-split-provider/src/test/java/ddf/catalog/solr/provider/SplitCatalogProviderTest.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.solr.provider;
+
+import static ddf.catalog.solr.provider.SplitCatalogProvider.COLLECTION_HINT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.UpdateResponse;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.CreateResponseImpl;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
+import ddf.catalog.operation.impl.DeleteResponseImpl;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.operation.impl.SourceResponseImpl;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.operation.impl.UpdateResponseImpl;
+import ddf.catalog.solr.collection.SolrCollectionProvider;
+import ddf.catalog.source.solr.ConfigurationStore;
+import ddf.catalog.source.solr.DynamicSchemaResolver;
+import ddf.catalog.source.solr.SolrCatalogProviderImpl;
+import ddf.catalog.source.solr.SolrFilterDelegateFactory;
+import ddf.catalog.source.solr.SolrMetacardClientImpl;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.SolrPingResponse;
+import org.codice.solr.client.solrj.SolrClient;
+import org.codice.solr.factory.SolrClientFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opengis.filter.Filter;
+
+public class SplitCatalogProviderTest {
+
+  private FilterBuilder filterBuilder;
+
+  private SolrCatalogProviderImpl catalogProvider;
+
+  private SplitCatalogProvider splitProvider;
+
+  private FilterAdapter filterAdapter;
+
+  private SolrClient solrClientMock;
+
+  private SolrClientFactory cloudClientMock;
+
+  private SolrCollectionProvider collectionProvider;
+
+  @Before
+  public void setUp() {
+    cloudClientMock = mock(SolrClientFactory.class);
+    solrClientMock = mock(SolrClient.class);
+    filterAdapter = mock(FilterAdapter.class);
+    filterBuilder = new GeotoolsFilterBuilder();
+
+    when(cloudClientMock.newClient(any(), any())).thenReturn(solrClientMock);
+
+    collectionProvider = mock(SolrCollectionProvider.class);
+    when(collectionProvider.getCollection(any())).thenReturn("default");
+
+    splitProvider =
+        new SplitCatalogProvider(
+            cloudClientMock,
+            filterAdapter,
+            mock(SolrFilterDelegateFactory.class),
+            mock(DynamicSchemaResolver.class),
+            Collections.singletonList(collectionProvider));
+    splitProvider.setGetHandlerWorkaround(false);
+    splitProvider.setCollectionAlias("catalog");
+
+    catalogProvider = mock(SolrCatalogProviderImpl.class);
+  }
+
+  @Test
+  public void testCreate() throws Exception {
+    splitProvider.catalogProviders.put("catalog_default", catalogProvider);
+    CreateResponse response = createRecord(splitProvider);
+    assertThat(response.getCreatedMetacards().size(), equalTo(2));
+  }
+
+  @Test
+  public void testQuery() throws Exception {
+    splitProvider.catalogProviders.put("catalog", catalogProvider);
+    when(filterAdapter.adapt(any(), any())).thenReturn(false);
+    Filter filter = filterBuilder.attribute("anyText").is().like().text("*");
+    List<Metacard> records = getTestRecords();
+
+    QueryRequest request = new QueryRequestImpl(new QueryImpl(filter));
+    when(catalogProvider.query(request))
+        .thenReturn(
+            new SourceResponseImpl(
+                request,
+                records.stream().map(this::getScoredResult).collect(Collectors.toList()),
+                Long.valueOf(records.size())));
+
+    SourceResponse response = splitProvider.query(request);
+    assertThat(response.getHits(), equalTo(2L));
+  }
+
+  @Test
+  public void testQueryWorkAround() throws Exception {
+    splitProvider.catalogProviders.put("catalog_default", catalogProvider);
+    splitProvider.setGetHandlerWorkaround(true);
+    when(filterAdapter.adapt(any(), any())).thenReturn(true);
+    Filter filter = filterBuilder.attribute(Metacard.ID).is().like().text("1234");
+    List<Metacard> records = getTestRecords();
+
+    QueryRequest request = new QueryRequestImpl(new QueryImpl(filter));
+    request.getProperties().put(SolrMetacardClientImpl.DO_REALTIME_GET, true);
+    when(catalogProvider.query(request))
+        .thenReturn(
+            new SourceResponseImpl(
+                request,
+                records.stream().map(this::getScoredResult).collect(Collectors.toList()),
+                Long.valueOf(records.size())));
+
+    SourceResponse response = splitProvider.query(request);
+    assertThat(response.getHits(), equalTo(2L));
+  }
+
+  @Test
+  public void testQueryWithHint() throws Exception {
+    splitProvider.catalogProviders.put("catalog_default", catalogProvider);
+    when(filterAdapter.adapt(any(), any())).thenReturn(true);
+    Filter filter = filterBuilder.attribute(Metacard.ID).is().like().text("1234");
+    List<Metacard> records = getTestRecords();
+
+    QueryRequest request = new QueryRequestImpl(new QueryImpl(filter));
+    request.getProperties().put(COLLECTION_HINT, "catalog_default");
+    request.getProperties().put(SolrMetacardClientImpl.DO_REALTIME_GET, true);
+    when(catalogProvider.query(request))
+        .thenReturn(
+            new SourceResponseImpl(
+                request,
+                records.stream().map(this::getScoredResult).collect(Collectors.toList()),
+                Long.valueOf(records.size())));
+
+    SourceResponse response = splitProvider.query(request);
+    assertThat(response.getHits(), equalTo(2L));
+  }
+
+  @Test
+  public void testQueryWithHintNotRealTime() throws Exception {
+    splitProvider.catalogProviders.put("catalog_default", catalogProvider);
+    when(filterAdapter.adapt(any(), any())).thenReturn(false);
+    Filter filter = filterBuilder.attribute(Metacard.ID).is().like().text("1234");
+    List<Metacard> records = getTestRecords();
+
+    QueryRequest request = new QueryRequestImpl(new QueryImpl(filter));
+    request.getProperties().put(COLLECTION_HINT, "catalog_default");
+    when(catalogProvider.query(request))
+        .thenReturn(
+            new SourceResponseImpl(
+                request,
+                records.stream().map(this::getScoredResult).collect(Collectors.toList()),
+                Long.valueOf(records.size())));
+
+    SourceResponse response = splitProvider.query(request);
+    assertThat(response.getHits(), equalTo(2L));
+  }
+
+  @Test
+  public void testRealTimeQuery() throws Exception {
+    splitProvider.catalogProviders.put("catalog", catalogProvider);
+    when(filterAdapter.adapt(any(), any())).thenReturn(true);
+
+    Filter filter = filterBuilder.attribute(Metacard.ID).is().like().text("1234");
+    List<Metacard> records = getTestRecords();
+
+    QueryRequest request = new QueryRequestImpl(new QueryImpl(filter));
+    request.getProperties().put(SolrMetacardClientImpl.DO_REALTIME_GET, true);
+    when(catalogProvider.query(any()))
+        .thenReturn(
+            new SourceResponseImpl(
+                request,
+                records.stream().map(this::getScoredResult).collect(Collectors.toList()),
+                Long.valueOf(records.size())));
+
+    SourceResponse response = splitProvider.query(request);
+    assertThat(response.getHits(), equalTo(2L));
+  }
+
+  @Test
+  public void testUpdate() throws Exception {
+    splitProvider.catalogProviders.put("catalog", catalogProvider);
+    splitProvider.catalogProviders.put("catalog_default", catalogProvider);
+
+    List<Metacard> records = getTestRecords();
+
+    UpdateRequest request =
+        new UpdateRequestImpl(
+            records.stream().map(Metacard::getId).toArray(String[]::new), records);
+
+    when(catalogProvider.update(any()))
+        .thenReturn(new UpdateResponseImpl(request, request.getProperties(), records, records));
+    UpdateResponse response = splitProvider.update(request);
+    assertThat(response.getUpdatedMetacards().size(), equalTo(2));
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    splitProvider.catalogProviders.put("catalog", catalogProvider);
+    splitProvider.catalogProviders.put("catalog_default", catalogProvider);
+
+    List<Metacard> records = getTestRecords();
+    DeleteRequest deleteRequest =
+        new DeleteRequestImpl(records.stream().map(Metacard::getId).toArray(String[]::new));
+
+    when(catalogProvider.delete(any()))
+        .thenReturn(new DeleteResponseImpl(deleteRequest, Collections.emptyMap(), records));
+
+    splitProvider.delete(deleteRequest);
+  }
+
+  @Test
+  public void testIsAvailableFalse() throws SolrServerException, IOException {
+    SolrPingResponse pingResponse = mock(SolrPingResponse.class, Mockito.RETURNS_DEEP_STUBS);
+    when(pingResponse.getResponse().get("status")).thenReturn("FALSE");
+    when(solrClientMock.ping()).thenReturn(pingResponse);
+    boolean avail = splitProvider.isAvailable();
+    assertThat(avail, is(false));
+  }
+
+  @Test
+  public void testIsAvailableTrue() throws SolrServerException, IOException {
+    SolrPingResponse pingResponse = mock(SolrPingResponse.class, Mockito.RETURNS_DEEP_STUBS);
+    when(pingResponse.getResponse().get("status")).thenReturn("OK");
+    when(solrClientMock.ping()).thenReturn(pingResponse);
+    boolean avail = splitProvider.isAvailable();
+    assertThat(avail, is(true));
+  }
+
+  @Test
+  public void testForceAutoCommit() {
+    splitProvider.setForceAutoCommit(true);
+    assertThat(ConfigurationStore.getInstance().isForceAutoCommit(), is(true));
+  }
+
+  @Test
+  public void testRefresh() {
+    final String alias = "mycatalog";
+    Map<String, Object> props = new HashMap<>();
+    props.put(SplitCatalogProvider.GET_HANDLER_WORKAROUND_PROP, Boolean.TRUE);
+    props.put(SplitCatalogProvider.COLLECTION_ALIAS_PROP, alias);
+    splitProvider.refresh(props);
+
+    assertThat(splitProvider.isGetHandlerWorkaround(), is(true));
+    assertThat(splitProvider.getCollectionAlias(), is(alias));
+  }
+
+  private CreateResponse createRecord(SplitCatalogProvider provider) throws Exception {
+    List<Metacard> list =
+        Arrays.asList(
+            MockMetacard.createMetacard(MockMetacard.getFlagstaffRecord()),
+            MockMetacard.createMetacard(MockMetacard.getTampaRecord()));
+
+    CreateRequest request = new CreateRequestImpl(list);
+    when(catalogProvider.create(any()))
+        .thenReturn(new CreateResponseImpl(request, request.getProperties(), list));
+
+    return provider.create(request);
+  }
+
+  private List<Metacard> getTestRecords() {
+    Metacard metacard1 = MockMetacard.createMetacard(MockMetacard.getFlagstaffRecord());
+    metacard1.setAttribute(new AttributeImpl(Core.ID, "1"));
+    Metacard metacard2 = MockMetacard.createMetacard(MockMetacard.getTampaRecord());
+    metacard2.setAttribute(new AttributeImpl(Core.ID, "2"));
+    return Arrays.asList(metacard1, metacard2);
+  }
+
+  private Result getScoredResult(Metacard metacard) {
+    return new ResultImpl(metacard);
+  }
+
+  @Test
+  public void testShutdown() {
+    splitProvider.shutdown();
+  }
+
+  @Test
+  public void testMaskId() {
+    splitProvider.maskId("id");
+  }
+}

--- a/catalog/solr/pom.xml
+++ b/catalog/solr/pom.xml
@@ -36,5 +36,10 @@
         <module>catalog-solr-provider</module>
         <module>catalog-solr-solrclient</module>
         <module>catalog-solr-app</module>
+        <module>catalog-solr-collection-api</module>
+        <module>catalog-solr-collection-impl</module>
+        <module>catalog-solr-defaultcollectionprovider</module>
+        <module>catalog-split-provider</module>
+        <module>split-solr-app</module>
     </modules>
 </project>

--- a/catalog/solr/split-solr-app/pom.xml
+++ b/catalog/solr/split-solr-app/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.catalog.solr</groupId>
+        <artifactId>catalog-solr</artifactId>
+        <version>2.24.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>split-solr-app</artifactId>
+    <packaging>pom</packaging>
+    <name>DDF :: Solr Split Solr App</name>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Puts the features XML file for this app into the maven repo. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <inherited>false</inherited>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/classes/features.xml</file>
+                                    <type>xml</type>
+                                    <classifier>features</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.thirdparty</groupId>
+            <artifactId>jts</artifactId>
+            <version>${jts.bundle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.solr</groupId>
+            <artifactId>catalog-solr-solrclient</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.solr</groupId>
+            <artifactId>catalog-solr-defaultcollectionprovider</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.solr</groupId>
+            <artifactId>catalog-split-provider</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.solr</groupId>
+            <artifactId>catalog-solr-collection-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/catalog/solr/split-solr-app/src/main/resources/features.xml
+++ b/catalog/solr/split-solr-app/src/main/resources/features.xml
@@ -1,0 +1,45 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+
+<!--
+     NOTE: This features XML file uses the Karaf "install" attribute to specify whether a feature
+     is automatically installed when an app's KAR file is hot deployed.
+     
+     Description of the install attribute from the Karaf features XSD:
+     
+     "Installation mode. Can be either manual or auto. Specifies whether the feature should be 
+     automatically installed when dropped inside the deploy folder. Note: This attribute doesn't 
+     affect feature descriptors that are installed from the command line or as part of the 
+     org.apache.karaf.features.cfg." 
+-->
+<features name="${project.artifactId}-${project.version}"
+          xmlns="http://karaf.apache.org/xmlns/features/v1.3.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
+
+    <feature name="split-solr-provider" version="${project.version}"
+      description="Split Catalog Provider to interface with Solr ${solr.version}">
+        <bundle>mvn:ddf.catalog.solr/catalog-solr-defaultcollectionprovider/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.solr/catalog-split-provider/${project.version}</bundle>
+    </feature>
+
+    <feature name="split-solr-app" version="${project.version}"
+      description="The Split Solr Catalog Provider (SSCP) is an implementation of the CatalogProvider interface using Apache Solr ${solr.version} as a data store.\nThe SSCP supports extensible metacards, fast/simple contextual searching, indexes xml attributes/CDATA sections/XML text elements, contains full XPath support, works with a standalone Solr Server or Solr Cloud instance">
+        <bundle>mvn:org.codice.thirdparty/jts/${jts.bundle.version}</bundle>
+        <bundle>mvn:ddf.catalog.solr/catalog-solr-solrclient/${project.version}</bundle>
+        <feature>split-solr-provider</feature>
+    </feature>
+
+</features>
+    

--- a/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/pom.xml
@@ -131,12 +131,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.71</minimum>
+                                            <minimum>0.74</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.53</minimum>
+                                            <minimum>0.61</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/src/main/java/org/codice/ddf/spatial/geocoding/query/GazetteerQueryCatalog.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/src/main/java/org/codice/ddf/spatial/geocoding/query/GazetteerQueryCatalog.java
@@ -91,6 +91,10 @@ public class GazetteerQueryCatalog implements GeoEntryQueryable {
 
   private static final long TIMEOUT = 10000L;
 
+  private static final String COLLECTION_HINT_PROP = "geocoderCollection";
+
+  private static final String COLLECTION_HINT = "collection-hint";
+
   private CatalogFramework catalogFramework;
 
   private FilterBuilder filterBuilder;
@@ -98,6 +102,8 @@ public class GazetteerQueryCatalog implements GeoEntryQueryable {
   private Filter tagFilter;
 
   private List<Filter> featureCodeFilters;
+
+  private String geocoderCollection = "gazetteer";
 
   public GazetteerQueryCatalog(CatalogFramework catalogFramework, FilterBuilder filterBuilder) {
     this.catalogFramework = catalogFramework;
@@ -130,6 +136,9 @@ public class GazetteerQueryCatalog implements GeoEntryQueryable {
         new SortByImpl(GeoEntryAttributes.POPULATION_ATTRIBUTE_NAME, SortOrder.DESCENDING);
     SortBy[] sortbys = {populationSortBy};
     properties.put(ADDITIONAL_SORT_BYS, sortbys);
+    if (StringUtils.isNotBlank(geocoderCollection)) {
+      properties.put(COLLECTION_HINT, geocoderCollection);
+    }
 
     Query query = new QueryImpl(queryFilter, 1, maxResults, featureCodeSortBy, false, TIMEOUT);
     QueryRequest queryRequest = new QueryRequestImpl(query, properties);
@@ -158,9 +167,15 @@ public class GazetteerQueryCatalog implements GeoEntryQueryable {
     Filter idFilter = filterBuilder.attribute(Core.ID).is().text(id);
     Filter queryFilter = filterBuilder.allOf(tagFilter, idFilter);
 
+    Map<String, Serializable> properties = new HashMap<>();
+    if (StringUtils.isNotBlank(geocoderCollection)) {
+      properties.put(COLLECTION_HINT, geocoderCollection);
+    }
+
     QueryResponse queryResponse;
     try {
-      queryResponse = catalogFramework.query(new QueryRequestImpl(new QueryImpl(queryFilter)));
+      queryResponse =
+          catalogFramework.query(new QueryRequestImpl(new QueryImpl(queryFilter), properties));
     } catch (UnsupportedQueryException | SourceUnavailableException | FederationException e) {
       throw new GeoEntryQueryException(ERROR_MESSAGE, e);
     }
@@ -180,6 +195,10 @@ public class GazetteerQueryCatalog implements GeoEntryQueryable {
     suggestProps.put(SUGGESTION_QUERY_KEY, queryString);
     suggestProps.put(SUGGESTION_CONTEXT_KEY, GAZETTEER_METACARD_TAG);
     suggestProps.put(SUGGESTION_DICT_KEY, SUGGEST_PLACE_KEY);
+
+    if (StringUtils.isNotBlank(geocoderCollection)) {
+      suggestProps.put(COLLECTION_HINT, geocoderCollection);
+    }
 
     Query suggestionQuery = new QueryImpl(filterBuilder.attribute(Core.TITLE).text(queryString));
 
@@ -277,7 +296,12 @@ public class GazetteerQueryCatalog implements GeoEntryQueryable {
 
     Filter queryFilter = filterBuilder.allOf(featureCodeFilter, tagFilter, textFilter);
     Query query = new QueryImpl(queryFilter, 1, maxResults, SortBy.NATURAL_ORDER, false, TIMEOUT);
-    QueryRequest queryRequest = new QueryRequestImpl(query);
+
+    Map<String, Serializable> properties = new HashMap<>();
+    if (StringUtils.isNotBlank(geocoderCollection)) {
+      properties.put(COLLECTION_HINT, geocoderCollection);
+    }
+    QueryRequest queryRequest = new QueryRequestImpl(query, properties);
 
     QueryResponse queryResponse;
     try {
@@ -341,7 +365,12 @@ public class GazetteerQueryCatalog implements GeoEntryQueryable {
     Filter filter = filterBuilder.attribute(Core.LOCATION).withinBuffer().wkt(wkt, radiusInMeters);
     Filter queryFilter = filterBuilder.allOf(tagFilter, filter);
     Query query = new QueryImpl(queryFilter);
-    QueryRequest queryRequest = new QueryRequestImpl(query);
+
+    Map<String, Serializable> properties = new HashMap<>();
+    if (StringUtils.isNotBlank(geocoderCollection)) {
+      properties.put(COLLECTION_HINT, geocoderCollection);
+    }
+    QueryRequest queryRequest = new QueryRequestImpl(query, properties);
     QueryResponse queryResponse;
     try {
       queryResponse = catalogFramework.query(queryRequest);
@@ -357,5 +386,17 @@ public class GazetteerQueryCatalog implements GeoEntryQueryable {
       return Optional.ofNullable(countryCode);
     }
     return Optional.empty();
+  }
+
+  public void refresh(Map<String, Object> properties) {
+    Optional.ofNullable(properties)
+        .map(p -> p.get(COLLECTION_HINT_PROP))
+        .filter(String.class::isInstance)
+        .map(String.class::cast)
+        .ifPresent(this::setGeocoderCollection);
+  }
+
+  public void setGeocoderCollection(String geocoderCollection) {
+    this.geocoderCollection = geocoderCollection;
   }
 }

--- a/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,15 +10,22 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/ -->
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+<blueprint xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <ext:property-placeholder/>
 
     <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework" />
 
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder" />
 
     <bean id="gazetteerQueryable" class="org.codice.ddf.spatial.geocoding.query.GazetteerQueryCatalog">
+        <cm:managed-properties persistent-id="org.codice.ddf.spatial.geocoding.query.GazetteerQueryCatalog"
+          update-strategy="container-managed"/>
         <argument ref="catalogFramework"/>
         <argument ref="filterBuilder"/>
+        <property name="geocoderCollection" value="gazetteer"/>
     </bean>
 
     <service ref="gazetteerQueryable" interface="org.codice.ddf.spatial.geocoding.GeoEntryQueryable" ranking="50"/>

--- a/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+  <OCD name="Gazetteer Query Catalog" id="org.codice.ddf.spatial.geocoding.query.GazetteerQueryCatalog">
+    <AD description="Collection to search for GeoCoder information. Must be a single collection. Leave blank for default query to the full catalog."
+      name="GeoCoder Collection" id="geocoderCollection" required="false" type="String"
+      default="gazetteer"/>
+  </OCD>
+
+  <Designate pid="org.codice.ddf.spatial.geocoding.query.GazetteerQueryCatalog">
+    <Object ocdref="org.codice.ddf.spatial.geocoding.query.GazetteerQueryCatalog"/>
+  </Designate>
+
+</metatype:MetaData>

--- a/catalog/spatial/spatial-app/src/main/resources/features.xml
+++ b/catalog/spatial/spatial-app/src/main/resources/features.xml
@@ -132,7 +132,6 @@
 
     <feature name="offline-gazetteer" version="${project.version}"
              description="Offline gazetteer service utilizing a local GeoNames index.">
-        <feature>catalog-solr-provider</feature>
         <feature>spatial-geocoding-endpoint</feature>
         <feature>catalog-core-plugins</feature>
         <bundle>mvn:commons-digester/commons-digester/${commons-digester.version}</bundle>

--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/solr-split.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/solr-split.json
@@ -1,0 +1,10 @@
+{
+  "name": "split-solr-app",
+  "description": "The Solr Split Catalog Provider (SCP) is an implementation of the CatalogProvider interface using Apache Solr ${solr.version} as a data store.\nThe Solr Split supports the same capabilities as the Solr Provider only allows further abilities to split into multiple solr collections via this single provider.",
+  "bundleLocations": [
+    "mvn:org.codice.thirdparty/jts/${jts.bundle.version}",
+    "mvn:ddf.catalog.solr/catalog-solr-solrclient/${project.version}",
+    "mvn:ddf.catalog.solr/catalog-solr-defaultcollectionprovider/${project.version}",
+    "mvn:ddf.catalog.solr/catalog-split-provider/${project.version}"
+  ]
+}

--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/solr.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/solr.json
@@ -2,6 +2,7 @@
   "name": "catalog-solr-app",
   "description": "The Solr Catalog Provider (SCP) is an implementation of the CatalogProvider interface using Apache Solr ${solr.version} as a data store.\nThe SCP supports extensible metacards, fast/simple contextual searching, indexes xml attributes/CDATA sections/XML text elements, contains full XPath support, works with an embedded local Solr Server, and also works with a standalone Solr Server.::Solr Catalog",
   "bundleLocations": [
+    "mvn:org.codice.thirdparty/jts/${jts.bundle.version}",
     "mvn:ddf.catalog.solr/catalog-solr-provider/${project.version}",
     "mvn:ddf.catalog.solr/catalog-solr-solrclient/${project.version}"
   ]

--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/spatial.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/spatial.json
@@ -12,6 +12,7 @@
     "mvn:org.codice.ddf.spatial/spatial-wfs-v1_0_0-source/${project.version}",
     "mvn:org.codice.ddf.spatial/spatial-wfs-v1_1_0-source/${project.version}",
     "mvn:org.codice.ddf.spatial/spatial-wfs-v2_0_0-source/${project.version}",
-    "mvn:org.codice.ddf.spatial/spatial-wfs-featuretransformer-handlebars/${project.version}"
+    "mvn:org.codice.ddf.spatial/spatial-wfs-featuretransformer-handlebars/${project.version}",
+    "mvn:org.codice.ddf.spatial/spatial-geocoding-offline-catalog/${project.version}"
   ]
 }

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -16,7 +16,6 @@ package org.codice.ddf.itests.common;
 import static com.jayway.restassured.RestAssured.given;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.with;
-import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.INSECURE_ROOT;
 import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.SECURE_ROOT;
 import static org.codice.ddf.itests.common.csw.CswQueryBuilder.PROPERTY_IS_LIKE;
 import static org.hamcrest.Matchers.hasXPath;
@@ -141,8 +140,6 @@ public abstract class AbstractIntegrationTest {
 
   public static final String REMOVE_ALL = "catalog:removeall -f -p";
 
-  public static final long REMOVE_ALL_TIMEOUT = TimeUnit.MINUTES.toMillis(5);
-
   private static final String CLEAR_CACHE = "catalog:removeall -f -p --cache";
 
   private static final File UNPACK_DIRECTORY = new File("target/exam");
@@ -190,7 +187,7 @@ public abstract class AbstractIntegrationTest {
   @Filter(timeout = 300000L)
   BootFinished bootFinished;
 
-  private AdminConfig adminConfig;
+  protected AdminConfig adminConfig;
 
   private ServiceManager serviceManager;
 
@@ -328,9 +325,6 @@ public abstract class AbstractIntegrationTest {
 
   public static final DynamicUrl SERVICE_ROOT =
       new DynamicUrl(SECURE_ROOT, HTTPS_PORT, "/services");
-
-  public static final DynamicUrl INSECURE_SERVICE_ROOT =
-      new DynamicUrl(INSECURE_ROOT, HTTP_PORT, "/services");
 
   public static final DynamicUrl REST_PATH = new DynamicUrl(SERVICE_ROOT, "/catalog/");
 
@@ -556,7 +550,12 @@ public abstract class AbstractIntegrationTest {
             getClass()
                 .getClassLoader()
                 .getResource("ddf.catalog.solr.provider.SolrCatalogProvider.config"),
-            "/etc/ddf.catalog.solr.provider.SolrCatalogProvider.config"));
+            "/etc/ddf.catalog.solr.provider.SolrCatalogProvider.config"),
+        installStartupFile(
+            getClass()
+                .getClassLoader()
+                .getResource("ddf.catalog.provider.SplitCatalogProvider.config"),
+            "/etc/ddf.catalog.provider.SplitCatalogProvider.config"));
   }
 
   protected Option[] configureMavenRepos() {

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/catalog/CatalogTestCommons.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/catalog/CatalogTestCommons.java
@@ -396,6 +396,6 @@ public class CatalogTestCommons {
   public static void deleteMetacardUsingCswResponseId(Response response)
       throws IOException, XPathExpressionException {
     String id = getMetacardIdFromCswInsertResponse(response);
-    CatalogTestCommons.delete(id);
+    delete(id);
   }
 }

--- a/distribution/test/itests/test-itests-common/src/main/resources/ddf.catalog.provider.SplitCatalogProvider.config
+++ b/distribution/test/itests/test-itests-common/src/main/resources/ddf.catalog.provider.SplitCatalogProvider.config
@@ -1,0 +1,1 @@
+forceAutoCommit=B"true"

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/ContainerPerSuiteItestSuite.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/ContainerPerSuiteItestSuite.java
@@ -19,6 +19,7 @@ import ddf.test.itests.catalog.TestFanout;
 import ddf.test.itests.catalog.TestFederation;
 import ddf.test.itests.catalog.TestSecurityAuditPlugin;
 import ddf.test.itests.catalog.TestSpatial;
+import ddf.test.itests.catalog.TestSplitCatalog;
 import ddf.test.itests.platform.TestOidc;
 import ddf.test.itests.platform.TestPlatform;
 import ddf.test.itests.platform.TestSecurity;
@@ -42,5 +43,6 @@ import org.junit.runners.Suite;
   TestFanout.class,
   TestOidc.class,
   TestSecurityAuditPlugin.class,
+  TestSplitCatalog.class
 })
 public class ContainerPerSuiteItestSuite {}

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSplitCatalog.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestSplitCatalog.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.test.itests.catalog;
+
+import java.util.Arrays;
+import org.codice.ddf.test.common.LoggingUtils;
+import org.codice.ddf.test.common.annotations.BeforeExam;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerSuite;
+
+/** Tests the Split Catalog framework components. Includes helper methods at the Catalog level. */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerSuite.class)
+public class TestSplitCatalog extends TestCatalog {
+
+  protected static final String[] DEFAULT_REQUIRED_SPLIT_APPS = {
+    "catalog-app", "split-solr-app", "spatial-app", "test-rest-endpoint", "test-storageplugins"
+  };
+
+  @BeforeExam
+  public void beforeExam() throws Exception {
+    try {
+      waitForSystemReady();
+    } catch (Exception e) {
+      LoggingUtils.failWithThrowableStacktrace(e, "Failed in @BeforeExam: ");
+    }
+  }
+
+  @SuppressWarnings({
+    "squid:S2696" /* writing to static basePort to share state between test methods */
+  })
+  @Override
+  public void waitForBaseSystemFeatures() {
+    try {
+      basePort = getBasePort();
+      getServiceManager().stopBundle("catalog-solr-provider");
+      getServiceManager()
+          .startFeature(
+              true, Arrays.copyOf(DEFAULT_REQUIRED_SPLIT_APPS, DEFAULT_REQUIRED_SPLIT_APPS.length));
+      getServiceManager().waitForAllBundles();
+      getCatalogBundle().waitForCatalogProvider();
+
+      getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query?_wadl");
+      getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/csw?_wadl");
+      getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog?_wadl");
+
+      getServiceManager().startFeature(true, "search-ui-app");
+      getServiceManager().waitForAllBundles();
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to start up required features.", e);
+    }
+  }
+}

--- a/features/apps/pom.xml
+++ b/features/apps/pom.xml
@@ -125,6 +125,13 @@
             <classifier>features</classifier>
         </dependency>
         <dependency>
+            <groupId>ddf.catalog.solr</groupId>
+            <artifactId>split-solr-app</artifactId>
+            <version>${project.version}</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.codice.opendj.embedded</groupId>
             <artifactId>opendj-embedded-app</artifactId>
             <version>${opendj-embedded.app.version}</version>

--- a/features/apps/src/main/feature/feature.xml
+++ b/features/apps/src/main/feature/feature.xml
@@ -24,6 +24,7 @@
     <repository>mvn:ddf.features/solr/${project.version}/xml/features</repository>
     <repository>mvn:ddf.features/utilities/${project.version}/xml/features</repository>
     <repository>mvn:ddf.catalog.solr/catalog-solr-app/${project.version}/xml/features</repository>
+    <repository>mvn:ddf.catalog.solr/split-solr-app/${project.version}/xml/features</repository>
 
     <feature name="ddf-core" version="${project.version}"
              description="Features that will be started on container startup.">

--- a/features/install-profiles/src/main/feature/feature.xml
+++ b/features/install-profiles/src/main/feature/feature.xml
@@ -53,4 +53,14 @@
         <!--<feature>opendj-embedded</feature>-->
     </feature>
 
+    <feature name="profile-split" version="${project.version}"
+      description="This will install standard application and the Solr Split App."
+      start-level="4">
+        <feature>ddf-boot-features</feature>
+        <feature>catalog-app</feature>
+        <feature>search-ui-app</feature>
+        <feature>split-solr-app</feature>
+        <feature>spatial-app</feature>
+    </feature>
+
 </features>

--- a/platform/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
+++ b/platform/persistence/platform-persistence-core-impl/src/main/java/org/codice/ddf/persistence/internal/PersistentStoreImpl.java
@@ -295,7 +295,7 @@ public class PersistentStoreImpl implements PersistentStore {
       final SolrClient solrClient =
           solrClients.computeIfAbsent(storeName, clientFactory::newClient);
 
-      if (solrClient.isAvailable(5, TimeUnit.SECONDS)) {
+      if (solrClient.isAvailable(30, TimeUnit.SECONDS)) {
         return solrClient;
       }
     } catch (InterruptedException e) {

--- a/platform/solr/solr-factory-impl/pom.xml
+++ b/platform/solr/solr-factory-impl/pom.xml
@@ -174,12 +174,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.42</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.57</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/HttpSolrClientFactory.java
+++ b/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/HttpSolrClientFactory.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpHead;
@@ -136,7 +137,14 @@ public final class HttpSolrClientFactory implements SolrClientFactory {
       ConfigurationStore.getInstance().setDataDirectoryPath(solrDataDir);
     }
     LOGGER.debug("Solr({}): Creating an HTTP Solr client using url [{}]", core, coreUrl);
+
     return new SolrClientAdapter(core, () -> createSolrHttpClient(solrUrl, core, coreUrl));
+  }
+
+  @Override
+  public org.codice.solr.client.solrj.SolrClient newClient(
+      String collection, Map<String, Object> properties) {
+    return newClient(collection);
   }
 
   @VisibleForTesting

--- a/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/SolrClientFactoryImpl.java
+++ b/platform/solr/solr-factory-impl/src/main/java/org/codice/solr/factory/impl/SolrClientFactoryImpl.java
@@ -18,7 +18,7 @@ import static org.apache.commons.lang.Validate.notNull;
 import com.google.common.annotations.VisibleForTesting;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.function.BiFunction;
+import java.util.Map;
 import org.codice.solr.client.solrj.SolrClient;
 import org.codice.solr.factory.SolrClientFactory;
 
@@ -28,38 +28,34 @@ import org.codice.solr.factory.SolrClientFactory;
  */
 public final class SolrClientFactoryImpl implements SolrClientFactory {
 
-  private final BiFunction<SolrClientFactory, String, SolrClient> newClientFunction;
-  private final HttpSolrClientFactory httpSolrClientFactory;
+  private String clientType;
+  private SolrClientFactory factory;
 
-  @SuppressWarnings("unused" /* used by blueprint */)
   public SolrClientFactoryImpl(HttpSolrClientFactory httpSolrClientFactory) {
-    this.newClientFunction = (factory, core) -> factory.newClient(core);
-    this.httpSolrClientFactory = httpSolrClientFactory;
-  }
-
-  @VisibleForTesting
-  SolrClientFactoryImpl(
-      HttpSolrClientFactory httpSolrClientFactory,
-      BiFunction<SolrClientFactory, String, SolrClient> newClientFunction) {
-    this.newClientFunction = newClientFunction;
-    this.httpSolrClientFactory = httpSolrClientFactory;
-  }
-
-  @Override
-  public SolrClient newClient(String core) {
-    notNull(core, "Solr core name cannot be null");
-
-    String clientType =
+    this.clientType =
         AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> System.getProperty("solr.client", "HttpSolrClient"));
-    SolrClientFactory factory;
 
     if ("CloudSolrClient".equals(clientType)) {
       factory = new SolrCloudClientFactory();
     } else { // Use HttpSolrClient by default
       factory = httpSolrClientFactory;
     }
+  }
 
-    return newClientFunction.apply(factory, core);
+  @Override
+  public SolrClient newClient(String core) {
+    notNull(core, "Solr core name cannot be null");
+    return factory.newClient(core);
+  }
+
+  @Override
+  public SolrClient newClient(String collection, Map<String, Object> properties) {
+    return factory.newClient(collection, properties);
+  }
+
+  @VisibleForTesting
+  SolrClientFactory getFactory() {
+    return factory;
   }
 }

--- a/platform/solr/solr-factory-impl/src/test/groovy/org/codice/solr/factory/impl/SolrClientAdapterAsyncSpec.groovy
+++ b/platform/solr/solr-factory-impl/src/test/groovy/org/codice/solr/factory/impl/SolrClientAdapterAsyncSpec.groovy
@@ -229,7 +229,7 @@ class SolrClientAdapterAsyncSpec extends Specification {
     and: "controllers that mocks every execution/attempts"
       // be careful here as the mocking conditions are changed based on blocking_create and blocking_ping
       // although not necessarly a good practice, I feel like this avoids duplicating this test 3 times
-      // the hope is that this comment is enough to warn developers to not use this approach all the times 
+      // the hope is that this comment is enough to warn developers to not use this approach all the times
       def createController = new FailsafeController('SolrClient Creation') >> {
         waitTo('create').onlyIf(blocking_create)
             .then().doReturn(client)

--- a/platform/solr/solr-factory-impl/src/test/groovy/org/codice/solr/factory/impl/SolrCloudClientFactorySpec.groovy
+++ b/platform/solr/solr-factory-impl/src/test/groovy/org/codice/solr/factory/impl/SolrCloudClientFactorySpec.groovy
@@ -13,6 +13,7 @@
  */
 package org.codice.solr.factory.impl
 
+
 import net.jodah.failsafe.FailsafeException
 import net.jodah.failsafe.RetryPolicy
 import org.apache.solr.client.solrj.SolrClient
@@ -20,7 +21,6 @@ import org.apache.solr.client.solrj.SolrServerException
 import org.apache.solr.client.solrj.impl.CloudSolrClient
 import org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider
 import org.apache.solr.client.solrj.request.CollectionAdminRequest
-import org.apache.solr.client.solrj.response.CollectionAdminResponse
 import org.apache.solr.client.solrj.response.SolrPingResponse
 import org.apache.solr.common.SolrException
 import org.apache.solr.common.cloud.ClusterState
@@ -33,6 +33,7 @@ import org.codice.spock.ClearInterruptions
 import org.codice.spock.Supplemental
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Timeout
 import spock.lang.Unroll
@@ -54,14 +55,34 @@ class SolrCloudClientFactorySpec extends Specification {
 
   static final int MAX_RETRIES = 2
 
-  static final int AVAILABLE_TIMEOUT_IN_SECS = 25
+  static final int AVAILABLE_TIMEOUT_IN_SECS = 45
+
+  @Shared
+  def aliasResponseWithAlias = Mock(NamedList) {
+    get("aliases") >> Collections.singletonMap("test_alias", CORE)
+  }
+
+  @Shared
+  def aliasResponseWithOtherAlias = Mock(NamedList) {
+    get("aliases") >> Collections.singletonMap("test_alias", "collection_1,collection_2")
+  }
+
+  @Shared
+  def aliasResponseWithNullAliases = Mock(NamedList) {
+    get("aliases") >> null
+  }
+
+  @Shared
+  def aliasResponseWithoutAlias = Mock(NamedList)
+
 
   @Rule
-  TemporaryFolder tempFolder = new TemporaryFolder();
+  TemporaryFolder tempFolder = new TemporaryFolder()
 
   def setup() {
     tempFolder.create();
     System.setProperty("ddf.home", tempFolder.root.absolutePath)
+    System.setProperty("solr.cloud.zookeeper", SOLR_CLOUD_ZOOKEEPERS)
   }
 
   def cleanup() {
@@ -86,11 +107,8 @@ class SolrCloudClientFactorySpec extends Specification {
         // verify an actual Solr cloud client will be created
         // must be done in 'given' because it will be called from a different thread and if
         // declared in 'then', it will be out of scope and not matched
-        1 * createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE) >> cloudClient
+        1 * createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null) >> cloudClient
       }
-
-    and:
-      System.setProperty("solr.cloud.zookeeper", SOLR_CLOUD_ZOOKEEPERS)
 
     when:
       def client = factory.newClient(CORE)
@@ -117,10 +135,8 @@ class SolrCloudClientFactorySpec extends Specification {
   @Unroll
   def 'test new client when system property solr.cloud.zookeeper is #solr_cloud_zookeeper_is'() {
     given:
-      def factory = new SolrCloudClientFactory()
-
-    and:
       System.setPropertyIfNotNull("solr.cloud.zookeeper", solr_cloud_zookeeper)
+      def factory = new SolrCloudClientFactory()
 
     when:
       factory.newClient(CORE)
@@ -140,9 +156,6 @@ class SolrCloudClientFactorySpec extends Specification {
     given:
       def factory = new SolrCloudClientFactory();
 
-    and:
-      System.setProperty("solr.cloud.zookeeper", SOLR_CLOUD_ZOOKEEPERS)
-
     when:
       factory.newClient(null)
 
@@ -152,20 +165,21 @@ class SolrCloudClientFactorySpec extends Specification {
       e.message.contains("invalid null Solr core")
   }
 
-  def 'test creating a Solr cloud client when configuration is already uploaded and the collection already exists'() {
+  def 'test creating a Solr cloud client when collection alias already exists'() {
     given:
       def zkClient = Mock(SolrZkClient)
-      def listResponse = Mock(NamedList)
       def aliasResponse = Mock(NamedList)
+      def zkStateProvider = Mock(ZkClientClusterStateProvider)
       def cloudClient = Mock(CloudSolrClient) {
         getZkStateReader() >> Mock(ZkStateReader) {
           getZkClient() >> zkClient
         }
+        newZkStateProvider() >> zkStateProvider
       }
       def factory = Spy(SolrCloudClientFactory)
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, CORE)
 
     then: "verify the Solr cloud client is created"
       1 * factory.newCloudSolrClient(SOLR_CLOUD_ZOOKEEPERS) >> cloudClient
@@ -176,14 +190,67 @@ class SolrCloudClientFactorySpec extends Specification {
     and: "it is being connected"
       1 * cloudClient.connect() >> null
 
+    then: "verify zookeeper is consulted to see if the alias exists"
+      1 * cloudClient.request({
+        it instanceof CollectionAdminRequest.ListAliases
+      }, null) >> aliasResponse
+      aliasResponse.get('aliases') >> Collections.singletonMap(CORE, Collections.singletonList("CORE"))
+
+    then: "verify zookeeper is consulted to see if the configuration exists"
+      0 * zkClient.exists("/configs/$CORE", true)
+
+    and: "therefore, the config is never uploaded to zookeeper"
+      0 * zkStateProvider.uploadConfig(*_)
+
+    and: "the collection is never created"
+      0 * cloudClient.request({ it instanceof CollectionAdminRequest.Create }, null)
+
+    and: "close() is never called on the underlying client"
+      0 * cloudClient.close()
+  }
+
+  def 'test creating a Solr cloud client when configuration is already uploaded and the collection already exists'() {
+    given:
+      def zkClient = Mock(SolrZkClient)
+      def listResponse = Mock(NamedList)
+      def aliasResponse = Mock(NamedList)
+      def zkStateProvider = Mock(ZkClientClusterStateProvider)
+      def cloudClient = Mock(CloudSolrClient) {
+        getZkStateReader() >> Mock(ZkStateReader) {
+          getZkClient() >> zkClient
+        }
+        newZkStateProvider() >> zkStateProvider
+      }
+      def factory = Spy(SolrCloudClientFactory)
+
+    when:
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, CORE)
+
+    then: "verify the Solr cloud client is created"
+      1 * factory.newCloudSolrClient(SOLR_CLOUD_ZOOKEEPERS) >> cloudClient
+
+    and: "the returned client is the one we created"
+      createdClient.is(cloudClient)
+
+    and: "it is being connected"
+      1 * cloudClient.connect() >> null
+
+    then: "verify zookeeper is consulted to see if the alias exists"
+      1 * cloudClient.request({
+        it instanceof CollectionAdminRequest.ListAliases
+      }, null) >> aliasResponse
+
     then: "verify zookeeper is consulted to see if the configuration exists"
       1 * zkClient.exists("/configs/$CORE", true) >> true
 
     and: "therefore, the config is never uploaded to zookeeper"
-      0 * cloudClient.uploadConfig(*_)
+      0 * factory.newZkStateProvider(*_) >> zkStateProvider
+      0 * zkStateProvider.uploadConfig(*_)
 
     then: "verify zookeeper is consulted to see if the collection exists"
-      1 * cloudClient.request({ it instanceof CollectionAdminRequest.ListAliases }, null) >> aliasResponse
+      1 * cloudClient.request({
+        it instanceof CollectionAdminRequest.ListAliases
+      }, null) >> aliasResponse
       1 * cloudClient.request({ it instanceof CollectionAdminRequest.List }, null) >> listResponse
       1 * listResponse.get('collections') >> Collections.singletonList(CORE)
 
@@ -194,47 +261,33 @@ class SolrCloudClientFactorySpec extends Specification {
       0 * cloudClient.close()
   }
 
-  def 'test creating a Solr cloud client when configuration is already uploaded and the collection alias already exists'() {
+  @Unroll
+  def 'test add configuration where #add_configuration'() {
     given:
-    def zkClient = Mock(SolrZkClient)
-    def listResponse = Mock(NamedList)
-    def aliasResponse = Mock(NamedList)
-    def cloudClient = Mock(CloudSolrClient) {
-      getZkStateReader() >> Mock(ZkStateReader) {
-        getZkClient() >> zkClient
+      def zkClient = Mock(SolrZkClient)
+      def zkStateProvider = Mock(ZkClientClusterStateProvider)
+      def cloudClient = Mock(CloudSolrClient) {
+        getZkStateReader() >> Mock(ZkStateReader) {
+          getZkClient() >> zkClient
+        }
+        newZkStateProvider() >> zkStateProvider
       }
-    }
-    def factory = Spy(SolrCloudClientFactory)
+      def factory = Spy(SolrCloudClientFactory)
 
     when:
-    def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
-
-    then: "verify the Solr cloud client is created"
-    1 * factory.newCloudSolrClient(SOLR_CLOUD_ZOOKEEPERS) >> cloudClient
-
-    and: "the returned client is the one we created"
-    createdClient.is(cloudClient)
-
-    and: "it is being connected"
-    1 * cloudClient.connect() >> null
+      factory.uploadCoreConfiguration(CORE, cloudClient)
 
     then: "verify zookeeper is consulted to see if the configuration exists"
-    1 * zkClient.exists("/configs/$CORE", true) >> true
+      1 * zkClient.exists("/configs/$CORE", true) >> zk_config_exists
 
-    and: "therefore, the config is never uploaded to zookeeper"
-    0 * cloudClient.uploadConfig(*_)
+    and: "check configuration uploaded"
+      upload_count * factory.newZkStateProvider(*_) >> zkStateProvider
+      upload_count * zkStateProvider.uploadConfig(*_) >> null
 
-    then: "verify zookeeper is consulted to see if the collection exists"
-    1 * cloudClient.request({ it instanceof CollectionAdminRequest.ListAliases }, null) >> aliasResponse
-    aliasResponse.get('aliases') >> Collections.singletonMap(CORE, Collections.singletonList("CORE"))
-    0 * cloudClient.request({ it instanceof CollectionAdminRequest.List }, null) >> listResponse
-    0 * listResponse.get('collections') >> Collections.singletonList(CORE)
-
-    and: "the collection is never created"
-    0 * cloudClient.request({ it instanceof CollectionAdminRequest.Create }, null)
-
-    and: "close() is never called on the underlying client"
-    0 * cloudClient.close()
+    where:
+      add_configuration        || zk_config_exists | upload_count
+      'config does not exist'  || false            | 1
+      'config exists'          || true             | 0
   }
 
   def 'test creating a Solr cloud client when configuration is already uploaded and the collection does not exists'() {
@@ -248,6 +301,7 @@ class SolrCloudClientFactorySpec extends Specification {
       def listResponse = Mock(NamedList)
       def createResponse = Mock(NamedList)
       def aliasResponse = Mock(NamedList)
+      def zkStateProvider = Mock(ZkClientClusterStateProvider)
       def clusterState = Mock(ClusterState) {
         hasCollection(CORE) >> true
         getCollection(CORE) >> Mock(DocCollection)
@@ -257,11 +311,12 @@ class SolrCloudClientFactorySpec extends Specification {
           getZkClient() >> zkClient
           getClusterState() >> clusterState
         }
+        newZkStateProvider() >> zkStateProvider
       }
       def factory = Spy(SolrCloudClientFactory)
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null)
 
     then: "verify the Solr cloud client is created"
       1 * factory.newCloudSolrClient(SOLR_CLOUD_ZOOKEEPERS) >> cloudClient
@@ -272,14 +327,21 @@ class SolrCloudClientFactorySpec extends Specification {
     and: "it is being connected"
       1 * cloudClient.connect() >> null
 
+    then: "verify zookeeper is consulted to see if the alias exists"
+      1 * cloudClient.request({
+        it instanceof CollectionAdminRequest.ListAliases
+      }, null) >> aliasResponse
+
     then: "verify zookeeper is consulted to see if the configuration exists"
       1 * zkClient.exists("/configs/$CORE", true) >> true
 
     and: "therefore, the config is never uploaded to zookeeper"
-      0 * cloudClient.uploadConfig(*_)
+      0 * zkStateProvider.uploadConfig(*_)
 
     then: "verify zookeeper is consulted to see if the collection exists"
-      1 * cloudClient.request({ it instanceof CollectionAdminRequest.ListAliases }, null) >> aliasResponse
+      1 * cloudClient.request({
+        it instanceof CollectionAdminRequest.ListAliases
+      }, null) >> aliasResponse
       1 * cloudClient.request({ it instanceof CollectionAdminRequest.List }, null) >> listResponse
       1 * listResponse.get('collections') >> Collections.emptyList()
 
@@ -299,6 +361,10 @@ class SolrCloudClientFactorySpec extends Specification {
     and: "verify zookeeper is consulted to see if the shards were started"
       1 * clusterState.getCollection(CORE).getSlices() >> ['shard'] * SOLR_SHARD_COUNT
 
+    and:
+      1 * cloudClient.request({ it instanceof CollectionAdminRequest.List }, null) >> listResponse
+      1 * listResponse.get('collections') >> Collections.singletonList(CORE)
+
     and: "close() is never called on the underlying client"
       0 * cloudClient.close()
   }
@@ -311,6 +377,7 @@ class SolrCloudClientFactorySpec extends Specification {
   def 'test creating a Solr cloud client when failing to check if the configuration was already uploaded with #exception.class.noSpockSimpleName'() {
     given:
       def zkClient = Mock(SolrZkClient)
+      def aliasResponse = Mock(NamedList)
       def cloudClient = Mock(CloudSolrClient) {
         connect() >> null
         getZkStateReader() >> Mock(ZkStateReader) {
@@ -322,7 +389,12 @@ class SolrCloudClientFactorySpec extends Specification {
       }
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null)
+
+    then: "verify zookeeper is consulted to see if the alias exists"
+      1 * cloudClient.request({
+        it instanceof CollectionAdminRequest.ListAliases
+      }, null) >> aliasResponse
 
     then: "fail when zookeeper is consulted to see if the configuration exists"
       1 * zkClient.exists("/configs/$CORE", true) >> { throw exception }
@@ -360,7 +432,7 @@ class SolrCloudClientFactorySpec extends Specification {
       }
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null)
 
     then: "verify the Solr cloud client is created"
       1 * factory.newCloudSolrClient(SOLR_CLOUD_ZOOKEEPERS) >> cloudClient
@@ -398,10 +470,12 @@ class SolrCloudClientFactorySpec extends Specification {
       }
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null)
 
     then: "fail when trying to list existing collections"
-      1 * cloudClient.request({ it instanceof CollectionAdminRequest.ListAliases }, null) >> aliasResponse
+      2 * cloudClient.request({
+        it instanceof CollectionAdminRequest.ListAliases
+      }, null) >> aliasResponse
       1 * cloudClient.request({ it instanceof CollectionAdminRequest.List }, null) >> {
         throw exception
       }
@@ -432,10 +506,12 @@ class SolrCloudClientFactorySpec extends Specification {
       }
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null)
 
     then: "fail when trying to list existing collections"
-      1 * cloudClient.request({ it instanceof CollectionAdminRequest.ListAliases }, null) >> Mock(NamedList)
+      2 * cloudClient.request({
+        it instanceof CollectionAdminRequest.ListAliases
+      }, null) >> Mock(NamedList)
       1 * cloudClient.request({ it instanceof CollectionAdminRequest.List }, null) >> list_response
 
     then: "verify the underlying client is closed"
@@ -470,7 +546,7 @@ class SolrCloudClientFactorySpec extends Specification {
       }
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null)
 
     then: "fail when trying to create the collection"
       1 * cloudClient.request({ it instanceof CollectionAdminRequest.Create }, null) >> {
@@ -507,7 +583,7 @@ class SolrCloudClientFactorySpec extends Specification {
       }
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null)
 
     then: "fail when trying to create the collection"
       1 * cloudClient.request({
@@ -549,7 +625,7 @@ class SolrCloudClientFactorySpec extends Specification {
       }
 
     when:
-      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE)
+      def createdClient = factory.createSolrCloudClient(SOLR_CLOUD_ZOOKEEPERS, CORE, null)
 
     then: "fail or not when checking if the collection was created"
       expected_retries_for_has_collection * factory.withRetry() >> {
@@ -581,5 +657,69 @@ class SolrCloudClientFactorySpec extends Specification {
       'a retry failure occurred while creating it'           || 1                                   | false                | 0                                     | false          | 0                               | null             | 0                                 | SOLR_SHARD_COUNT
       'the shards are not started'                           || 1                                   | true                 | 1                                     | true           | 1                               | true             | MAX_RETRIES + 1                   | 0
       'a retry failure occurred while retrieving the shards' || 1                                   | true                 | 1                                     | true           | 1                               | false            | 0                                 | 0
+  }
+
+
+  @Unroll
+  def 'test adding collection to alias because #alias_creation_because'() {
+    given:
+      def zkClient = Mock(SolrZkClient)  {
+        exists(*_) >> true
+      }
+      def aliasCreateResponse = Mock(NamedList)
+      def zkStateProvider = Mock(ZkClientClusterStateProvider)
+      def cloudClient = Mock(CloudSolrClient) {
+        getZkStateReader() >> Mock(ZkStateReader) {
+          getZkClient() >> zkClient
+        }
+      }
+      def factory = Spy(SolrCloudClientFactory)
+
+    when: "add collection to alias"
+      factory.addCollectionToAlias("test_alias", CORE, cloudClient)
+
+    then: "list aliases called"
+      list_invocations * cloudClient.request({ it instanceof CollectionAdminRequest.ListAliases }, null) >>> alias_response
+
+    and: "create alias called"
+      create_invocations * cloudClient.request({ it instanceof CollectionAdminRequest.CreateAlias }, null) >> aliasCreateResponse
+
+    where:
+      alias_creation_because      || list_invocations | create_invocations | alias_response
+      'no existing alias'         || 3                | 1                  | [aliasResponseWithoutAlias, aliasResponseWithoutAlias, aliasResponseWithAlias]
+      'existing other aliases'    || 2                | 1                  | [aliasResponseWithOtherAlias, aliasResponseWithOtherAlias, aliasResponseWithAlias]
+      'alias already exists'      || 1                | 0                  | [aliasResponseWithAlias]
+  }
+
+  @Unroll
+  def 'test collections exists because #collection_exists_because'() {
+    given:
+      def zkStateProvider = Mock(ZkClientClusterStateProvider)
+      def cloudClient = Mock(CloudSolrClient) {
+        connect() >> null
+        getZkStateReader() >> Mock(ZkStateReader) {
+          getZkClient() >> Mock(SolrZkClient) {
+            exists(*_) >> true
+          }
+        }
+        request({ it instanceof CollectionAdminRequest.List }, null) >> Mock(NamedList) {
+          1 * get("collections") >> collections
+        }
+      }
+      def factory = Spy(SolrCloudClientFactory)
+
+    when: "add collection to alias"
+      def exist = factory.collectionExists(collection_name, cloudClient)
+
+    then:
+      exist == collection_exists
+
+    where:
+      collection_exists_because  || collections                                  | collection_name   | collection_exists
+      'no collections'           || Collections.emptyList()                      | "test_collection" | false
+      'does not exist'           || Collections.singletonList("coll2")           | "test_collection" | false
+      'does not exist multi'     || Arrays.asList("coll1","coll2")               | "test_collection" | false
+      'exist single'             || Collections.singletonList("test_collection") | "test_collection" | true
+      'exist multi'              || Arrays.asList("coll1","test_collection")     | "test_collection" | true
   }
 }

--- a/platform/solr/solr-factory-impl/src/test/java/org/codice/solr/factory/impl/SolrClientFactoryImplTest.java
+++ b/platform/solr/solr-factory-impl/src/test/java/org/codice/solr/factory/impl/SolrClientFactoryImplTest.java
@@ -16,10 +16,11 @@ package org.codice.solr.factory.impl;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
 
-import java.util.function.BiFunction;
 import org.codice.solr.client.solrj.SolrClient;
-import org.codice.solr.factory.SolrClientFactory;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -32,52 +33,42 @@ public class SolrClientFactoryImplTest {
 
   @Mock private HttpSolrClientFactory mockHttpSolrClientFactory;
 
-  // Used to keep and assert on the SolrClientFactory instance newClient would be called on
-  private SolrClientFactory solrClientFactory;
-
-  private final BiFunction<SolrClientFactory, String, SolrClient> newClientFunction =
-      (factory, core) -> {
-        this.solrClientFactory = factory;
-        return mockClient;
-      };
+  @Before
+  public void setup() {
+    when(mockHttpSolrClientFactory.newClient(anyString())).thenReturn(mockClient);
+  }
 
   @Test(expected = IllegalArgumentException.class)
   public void newClientWithNullCoreName() {
-    SolrClientFactoryImpl factory =
-        new SolrClientFactoryImpl(mockHttpSolrClientFactory, newClientFunction);
+    SolrClientFactoryImpl factory = new SolrClientFactoryImpl(mockHttpSolrClientFactory);
     factory.newClient(null);
   }
 
   @Test
   public void newHttpSolrClient() {
     System.setProperty("solr.client", "HttpSolrClient");
-    SolrClientFactoryImpl factory =
-        new SolrClientFactoryImpl(mockHttpSolrClientFactory, newClientFunction);
+    SolrClientFactoryImpl factory = new SolrClientFactoryImpl(mockHttpSolrClientFactory);
 
     SolrClient client = factory.newClient("core");
-    assertThat(solrClientFactory, is(mockHttpSolrClientFactory));
+    assertThat(factory.getFactory(), is(mockHttpSolrClientFactory));
     assertThat(client, is(mockClient));
   }
 
   @Test
   public void newCloudSolrClient() {
     System.setProperty("solr.client", "CloudSolrClient");
-    SolrClientFactoryImpl factory =
-        new SolrClientFactoryImpl(mockHttpSolrClientFactory, newClientFunction);
+    SolrClientFactoryImpl factory = new SolrClientFactoryImpl(mockHttpSolrClientFactory);
 
-    SolrClient client = factory.newClient("core");
-    assertThat(solrClientFactory, is(instanceOf(SolrCloudClientFactory.class)));
-    assertThat(client, is(mockClient));
+    assertThat(factory.getFactory(), is(instanceOf(SolrCloudClientFactory.class)));
   }
 
   @Test
   public void newClientWithUnknownClientType() {
     System.setProperty("solr.client", "Unknown");
-    SolrClientFactoryImpl factory =
-        new SolrClientFactoryImpl(mockHttpSolrClientFactory, newClientFunction);
+    SolrClientFactoryImpl factory = new SolrClientFactoryImpl(mockHttpSolrClientFactory);
 
     SolrClient client = factory.newClient("core");
-    assertThat(solrClientFactory, is(mockHttpSolrClientFactory));
+    assertThat(factory.getFactory(), is(mockHttpSolrClientFactory));
     assertThat(client, is(mockClient));
   }
 }

--- a/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/SolrClientFactory.java
+++ b/platform/solr/solr-factory/src/main/java/org/codice/solr/factory/SolrClientFactory.java
@@ -13,6 +13,7 @@
  */
 package org.codice.solr.factory;
 
+import java.util.Map;
 import org.codice.solr.client.solrj.SolrClient;
 
 /** Interface implemented by factory classes used to create new {@link SolrClient} instances. */
@@ -30,5 +31,7 @@ public interface SolrClientFactory {
    * @return the newly created {@code SolrClient}
    * @throws IllegalArgumentException if <code>core</code> is <code>null</code>
    */
-  public SolrClient newClient(String core);
+  SolrClient newClient(String core);
+
+  SolrClient newClient(String collection, Map<String, Object> properties);
 }

--- a/platform/solr/solr-schema/src/main/resources/solr/conf/solrconfig.xml
+++ b/platform/solr/solr-schema/src/main/resources/solr/conf/solrconfig.xml
@@ -1305,4 +1305,11 @@
 
   <queryParser name="xpath" class="org.codice.solr.xpath.XpathQParserPlugin"/>
 
+  <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
+    <lst name="invariants">
+      <str name="qt">/query</str>
+      <str name="q">id_txt:*</str>
+    </lst>
+  </requestHandler>
+
 </config>


### PR DESCRIPTION
#### What does this PR do?
address improvement in
https://github.com/codice/ddf/issues/5802

The SplitCatalogProvider implements the CatalogProvider interface. It manages the configuration and connection to multiple solr collections.  SolrCollectionProvider implementations are chained together to process each modify request. During ingest/update the metacard tag is parsed by the SolrCollectionProvider to determine which solr collection to create/update. During query, the solr alias is used to query across all collections. Special logic is added to handle realtime get query which doesn't with alias

1. Rename SolrCatalogProvider to SolrCatalogProviderImpl
2. Adding timeout for isAvailable check
3. SolrCloudClientFactory handling of multiple collection configs
4. Add SplitCatalogProvider to implement CatalogProvider interface
5. Implement a DefaultSolrCollectionProvider as the default SolrCollectionProvider implementation
6. Add split profile 
7. Add TestSplitCatalog itest which extends TestCatalog

Who is reviewing it?

Select relevant component teams:
@codice/core-apis
@codice/solr

Ask 2 committers to review/merge the PR and tag them here.
@pklinef
@bdeining
@millerw8
@paouelle 
@leo-sakh 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

- Start up solrCloud docker
-  profile:Install split
- Verify catalog_default collection is created
- Ingest some record and query
- Verify some record is in catalog_default collection
- http://localhost:8994/solr/catalog_default/select?q=*%3A*
- http://localhost:8994/solr/catalog/select?q=*%3A*
- Verify alias is associated with catalog_default collection
- http://localhost:8994/solr/admin/collections?action=LISTALIASES&wt=xml

#### Any background context you want to provide?
This is part 1/3 of this effort
https://connexta.atlassian.net/wiki/spaces/ARCH/pages/758939649/Ingest+Query+Performance+Enhancements

1. Next issue https://github.com/codice/ddf/issues/5859  will add a SuggesterCollectionProvider, this will provides a new CollectionProvider to handle all gazetteer data on a separate solr collection
2. Implement NtrCollectionProvider to handler all user related data https://github.com/codice/ddf/issues/5860

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ x ] Update / Add Unit Tests
- [ x ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
