### PR TITLE
[2.19.x] DDF-5793 anyGeo search validation refactor and UX improvements

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/actions.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/actions.js
@@ -40,7 +40,7 @@ exports.announce = function(announcement, timeout) {
       .filter(
         a =>
           a.title === announcement.title &&
-          a.message === announcement.message &&
+          JSON.stringify(a.message) === JSON.stringify(announcement.message) &&
           a.type === announcement.type
       )
       .map(a => a.id)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -111,7 +111,7 @@ module.exports = Backbone.AssociatedModel.extend({
   turnOnDrawing(model) {
     this.set('drawing', true)
     this.set('drawingModel', model)
-    model.set('drawing', true)
+    this.get('drawingModel').set('drawing', true)
     $('html').toggleClass('is-drawing', true)
   },
   turnOffDrawing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -117,9 +117,8 @@ module.exports = Backbone.AssociatedModel.extend({
     }
     $('html').toggleClass('is-drawing', true)
   },
-  turnOffDrawing(model) {
+  turnOffDrawing() {
     this.set('drawing', false)
-    model.set('drawing', false)
     $('html').toggleClass('is-drawing', false)
   },
   isEditing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -112,6 +112,9 @@ module.exports = Backbone.AssociatedModel.extend({
     this.set('drawing', true)
     model.set('drawing', true)
     this.set('drawingModel', model)
+    if (model.get('mode') === 'line' && !model.get('lineWidth')) {
+      model.set('lineWidth', 1)
+    }
     $('html').toggleClass('is-drawing', true)
   },
   turnOffDrawing(model) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -110,11 +110,7 @@ module.exports = Backbone.AssociatedModel.extend({
   },
   turnOnDrawing(model) {
     this.set('drawing', true)
-    model.set('drawing', true)
     this.set('drawingModel', model)
-    if (model.get('mode') === 'line' && !model.get('lineWidth')) {
-      model.set('lineWidth', 1)
-    }
     $('html').toggleClass('is-drawing', true)
   },
   turnOffDrawing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -114,9 +114,11 @@ module.exports = Backbone.AssociatedModel.extend({
     model.set('drawing', true)
     $('html').toggleClass('is-drawing', true)
   },
-  turnOffDrawing(model) {
+  turnOffDrawing() {
     this.set('drawing', false)
-    model.set('drawing', false)
+    if (this.get('drawingModel')) {
+      this.get('drawingModel').set('drawing', false)
+    }
     $('html').toggleClass('is-drawing', false)
   },
   isEditing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -110,11 +110,13 @@ module.exports = Backbone.AssociatedModel.extend({
   },
   turnOnDrawing(model) {
     this.set('drawing', true)
+    model.set('drawing', true)
     this.set('drawingModel', model)
     $('html').toggleClass('is-drawing', true)
   },
-  turnOffDrawing() {
+  turnOffDrawing(model) {
     this.set('drawing', false)
+    model.set('drawing', false)
     $('html').toggleClass('is-drawing', false)
   },
   isEditing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/content/content.js
@@ -111,10 +111,12 @@ module.exports = Backbone.AssociatedModel.extend({
   turnOnDrawing(model) {
     this.set('drawing', true)
     this.set('drawingModel', model)
+    model.set('drawing', true)
     $('html').toggleClass('is-drawing', true)
   },
-  turnOffDrawing() {
+  turnOffDrawing(model) {
     this.set('drawing', false)
+    model.set('drawing', false)
     $('html').toggleClass('is-drawing', false)
   },
   isEditing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
@@ -113,7 +113,10 @@ const UsngCoordinate = props => {
   )
 }
 
-const pad = (coordinate = '') => {
+const pad = (coordinate) => {
+  if (coordinate === undefined) {
+    return coordinate
+  }
   const matches = dmsRegex.exec(coordinate)
   if (!matches) {
     return coordinate

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
@@ -56,8 +56,8 @@ const DmsLatitude = props => {
       mask={latitudeDMSMask}
       placeholderChar="_"
       {...props}
-      onBlur={() => {
-        props.onChange(pad(props.value))
+      onBlur={event => {
+        props.onChange(pad(props.value), event.type)
       }}
     />
   )
@@ -70,8 +70,8 @@ const DmsLongitude = props => {
       mask={longitudeDMSMask}
       placeholderChar="_"
       {...props}
-      onBlur={() => {
-        props.onChange(pad(props.value))
+      onBlur={event => {
+        props.onChange(pad(props.value), event.type)
       }}
     />
   )
@@ -115,6 +115,9 @@ const UsngCoordinate = props => {
 
 const pad = (coordinate = '') => {
   const matches = dmsRegex.exec(coordinate)
+  if (!matches) {
+    return coordinate
+  }
   let deg = matches[1]
   let min = matches[2]
   let sec = matches[3]

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/geo-components/coordinates.js
@@ -113,7 +113,7 @@ const UsngCoordinate = props => {
   )
 }
 
-const pad = (coordinate) => {
+const pad = coordinate => {
   if (coordinate === undefined) {
     return coordinate
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/inputs/masked-text-field.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/inputs/masked-text-field.js
@@ -21,7 +21,7 @@ const Component = CustomElements.registerReact('text-field')
 class MaskedTextField extends React.Component {
   render() {
     // eslint-disable-next-line no-unused-vars
-    const { label, addon, onChange, value = '', ...args } = this.props
+    const { label, addon, onChange, value, ...args } = this.props
     return (
       <Component>
         <Group>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/models/usng-model.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/models/usng-model.js
@@ -17,7 +17,7 @@ const usngModel = {
   point: '',
   circle: {
     point: '',
-    radius: 1,
+    radius: '',
     units: 'meters',
   },
   line: {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
@@ -396,6 +396,9 @@ function ddToDmsCoordinateLon(
 }
 
 function getSecondsPrecision(dmsCoordinate) {
+  if (dmsCoordinate === undefined) {
+    return
+  }
   const decimalIndex = dmsCoordinate.indexOf('.')
   // Must subtract 2 instead of 1 because the DMS coordinate ends with "
   const lastNumberIndex = dmsCoordinate.length - 2

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/utils/dms-utils.js
@@ -404,106 +404,6 @@ function getSecondsPrecision(dmsCoordinate) {
   }
 }
 
-const lat = {
-  degreesBegin: 0,
-  degreesEnd: 2,
-  minutesBegin: 3,
-  minutesEnd: 5,
-  secondsBegin: 6,
-  secondsEnd: -1,
-}
-const lon = {
-  degreesBegin: 0,
-  degreesEnd: 3,
-  minutesBegin: 4,
-  minutesEnd: 6,
-  secondsBegin: 7,
-  secondsEnd: -1,
-}
-
-const validateDmsLatInput = input => {
-  const degrees = input.slice(lat.degreesBegin, lat.degreesEnd)
-  const minutes = input.slice(lat.minutesBegin, lat.minutesEnd)
-  const seconds = input.slice(lat.secondsBegin, lat.secondsEnd)
-  const maxDmsLat = '90°00\'00"'
-  if (degrees > 90) {
-    return maxDmsLat
-  } else if (minutes >= 60) {
-    if (degrees < 90) {
-      return (Number.parseInt(degrees) + 1).toString() + '°00\'00"'
-    } else {
-      return maxDmsLat
-    }
-  } else if (seconds >= 60) {
-    if (minutes < 59) {
-      return degrees + '°' + (Number.parseInt(minutes) + 1).toString() + '\'00"'
-    } else {
-      if (degrees >= '90') {
-        return maxDmsLat
-      } else {
-        return (Number.parseInt(degrees) + 1).toString() + '°00\'00"'
-      }
-    }
-  } else if (
-    input.slice(lat.degreesBegin, lat.degreesEnd) === '9_' &&
-    input.slice(lat.degreesEnd) === '°00\'00"'
-  ) {
-    return '9_°__\'__"'
-  } else if (
-    input.slice(lat.minutesBegin, lat.minutesEnd) === '6_' &&
-    input.slice(lat.minutesEnd) === '\'00"'
-  ) {
-    return input.slice(lat.degreesBegin, lat.degreesEnd) + '°6_\'__"'
-  } else {
-    return input
-  }
-}
-
-const validateDmsLonInput = input => {
-  const degrees = input.slice(lon.degreesBegin, lon.degreesEnd)
-  const minutes = input.slice(lon.minutesBegin, lon.minutesEnd)
-  const seconds = input.slice(lon.secondsBegin, lon.secondsEnd)
-  const maxDmsLon = '180°00\'00"'
-  if (degrees > 180) {
-    return maxDmsLon
-  } else if (minutes >= 60) {
-    if (degrees < 180) {
-      return (Number.parseInt(degrees) + 1).toString() + '°00\'00"'
-    } else {
-      return maxDmsLon
-    }
-  } else if (seconds > 60) {
-    if (minutes < 59) {
-      return degrees + '°' + (Number.parseInt(minutes) + 1).toString() + '\'00"'
-    } else {
-      if (degrees >= '180') {
-        return maxDmsLon
-      } else {
-        return (Number.parseInt(degrees) + 1).toString() + '°00\'00"'
-      }
-    }
-  } else if (
-    input.slice(lon.degreesBegin, lon.degreesEnd) === '18_' &&
-    input.slice(lon.degreesEnd) === '°00\'00"'
-  ) {
-    return '18_°__\'__"'
-  } else if (
-    input.slice(lon.minutesBegin, lon.minutesEnd) === '6_' &&
-    input.slice(lon.minutesEnd) === '\'00"'
-  ) {
-    return input.slice(lon.degreesBegin, lon.degreesEnd) + '°6_\'__"'
-  } else {
-    return input
-  }
-}
-const validateInput = (input, placeHolder) => {
-  if (input !== undefined && placeHolder === 'dd°mm\'ss.s"') {
-    return validateDmsLatInput(input)
-  } else if (input !== undefined && placeHolder === 'ddd°mm\'ss.s"') {
-    return validateDmsLonInput(input)
-  }
-}
-
 module.exports = {
   dmsToWkt,
   validateDms,
@@ -514,5 +414,4 @@ module.exports = {
   ddToDmsCoordinateLon,
   getSecondsPrecision,
   Direction,
-  validateInput,
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -227,8 +227,7 @@ module.exports = Backbone.AssociatedModel.extend({
       this.set('prevLocationType', '')
       this.set('locationType', 'utmUps')
     }
-    this.set('drawing', false)
-    store.get('content').turnOffDrawing()
+    store.get('content').turnOffDrawing(this)
   },
 
   drawingOn() {
@@ -236,10 +235,6 @@ module.exports = Backbone.AssociatedModel.extend({
     if (locationType === 'utmUps') {
       this.set('prevLocationType', 'utmUps')
       this.set('locationType', 'dd')
-    }
-    this.set('drawing', true)
-    if (this.get('mode') === 'line' && !this.get('lineWidth')) {
-      this.set('lineWidth', 1)
     }
     store.get('content').turnOnDrawing(this)
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -228,7 +228,8 @@ module.exports = Backbone.AssociatedModel.extend({
       this.set('locationType', 'utmUps')
     }
     this.drawing = false
-    store.get('content').turnOffDrawing(this)
+    this.set('drawing', false)
+    store.get('content').turnOffDrawing()
   },
 
   drawingOn() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -65,19 +65,6 @@ function convertToValid(key, model) {
     key.mapEast = Math.max(-180, key.mapEast)
     key.mapEast = Math.min(180, key.mapEast)
   }
-  // Leave the value alone if it is an empty string, otherwise it will be converted to 0
-  if (key.lat) {
-    key.lat = Math.max(-90, key.lat)
-    key.lat = Math.min(90, key.lat)
-  }
-  if (key.lon) {
-    key.lon = Math.max(-180, key.lon)
-    key.lon = Math.min(180, key.lon)
-  }
-  if (key.radius !== undefined) {
-    let tempRadius = Number(key.radius)
-    key.radius = isNaN(tempRadius) ? model.get('radius') : key.radius
-  }
 }
 
 module.exports = Backbone.AssociatedModel.extend({
@@ -227,7 +214,7 @@ module.exports = Backbone.AssociatedModel.extend({
       this.set('prevLocationType', '')
       this.set('locationType', 'utmUps')
     }
-    store.get('content').turnOffDrawing(this)
+    store.get('content').turnOffDrawing()
   },
 
   drawingOn() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -228,7 +228,7 @@ module.exports = Backbone.AssociatedModel.extend({
       this.set('locationType', 'utmUps')
     }
     this.drawing = false
-    store.get('content').turnOffDrawing()
+    store.get('content').turnOffDrawing(this)
   },
 
   drawingOn() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -87,10 +87,10 @@ module.exports = Backbone.AssociatedModel.extend({
     east: undefined,
     south: undefined,
     west: undefined,
-    dmsNorth: '',
-    dmsSouth: '',
-    dmsEast: '',
-    dmsWest: '',
+    dmsNorth: undefined,
+    dmsSouth: undefined,
+    dmsEast: undefined,
+    dmsWest: undefined,
     dmsNorthDirection: Direction.North,
     dmsSouthDirection: Direction.North,
     dmsEastDirection: Direction.East,
@@ -105,8 +105,8 @@ module.exports = Backbone.AssociatedModel.extend({
     prevLocationType: 'dd',
     lat: undefined,
     lon: undefined,
-    dmsLat: '',
-    dmsLon: '',
+    dmsLat: undefined,
+    dmsLon: undefined,
     dmsLatDirection: Direction.North,
     dmsLonDirection: Direction.East,
     bbox: undefined,
@@ -815,13 +815,13 @@ module.exports = Backbone.AssociatedModel.extend({
     )
     this.set(
       {
-        dmsNorth: (dmsNorth && dmsNorth.coordinate) || '',
+        dmsNorth: (dmsNorth && dmsNorth.coordinate),
         dmsNorthDirection: (dmsNorth && dmsNorth.direction) || Direction.North,
-        dmsSouth: (dmsSouth && dmsSouth.coordinate) || '',
+        dmsSouth: (dmsSouth && dmsSouth.coordinate),
         dmsSouthDirection: (dmsSouth && dmsSouth.direction) || Direction.North,
-        dmsWest: (dmsWest && dmsWest.coordinate) || '',
+        dmsWest: (dmsWest && dmsWest.coordinate),
         dmsWestDirection: (dmsWest && dmsWest.direction) || Direction.East,
-        dmsEast: (dmsEast && dmsEast.coordinate) || '',
+        dmsEast: (dmsEast && dmsEast.coordinate),
         dmsEastDirection: (dmsEast && dmsEast.direction) || Direction.East,
       },
       { silent: true }
@@ -839,9 +839,9 @@ module.exports = Backbone.AssociatedModel.extend({
     )
     this.set(
       {
-        dmsLat: (dmsLat && dmsLat.coordinate) || '',
+        dmsLat: (dmsLat && dmsLat.coordinate),
         dmsLatDirection: (dmsLat && dmsLat.direction) || Direction.North,
-        dmsLon: (dmsLon && dmsLon.coordinate) || '',
+        dmsLon: (dmsLon && dmsLon.coordinate),
         dmsLonDirection: (dmsLon && dmsLon.direction) || Direction.East,
       },
       { silent: true }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -227,7 +227,6 @@ module.exports = Backbone.AssociatedModel.extend({
       this.set('prevLocationType', '')
       this.set('locationType', 'utmUps')
     }
-    this.drawing = false
     this.set('drawing', false)
     store.get('content').turnOffDrawing()
   },
@@ -238,7 +237,6 @@ module.exports = Backbone.AssociatedModel.extend({
       this.set('prevLocationType', 'utmUps')
       this.set('locationType', 'dd')
     }
-    this.drawing = true
     store.get('content').turnOnDrawing(this)
   },
 
@@ -417,7 +415,7 @@ module.exports = Backbone.AssociatedModel.extend({
       this.setUtmUpsLowerRight(utmUpsParts, !this.isLocationTypeUtmUps())
     }
 
-    if (this.isLocationTypeUtmUps() && this.drawing) {
+    if (this.isLocationTypeUtmUps() && this.get('drawing')) {
       this.repositionLatLon()
     }
 
@@ -437,7 +435,7 @@ module.exports = Backbone.AssociatedModel.extend({
       silent: this.get('locationType') !== 'usng',
     })
 
-    if (this.get('locationType') === 'usng' && this.drawing) {
+    if (this.get('locationType') === 'usng' && this.get('drawing')) {
       this.repositionLatLon()
     }
   },
@@ -598,7 +596,7 @@ module.exports = Backbone.AssociatedModel.extend({
         silent:
           (this.get('locationType') === 'usng' ||
             this.isLocationTypeUtmUps()) &&
-          !this.drawing,
+          !this.get('drawing'),
       })
     }
     if (this.get('locationType') !== 'usng' && !this.isLocationTypeUtmUps()) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -24,7 +24,6 @@ const DistanceUtils = require('../../js/DistanceUtils.js')
 
 const converter = new usngs.Converter()
 const minimumDifference = 0.0001
-const minimumBuffer = 0.000001
 const utmUpsLocationType = 'utmUps'
 // offset used by utmUps for southern hemisphere
 const utmUpsBoundaryNorth = 84
@@ -76,14 +75,8 @@ function convertToValid(key, model) {
     key.lon = Math.min(180, key.lon)
   }
   if (key.radius !== undefined) {
-    let tempRadius = Math.max(minimumBuffer, key.radius)
-    key.radius = isNaN(tempRadius) ? model.get('radius') : tempRadius
-  }
-  if (key.lineWidth !== undefined) {
-    key.lineWidth = Math.max(minimumBuffer, key.lineWidth)
-  }
-  if (key.polygonBufferWidth) {
-    key.polygonBufferWidth = Math.max(minimumBuffer, key.polygonBufferWidth)
+    let tempRadius = Number(key.radius)
+    key.radius = isNaN(tempRadius) ? model.get('radius') : key.radius
   }
 }
 
@@ -107,9 +100,9 @@ module.exports = Backbone.AssociatedModel.extend({
     mapWest: undefined,
     mapSouth: undefined,
     radiusUnits: 'meters',
-    radius: 1,
-    locationType: 'latlon',
-    prevLocationType: 'latlon',
+    radius: '',
+    locationType: 'dd',
+    prevLocationType: 'dd',
     lat: undefined,
     lon: undefined,
     dmsLat: '',
@@ -122,7 +115,7 @@ module.exports = Backbone.AssociatedModel.extend({
     color: undefined,
     line: undefined,
     multiline: undefined,
-    lineWidth: 1,
+    lineWidth: '',
     lineUnits: 'meters',
     polygon: undefined,
     polygonBufferWidth: 0,
@@ -242,7 +235,7 @@ module.exports = Backbone.AssociatedModel.extend({
     const locationType = this.get('locationType')
     if (locationType === 'utmUps') {
       this.set('prevLocationType', 'utmUps')
-      this.set('locationType', 'latlon')
+      this.set('locationType', 'dd')
     }
     this.drawing = true
     store.get('content').turnOnDrawing(this)
@@ -328,7 +321,7 @@ module.exports = Backbone.AssociatedModel.extend({
   },
 
   setLatLon() {
-    if (this.get('locationType') === 'latlon') {
+    if (this.get('locationType') === 'dd') {
       let result = {}
       result.north = this.get('mapNorth')
       result.south = this.get('mapSouth')
@@ -454,7 +447,7 @@ module.exports = Backbone.AssociatedModel.extend({
 
     if (
       (!store.get('content').get('drawing') &&
-        this.get('locationType') !== 'latlon') ||
+        this.get('locationType') !== 'dd') ||
       !this.isLatLonValid(lat, lon)
     ) {
       return
@@ -682,7 +675,7 @@ module.exports = Backbone.AssociatedModel.extend({
         lat: undefined,
         lon: undefined,
         usng: undefined,
-        radius: 1,
+        radius: '',
       })
       return
     }
@@ -878,7 +871,7 @@ module.exports = Backbone.AssociatedModel.extend({
   },
 
   handleLocationType() {
-    if (this.get('locationType') === 'latlon') {
+    if (this.get('locationType') === 'dd') {
       this.set({
         north: this.get('mapNorth'),
         south: this.get('mapSouth'),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -634,8 +634,8 @@ module.exports = Backbone.AssociatedModel.extend({
     } else {
       this.clearUtmUpsPointRadius(true)
       this.set({
-        lat: 0,
-        lon: 0,
+        lat: undefined,
+        lon: undefined,
       })
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -105,7 +105,7 @@ module.exports = Backbone.AssociatedModel.extend({
     lineWidth: '',
     lineUnits: 'meters',
     polygon: undefined,
-    polygonBufferWidth: 0,
+    polygonBufferWidth: '',
     polyType: undefined,
     polygonBufferUnits: 'meters',
     hasKeyword: false,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -815,13 +815,13 @@ module.exports = Backbone.AssociatedModel.extend({
     )
     this.set(
       {
-        dmsNorth: (dmsNorth && dmsNorth.coordinate),
+        dmsNorth: dmsNorth && dmsNorth.coordinate,
         dmsNorthDirection: (dmsNorth && dmsNorth.direction) || Direction.North,
-        dmsSouth: (dmsSouth && dmsSouth.coordinate),
+        dmsSouth: dmsSouth && dmsSouth.coordinate,
         dmsSouthDirection: (dmsSouth && dmsSouth.direction) || Direction.North,
-        dmsWest: (dmsWest && dmsWest.coordinate),
+        dmsWest: dmsWest && dmsWest.coordinate,
         dmsWestDirection: (dmsWest && dmsWest.direction) || Direction.East,
-        dmsEast: (dmsEast && dmsEast.coordinate),
+        dmsEast: dmsEast && dmsEast.coordinate,
         dmsEastDirection: (dmsEast && dmsEast.direction) || Direction.East,
       },
       { silent: true }
@@ -839,9 +839,9 @@ module.exports = Backbone.AssociatedModel.extend({
     )
     this.set(
       {
-        dmsLat: (dmsLat && dmsLat.coordinate),
+        dmsLat: dmsLat && dmsLat.coordinate,
         dmsLatDirection: (dmsLat && dmsLat.direction) || Direction.North,
-        dmsLon: (dmsLon && dmsLon.coordinate),
+        dmsLon: dmsLon && dmsLon.coordinate,
         dmsLonDirection: (dmsLon && dmsLon.direction) || Direction.East,
       },
       { silent: true }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.js
@@ -237,6 +237,10 @@ module.exports = Backbone.AssociatedModel.extend({
       this.set('prevLocationType', 'utmUps')
       this.set('locationType', 'dd')
     }
+    this.set('drawing', true)
+    if (this.get('mode') === 'line' && !this.get('lineWidth')) {
+      this.set('lineWidth', 1)
+    }
     store.get('content').turnOnDrawing(this)
   },
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -57,8 +57,6 @@ const { Direction } = require('../location-new/utils/dms-utils.js')
 import { deserialize } from './location-serialization'
 const wkx = require('wkx')
 
-const minimumBuffer = 0.000001
-
 const filterToLocationOldModel = filter => {
   if (filter === '') return filter
 
@@ -205,7 +203,7 @@ module.exports = Marionette.LayoutView.extend({
       dmsLon: '',
       dmsLatDirection: Direction.North,
       dmsLonDirection: Direction.East,
-      radius: 1,
+      radius: '',
       bbox: undefined,
       polygon: undefined,
       hasKeyword: false,
@@ -224,7 +222,7 @@ module.exports = Marionette.LayoutView.extend({
       utmUpsLowerRightZone: 1,
       utmUpsLowerRightHemisphere: 'Northern',
       line: undefined,
-      lineWidth: 1,
+      lineWidth: '',
     })
     wreqr.vent.trigger('search:drawend', this.model)
     this.$el.trigger('change')
@@ -258,8 +256,8 @@ module.exports = Marionette.LayoutView.extend({
 
     return _.extend(modelJSON, {
       type,
-      lineWidth: Math.max(modelJSON.lineWidth, minimumBuffer),
-      radius: Math.max(modelJSON.radius, minimumBuffer),
+      lineWidth: modelJSON.lineWidth,
+      radius: modelJSON.radius,
     })
   },
   onDestroy() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -106,7 +106,7 @@ const Point = {
     }
   },
   'location->json': location => {
-    const { lat = '', lon = '', radius = '', radiusUnits = 'meters' } = location
+    const { lat = '', lon = '', radius = 1, radiusUnits = 'meters' } = location
 
     return {
       type: 'Feature',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -106,7 +106,7 @@ const Point = {
     }
   },
   'location->json': location => {
-    const { lat = '', lon = '', radius = 0, radiusUnits = 'meters' } = location
+    const { lat = '', lon = '', radius = '', radiusUnits = 'meters' } = location
 
     return {
       type: 'Feature',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.js
@@ -98,7 +98,7 @@ const Point = {
 
     return {
       mode: 'circle',
-      locationType: 'latlon',
+      locationType: 'dd',
       lat,
       lon,
       radius: width,
@@ -106,7 +106,7 @@ const Point = {
     }
   },
   'location->json': location => {
-    const { lat = 0, lon = 0, radius = 1, radiusUnits = 'meters' } = location
+    const { lat = '', lon = '', radius = 0, radiusUnits = 'meters' } = location
 
     return {
       type: 'Feature',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-serialization.spec.js
@@ -101,7 +101,7 @@ describe('serialize/deserialize point', () => {
 
   const deserializedPoint = {
     mode: 'circle',
-    locationType: 'latlon',
+    locationType: 'dd',
     lat: -111.131821,
     lon: 31.964569,
     radius: 140603.222706,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -34,6 +34,8 @@ const LayerCollectionController = require('../../../../js/controllers/ol.layerCo
 const user = require('../../../singletons/user-instance.js')
 const User = require('../../../../js/model/User.js')
 const wreqr = require('../../../../js/wreqr.js')
+import { validateGeo } from '../../../../react-component/utils/validation'
+
 
 const defaultColor = '#3c6dd5'
 
@@ -604,7 +606,10 @@ module.exports = function OpenlayersMap(
     showMultiLineShape(locationModel) {
       let lineObject = locationModel
         .get('multiline')
-        .map(line => line.map(coords => convertPointCoordinate(coords)))
+      if (validateGeo('multiline', JSON.stringify(lineObject)).error) {
+        return
+      }
+      lineObject = lineObject.map(line => line.map(coords => convertPointCoordinate(coords)))
 
       let feature = new Openlayers.Feature({
         geometry: new Openlayers.geom.MultiLineString(lineObject),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -36,7 +36,6 @@ const User = require('../../../../js/model/User.js')
 const wreqr = require('../../../../js/wreqr.js')
 import { validateGeo } from '../../../../react-component/utils/validation'
 
-
 const defaultColor = '#3c6dd5'
 
 const OpenLayerCollectionController = LayerCollectionController.extend({
@@ -604,12 +603,13 @@ module.exports = function OpenlayersMap(
       shapes.push(line)
     },
     showMultiLineShape(locationModel) {
-      let lineObject = locationModel
-        .get('multiline')
+      let lineObject = locationModel.get('multiline')
       if (validateGeo('multiline', JSON.stringify(lineObject)).error) {
         return
       }
-      lineObject = lineObject.map(line => line.map(coords => convertPointCoordinate(coords)))
+      lineObject = lineObject.map(line =>
+        line.map(coords => convertPointCoordinate(coords))
+      )
 
       let feature = new Openlayers.Feature({
         geometry: new Openlayers.geom.MultiLineString(lineObject),

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -78,6 +78,13 @@ function generateAnyGeoFilter(property, model) {
 
   switch (model.type) {
     case 'LINE':
+      if(!Array.isArray(model.line)) {
+        return {
+          type: 'INTERSECTS',
+          property,
+          value: '',
+        }
+      }
       return {
         type: 'DWITHIN',
         property,
@@ -90,6 +97,13 @@ function generateAnyGeoFilter(property, model) {
         ),
       }
     case 'POLYGON':
+      if(!Array.isArray(model.polygon)) {
+        return {
+          type: 'INTERSECTS',
+          property,
+          value: '',
+        }
+      }
       return {
         type: model.polygonBufferWidth > 0 ? 'DWITHIN' : 'INTERSECTS',
         property,
@@ -104,6 +118,13 @@ function generateAnyGeoFilter(property, model) {
         }),
       }
     case 'MULTIPOLYGON':
+      if(!Array.isArray(model.polygon)) {
+        return {
+          type: 'INTERSECTS',
+          property,
+          value: '',
+        }
+      }
       const poly =
         'MULTIPOLYGON' +
         sanitizeForCql(JSON.stringify(polygonToCQLMultiPolygon(model.polygon)))

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -75,15 +75,16 @@ function generateAnyGeoFilter(property, model) {
       value: null,
     }
   }
+  const defaultGeoFilter = {
+    type: 'INTERSECTS',
+    property,
+    value: '',
+  }
 
   switch (model.type) {
     case 'LINE':
       if(!Array.isArray(model.line)) {
-        return {
-          type: 'INTERSECTS',
-          property,
-          value: '',
-        }
+        return defaultGeoFilter
       }
       return {
         type: 'DWITHIN',
@@ -98,11 +99,7 @@ function generateAnyGeoFilter(property, model) {
       }
     case 'POLYGON':
       if(!Array.isArray(model.polygon)) {
-        return {
-          type: 'INTERSECTS',
-          property,
-          value: '',
-        }
+        return defaultGeoFilter
       }
       return {
         type: model.polygonBufferWidth > 0 ? 'DWITHIN' : 'INTERSECTS',
@@ -119,11 +116,7 @@ function generateAnyGeoFilter(property, model) {
       }
     case 'MULTIPOLYGON':
       if(!Array.isArray(model.polygon)) {
-        return {
-          type: 'INTERSECTS',
-          property,
-          value: '',
-        }
+        return defaultGeoFilter
       }
       const poly =
         'MULTIPOLYGON' +
@@ -159,11 +152,7 @@ function generateAnyGeoFilter(property, model) {
         ),
       }
     default:
-      return {
-        type: 'INTERSECTS',
-        property,
-        value: '',
-      }
+      return defaultGeoFilter
   }
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.js
@@ -83,7 +83,7 @@ function generateAnyGeoFilter(property, model) {
 
   switch (model.type) {
     case 'LINE':
-      if(!Array.isArray(model.line)) {
+      if (!Array.isArray(model.line)) {
         return defaultGeoFilter
       }
       return {
@@ -98,7 +98,7 @@ function generateAnyGeoFilter(property, model) {
         ),
       }
     case 'POLYGON':
-      if(!Array.isArray(model.polygon)) {
+      if (!Array.isArray(model.polygon)) {
         return defaultGeoFilter
       }
       return {
@@ -115,7 +115,7 @@ function generateAnyGeoFilter(property, model) {
         }),
       }
     case 'MULTIPOLYGON':
-      if(!Array.isArray(model.polygon)) {
+      if (!Array.isArray(model.polygon)) {
         return defaultGeoFilter
       }
       const poly =

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/CQLUtils.spec.js
@@ -269,13 +269,13 @@ describe('CQL Utils', () => {
       )
     })
 
-    it('generates filter with anyGeo property and BBOX type (latlon)', () => {
+    it('generates filter with anyGeo property and BBOX type (dd)', () => {
       const filter = CQLUtils.generateFilter(
         'some type',
         'anyGeo',
         {
           type: 'BBOX',
-          locationType: 'latlon',
+          locationType: 'dd',
           west: -97,
           south: 41,
           east: -90,

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/DistanceUtils.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/DistanceUtils.js
@@ -56,7 +56,7 @@ module.exports = {
         return distance * METERS_NAUTICAL_MILES
       case 'meters':
       default:
-        return distance
+        return Number(distance)
     }
   },
   getDistanceFromMeters(distance, units) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
@@ -53,7 +53,7 @@ class LineRenderView extends GeometryRenderView {
         json.lineWidth,
         model.get('lineUnits')
       ) || 1
-    if (!linePoints) {
+    if (!linePoints || !linePoints[0]) {
       return
     }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
@@ -17,7 +17,7 @@ const Cesium = require('cesium')
 const _ = require('underscore')
 const Turf = require('@turf/turf')
 const DistanceUtils = require('../DistanceUtils.js')
-
+import { validateGeo } from '../../react-component/utils/validation'
 const {
   GeometryRenderView,
   GeometryController,
@@ -53,7 +53,7 @@ class LineRenderView extends GeometryRenderView {
         json.lineWidth,
         model.get('lineUnits')
       ) || 1
-    if (!linePoints || !Array.isArray(linePoints[0])) {
+    if (linePoints === undefined || validateGeo('line', JSON.stringify(linePoints)).error) {
       return
     }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
@@ -53,7 +53,7 @@ class LineRenderView extends GeometryRenderView {
         json.lineWidth,
         model.get('lineUnits')
       ) || 1
-    if (!linePoints || linePoints[0] === undefined) {
+    if (!linePoints || !Array.isArray(linePoints[0])) {
       return
     }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
@@ -53,7 +53,10 @@ class LineRenderView extends GeometryRenderView {
         json.lineWidth,
         model.get('lineUnits')
       ) || 1
-    if (linePoints === undefined || validateGeo('line', JSON.stringify(linePoints)).error) {
+    if (
+      linePoints === undefined ||
+      validateGeo('line', JSON.stringify(linePoints)).error
+    ) {
       return
     }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.line.js
@@ -53,7 +53,7 @@ class LineRenderView extends GeometryRenderView {
         json.lineWidth,
         model.get('lineUnits')
       ) || 1
-    if (!linePoints || !linePoints[0]) {
+    if (!linePoints || linePoints[0] === undefined) {
       return
     }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
@@ -61,6 +61,9 @@ class PolygonRenderView extends GeometryRenderView {
 
   drawGeometry = model => {
     const json = model.toJSON()
+    if(!Array.isArray(json.polygon)) {
+      return
+    }
     const isMultiPolygon = ShapeUtils.isArray3D(json.polygon)
     const polygons = isMultiPolygon ? json.polygon : [json.polygon]
 
@@ -73,7 +76,7 @@ class PolygonRenderView extends GeometryRenderView {
     this.cameraMagnitude = this.map.camera.getMagnitude()
     ;(polygons || []).forEach(polygonPoints => {
       if (
-        !polygonPoints ||
+        !Array.isArray(polygonPoints) ||
         polygonPoints[0] === undefined ||
         polygonPoints.length < 3
       ) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
@@ -76,7 +76,7 @@ class PolygonRenderView extends GeometryRenderView {
     this.primitive = new Cesium.PolylineCollection()
     this.cameraMagnitude = this.map.camera.getMagnitude()
     ;(polygons || []).forEach(polygonPoints => {
-      if (validateGeo('polygon', polygonPoints).error) {
+      if (!polygonPoints || polygonPoints.length < 3) {
         return
       }
       if (
@@ -84,6 +84,9 @@ class PolygonRenderView extends GeometryRenderView {
         polygonPoints[polygonPoints.length - 1].toString()
       ) {
         polygonPoints.push(polygonPoints[0])
+      }
+      if(validateGeo('polygon', JSON.stringify(polygonPoints)).error) {
+        return
       }
       polygonPoints.forEach(point => {
         point[0] = DistanceUtils.coordinateRound(point[0])

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
@@ -72,7 +72,11 @@ class PolygonRenderView extends GeometryRenderView {
     this.primitive = new Cesium.PolylineCollection()
     this.cameraMagnitude = this.map.camera.getMagnitude()
     ;(polygons || []).forEach(polygonPoints => {
-      if (!polygonPoints || polygonPoints[0] === undefined || polygonPoints.length < 3) {
+      if (
+        !polygonPoints ||
+        polygonPoints[0] === undefined ||
+        polygonPoints.length < 3
+      ) {
         return
       }
       if (

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
@@ -72,7 +72,7 @@ class PolygonRenderView extends GeometryRenderView {
     this.primitive = new Cesium.PolylineCollection()
     this.cameraMagnitude = this.map.camera.getMagnitude()
     ;(polygons || []).forEach(polygonPoints => {
-      if (!polygonPoints || !polygonPoints[0] || polygonPoints.length < 3) {
+      if (!polygonPoints || polygonPoints[0] === undefined || polygonPoints.length < 3) {
         return
       }
       if (

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
@@ -17,6 +17,7 @@ const Cesium = require('cesium')
 const ShapeUtils = require('../ShapeUtils.js')
 const Turf = require('@turf/turf')
 const DistanceUtils = require('../DistanceUtils.js')
+import { validateGeo } from '../../react-component/utils/validation'
 
 const { GeometryRenderView, GeometryController } = require('./cesium.base.line')
 
@@ -75,11 +76,7 @@ class PolygonRenderView extends GeometryRenderView {
     this.primitive = new Cesium.PolylineCollection()
     this.cameraMagnitude = this.map.camera.getMagnitude()
     ;(polygons || []).forEach(polygonPoints => {
-      if (
-        !Array.isArray(polygonPoints) ||
-        polygonPoints[0] === undefined ||
-        polygonPoints.length < 3
-      ) {
+      if (validateGeo('polygon', polygonPoints).error) {
         return
       }
       if (

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
@@ -62,7 +62,7 @@ class PolygonRenderView extends GeometryRenderView {
 
   drawGeometry = model => {
     const json = model.toJSON()
-    if(!Array.isArray(json.polygon)) {
+    if (!Array.isArray(json.polygon)) {
       return
     }
     const isMultiPolygon = ShapeUtils.isArray3D(json.polygon)
@@ -85,7 +85,7 @@ class PolygonRenderView extends GeometryRenderView {
       ) {
         polygonPoints.push(polygonPoints[0])
       }
-      if(validateGeo('polygon', JSON.stringify(polygonPoints)).error) {
+      if (validateGeo('polygon', JSON.stringify(polygonPoints)).error) {
         return
       }
       polygonPoints.forEach(point => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/cesium.polygon.js
@@ -72,7 +72,7 @@ class PolygonRenderView extends GeometryRenderView {
     this.primitive = new Cesium.PolylineCollection()
     this.cameraMagnitude = this.map.camera.getMagnitude()
     ;(polygons || []).forEach(polygonPoints => {
-      if (!polygonPoints || polygonPoints.length < 3) {
+      if (!polygonPoints || !polygonPoints[0] || polygonPoints.length < 3) {
         return
       }
       if (

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -97,14 +97,14 @@ Draw.LineView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon && !_.isUndefined(polygon)) {
+    if (polygon && polygon[0] && !_.isUndefined(polygon)) {
       this.drawBorderedPolygon(polygon)
     }
   },
 
   updateGeometry(model) {
     const rectangle = this.modelToPolygon(model)
-    if (rectangle) {
+    if (rectangle && rectangle[0]) {
       this.drawBorderedPolygon(rectangle)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -98,7 +98,7 @@ Draw.LineView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon !== undefined && validateGeo('polygon', polygon.getCoordinates())) {
+    if (polygon !== undefined && !validateGeo('polygon', polygon.getCoordinates()).error) {
       this.drawBorderedPolygon(polygon)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -98,7 +98,7 @@ Draw.LineView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon !== undefined && !validateGeo('polygon', polygon.getCoordinates()).error) {
+    if (polygon !== undefined && !validateGeo('polygon', JSON.stringify(polygon.getCoordinates())).error) {
       this.drawBorderedPolygon(polygon)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -23,6 +23,7 @@ const Turf = require('@turf/turf')
 const DrawingController = require('./drawing.controller')
 const olUtils = require('../OpenLayersGeometryUtils')
 const DistanceUtils = require('../DistanceUtils.js')
+import { validateGeo } from '../../react-component/utils/validation'
 
 function translateFromOpenlayersCoordinates(coords) {
   const coordinates = []
@@ -97,7 +98,7 @@ Draw.LineView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon && polygon[0] !== undefined && !_.isUndefined(polygon)) {
+    if (polygon !== undefined && validateGeo('polygon', polygon.getCoordinates())) {
       this.drawBorderedPolygon(polygon)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -97,14 +97,14 @@ Draw.LineView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon && polygon[0] && !_.isUndefined(polygon)) {
+    if (polygon && polygon[0] !== undefined && !_.isUndefined(polygon)) {
       this.drawBorderedPolygon(polygon)
     }
   },
 
   updateGeometry(model) {
     const rectangle = this.modelToPolygon(model)
-    if (rectangle && rectangle[0]) {
+    if (rectangle && rectangle[0] !== undefined) {
       this.drawBorderedPolygon(rectangle)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -98,7 +98,7 @@ Draw.LineView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon !== undefined && !validateGeo('polygon', JSON.stringify(polygon.getCoordinates())).error) {
+    if (polygon !== undefined && !validateGeo('line', JSON.stringify(polygon.getCoordinates())).error) {
       this.drawBorderedPolygon(polygon)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -98,7 +98,10 @@ Draw.LineView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon !== undefined && !validateGeo('line', JSON.stringify(polygon.getCoordinates())).error) {
+    if (
+      polygon !== undefined &&
+      !validateGeo('line', JSON.stringify(polygon.getCoordinates())).error
+    ) {
       this.drawBorderedPolygon(polygon)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -102,7 +102,7 @@ Draw.PolygonView = Marionette.View.extend({
 
   modelToPolygon(model) {
     const coords = model.get('polygon')
-    if (!coords) {
+    if (!Array.isArray(coords)) {
       return
     }
     const isMultiPolygon = ShapeUtils.isArray3D(coords)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -120,14 +120,14 @@ Draw.PolygonView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon && polygon[0] && !_.isUndefined(polygon)) {
+    if (polygon && polygon[0] !== undefined && !_.isUndefined(polygon)) {
       this.drawBorderedPolygon(polygon)
     }
   },
 
   updateGeometry(model) {
     const rectangle = this.modelToPolygon(model)
-    if (rectangle && rectangle[0]) {
+    if (rectangle && rectangle[0] !== undefined) {
       this.drawBorderedPolygon(rectangle)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -120,14 +120,14 @@ Draw.PolygonView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon && !_.isUndefined(polygon)) {
+    if (polygon && polygon[0] && !_.isUndefined(polygon)) {
       this.drawBorderedPolygon(polygon)
     }
   },
 
   updateGeometry(model) {
     const rectangle = this.modelToPolygon(model)
-    if (rectangle) {
+    if (rectangle && rectangle[0]) {
       this.drawBorderedPolygon(rectangle)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -103,7 +103,10 @@ Draw.PolygonView = Marionette.View.extend({
 
   modelToPolygon(model) {
     const coords = model.get('polygon')
-    if (coords === undefined || validateGeo('polygon', JSON.stringify(coords)).error) {
+    if (
+      coords === undefined ||
+      validateGeo('polygon', JSON.stringify(coords)).error
+    ) {
       return
     }
     const isMultiPolygon = ShapeUtils.isArray3D(coords)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -103,7 +103,7 @@ Draw.PolygonView = Marionette.View.extend({
 
   modelToPolygon(model) {
     const coords = model.get('polygon')
-    if (validateGeo('polygon', JSON.stringify(coords)).error) {
+    if (coords === undefined || validateGeo('polygon', JSON.stringify(coords)).error) {
       return
     }
     const isMultiPolygon = ShapeUtils.isArray3D(coords)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -25,6 +25,7 @@ const Turf = require('@turf/turf')
 const DrawingController = require('./drawing.controller')
 const olUtils = require('../OpenLayersGeometryUtils')
 const DistanceUtils = require('../DistanceUtils.js')
+import { validateGeo } from '../../react-component/utils/validation'
 
 const translateFromOpenlayersCoordinates = coords => {
   return coords
@@ -102,7 +103,7 @@ Draw.PolygonView = Marionette.View.extend({
 
   modelToPolygon(model) {
     const coords = model.get('polygon')
-    if (!Array.isArray(coords)) {
+    if (validateGeo('polygon', JSON.stringify(coords)).error) {
       return
     }
     const isMultiPolygon = ShapeUtils.isArray3D(coords)
@@ -120,7 +121,7 @@ Draw.PolygonView = Marionette.View.extend({
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
     // make sure the current model has width and height before drawing
-    if (polygon && polygon[0] !== undefined && !_.isUndefined(polygon)) {
+    if (polygon !== undefined) {
       this.drawBorderedPolygon(polygon)
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -53,8 +53,6 @@ const filterToLocationOldModel = filter => {
   }
 }
 
-const minimumBuffer = 0.000001
-
 class LocationInput extends React.Component {
   locationModel
   constructor(props) {
@@ -162,8 +160,8 @@ class LocationInput extends React.Component {
 
     return Object.assign(modelJSON, {
       type,
-      lineWidth: Math.max(modelJSON.lineWidth, minimumBuffer),
-      radius: Math.max(modelJSON.radius, minimumBuffer),
+      lineWidth: modelJSON.lineWidth,
+      radius: modelJSON.radius,
     })
   }
   onChange = () => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -117,12 +117,7 @@ const BaseLine = props => {
             value = convertWktString(value.trim())
             setCurrentValue(value)
             try {
-              //handle case where user clears input; JSON.parse('') would throw an error and maintain previous state
-              if (value === '') {
-                setState({ [geometryKey]: undefined })
-              } else {
-                setState({ [geometryKey]: JSON.parse(value) })
-              }
+              setState({ [geometryKey]: JSON.parse(value) })
             } catch (e) {
               // Set state with invalid value to trigger error messaging
               setState({ [geometryKey]: value })

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -121,7 +121,7 @@ const BaseLine = props => {
             setBaseLineError(validateGeo(mode || polyType, currentValue))
           }
         />
-        <ErrorComponent errorState={baseLineError}/>
+        <ErrorComponent errorState={baseLineError} />
         <Units
           value={props[unitKey]}
           onChange={value => {
@@ -144,7 +144,7 @@ const BaseLine = props => {
             }}
           />
         </Units>
-        <ErrorComponent errorState={bufferError}/>
+        <ErrorComponent errorState={bufferError} />
       </div>
     </div>
   )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -81,6 +81,10 @@ const BaseLine = props => {
     () => {
       const { geometryKey } = props
       setCurrentValue(JSON.stringify(props[geometryKey]))
+      if(props.drawing) {
+        setBaseLineError(initialErrorState)
+        setBufferError(initialErrorState)
+      }
     },
     [props.polygon, props.line]
   )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -14,7 +14,7 @@
  **/
 import React, { useState, useEffect } from 'react'
 import {
-  getErrorComponent,
+  ErrorComponent,
   validateGeo,
   initialErrorState,
 } from '../utils/validation'
@@ -121,7 +121,7 @@ const BaseLine = props => {
             setBaseLineError(validateGeo(mode || polyType, currentValue))
           }
         />
-        {getErrorComponent(baseLineError)}
+        <ErrorComponent errorState={baseLineError}/>
         <Units
           value={props[unitKey]}
           onChange={value => {
@@ -144,7 +144,7 @@ const BaseLine = props => {
             }}
           />
         </Units>
-        {getErrorComponent(bufferError)}
+        <ErrorComponent errorState={bufferError}/>
       </div>
     </div>
   )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -87,9 +87,12 @@ const BaseLine = props => {
 
   useEffect(
     () => {
-      const { geometryKey } = props
-      setCurrentValue(JSON.stringify(props[geometryKey]))
+      const { geometryKey, lineWidth } = props
+      setCurrentValue(typeof(props[geometryKey]) === 'string' ? props[geometryKey] : JSON.stringify(props[geometryKey]))
       if (props.drawing) {
+        if(lineWidth === undefined || Number(lineWidth) === 0) {
+          setState({ [widthKey]: 1 })
+        }
         setBaseLineError(initialErrorState)
         setBufferError(initialErrorState)
       }
@@ -115,6 +118,7 @@ const BaseLine = props => {
               }
             } catch (e) {
               // do nothing
+              setState({ [geometryKey]: value })
             }
           }}
           onBlur={() =>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -70,20 +70,24 @@ function convertMultiWkt(isPolygon, value) {
 }
 
 function getPolygonValue(currentValue, value) {
-    // if current value's 1st coord is different
-    // from value's first coord, then delete value's last coord
-    try {
+  // if current value's 1st coord is different
+  // from value's first coord, then delete value's last coord
+  try {
     const parsedValue = JSON.parse(value)
     const parsedCurrentValue = JSON.parse(currentValue)
-    if (Array.isArray(parsedValue) && Array.isArray(parsedCurrentValue) && !_.isEqual(parsedValue[0], parsedCurrentValue[0])) {
-      parsedValue.splice(-1,1)
+    if (
+      Array.isArray(parsedValue) &&
+      Array.isArray(parsedCurrentValue) &&
+      !_.isEqual(parsedValue[0], parsedCurrentValue[0])
+    ) {
+      parsedValue.splice(-1, 1)
       return JSON.stringify(parsedValue)
     } else {
       return value
     }
-    } catch (e) {
-      return value
-    }
+  } catch (e) {
+    return value
+  }
 }
 
 const BaseLine = props => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -88,9 +88,16 @@ const BaseLine = props => {
   useEffect(
     () => {
       const { geometryKey, lineWidth } = props
-      setCurrentValue(typeof(props[geometryKey]) === 'string' ? props[geometryKey] : JSON.stringify(props[geometryKey]))
+      setCurrentValue(
+        typeof props[geometryKey] === 'string'
+          ? props[geometryKey]
+          : JSON.stringify(props[geometryKey])
+      )
       if (props.drawing) {
-        if(geometryKey === 'line' && (lineWidth === undefined || Number(lineWidth) <= 0)) {
+        if (
+          geometryKey === 'line' &&
+          (lineWidth === undefined || Number(lineWidth) <= 0)
+        ) {
           setState({ [widthKey]: 1 })
         }
         setBaseLineError(initialErrorState)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -94,7 +94,10 @@ const BaseLine = props => {
           : JSON.stringify(props[geometryKey])
       )
       if (props.drawing) {
-        if (lineWidth === undefined || Number(lineWidth) <= 0) {
+        if (
+          geometryKey.includes('line') &&
+          (lineWidth === undefined || Number(lineWidth) <= 0)
+        ) {
           setState({ [widthKey]: 1 })
         }
         setBaseLineError(initialErrorState)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -150,14 +150,12 @@ const BaseLine = props => {
                 : setState({ [widthKey]: value })
             }}
             onBlur={e => {
-              if (widthKey === 'lineWidth' || 'polygonBufferWidth') {
-                setBufferError(
-                  validateGeo(widthKey, {
-                    value: e.target.value,
-                    units: props[unitKey],
-                  })
-                )
-              }
+              setBufferError(
+                validateGeo(widthKey, {
+                  value: e.target.value,
+                  units: props[unitKey],
+                }
+              ))
             }}
           />
         </Units>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -121,6 +121,7 @@ const BaseLine = props => {
           (lineWidth === undefined || Number(lineWidth) <= 0)
         ) {
           setState({ [widthKey]: 1 })
+          setBufferError(initialErrorState)
         }
         setBaseLineError(initialErrorState)
       }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -90,7 +90,7 @@ const BaseLine = props => {
       const { geometryKey, lineWidth } = props
       setCurrentValue(typeof(props[geometryKey]) === 'string' ? props[geometryKey] : JSON.stringify(props[geometryKey]))
       if (props.drawing) {
-        if(geometryKey === 'line' && (lineWidth === undefined || Number(lineWidth) === 0)) {
+        if(geometryKey === 'line' && (lineWidth === undefined || Number(lineWidth) <= 0)) {
           setState({ [widthKey]: 1 })
         }
         setBaseLineError(initialErrorState)
@@ -117,7 +117,7 @@ const BaseLine = props => {
                 setState({ [geometryKey]: JSON.parse(value) })
               }
             } catch (e) {
-              // do nothing
+              // Set state with invalid value to trigger error messaging
               setState({ [geometryKey]: value })
             }
           }}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -134,6 +134,14 @@ const BaseLine = props => {
             typeof setBufferState === 'function'
               ? setBufferState(unitKey, value)
               : setState({ [unitKey]: value })
+            if (widthKey === 'lineWidth') {
+              setBufferError(
+                validateGeo('lineWidth', {
+                  value: props[widthKey],
+                  units: value,
+                })
+              )
+            }
           }}
         >
           <TextField
@@ -141,12 +149,19 @@ const BaseLine = props => {
             label="Buffer width"
             value={String(props[widthKey])}
             onChange={value => {
-              if (widthKey === 'lineWidth') {
-                setBufferError(validateGeo('lineWidth', value))
-              }
               typeof setBufferState === 'function'
                 ? setBufferState(widthKey, value)
                 : setState({ [widthKey]: value })
+            }}
+            onBlur={e => {
+              if (widthKey === 'lineWidth') {
+                setBufferError(
+                  validateGeo('lineWidth', {
+                    value: e.target.value,
+                    units: props[unitKey],
+                  })
+                )
+              }
             }}
           />
         </Units>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -16,7 +16,6 @@ import React, { useState, useEffect } from 'react'
 import {
   getErrorComponent,
   validateGeo,
-  validateLinePolygon,
   initialErrorState,
 } from '../utils/validation'
 const { Units } = require('./common')
@@ -70,7 +69,16 @@ function convertMultiWkt(isPolygon, value) {
 }
 
 const BaseLine = props => {
-  const { label, geometryKey, setState, setBufferState, unitKey, widthKey, mode, polyType } = props
+  const {
+    label,
+    geometryKey,
+    setState,
+    setBufferState,
+    unitKey,
+    widthKey,
+    mode,
+    polyType,
+  } = props
   const [currentValue, setCurrentValue] = useState(
     JSON.stringify(props[geometryKey])
   )
@@ -81,7 +89,7 @@ const BaseLine = props => {
     () => {
       const { geometryKey } = props
       setCurrentValue(JSON.stringify(props[geometryKey]))
-      if(props.drawing) {
+      if (props.drawing) {
         setBaseLineError(initialErrorState)
         setBufferError(initialErrorState)
       }
@@ -101,21 +109,25 @@ const BaseLine = props => {
             try {
               //handle case where user clears input; JSON.parse('') would throw an error and maintain previous state
               if (value === '') {
-                setState({[geometryKey]: undefined})
+                setState({ [geometryKey]: undefined })
               } else {
-                setState({[geometryKey]: JSON.parse(value)})
+                setState({ [geometryKey]: JSON.parse(value) })
               }
             } catch (e) {
               // do nothing
             }
           }}
-          onBlur={() => setBaseLineError(validateLinePolygon(currentValue, mode || polyType))}
+          onBlur={() =>
+            setBaseLineError(validateGeo(mode || polyType, currentValue))
+          }
         />
         {getErrorComponent(baseLineError)}
         <Units
           value={props[unitKey]}
           onChange={value => {
-            typeof setBufferState === 'function' ? setBufferState(unitKey, value) : setState({ [unitKey]: value })
+            typeof setBufferState === 'function'
+              ? setBufferState(unitKey, value)
+              : setState({ [unitKey]: value })
           }}
         >
           <TextField
@@ -126,7 +138,9 @@ const BaseLine = props => {
               if (widthKey === 'lineWidth') {
                 setBufferError(validateGeo('lineWidth', value))
               }
-              typeof setBufferState === 'function' ? setBufferState(widthKey, value) : setState({ [widthKey]: value })
+              typeof setBufferState === 'function'
+                ? setBufferState(widthKey, value)
+                : setState({ [widthKey]: value })
             }}
           />
         </Units>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -94,14 +94,10 @@ const BaseLine = props => {
           : JSON.stringify(props[geometryKey])
       )
       if (props.drawing) {
-        if (
-          geometryKey === 'line' &&
-          (lineWidth === undefined || Number(lineWidth) <= 0)
-        ) {
+        if (lineWidth === undefined || Number(lineWidth) <= 0) {
           setState({ [widthKey]: 1 })
         }
         setBaseLineError(initialErrorState)
-        setBufferError(initialErrorState)
       }
     },
     [props.polygon, props.line]
@@ -134,9 +130,9 @@ const BaseLine = props => {
             typeof setBufferState === 'function'
               ? setBufferState(unitKey, value)
               : setState({ [unitKey]: value })
-            if (widthKey === 'lineWidth') {
+            if (widthKey === 'lineWidth' || 'bufferWidth') {
               setBufferError(
-                validateGeo('lineWidth', {
+                validateGeo(widthKey, {
                   value: props[widthKey],
                   units: value,
                 })
@@ -154,9 +150,9 @@ const BaseLine = props => {
                 : setState({ [widthKey]: value })
             }}
             onBlur={e => {
-              if (widthKey === 'lineWidth') {
+              if (widthKey === 'lineWidth' || 'polygonBufferWidth') {
                 setBufferError(
-                  validateGeo('lineWidth', {
+                  validateGeo(widthKey, {
                     value: e.target.value,
                     units: props[unitKey],
                   })

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -154,8 +154,8 @@ const BaseLine = props => {
                 validateGeo(widthKey, {
                   value: e.target.value,
                   units: props[unitKey],
-                }
-              ))
+                })
+              )
             }}
           />
         </Units>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -16,7 +16,7 @@ import React, { useState, useEffect } from 'react'
 import {
   getErrorComponent,
   validateGeo,
-  validateListOfPoints,
+  validateLinePolygon,
   initialErrorState,
 } from '../utils/validation'
 const { Units } = require('./common')
@@ -69,15 +69,6 @@ function convertMultiWkt(isPolygon, value) {
       : '[' + shapes.map(shapeCoords => buildWktString(shapeCoords)) + ']'
 }
 
-function is2DArray(coordinates) {
-  try {
-    const parsedCoords = JSON.parse(coordinates)
-    return Array.isArray(parsedCoords) && Array.isArray(parsedCoords[0])
-  } catch (e) {
-    return false
-  }
-}
-
 const BaseLine = props => {
   const { label, geometryKey, setState, setBufferState, unitKey, widthKey, mode, polyType } = props
   const [currentValue, setCurrentValue] = useState(
@@ -93,18 +84,6 @@ const BaseLine = props => {
     },
     [props.polygon, props.line]
   )
-
-  function testValidity() {
-    if (!is2DArray(currentValue)) {
-      return { error: true, message: 'Not an acceptable value' }
-    }
-    try {
-      const pointsValid = validateListOfPoints(JSON.parse(currentValue), mode || polyType) 
-      return pointsValid === undefined ? initialErrorState : pointsValid
-    } catch (e) {
-      return initialErrorState
-    }
-  }
 
   return (
     <div>
@@ -126,7 +105,7 @@ const BaseLine = props => {
               // do nothing
             }
           }}
-          onBlur={() => setBaseLineError(testValidity())}
+          onBlur={() => setBaseLineError(validateLinePolygon(currentValue, mode || polyType))}
         />
         {getErrorComponent(baseLineError)}
         <Units

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -97,9 +97,9 @@ const BaseLine = props => {
             try {
               //handle case where user clears input; JSON.parse('') would throw an error and maintain previous state
               if (value === '') {
-                setState(geometryKey, undefined)
+                setState({[geometryKey]: undefined})
               } else {
-                setState(geometryKey, JSON.parse(value))
+                setState({[geometryKey]: JSON.parse(value)})
               }
             } catch (e) {
               // do nothing
@@ -111,8 +111,7 @@ const BaseLine = props => {
         <Units
           value={props[unitKey]}
           onChange={value => {
-            setState(unitKey, value)
-            typeof setBufferState === 'function' ? setBufferState(unitKey, value) : setState(unitKey, value)
+            typeof setBufferState === 'function' ? setBufferState(unitKey, value) : setState({ [unitKey]: value })
           }}
         >
           <TextField
@@ -123,7 +122,7 @@ const BaseLine = props => {
               if (widthKey === 'lineWidth') {
                 setBufferError(validateGeo('lineWidth', value))
               }
-              typeof setBufferState === 'function' ? setBufferState(widthKey, value) : setState(widthKey, value)
+              typeof setBufferState === 'function' ? setBufferState(widthKey, value) : setState({ [widthKey]: value })
             }}
           />
         </Units>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -12,204 +12,146 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-const React = require('react')
-
+import React, { useState, useEffect } from 'react'
+import {
+  getErrorComponent,
+  validateGeo,
+  validateListOfPoints,
+  initialErrorState,
+} from '../utils/validation'
 const { Units } = require('./common')
 const TextField = require('../text-field')
-import styled from 'styled-components'
 
 const coordinatePairRegex = /-?\d{1,3}(\.\d*)?\s-?\d{1,3}(\.\d*)?/g
 
-const Invalid = styled.div`
-  background-color: ${props => props.theme.negativeColor};
-  height: 100%;
-  display: block;
-  overflow: hidden;
-  color: white;
-`
+function buildWktString(coordinates) {
+  return '[[' + coordinates.join('],[') + ']]'
+}
 
-class BaseLine extends React.Component {
-  invalidMessage = ''
-  constructor(props) {
-    super(props)
-    const { geometryKey } = props
-    const value = JSON.stringify(props[geometryKey])
-    this.state = { value, isValid: true }
-    this.state.isValid = true
-    this.is2DArray = this.is2DArray.bind(this)
-    this.validateListOfPoints = this.validateListOfPoints.bind(this)
-    this.isValidPolygon = this.isValidPolygon.bind(this)
-    this.isValidInput = this.isValidInput.bind(this)
-    this.removeErrorBox = this.removeErrorBox.bind(this)
+function convertWktString(value) {
+  if (value.includes('MULTI')) {
+    return convertMultiWkt(value.includes('POLYGON'), value)
+  } else if (value.includes('POLYGON') && value.endsWith('))')) {
+    return convertWkt(value, 4)
+  } else if (value.includes('LINESTRING') && value.endsWith(')')) {
+    return convertWkt(value, 2)
   }
-  componentWillReceiveProps(props) {
-    if (document.activeElement !== this.ref) {
+  return value
+}
+
+function convertWkt(value, numCoords) {
+  const coordinatePairs = value.match(coordinatePairRegex)
+  if (!coordinatePairs || coordinatePairs.length < numCoords) {
+    return value
+  }
+  const coordinates = coordinatePairs.map(coord => coord.replace(' ', ','))
+  return buildWktString(coordinates)
+}
+
+function convertMultiWkt(isPolygon, value) {
+  if (isPolygon && !value.endsWith(')))')) {
+    return value
+  } else if (!value.endsWith('))')) {
+    return value
+  }
+  const splitter = isPolygon ? '))' : ')'
+  const numPoints = isPolygon ? 4 : 2
+  let shapes = value
+    .split(splitter)
+    .map(shape => shape.match(coordinatePairRegex))
+  shapes = shapes
+    .filter(shape => shape !== null && shape.length >= numPoints)
+    .map(shape => shape.map(coordinatePair => coordinatePair.replace(' ', ',')))
+  return shapes.length === 0
+    ? value
+    : shapes.length === 1
+      ? buildWktString(shapes[0])
+      : '[' + shapes.map(shapeCoords => buildWktString(shapeCoords)) + ']'
+}
+
+function is2DArray(coordinates) {
+  try {
+    const parsedCoords = JSON.parse(coordinates)
+    return Array.isArray(parsedCoords) && Array.isArray(parsedCoords[0])
+  } catch (e) {
+    return false
+  }
+}
+
+const BaseLine = props => {
+  const { label, geometryKey, setState, setBufferState, unitKey, widthKey, mode, polyType } = props
+  const [currentValue, setCurrentValue] = useState(
+    JSON.stringify(props[geometryKey])
+  )
+  const [baseLineError, setBaseLineError] = useState(initialErrorState)
+  const [bufferError, setBufferError] = useState(initialErrorState)
+
+  useEffect(
+    () => {
       const { geometryKey } = props
-      const value = JSON.stringify(props[geometryKey])
-      this.setState({ value })
+      setCurrentValue(JSON.stringify(props[geometryKey]))
+    },
+    [props.polygon, props.line]
+  )
+
+  function testValidity() {
+    if (!is2DArray(currentValue)) {
+      return { error: true, message: 'Not an acceptable value' }
+    }
+    try {
+      const pointsValid = validateListOfPoints(JSON.parse(currentValue), mode || polyType) 
+      return pointsValid === undefined ? initialErrorState : pointsValid
+    } catch (e) {
+      return initialErrorState
     }
   }
-  render() {
-    const props = this.props
-    const { label, cursor, geometryKey, unitKey, widthKey } = props
-    return (
-      <React.Fragment>
-        <div className="input-location">
+
+  return (
+    <div>
+      <div className="input-location">
+        <TextField
+          label={label}
+          value={currentValue}
+          onChange={value => {
+            value = convertWktString(value.trim())
+            setCurrentValue(value)
+            try {
+              //handle case where user clears input; JSON.parse('') would throw an error and maintain previous state
+              if (value === '') {
+                setState(geometryKey, undefined)
+              } else {
+                setState(geometryKey, JSON.parse(value))
+              }
+            } catch (e) {
+              // do nothing
+            }
+          }}
+          onBlur={() => setBaseLineError(testValidity())}
+        />
+        {getErrorComponent(baseLineError)}
+        <Units
+          value={props[unitKey]}
+          onChange={value => {
+            setState(unitKey, value)
+            typeof setBufferState === 'function' ? setBufferState(unitKey, value) : setState(unitKey, value)
+          }}
+        >
           <TextField
-            label={label}
-            value={this.state.value}
+            type="number"
+            label="Buffer width"
+            value={String(props[widthKey])}
             onChange={value => {
-              value = value.trim()
-              if (value.includes('MULTI')) {
-                value = this.convertMultiWkt(value.includes('POLYGON'), value)
-              } else if (value.includes('POLYGON') && value.endsWith('))')) {
-                value = this.convertWkt(value, 4)
-              } else if (value.includes('LINESTRING') && value.endsWith(')')) {
-                value = this.convertWkt(value, 2)
+              if (widthKey === 'lineWidth') {
+                setBufferError(validateGeo('lineWidth', value))
               }
-              this.setState({ value })
-              const fn = cursor(geometryKey)
-              try {
-                fn(JSON.parse(value))
-              } catch (e) {
-                // do nothing
-              }
-            }}
-            onBlur={() => this.isValidInput(this.state.value)}
-            onFocus={value => {
-              this.setState({ isValid: true })
+              typeof setBufferState === 'function' ? setBufferState(widthKey, value) : setState(widthKey, value)
             }}
           />
-          <Units value={props[unitKey]} onChange={cursor(unitKey)}>
-            <TextField
-              type="number"
-              label="Buffer width"
-              min={0.000001}
-              value={`${props[widthKey]}`}
-              onChange={cursor(widthKey)}
-            />
-          </Units>
-        </div>
-        {this.state.isValid ? (
-          ''
-        ) : (
-          <Invalid>
-            &nbsp;
-            <span className="fa fa-exclamation-triangle" />
-            &nbsp; {this.invalidMessage} &nbsp; &nbsp;
-            <span className="fa fa-times" onClick={this.removeErrorBox} />
-          </Invalid>
-        )}
-      </React.Fragment>
-    )
-  }
-  removeErrorBox() {
-    this.setState({ isValid: true })
-  }
-  isValidInput(value) {
-    this.invalidMessage = ''
-    this.setState({ value, isValid: this.isValidPolygon(value) })
-  }
-  is2DArray(coordinates) {
-    try {
-      const parsedCoords = JSON.parse(coordinates)
-      return Array.isArray(parsedCoords) && Array.isArray(parsedCoords[0])
-    } catch (e) {
-      return false
-    }
-  }
-  validatePoint(point) {
-    if (
-      point.length !== 2 ||
-      (Number.isNaN(Number.parseFloat(point[0])) &&
-        Number.isNaN(Number.parseFloat(point[1])))
-    ) {
-      return JSON.stringify(point) + ' is not a valid point.'
-    } else if (
-      point[0] > 180 ||
-      point[0] < -180 ||
-      point[1] > 90 ||
-      point[1] < -90
-    ) {
-      return JSON.stringify(point) + ' is not a valid point.'
-    }
-    return ''
-  }
-  validateListOfPoints(coordinates) {
-    let message = ''
-    const isLine = this.props.mode.includes('line')
-    let numPoints = isLine ? 2 : 4
-    if (!this.props.mode.includes('multi')) {
-      if (coordinates.some(coords => coords.length > 2)) {
-        message = ''
-      } else if (coordinates.length < numPoints) {
-        message = `Minimum of ${numPoints} points needed for ${
-          isLine ? 'Line' : 'Polygon'
-        }`
-      }
-    }
-    for (let i = 0; i < coordinates.length; i++) {
-      if (coordinates[i].length > 2) {
-        coordinates[i].forEach(coordinate => {
-          if (this.validatePoint(coordinate)) {
-            message = this.validatePoint(coordinate)
-          }
-        })
-      } else {
-        if (this.props.mode.includes('multi')) {
-          message = `Switch to ${isLine ? 'Line' : 'Polygon'}`
-        } else if (this.validatePoint(coordinates[i])) {
-          message = this.validatePoint(coordinates[i])
-        }
-      }
-    }
-    if (message !== '') {
-      this.invalidMessage = message
-      throw 'Invalid coordinates.'
-    }
-  }
-  isValidPolygon(coordinates) {
-    if (!this.is2DArray(coordinates)) {
-      this.invalidMessage = 'Not an acceptable value.'
-      return false
-    }
-    try {
-      this.validateListOfPoints(JSON.parse(coordinates))
-      return true
-    } catch (e) {
-      return false
-    }
-  }
-  convertWkt(value, numCoords) {
-    const coordinatePairs = value.match(coordinatePairRegex)
-    if (!coordinatePairs || coordinatePairs.length < numCoords) {
-      return value
-    }
-    const coordinates = coordinatePairs.map(coord => coord.replace(' ', ','))
-    return `[[${coordinates.join('],[')}]]`
-  }
-  convertMultiWkt(isPolygon, value) {
-    if (isPolygon && !value.endsWith(')))')) {
-      return value
-    } else if (!value.endsWith('))')) {
-      return value
-    }
-    const splitter = isPolygon ? '))' : ')'
-    const numPoints = isPolygon ? 4 : 2
-    let shapes = value
-      .split(splitter)
-      .map(shape => shape.match(coordinatePairRegex))
-    shapes = shapes
-      .filter(shape => shape !== null && shape.length >= numPoints)
-      .map(shape =>
-        shape.map(coordinatePair => coordinatePair.replace(' ', ','))
-      )
-    return shapes.length === 0
-      ? value
-      : shapes.length === 1
-        ? `[[${shapes[0].join('],[')}]]`
-        : `[${shapes.map(shapeCoords => `[[${shapeCoords.join('],[')}]]`)}]`
-  }
+        </Units>
+        {getErrorComponent(bufferError)}
+      </div>
+    </div>
+  )
 }
 
 module.exports = BaseLine

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -20,6 +20,7 @@ import {
 } from '../utils/validation'
 const { Units } = require('./common')
 const TextField = require('../text-field')
+const _ = require('underscore')
 
 const coordinatePairRegex = /-?\d{1,3}(\.\d*)?\s-?\d{1,3}(\.\d*)?/g
 
@@ -68,6 +69,23 @@ function convertMultiWkt(isPolygon, value) {
       : '[' + shapes.map(shapeCoords => buildWktString(shapeCoords)) + ']'
 }
 
+function getPolygonValue(currentValue, value) {
+    // if current value's 1st coord is different
+    // from value's first coord, then delete value's last coord
+    try {
+    const parsedValue = JSON.parse(value)
+    const parsedCurrentValue = JSON.parse(currentValue)
+    if (Array.isArray(parsedValue) && Array.isArray(parsedCurrentValue) && !_.isEqual(parsedValue[0], parsedCurrentValue[0])) {
+      parsedValue.splice(-1,1)
+      return JSON.stringify(parsedValue)
+    } else {
+      return value
+    }
+    } catch (e) {
+      return value
+    }
+}
+
 const BaseLine = props => {
   const {
     label,
@@ -114,6 +132,9 @@ const BaseLine = props => {
           value={currentValue}
           onChange={value => {
             value = convertWktString(value.trim())
+            if (geometryKey.includes('poly')) {
+              value = getPolygonValue(currentValue, value)
+            }
             setCurrentValue(value)
             try {
               setState({ [geometryKey]: JSON.parse(value) })

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -90,7 +90,7 @@ const BaseLine = props => {
       const { geometryKey, lineWidth } = props
       setCurrentValue(typeof(props[geometryKey]) === 'string' ? props[geometryKey] : JSON.stringify(props[geometryKey]))
       if (props.drawing) {
-        if(lineWidth === undefined || Number(lineWidth) === 0) {
+        if(geometryKey === 'line' && (lineWidth === undefined || Number(lineWidth) === 0)) {
           setState({ [widthKey]: 1 })
         }
         setBaseLineError(initialErrorState)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -60,7 +60,9 @@ const BoundingBoxLatLonDd = props => {
     [props.east, props.west, props.south, props.north]
   )
 
-  function onChangeDd(key, label, value) {
+  function onChangeDd(key, value) {
+    const label =
+      key.includes('east') || key.includes('west') ? 'lon' : 'lat'
     const { error, message, defaultValue } = validateGeo(label, value)
     if (defaultValue) {
       setDdError({ error, message, defaultValue })
@@ -74,7 +76,7 @@ const BoundingBoxLatLonDd = props => {
       <TextField
         label="West"
         value={west !== undefined ? String(west) : west}
-        onChange={value => onChangeDd('west', 'lon', value)}
+        onChange={value => onChangeDd('west', value)}
         onBlur={() => setDdError(validateGeo('lon', west))}
         type="number"
         step="any"
@@ -85,7 +87,7 @@ const BoundingBoxLatLonDd = props => {
       <TextField
         label="South"
         value={south !== undefined ? String(south) : south}
-        onChange={value => onChangeDd('south', 'lat', value)}
+        onChange={value => onChangeDd('south', value)}
         onBlur={() => setDdError(validateGeo('lat', south))}
         type="number"
         step="any"
@@ -96,7 +98,7 @@ const BoundingBoxLatLonDd = props => {
       <TextField
         label="East"
         value={east !== undefined ? String(east) : east}
-        onChange={value => onChangeDd('east', 'lon', value)}
+        onChange={value => onChangeDd('east', value)}
         onBlur={() => setDdError(validateGeo('lon', east))}
         type="number"
         step="any"
@@ -107,7 +109,7 @@ const BoundingBoxLatLonDd = props => {
       <TextField
         label="North"
         value={north !== undefined ? String(north) : north}
-        onChange={value => onChangeDd('north', 'lat', value)}
+        onChange={value => onChangeDd('north', value)}
         onBlur={() => setDdError(validateGeo('lat', north))}
         type="number"
         step="any"
@@ -138,7 +140,6 @@ const BoundingBoxLatLonDms = props => {
 
   useEffect(
     () => {
-      console.log(props.drawing)
       if (props.drawing) {
         setDmsError(initialErrorStateWithDefault)
       }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -12,15 +12,18 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-const React = require('react')
-
+import React, { useState } from 'react'
+import {
+  validateGeo,
+  getErrorComponent,
+  initialErrorState,
+  initialErrorStateWithDefault,
+} from '../utils/validation'
 const Group = require('../group')
 const Label = require('./label')
 const TextField = require('../text-field')
 const { Radio, RadioItem } = require('../radio')
-
 const { Zone, Hemisphere, MinimumSpacing } = require('./common')
-
 const {
   DmsLatitude,
   DmsLongitude,
@@ -30,22 +33,39 @@ const { Direction } = require('../../component/location-new/utils/dms-utils.js')
 
 const minimumDifference = 0.0001
 
-const BoundingBoxLatLon = props => {
-  const { north, east, south, west, cursor } = props
-
-  const { mapEast, mapWest, mapSouth, mapNorth } = props
-
+const BoundingBoxLatLonDd = props => {
+  const {
+    north,
+    east,
+    south,
+    west,
+    setState,
+    mapEast,
+    mapWest,
+    mapSouth,
+    mapNorth,
+  } = props
+  const [ddError, setDdError] = useState(initialErrorStateWithDefault)
   const westMax = parseFloat(mapEast) - minimumDifference
   const eastMin = parseFloat(mapWest) + minimumDifference
   const northMin = parseFloat(mapSouth) + minimumDifference
   const southMax = parseFloat(mapNorth) - minimumDifference
-
+  function onChangeDd(key, label, value) {
+    const { error, message, defaultValue } = validateGeo(label, value)
+    if (defaultValue) {
+      setDdError({ error, message, defaultValue })
+      setState(key, defaultValue)
+    } else {
+      setState(key, value)
+    }
+  }
   return (
     <div className="input-location">
       <TextField
         label="West"
-        value={west}
-        onChange={cursor('west')}
+        value={west !== undefined ? String(west) : west}
+        onChange={value => onChangeDd('west', 'lon', value)}
+        onBlur={() => setDdError(validateGeo('lon', west))}
         type="number"
         step="any"
         min={-180}
@@ -54,8 +74,9 @@ const BoundingBoxLatLon = props => {
       />
       <TextField
         label="South"
-        value={south}
-        onChange={cursor('south')}
+        value={south !== undefined ? String(south) : south}
+        onChange={value => onChangeDd('south', 'lat', value)}
+        onBlur={() => setDdError(validateGeo('lat', south))}
         type="number"
         step="any"
         min={-90}
@@ -64,8 +85,9 @@ const BoundingBoxLatLon = props => {
       />
       <TextField
         label="East"
-        value={east}
-        onChange={cursor('east')}
+        value={east !== undefined ? String(east) : east}
+        onChange={value => onChangeDd('east', 'lon', value)}
+        onBlur={() => setDdError(validateGeo('lon', east))}
         type="number"
         step="any"
         min={eastMin || -180}
@@ -74,34 +96,127 @@ const BoundingBoxLatLon = props => {
       />
       <TextField
         label="North"
-        value={north}
-        onChange={cursor('north')}
+        value={north !== undefined ? String(north) : north}
+        onChange={value => onChangeDd('north', 'lat', value)}
+        onBlur={() => setDdError(validateGeo('lat', north))}
         type="number"
         step="any"
         min={northMin || -90}
         max={90}
         addon="°"
       />
+      {getErrorComponent(ddError)}
+    </div>
+  )
+}
+
+const BoundingBoxLatLonDms = props => {
+  const {
+    dmsSouth,
+    dmsNorth,
+    dmsWest,
+    dmsEast,
+    dmsSouthDirection,
+    dmsNorthDirection,
+    dmsWestDirection,
+    dmsEastDirection,
+    setState,
+  } = props
+  const [dmsError, setDmsError] = useState(initialErrorStateWithDefault)
+  const latitudeDirections = [Direction.North, Direction.South]
+  const longitudeDirections = [Direction.East, Direction.West]
+
+  function validate(key, type, value) {
+    const label =
+      key.includes('East') || key.includes('West') ? 'dmsLon' : 'dmsLat'
+    const { error, message, defaultValue } = validateGeo(label, value)
+    if (type === 'blur') {
+      setDmsError({
+        error: value !== undefined && value.length === 0,
+        message,
+        defaultValue,
+      })
+    } else if (defaultValue) {
+      setDmsError({
+        error,
+        message,
+        defaultValue,
+      })
+    }
+    defaultValue ? setState(key, defaultValue) : setState(key, value)
+  }
+
+  return (
+    <div className="input-location">
+      <DmsLongitude
+        label="West"
+        value={dmsWest}
+        onChange={(value, type) => validate('dmsWest', type, value)}
+      >
+        <DirectionInput
+          options={longitudeDirections}
+          value={dmsWestDirection}
+          onChange={value => setState('dmsWestDirection', value)}
+        />
+      </DmsLongitude>
+      <DmsLatitude
+        label="South"
+        value={dmsSouth}
+        onChange={(value, type) => validate('dmsSouth', type, value)}
+      >
+        <DirectionInput
+          options={latitudeDirections}
+          value={dmsSouthDirection}
+          onChange={value => setState('dmsSouthDirection', value)}
+        />
+      </DmsLatitude>
+      <DmsLongitude
+        label="East"
+        value={dmsEast}
+        onChange={(value, type) => validate('dmsEast', type, value)}
+      >
+        <DirectionInput
+          options={longitudeDirections}
+          value={dmsEastDirection}
+          onChange={value => setState('dmsEastDirection', value)}
+        />
+      </DmsLongitude>
+      <DmsLatitude
+        label="North"
+        value={dmsNorth}
+        onChange={(value, type) => validate('dmsNorth', type, value)}
+      >
+        <DirectionInput
+          options={latitudeDirections}
+          value={dmsNorthDirection}
+          onChange={value => setState('dmsNorthDirection', value)}
+        />
+      </DmsLatitude>
+      {getErrorComponent(dmsError)}
     </div>
   )
 }
 
 const BoundingBoxUsngMgrs = props => {
-  const { usngbbUpperLeft, usngbbLowerRight, cursor } = props
+  const { usngbbUpperLeft, usngbbLowerRight, setState } = props
+  const [usngError, setUsngError] = useState(initialErrorState)
   return (
     <div className="input-location">
       <TextField
         label="Upper Left"
         style={{ minWidth: 200 }}
         value={usngbbUpperLeft}
-        onChange={cursor('usngbbUpperLeft')}
+        onChange={value => setState('usngbbUpperLeft', value)}
+        onBlur={() => setUsngError(validateGeo('usng', usngbbUpperLeft))}
       />
       <TextField
         label="Lower Right"
         style={{ minWidth: 200 }}
         value={usngbbLowerRight}
-        onChange={cursor('usngbbLowerRight')}
+        onChange={value => setState('usngbbLowerRight', value)}
+        onBlur={() => setUsngError(validateGeo('usng', usngbbLowerRight))}
       />
+      {getErrorComponent(usngError)}
     </div>
   )
 }
@@ -112,15 +227,14 @@ const BoundingBoxUtmUps = props => {
     utmUpsUpperLeftNorthing,
     utmUpsUpperLeftZone,
     utmUpsUpperLeftHemisphere,
-
     utmUpsLowerRightEasting,
     utmUpsLowerRightNorthing,
     utmUpsLowerRightZone,
     utmUpsLowerRightHemisphere,
-
-    cursor,
+    setState,
   } = props
-
+  const [upperLeftError, setUpperLeftError] = useState(initialErrorState)
+  const [lowerRightError, setLowerRightError] = useState(initialErrorState)
   return (
     <div>
       <div className="input-location">
@@ -129,26 +243,79 @@ const BoundingBoxUtmUps = props => {
           <div>
             <TextField
               label="Easting"
-              value={utmUpsUpperLeftEasting}
-              onChange={cursor('utmUpsUpperLeftEasting')}
+              value={
+                utmUpsUpperLeftEasting !== undefined
+                  ? String(utmUpsUpperLeftEasting)
+                  : utmUpsUpperLeftEasting
+              }
+              onChange={value => setState('utmUpsUpperLeftEasting', value)}
+              onBlur={() =>
+                setUpperLeftError(
+                  validateGeo(
+                    'utmUpsEasting',
+                    utmUpsUpperLeftEasting,
+                    utmUpsUpperLeftNorthing,
+                    utmUpsUpperLeftZone,
+                    utmUpsUpperLeftHemisphere
+                  )
+                )
+              }
               addon="m"
             />
             <TextField
               label="Northing"
-              value={utmUpsUpperLeftNorthing}
-              onChange={cursor('utmUpsUpperLeftNorthing')}
+              value={
+                utmUpsUpperLeftNorthing !== undefined
+                  ? String(utmUpsUpperLeftNorthing)
+                  : utmUpsUpperLeftNorthing
+              }
+              onChange={value => setState('utmUpsUpperLeftNorthing', value)}
+              onBlur={() =>
+                setUpperLeftError(
+                  validateGeo(
+                    'utmUpsNorthing',
+                    utmUpsUpperLeftEasting,
+                    utmUpsUpperLeftNorthing,
+                    utmUpsUpperLeftZone,
+                    utmUpsUpperLeftHemisphere
+                  )
+                )
+              }
               addon="m"
             />
             <Zone
               value={utmUpsUpperLeftZone}
-              onChange={cursor('utmUpsUpperLeftZone')}
+              onChange={value => setState('utmUpsUpperLeftZone', value)}
+              onBlur={() =>
+                setUpperLeftError(
+                  validateGeo(
+                    'utmUpsZone',
+                    utmUpsUpperLeftEasting,
+                    utmUpsUpperLeftNorthing,
+                    utmUpsUpperLeftZone,
+                    utmUpsUpperLeftHemisphere
+                  )
+                )
+              }
             />
             <Hemisphere
               value={utmUpsUpperLeftHemisphere}
-              onChange={cursor('utmUpsUpperLeftHemisphere')}
+              onChange={value => setState('utmUpsUpperLeftHemisphere', value)}
+              onBlur={() =>
+                setUpperLeftError(
+                  validateGeo(
+                    'utmUpsHemisphere',
+                    utmUpsUpperLeftEasting,
+                    utmUpsUpperLeftNorthing,
+                    utmUpsUpperLeftZone,
+                    utmUpsUpperLeftHemisphere
+                  )
+                )
+              }
             />
           </div>
         </Group>
+        {getErrorComponent(upperLeftError)}
       </div>
       <div className="input-location">
         <Group>
@@ -156,99 +323,103 @@ const BoundingBoxUtmUps = props => {
           <div>
             <TextField
               label="Easting"
-              value={utmUpsLowerRightEasting}
-              onChange={cursor('utmUpsLowerRightEasting')}
+              value={
+                utmUpsLowerRightEasting !== undefined
+                  ? String(utmUpsLowerRightEasting)
+                  : utmUpsLowerRightEasting
+              }
+              onChange={value => setState('utmUpsLowerRightEasting', value)}
+              onBlur={() =>
+                setLowerRightError(
+                  validateGeo(
+                    'utmUpsEasting',
+                    utmUpsLowerRightEasting,
+                    utmUpsLowerRightNorthing,
+                    utmUpsLowerRightZone,
+                    utmUpsLowerRightHemisphere
+                  )
+                )
+              }
               addon="m"
             />
             <TextField
               label="Northing"
-              value={utmUpsLowerRightNorthing}
-              onChange={cursor('utmUpsLowerRightNorthing')}
+              value={
+                utmUpsLowerRightNorthing !== undefined
+                  ? String(utmUpsLowerRightNorthing)
+                  : utmUpsLowerRightNorthing
+              }
+              onChange={value => setState('utmUpsLowerRightNorthing', value)}
+              onBlur={() =>
+                setLowerRightError(
+                  validateGeo(
+                    'utmUpsNorthing',
+                    utmUpsLowerRightEasting,
+                    utmUpsLowerRightNorthing,
+                    utmUpsLowerRightZone,
+                    utmUpsLowerRightHemisphere
+                  )
+                )
+              }
               addon="m"
             />
             <Zone
               value={utmUpsLowerRightZone}
-              onChange={cursor('utmUpsLowerRightZone')}
+              onChange={value => setState('utmUpsLowerRightZone', value)}
+              onBlur={() =>
+                setLowerRightError(
+                  validateGeo(
+                    'utmUpsZone',
+                    utmUpsLowerRightEasting,
+                    utmUpsLowerRightNorthing,
+                    utmUpsLowerRightZone,
+                    utmUpsLowerRightHemisphere
+                  )
+                )
+              }
             />
             <Hemisphere
               value={utmUpsLowerRightHemisphere}
-              onChange={cursor('utmUpsLowerRightHemisphere')}
+              onChange={value => setState('utmUpsLowerRightHemisphere', value)}
+              onBlur={() =>
+                setLowerRightError(
+                  validateGeo(
+                    'utmUpsHemisphere',
+                    utmUpsLowerRightEasting,
+                    utmUpsLowerRightNorthing,
+                    utmUpsLowerRightZone,
+                    utmUpsLowerRightHemisphere
+                  )
+                )
+              }
             />
           </div>
         </Group>
+        {getErrorComponent(lowerRightError)}
       </div>
     </div>
   )
 }
 
-const BoundingBoxDms = props => {
-  const {
-    dmsSouth,
-    dmsNorth,
-    dmsWest,
-    dmsEast,
-
-    dmsSouthDirection,
-    dmsNorthDirection,
-    dmsWestDirection,
-    dmsEastDirection,
-
-    cursor,
-  } = props
-
-  const latitudeDirections = [Direction.North, Direction.South]
-  const longitudeDirections = [Direction.East, Direction.West]
-
-  return (
-    <div className="input-location">
-      <DmsLongitude label="West" value={dmsWest} onChange={cursor('dmsWest')}>
-        <DirectionInput
-          options={longitudeDirections}
-          value={dmsWestDirection}
-          onChange={cursor('dmsWestDirection')}
-        />
-      </DmsLongitude>
-      <DmsLatitude label="South" value={dmsSouth} onChange={cursor('dmsSouth')}>
-        <DirectionInput
-          options={latitudeDirections}
-          value={dmsSouthDirection}
-          onChange={cursor('dmsSouthDirection')}
-        />
-      </DmsLatitude>
-      <DmsLongitude label="East" value={dmsEast} onChange={cursor('dmsEast')}>
-        <DirectionInput
-          options={longitudeDirections}
-          value={dmsEastDirection}
-          onChange={cursor('dmsEastDirection')}
-        />
-      </DmsLongitude>
-      <DmsLatitude label="North" value={dmsNorth} onChange={cursor('dmsNorth')}>
-        <DirectionInput
-          options={latitudeDirections}
-          value={dmsNorthDirection}
-          onChange={cursor('dmsNorthDirection')}
-        />
-      </DmsLatitude>
-    </div>
-  )
-}
-
 const BoundingBox = props => {
-  const { cursor, locationType } = props
+  const { setState, locationType } = props
 
   const inputs = {
-    latlon: BoundingBoxLatLon,
+    dd: BoundingBoxLatLonDd,
+    dms: BoundingBoxLatLonDms,
     usng: BoundingBoxUsngMgrs,
     utmUps: BoundingBoxUtmUps,
-    dms: BoundingBoxDms,
   }
 
   const Component = inputs[locationType] || null
 
   return (
     <div>
-      <Radio value={locationType} onChange={cursor('locationType')}>
-        <RadioItem value="latlon">Lat/Lon (DD)</RadioItem>
+      <Radio
+        value={locationType}
+        onChange={value => setState('locationType', value)}
+      >
+        <RadioItem value="dd">Lat/Lon (DD)</RadioItem>
         <RadioItem value="dms">Lat/Lon (DMS)</RadioItem>
         <RadioItem value="usng">USNG / MGRS</RadioItem>
         <RadioItem value="utmUps">UTM / UPS</RadioItem>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -54,9 +54,9 @@ const BoundingBoxLatLonDd = props => {
     const { error, message, defaultValue } = validateGeo(label, value)
     if (defaultValue) {
       setDdError({ error, message, defaultValue })
-      setState(key, defaultValue)
+      setState({[key]: defaultValue})
     } else {
-      setState(key, value)
+      setState({[key]: value})
     }
   }
   return (
@@ -143,7 +143,7 @@ const BoundingBoxLatLonDms = props => {
         defaultValue,
       })
     }
-    defaultValue ? setState(key, defaultValue) : setState(key, value)
+    defaultValue ? setState({[key]: defaultValue}) : setState({[key]: value})
   }
 
   return (
@@ -156,7 +156,7 @@ const BoundingBoxLatLonDms = props => {
         <DirectionInput
           options={longitudeDirections}
           value={dmsWestDirection}
-          onChange={value => setState('dmsWestDirection', value)}
+          onChange={value => setState({['dmsWestDirection']: value})}
         />
       </DmsLongitude>
       <DmsLatitude
@@ -167,7 +167,7 @@ const BoundingBoxLatLonDms = props => {
         <DirectionInput
           options={latitudeDirections}
           value={dmsSouthDirection}
-          onChange={value => setState('dmsSouthDirection', value)}
+          onChange={value => setState({['dmsSouthDirection']: value})}
         />
       </DmsLatitude>
       <DmsLongitude
@@ -178,7 +178,7 @@ const BoundingBoxLatLonDms = props => {
         <DirectionInput
           options={longitudeDirections}
           value={dmsEastDirection}
-          onChange={value => setState('dmsEastDirection', value)}
+          onChange={value => setState({['dmsEastDirection']: value})}
         />
       </DmsLongitude>
       <DmsLatitude
@@ -189,7 +189,7 @@ const BoundingBoxLatLonDms = props => {
         <DirectionInput
           options={latitudeDirections}
           value={dmsNorthDirection}
-          onChange={value => setState('dmsNorthDirection', value)}
+          onChange={value => setState({['dmsNorthDirection']: value})}
         />
       </DmsLatitude>
       {getErrorComponent(dmsError)}
@@ -206,14 +206,14 @@ const BoundingBoxUsngMgrs = props => {
         label="Upper Left"
         style={{ minWidth: 200 }}
         value={usngbbUpperLeft}
-        onChange={value => setState('usngbbUpperLeft', value)}
+        onChange={value => setState({['usngbbUpperLeft']: value})}
         onBlur={() => setUsngError(validateGeo('usng', usngbbUpperLeft))}
       />
       <TextField
         label="Lower Right"
         style={{ minWidth: 200 }}
         value={usngbbLowerRight}
-        onChange={value => setState('usngbbLowerRight', value)}
+        onChange={value => setState({['usngbbLowerRight']: value})}
         onBlur={() => setUsngError(validateGeo('usng', usngbbLowerRight))}
       />
       {getErrorComponent(usngError)}
@@ -248,7 +248,7 @@ const BoundingBoxUtmUps = props => {
                   ? String(utmUpsUpperLeftEasting)
                   : utmUpsUpperLeftEasting
               }
-              onChange={value => setState('utmUpsUpperLeftEasting', value)}
+              onChange={value => setState({['utmUpsUpperLeftEasting']: value})}
               onBlur={() =>
                 setUpperLeftError(
                   validateGeo(
@@ -269,7 +269,7 @@ const BoundingBoxUtmUps = props => {
                   ? String(utmUpsUpperLeftNorthing)
                   : utmUpsUpperLeftNorthing
               }
-              onChange={value => setState('utmUpsUpperLeftNorthing', value)}
+              onChange={value => setState({['utmUpsUpperLeftNorthing']: value})}
               onBlur={() =>
                 setUpperLeftError(
                   validateGeo(
@@ -285,7 +285,7 @@ const BoundingBoxUtmUps = props => {
             />
             <Zone
               value={utmUpsUpperLeftZone}
-              onChange={value => setState('utmUpsUpperLeftZone', value)}
+              onChange={value => setState({['utmUpsUpperLeftZone']: value})}
               onBlur={() =>
                 setUpperLeftError(
                   validateGeo(
@@ -300,7 +300,7 @@ const BoundingBoxUtmUps = props => {
             />
             <Hemisphere
               value={utmUpsUpperLeftHemisphere}
-              onChange={value => setState('utmUpsUpperLeftHemisphere', value)}
+              onChange={value => setState({['utmUpsUpperLeftHemisphere']: value})}
               onBlur={() =>
                 setUpperLeftError(
                   validateGeo(
@@ -328,7 +328,7 @@ const BoundingBoxUtmUps = props => {
                   ? String(utmUpsLowerRightEasting)
                   : utmUpsLowerRightEasting
               }
-              onChange={value => setState('utmUpsLowerRightEasting', value)}
+              onChange={value => setState({['utmUpsLowerRightEasting']: value})}
               onBlur={() =>
                 setLowerRightError(
                   validateGeo(
@@ -349,7 +349,7 @@ const BoundingBoxUtmUps = props => {
                   ? String(utmUpsLowerRightNorthing)
                   : utmUpsLowerRightNorthing
               }
-              onChange={value => setState('utmUpsLowerRightNorthing', value)}
+              onChange={value => setState({['utmUpsLowerRightNorthing']: value})}
               onBlur={() =>
                 setLowerRightError(
                   validateGeo(
@@ -365,7 +365,7 @@ const BoundingBoxUtmUps = props => {
             />
             <Zone
               value={utmUpsLowerRightZone}
-              onChange={value => setState('utmUpsLowerRightZone', value)}
+              onChange={value => setState({['utmUpsLowerRightZone']: value})}
               onBlur={() =>
                 setLowerRightError(
                   validateGeo(
@@ -380,7 +380,7 @@ const BoundingBoxUtmUps = props => {
             />
             <Hemisphere
               value={utmUpsLowerRightHemisphere}
-              onChange={value => setState('utmUpsLowerRightHemisphere', value)}
+              onChange={value => setState({['utmUpsLowerRightHemisphere']: value})}
               onBlur={() =>
                 setLowerRightError(
                   validateGeo(
@@ -417,7 +417,7 @@ const BoundingBox = props => {
     <div>
       <Radio
         value={locationType}
-        onChange={value => setState('locationType', value)}
+        onChange={value => setState({['locationType']: value})}
       >
         <RadioItem value="dd">Lat/Lon (DD)</RadioItem>
         <RadioItem value="dms">Lat/Lon (DMS)</RadioItem>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -51,19 +51,22 @@ const BoundingBoxLatLonDd = props => {
   const northMin = parseFloat(mapSouth) + minimumDifference
   const southMax = parseFloat(mapNorth) - minimumDifference
 
-  useEffect(() => {
-    if(props.drawing) {
-      setDdError(initialErrorStateWithDefault)
-    }
-  }, [props.east, props.west, props.south, props.north])
+  useEffect(
+    () => {
+      if (props.drawing) {
+        setDdError(initialErrorStateWithDefault)
+      }
+    },
+    [props.east, props.west, props.south, props.north]
+  )
 
   function onChangeDd(key, label, value) {
     const { error, message, defaultValue } = validateGeo(label, value)
     if (defaultValue) {
       setDdError({ error, message, defaultValue })
-      setState({[key]: defaultValue})
+      setState({ [key]: defaultValue })
     } else {
-      setState({[key]: value})
+      setState({ [key]: value })
     }
   }
   return (
@@ -133,12 +136,15 @@ const BoundingBoxLatLonDms = props => {
   const latitudeDirections = [Direction.North, Direction.South]
   const longitudeDirections = [Direction.East, Direction.West]
 
-  useEffect(() => {
-    console.log(props.drawing)
-    if(props.drawing) {
-      setDmsError(initialErrorStateWithDefault)
-    }
-  }, [props.dmsWest, props.dmsSouth, props.dmsEast, props.dmsNorth])
+  useEffect(
+    () => {
+      console.log(props.drawing)
+      if (props.drawing) {
+        setDmsError(initialErrorStateWithDefault)
+      }
+    },
+    [props.dmsWest, props.dmsSouth, props.dmsEast, props.dmsNorth]
+  )
 
   function validate(key, type, value) {
     const label =
@@ -157,7 +163,9 @@ const BoundingBoxLatLonDms = props => {
         defaultValue,
       })
     }
-    defaultValue ? setState({[key]: defaultValue}) : setState({[key]: value})
+    defaultValue
+      ? setState({ [key]: defaultValue })
+      : setState({ [key]: value })
   }
 
   return (
@@ -170,7 +178,7 @@ const BoundingBoxLatLonDms = props => {
         <DirectionInput
           options={longitudeDirections}
           value={dmsWestDirection}
-          onChange={value => setState({['dmsWestDirection']: value})}
+          onChange={value => setState({ ['dmsWestDirection']: value })}
         />
       </DmsLongitude>
       <DmsLatitude
@@ -181,7 +189,7 @@ const BoundingBoxLatLonDms = props => {
         <DirectionInput
           options={latitudeDirections}
           value={dmsSouthDirection}
-          onChange={value => setState({['dmsSouthDirection']: value})}
+          onChange={value => setState({ ['dmsSouthDirection']: value })}
         />
       </DmsLatitude>
       <DmsLongitude
@@ -192,7 +200,7 @@ const BoundingBoxLatLonDms = props => {
         <DirectionInput
           options={longitudeDirections}
           value={dmsEastDirection}
-          onChange={value => setState({['dmsEastDirection']: value})}
+          onChange={value => setState({ ['dmsEastDirection']: value })}
         />
       </DmsLongitude>
       <DmsLatitude
@@ -203,7 +211,7 @@ const BoundingBoxLatLonDms = props => {
         <DirectionInput
           options={latitudeDirections}
           value={dmsNorthDirection}
-          onChange={value => setState({['dmsNorthDirection']: value})}
+          onChange={value => setState({ ['dmsNorthDirection']: value })}
         />
       </DmsLatitude>
       {getErrorComponent(dmsError)}
@@ -215,11 +223,14 @@ const BoundingBoxUsngMgrs = props => {
   const { usngbbUpperLeft, usngbbLowerRight, setState } = props
   const [usngError, setUsngError] = useState(initialErrorState)
 
-  useEffect(() => {
-    if(props.drawing) {
-      setUsngError(initialErrorState)
-    }
-  }, [props.usngbbUpperLeft, props.usngbbLowerRight])
+  useEffect(
+    () => {
+      if (props.drawing) {
+        setUsngError(initialErrorState)
+      }
+    },
+    [props.usngbbUpperLeft, props.usngbbLowerRight]
+  )
 
   return (
     <div className="input-location">
@@ -227,14 +238,14 @@ const BoundingBoxUsngMgrs = props => {
         label="Upper Left"
         style={{ minWidth: 200 }}
         value={usngbbUpperLeft}
-        onChange={value => setState({['usngbbUpperLeft']: value})}
+        onChange={value => setState({ ['usngbbUpperLeft']: value })}
         onBlur={() => setUsngError(validateGeo('usng', usngbbUpperLeft))}
       />
       <TextField
         label="Lower Right"
         style={{ minWidth: 200 }}
         value={usngbbLowerRight}
-        onChange={value => setState({['usngbbLowerRight']: value})}
+        onChange={value => setState({ ['usngbbLowerRight']: value })}
         onBlur={() => setUsngError(validateGeo('usng', usngbbLowerRight))}
       />
       {getErrorComponent(usngError)}
@@ -257,12 +268,24 @@ const BoundingBoxUtmUps = props => {
   const [upperLeftError, setUpperLeftError] = useState(initialErrorState)
   const [lowerRightError, setLowerRightError] = useState(initialErrorState)
 
-  useEffect(() => {
-    if(props.drawing) {
-      setUpperLeftError(initialErrorState)
-      setLowerRightError(initialErrorState)
-    }
-  }, [props.utmUpsUpperLeftEasting, props.utmUpsUpperLeftNorthing, props.utmUpsUpperLeftZone, props.utmUpsUpperLeftHemisphere, props.utmUpsLowerRightEasting, props.utmUpsLowerRightNorthing, props.utmUpsLowerRightZone, props.utmUpsLowerRightHemisphere])
+  useEffect(
+    () => {
+      if (props.drawing) {
+        setUpperLeftError(initialErrorState)
+        setLowerRightError(initialErrorState)
+      }
+    },
+    [
+      props.utmUpsUpperLeftEasting,
+      props.utmUpsUpperLeftNorthing,
+      props.utmUpsUpperLeftZone,
+      props.utmUpsUpperLeftHemisphere,
+      props.utmUpsLowerRightEasting,
+      props.utmUpsLowerRightNorthing,
+      props.utmUpsLowerRightZone,
+      props.utmUpsLowerRightHemisphere,
+    ]
+  )
 
   return (
     <div>
@@ -277,7 +300,9 @@ const BoundingBoxUtmUps = props => {
                   ? String(utmUpsUpperLeftEasting)
                   : utmUpsUpperLeftEasting
               }
-              onChange={value => setState({['utmUpsUpperLeftEasting']: value})}
+              onChange={value =>
+                setState({ ['utmUpsUpperLeftEasting']: value })
+              }
               onBlur={() =>
                 setUpperLeftError(
                   validateGeo(
@@ -298,7 +323,9 @@ const BoundingBoxUtmUps = props => {
                   ? String(utmUpsUpperLeftNorthing)
                   : utmUpsUpperLeftNorthing
               }
-              onChange={value => setState({['utmUpsUpperLeftNorthing']: value})}
+              onChange={value =>
+                setState({ ['utmUpsUpperLeftNorthing']: value })
+              }
               onBlur={() =>
                 setUpperLeftError(
                   validateGeo(
@@ -314,7 +341,7 @@ const BoundingBoxUtmUps = props => {
             />
             <Zone
               value={utmUpsUpperLeftZone}
-              onChange={value => setState({['utmUpsUpperLeftZone']: value})}
+              onChange={value => setState({ ['utmUpsUpperLeftZone']: value })}
               onBlur={() =>
                 setUpperLeftError(
                   validateGeo(
@@ -329,7 +356,9 @@ const BoundingBoxUtmUps = props => {
             />
             <Hemisphere
               value={utmUpsUpperLeftHemisphere}
-              onChange={value => setState({['utmUpsUpperLeftHemisphere']: value})}
+              onChange={value =>
+                setState({ ['utmUpsUpperLeftHemisphere']: value })
+              }
               onBlur={() =>
                 setUpperLeftError(
                   validateGeo(
@@ -357,7 +386,9 @@ const BoundingBoxUtmUps = props => {
                   ? String(utmUpsLowerRightEasting)
                   : utmUpsLowerRightEasting
               }
-              onChange={value => setState({['utmUpsLowerRightEasting']: value})}
+              onChange={value =>
+                setState({ ['utmUpsLowerRightEasting']: value })
+              }
               onBlur={() =>
                 setLowerRightError(
                   validateGeo(
@@ -378,7 +409,9 @@ const BoundingBoxUtmUps = props => {
                   ? String(utmUpsLowerRightNorthing)
                   : utmUpsLowerRightNorthing
               }
-              onChange={value => setState({['utmUpsLowerRightNorthing']: value})}
+              onChange={value =>
+                setState({ ['utmUpsLowerRightNorthing']: value })
+              }
               onBlur={() =>
                 setLowerRightError(
                   validateGeo(
@@ -394,7 +427,7 @@ const BoundingBoxUtmUps = props => {
             />
             <Zone
               value={utmUpsLowerRightZone}
-              onChange={value => setState({['utmUpsLowerRightZone']: value})}
+              onChange={value => setState({ ['utmUpsLowerRightZone']: value })}
               onBlur={() =>
                 setLowerRightError(
                   validateGeo(
@@ -409,7 +442,9 @@ const BoundingBoxUtmUps = props => {
             />
             <Hemisphere
               value={utmUpsLowerRightHemisphere}
-              onChange={value => setState({['utmUpsLowerRightHemisphere']: value})}
+              onChange={value =>
+                setState({ ['utmUpsLowerRightHemisphere']: value })
+              }
               onBlur={() =>
                 setLowerRightError(
                   validateGeo(
@@ -446,7 +481,7 @@ const BoundingBox = props => {
     <div>
       <Radio
         value={locationType}
-        onChange={value => setState({['locationType']: value})}
+        onChange={value => setState({ ['locationType']: value })}
       >
         <RadioItem value="dd">Lat/Lon (DD)</RadioItem>
         <RadioItem value="dms">Lat/Lon (DMS)</RadioItem>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -60,7 +60,7 @@ const BoundingBoxLatLonDd = props => {
     [props.east, props.west, props.south, props.north]
   )
 
-  function onChangeDd(key, value) {
+  function validateDd(key, value) {
     const label =
       key.includes('east') || key.includes('west') ? 'lon' : 'lat'
     const { error, message, defaultValue } = validateGeo(label, value)
@@ -76,7 +76,7 @@ const BoundingBoxLatLonDd = props => {
       <TextField
         label="West"
         value={west !== undefined ? String(west) : west}
-        onChange={value => onChangeDd('west', value)}
+        onChange={value => validateDd('west', value)}
         onBlur={() => setDdError(validateGeo('lon', west))}
         type="number"
         step="any"
@@ -87,7 +87,7 @@ const BoundingBoxLatLonDd = props => {
       <TextField
         label="South"
         value={south !== undefined ? String(south) : south}
-        onChange={value => onChangeDd('south', value)}
+        onChange={value => validateDd('south', value)}
         onBlur={() => setDdError(validateGeo('lat', south))}
         type="number"
         step="any"
@@ -98,7 +98,7 @@ const BoundingBoxLatLonDd = props => {
       <TextField
         label="East"
         value={east !== undefined ? String(east) : east}
-        onChange={value => onChangeDd('east', value)}
+        onChange={value => validateDd('east', value)}
         onBlur={() => setDdError(validateGeo('lon', east))}
         type="number"
         step="any"
@@ -109,7 +109,7 @@ const BoundingBoxLatLonDd = props => {
       <TextField
         label="North"
         value={north !== undefined ? String(north) : north}
-        onChange={value => onChangeDd('north', value)}
+        onChange={value => validateDd('north', value)}
         onBlur={() => setDdError(validateGeo('lat', north))}
         type="number"
         step="any"
@@ -147,7 +147,7 @@ const BoundingBoxLatLonDms = props => {
     [props.dmsWest, props.dmsSouth, props.dmsEast, props.dmsNorth]
   )
 
-  function validate(key, type, value) {
+  function validateDms(key, type, value) {
     const label =
       key.includes('East') || key.includes('West') ? 'dmsLon' : 'dmsLat'
     const { error, message, defaultValue } = validateGeo(label, value)
@@ -174,7 +174,7 @@ const BoundingBoxLatLonDms = props => {
       <DmsLongitude
         label="West"
         value={dmsWest}
-        onChange={(value, type) => validate('dmsWest', type, value)}
+        onChange={(value, type) => validateDms('dmsWest', type, value)}
       >
         <DirectionInput
           options={longitudeDirections}
@@ -185,7 +185,7 @@ const BoundingBoxLatLonDms = props => {
       <DmsLatitude
         label="South"
         value={dmsSouth}
-        onChange={(value, type) => validate('dmsSouth', type, value)}
+        onChange={(value, type) => validateDms('dmsSouth', type, value)}
       >
         <DirectionInput
           options={latitudeDirections}
@@ -196,7 +196,7 @@ const BoundingBoxLatLonDms = props => {
       <DmsLongitude
         label="East"
         value={dmsEast}
-        onChange={(value, type) => validate('dmsEast', type, value)}
+        onChange={(value, type) => validateDms('dmsEast', type, value)}
       >
         <DirectionInput
           options={longitudeDirections}
@@ -207,7 +207,7 @@ const BoundingBoxLatLonDms = props => {
       <DmsLatitude
         label="North"
         value={dmsNorth}
-        onChange={(value, type) => validate('dmsNorth', type, value)}
+        onChange={(value, type) => validateDms('dmsNorth', type, value)}
       >
         <DirectionInput
           options={latitudeDirections}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -61,8 +61,7 @@ const BoundingBoxLatLonDd = props => {
   )
 
   function validateDd(key, value) {
-    const label =
-      key.includes('east') || key.includes('west') ? 'lon' : 'lat'
+    const label = key.includes('east') || key.includes('west') ? 'lon' : 'lat'
     const { error, message, defaultValue } = validateGeo(label, value)
     if (defaultValue) {
       setDdError({ error, message, defaultValue })

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -116,7 +116,7 @@ const BoundingBoxLatLonDd = props => {
         max={90}
         addon="°"
       />
-      <ErrorComponent errorState={ddError}/>
+      <ErrorComponent errorState={ddError} />
     </div>
   )
 }
@@ -214,7 +214,7 @@ const BoundingBoxLatLonDms = props => {
           onChange={value => setState({ ['dmsNorthDirection']: value })}
         />
       </DmsLatitude>
-      <ErrorComponent errorState={dmsError}/>
+      <ErrorComponent errorState={dmsError} />
     </div>
   )
 }
@@ -248,7 +248,7 @@ const BoundingBoxUsngMgrs = props => {
         onChange={value => setState({ ['usngbbLowerRight']: value })}
         onBlur={() => setUsngError(validateGeo('usng', usngbbLowerRight))}
       />
-      <ErrorComponent errorState={usngError}/>
+      <ErrorComponent errorState={usngError} />
     </div>
   )
 }
@@ -305,13 +305,12 @@ const BoundingBoxUtmUps = props => {
               }
               onBlur={() =>
                 setUpperLeftError(
-                  validateGeo(
-                    'utmUpsEasting',
-                    utmUpsUpperLeftEasting,
-                    utmUpsUpperLeftNorthing,
-                    utmUpsUpperLeftZone,
-                    utmUpsUpperLeftHemisphere
-                  )
+                  validateGeo('utmUpsEasting', {
+                    utmUpsEasting: utmUpsUpperLeftEasting,
+                    utmUpsNorthing: utmUpsUpperLeftNorthing,
+                    zoneNumber: utmUpsUpperLeftZone,
+                    hemisphere: utmUpsUpperLeftHemisphere,
+                  })
                 )
               }
               addon="m"
@@ -328,13 +327,12 @@ const BoundingBoxUtmUps = props => {
               }
               onBlur={() =>
                 setUpperLeftError(
-                  validateGeo(
-                    'utmUpsNorthing',
-                    utmUpsUpperLeftEasting,
-                    utmUpsUpperLeftNorthing,
-                    utmUpsUpperLeftZone,
-                    utmUpsUpperLeftHemisphere
-                  )
+                  validateGeo('utmUpsNorthing', {
+                    utmUpsEasting: utmUpsUpperLeftEasting,
+                    utmUpsNorthing: utmUpsUpperLeftNorthing,
+                    zoneNumber: utmUpsUpperLeftZone,
+                    hemisphere: utmUpsUpperLeftHemisphere,
+                  })
                 )
               }
               addon="m"
@@ -344,13 +342,12 @@ const BoundingBoxUtmUps = props => {
               onChange={value => setState({ ['utmUpsUpperLeftZone']: value })}
               onBlur={() =>
                 setUpperLeftError(
-                  validateGeo(
-                    'utmUpsZone',
-                    utmUpsUpperLeftEasting,
-                    utmUpsUpperLeftNorthing,
-                    utmUpsUpperLeftZone,
-                    utmUpsUpperLeftHemisphere
-                  )
+                  validateGeo('utmUpsZone', {
+                    utmUpsEasting: utmUpsUpperLeftEasting,
+                    utmUpsNorthing: utmUpsUpperLeftNorthing,
+                    zoneNumber: utmUpsUpperLeftZone,
+                    hemisphere: utmUpsUpperLeftHemisphere,
+                  })
                 )
               }
             />
@@ -361,19 +358,18 @@ const BoundingBoxUtmUps = props => {
               }
               onBlur={() =>
                 setUpperLeftError(
-                  validateGeo(
-                    'utmUpsHemisphere',
-                    utmUpsUpperLeftEasting,
-                    utmUpsUpperLeftNorthing,
-                    utmUpsUpperLeftZone,
-                    utmUpsUpperLeftHemisphere
-                  )
+                  validateGeo('utmUpsHemisphere', {
+                    utmUpsEasting: utmUpsUpperLeftEasting,
+                    utmUpsNorthing: utmUpsUpperLeftNorthing,
+                    zoneNumber: utmUpsUpperLeftZone,
+                    hemisphere: utmUpsUpperLeftHemisphere,
+                  })
                 )
               }
             />
           </div>
         </Group>
-        <ErrorComponent errorState={upperLeftError}/>
+        <ErrorComponent errorState={upperLeftError} />
       </div>
       <div className="input-location">
         <Group>
@@ -391,13 +387,12 @@ const BoundingBoxUtmUps = props => {
               }
               onBlur={() =>
                 setLowerRightError(
-                  validateGeo(
-                    'utmUpsEasting',
-                    utmUpsLowerRightEasting,
-                    utmUpsLowerRightNorthing,
-                    utmUpsLowerRightZone,
-                    utmUpsLowerRightHemisphere
-                  )
+                  validateGeo('utmUpsEasting', {
+                    utmUpsEasting: utmUpsLowerRightEasting,
+                    utmUpsNorthing: utmUpsLowerRightNorthing,
+                    zoneNumber: utmUpsLowerRightZone,
+                    hemisphere: utmUpsLowerRightHemisphere,
+                  })
                 )
               }
               addon="m"
@@ -414,13 +409,12 @@ const BoundingBoxUtmUps = props => {
               }
               onBlur={() =>
                 setLowerRightError(
-                  validateGeo(
-                    'utmUpsNorthing',
-                    utmUpsLowerRightEasting,
-                    utmUpsLowerRightNorthing,
-                    utmUpsLowerRightZone,
-                    utmUpsLowerRightHemisphere
-                  )
+                  validateGeo('utmUpsNorthing', {
+                    utmUpsEasting: utmUpsLowerRightEasting,
+                    utmUpsNorthing: utmUpsLowerRightNorthing,
+                    zoneNumber: utmUpsLowerRightZone,
+                    hemisphere: utmUpsLowerRightHemisphere,
+                  })
                 )
               }
               addon="m"
@@ -430,13 +424,12 @@ const BoundingBoxUtmUps = props => {
               onChange={value => setState({ ['utmUpsLowerRightZone']: value })}
               onBlur={() =>
                 setLowerRightError(
-                  validateGeo(
-                    'utmUpsZone',
-                    utmUpsLowerRightEasting,
-                    utmUpsLowerRightNorthing,
-                    utmUpsLowerRightZone,
-                    utmUpsLowerRightHemisphere
-                  )
+                  validateGeo('utmUpsZone', {
+                    utmUpsEasting: utmUpsLowerRightEasting,
+                    utmUpsNorthing: utmUpsLowerRightNorthing,
+                    zoneNumber: utmUpsLowerRightZone,
+                    hemisphere: utmUpsLowerRightHemisphere,
+                  })
                 )
               }
             />
@@ -447,19 +440,18 @@ const BoundingBoxUtmUps = props => {
               }
               onBlur={() =>
                 setLowerRightError(
-                  validateGeo(
-                    'utmUpsHemisphere',
-                    utmUpsLowerRightEasting,
-                    utmUpsLowerRightNorthing,
-                    utmUpsLowerRightZone,
-                    utmUpsLowerRightHemisphere
-                  )
+                  validateGeo('utmUpsHemisphere', {
+                    utmUpsEasting: utmUpsLowerRightEasting,
+                    utmUpsNorthing: utmUpsLowerRightNorthing,
+                    zoneNumber: utmUpsLowerRightZone,
+                    hemisphere: utmUpsLowerRightHemisphere,
+                  })
                 )
               }
             />
           </div>
         </Group>
-       <ErrorComponent errorState={lowerRightError}/>
+        <ErrorComponent errorState={lowerRightError} />
       </div>
     </div>
   )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import {
   validateGeo,
   getErrorComponent,
@@ -50,6 +50,13 @@ const BoundingBoxLatLonDd = props => {
   const eastMin = parseFloat(mapWest) + minimumDifference
   const northMin = parseFloat(mapSouth) + minimumDifference
   const southMax = parseFloat(mapNorth) - minimumDifference
+
+  useEffect(() => {
+    if(props.drawing) {
+      setDdError(initialErrorStateWithDefault)
+    }
+  }, [props.east, props.west, props.south, props.north])
+
   function onChangeDd(key, label, value) {
     const { error, message, defaultValue } = validateGeo(label, value)
     if (defaultValue) {
@@ -126,6 +133,13 @@ const BoundingBoxLatLonDms = props => {
   const latitudeDirections = [Direction.North, Direction.South]
   const longitudeDirections = [Direction.East, Direction.West]
 
+  useEffect(() => {
+    console.log(props.drawing)
+    if(props.drawing) {
+      setDmsError(initialErrorStateWithDefault)
+    }
+  }, [props.dmsWest, props.dmsSouth, props.dmsEast, props.dmsNorth])
+
   function validate(key, type, value) {
     const label =
       key.includes('East') || key.includes('West') ? 'dmsLon' : 'dmsLat'
@@ -200,6 +214,13 @@ const BoundingBoxLatLonDms = props => {
 const BoundingBoxUsngMgrs = props => {
   const { usngbbUpperLeft, usngbbLowerRight, setState } = props
   const [usngError, setUsngError] = useState(initialErrorState)
+
+  useEffect(() => {
+    if(props.drawing) {
+      setUsngError(initialErrorState)
+    }
+  }, [props.usngbbUpperLeft, props.usngbbLowerRight])
+
   return (
     <div className="input-location">
       <TextField
@@ -235,6 +256,14 @@ const BoundingBoxUtmUps = props => {
   } = props
   const [upperLeftError, setUpperLeftError] = useState(initialErrorState)
   const [lowerRightError, setLowerRightError] = useState(initialErrorState)
+
+  useEffect(() => {
+    if(props.drawing) {
+      setUpperLeftError(initialErrorState)
+      setLowerRightError(initialErrorState)
+    }
+  }, [props.utmUpsUpperLeftEasting, props.utmUpsUpperLeftNorthing, props.utmUpsUpperLeftZone, props.utmUpsUpperLeftHemisphere, props.utmUpsLowerRightEasting, props.utmUpsLowerRightNorthing, props.utmUpsLowerRightZone, props.utmUpsLowerRightHemisphere])
+
   return (
     <div>
       <div className="input-location">

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/bounding-box.js
@@ -15,7 +15,7 @@
 import React, { useState, useEffect } from 'react'
 import {
   validateGeo,
-  getErrorComponent,
+  ErrorComponent,
   initialErrorState,
   initialErrorStateWithDefault,
 } from '../utils/validation'
@@ -116,7 +116,7 @@ const BoundingBoxLatLonDd = props => {
         max={90}
         addon="°"
       />
-      {getErrorComponent(ddError)}
+      <ErrorComponent errorState={ddError}/>
     </div>
   )
 }
@@ -214,7 +214,7 @@ const BoundingBoxLatLonDms = props => {
           onChange={value => setState({ ['dmsNorthDirection']: value })}
         />
       </DmsLatitude>
-      {getErrorComponent(dmsError)}
+      <ErrorComponent errorState={dmsError}/>
     </div>
   )
 }
@@ -248,7 +248,7 @@ const BoundingBoxUsngMgrs = props => {
         onChange={value => setState({ ['usngbbLowerRight']: value })}
         onBlur={() => setUsngError(validateGeo('usng', usngbbLowerRight))}
       />
-      {getErrorComponent(usngError)}
+      <ErrorComponent errorState={usngError}/>
     </div>
   )
 }
@@ -373,7 +373,7 @@ const BoundingBoxUtmUps = props => {
             />
           </div>
         </Group>
-        {getErrorComponent(upperLeftError)}
+        <ErrorComponent errorState={upperLeftError}/>
       </div>
       <div className="input-location">
         <Group>
@@ -459,7 +459,7 @@ const BoundingBoxUtmUps = props => {
             />
           </div>
         </Group>
-        {getErrorComponent(lowerRightError)}
+       <ErrorComponent errorState={lowerRightError}/>
       </div>
     </div>
   )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/gazetteer.spec.js
@@ -13,10 +13,25 @@
  *
  **/
 import { expect } from 'chai'
-const { getLargestBbox } = require('./gazetteer')
+
+import {
+  mock as mockProperties,
+  unmock as unmockProperties,
+} from '../../test/mock-api/mock-properties'
+
+let GetLargestBbox
+
 const testData = require('./gazetteer-france-test-data.json')
 
 describe('getLargestBbox', () => {
+  before(() => {
+    mockProperties()
+    const { getLargestBbox } = require('./gazetteer')
+    GetLargestBbox = getLargestBbox
+  })
+  after(() => {
+    unmockProperties()
+  })
   const expectedAnswer = {
     maxX: 7.8125,
     minX: -5.1953125,
@@ -27,7 +42,7 @@ describe('getLargestBbox', () => {
     'Largest bounding box for France should equal  ' +
       JSON.stringify(expectedAnswer),
     () => {
-      const result = getLargestBbox(testData[0].geojson.coordinates, true)
+      const result = GetLargestBbox(testData[0].geojson.coordinates, true)
       console.log(result)
       expect(result).to.deep.equal(expectedAnswer)
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
@@ -55,7 +55,7 @@ class Keyword extends React.Component {
           const polygon = geometry.coordinates[0]
           this.props.setState({
             hasKeyword: true,
-            locationType: 'latlon',
+            locationType: 'dd',
             polygon,
             polyType: 'polygon',
             value: this.state.value,
@@ -70,7 +70,7 @@ class Keyword extends React.Component {
           )
           this.props.setState({
             hasKeyword: true,
-            locationType: 'latlon',
+            locationType: 'dd',
             polygon,
             polyType: 'multipolygon',
             value: this.state.value,
@@ -100,7 +100,8 @@ class Keyword extends React.Component {
     const suggester = this.props.suggester || (input => this.suggester(input))
     const {
       polygon,
-      cursor,
+      setState,
+      setBufferState,
       polygonBufferWidth,
       polygonBufferUnits,
       polyType,
@@ -124,17 +125,21 @@ class Keyword extends React.Component {
         {!loading && polygon !== undefined && polyType === 'polygon' ? (
           <Polygon
             polygon={polygon}
-            cursor={cursor}
+            setState={setState}
             polygonBufferWidth={polygonBufferWidth}
             polygonBufferUnits={polygonBufferUnits}
+            setBufferState={setBufferState}
+            polyType={polyType}
           />
         ) : null}
         {!loading && polygon !== undefined && polyType === 'multipolygon' ? (
           <MultiPolygon
             polygon={polygon}
-            cursor={cursor}
+            setState={setState}
             polygonBufferWidth={polygonBufferWidth}
             polygonBufferUnits={polygonBufferUnits}
+            setBufferState={setBufferState}
+            polyType={polyType}
           />
         ) : null}
       </div>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.spec.js
@@ -21,11 +21,23 @@ const { expect } = require('chai')
 
 Enzyme.configure({ adapter: new Adapter() })
 
-const Keyword = require('./keyword')
+let Keyword
+
+import {
+  mock as mockProperties,
+  unmock as unmockProperties,
+} from '../../test/mock-api/mock-properties'
 
 const { shallow } = Enzyme
 
 describe('<Keyword />', () => {
+  before(() => {
+    mockProperties()
+    Keyword = require('./keyword')
+  })
+  after(() => {
+    unmockProperties()
+  })
   it('should fetch features on select', done => {
     const coordinates = [1, 2, 3]
     const fetch = async url => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
@@ -20,9 +20,6 @@ const Button = require('../button')
 const Dropdown = require('../dropdown')
 const { Menu, MenuItem } = require('../menu')
 import styled from 'styled-components'
-const {
-  validateInput,
-} = require('../../component/location-new/utils/dms-utils')
 
 const Line = require('./line')
 const Polygon = require('./polygon')
@@ -30,32 +27,6 @@ const PointRadius = require('./point-radius')
 const BoundingBox = require('./bounding-box')
 const Keyword = require('./keyword')
 const plugin = require('plugins/location')
-
-const readableNames = {
-  lat: 'latitude',
-  lon: 'longitude',
-  west: 'longitude',
-  east: 'longitude',
-  north: 'latitude',
-  south: 'latitude',
-  dmsLat: 'latitude',
-  dmsLon: 'longitude',
-  dmsNorth: 'latitude',
-  dmsSouth: 'latitude',
-  dmsWest: 'longitude',
-  dmsEast: 'longitude',
-}
-
-const validLatLon = {
-  lat: '90',
-  lon: '180',
-  west: '180',
-  east: '180',
-  north: '90',
-  south: '90',
-  dmsLat: '90°00\'00"',
-  dmsLon: '180°00\'00"',
-}
 
 const inputs = plugin({
   line: {
@@ -84,6 +55,7 @@ const inputs = plugin({
           setState={({ value, ...data }) => {
             setState({ keywordValue: value, ...data })
           }}
+          setBufferState={(key, value) => setState(key, value)}
         />
       )
     },
@@ -103,35 +75,20 @@ const DrawButton = ({ onDraw }) => (
   </Button>
 )
 
-const Invalid = styled.div`
-  background-color: ${props => props.theme.negativeColor};
-  height: 100%;
-  display: block;
-  overflow: hidden;
-  color: white;
-`
-
 const Root = styled.div`
   height: ${props => (props.isOpen ? 'auto' : props.theme.minimumButtonSize)};
 `
 
 const Component = CustomElements.registerReact('location')
-let errors = false
-let inValidInput = ''
-let inValidKey = ''
-let defaultCoord = ''
 const LocationInput = props => {
-  const { mode, setState, cursor } = props
+  const { mode, setState } = props
   const input = inputs[mode] || {}
   const { Component: Input = null } = input
-  const removeErrorBox = () => {
-    setState((errors = false))
-  }
   return (
     <Root isOpen={input.label !== undefined}>
       <Component>
         <Dropdown label={input.label || 'Select Location Option'}>
-          <Menu value={mode} onChange={cursor('mode')}>
+          <Menu value={mode} onChange={value => setState('mode', value)}>
             {Object.keys(inputs).map(key => (
               <MenuItem key={key} value={key}>
                 {inputs[key].label}
@@ -141,17 +98,6 @@ const LocationInput = props => {
         </Dropdown>
         <Form>
           {Input !== null ? <Input {...props} /> : null}
-          {errors ? (
-            <Invalid>
-              &nbsp;
-              <span className="fa fa-exclamation-triangle" />
-              &nbsp; {inValidInput} is not an acceptable {inValidKey} value.
-              Defaulting to {defaultCoord}. &nbsp; &nbsp;
-              <span className="fa fa-times" onClick={removeErrorBox} />
-            </Invalid>
-          ) : (
-            ''
-          )}
           {drawTypes.includes(mode) ? (
             <DrawButton onDraw={props.onDraw} />
           ) : null}
@@ -161,72 +107,6 @@ const LocationInput = props => {
   )
 }
 
-const ddValidators = {
-  lat: value => value <= 90 && value >= -90,
-  lon: value => value <= 180 && value >= -180,
-  north: value => value <= 90 && value >= -90,
-  west: value => value <= 180 && value >= -180,
-  south: value => value <= 90 && value >= -90,
-  east: value => value <= 180 && value >= -180,
-}
-
-let isDms = false
-const dmsValidators = {
-  dmsLat: value => validateInput(value, 'dd°mm\'ss.s"'),
-  dmsLon: value => validateInput(value, 'ddd°mm\'ss.s"'),
-  dmsNorth: value => validateInput(value, 'dd°mm\'ss.s"'),
-  dmsSouth: value => validateInput(value, 'dd°mm\'ss.s"'),
-  dmsWest: value => validateInput(value, 'ddd°mm\'ss.s"'),
-  dmsEast: value => validateInput(value, 'ddd°mm\'ss.s"'),
-}
-
-const getNegOrPosLatLon = (key, value) => {
-  if (value < 0) {
-    return -1 * validLatLon[key]
-  } else {
-    return validLatLon[key]
-  }
-}
-
 module.exports = ({ state, setState, options }) => (
-  <LocationInput
-    {...state}
-    onDraw={options.onDraw}
-    setState={setState}
-    cursor={key => value => {
-      isDms = false
-      let coordValidator = ddValidators[key]
-      if (coordValidator === undefined) {
-        coordValidator = dmsValidators[key]
-        isDms = true
-      }
-      if (!isDms) {
-        if (typeof coordValidator === 'function' && !coordValidator(value)) {
-          errors = true
-          inValidInput = value
-          inValidKey = readableNames[key]
-          defaultCoord = getNegOrPosLatLon(key, value)
-          value = defaultCoord
-          setState(key, value)
-          return
-        }
-        setState(key, value, (errors = false))
-      } else {
-        if (
-          typeof coordValidator === 'function' &&
-          coordValidator(value) !== value &&
-          value !== ''
-        ) {
-          errors = true
-          inValidInput = value
-          inValidKey = readableNames[key]
-          defaultCoord = coordValidator(value)
-          value = defaultCoord
-          setState(key, value)
-          return
-        }
-        setState(key, value, (errors = false))
-      }
-    }}
-  />
+  <LocationInput {...state} onDraw={options.onDraw} setState={setState} />
 )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
@@ -55,7 +55,7 @@ const inputs = plugin({
           setState={({ value, ...data }) => {
             setState({ keywordValue: value, ...data })
           }}
-          setBufferState={(key, value) => setState(key, value)}
+          setBufferState={(key, value) => setState({ [key]: value })}
         />
       )
     },
@@ -88,7 +88,7 @@ const LocationInput = props => {
     <Root isOpen={input.label !== undefined}>
       <Component>
         <Dropdown label={input.label || 'Select Location Option'}>
-          <Menu value={mode} onChange={value => setState('mode', value)}>
+          <Menu value={mode} onChange={value => setState({['mode']: value})}>
             {Object.keys(inputs).map(key => (
               <MenuItem key={key} value={key}>
                 {inputs[key].label}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
@@ -88,7 +88,7 @@ const LocationInput = props => {
     <Root isOpen={input.label !== undefined}>
       <Component>
         <Dropdown label={input.label || 'Select Location Option'}>
-          <Menu value={mode} onChange={value => setState({['mode']: value})}>
+          <Menu value={mode} onChange={value => setState({ ['mode']: value })}>
             {Object.keys(inputs).map(key => (
               <MenuItem key={key} value={key}>
                 {inputs[key].label}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
@@ -69,7 +69,7 @@ const Form = ({ children }) => (
 )
 
 const DrawButton = ({ onDraw }) => (
-  <Button className="location-draw is-primary" onClick={onDraw}>
+  <Button className="location-draw is-primary" onMouseDown={onDraw}>
     <span className="fa fa-globe" />
     <span>Draw</span>
   </Button>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -16,10 +16,10 @@ import React, { useState, useEffect } from 'react'
 const { Radio, RadioItem } = require('../radio')
 const TextField = require('../text-field')
 import {
-  getErrorComponent,
   validateGeo,
   initialErrorState,
   initialErrorStateWithDefault,
+  ErrorComponent,
 } from '../utils/validation'
 const { Units, Zone, Hemisphere, MinimumSpacing } = require('./common')
 const {
@@ -72,7 +72,7 @@ const PointRadiusLatLonDd = props => {
         onBlur={() => setDdError(validateGeo('lon', lon))}
         addon="°"
       />
-      {getErrorComponent(ddError)}
+      <ErrorComponent errorState={ddError}/>
       <Units
         value={radiusUnits}
         onChange={value => setState({ ['radiusUnits']: value })}
@@ -87,7 +87,7 @@ const PointRadiusLatLonDd = props => {
           }}
         />
       </Units>
-      {getErrorComponent(radiusError)}
+      <ErrorComponent errorState={radiusError}/>
     </div>
   )
 }
@@ -161,7 +161,7 @@ const PointRadiusLatLonDms = props => {
           onChange={value => setState({ ['dmsLonDirection']: value })}
         />
       </DmsLongitude>
-      {getErrorComponent(dmsError)}
+      <ErrorComponent errorState={dmsError}/>
       <Units
         value={radiusUnits}
         onChange={value => setState({ ['radiusUnits']: value })}
@@ -176,7 +176,7 @@ const PointRadiusLatLonDms = props => {
           }}
         />
       </Units>
-      {getErrorComponent(radiusError)}
+      <ErrorComponent errorState={radiusError}/>
     </div>
   )
 }
@@ -204,7 +204,7 @@ const PointRadiusUsngMgrs = props => {
         onChange={value => setState({ ['usng']: value })}
         onBlur={() => setUsngError(validateGeo('usng', usng))}
       />
-      {getErrorComponent(usngError)}
+      <ErrorComponent errorState={usngError}/>
       <Units
         value={radiusUnits}
         onChange={value => setState({ ['radiusUnits']: value })}
@@ -219,7 +219,7 @@ const PointRadiusUsngMgrs = props => {
           }}
         />
       </Units>
-      {getErrorComponent(radiusError)}
+      <ErrorComponent errorState={radiusError}/>
     </div>
   )
 }
@@ -323,7 +323,7 @@ const PointRadiusUtmUps = props => {
           )
         }
       />
-      {getErrorComponent(utmError)}
+      <ErrorComponent errorState={utmError}/>
       <Units
         value={radiusUnits}
         onChange={value => setState({ ['radiusUnits']: value })}
@@ -338,7 +338,7 @@ const PointRadiusUtmUps = props => {
           }}
         />
       </Units>
-      {getErrorComponent(radiusError)}
+      <ErrorComponent errorState={radiusError}/>
     </div>
   )
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -211,7 +211,7 @@ const PointRadiusUsngMgrs = props => {
       >
         <TextField
           label="Radius"
-          type='number'
+          type="number"
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
@@ -330,7 +330,7 @@ const PointRadiusUtmUps = props => {
       >
         <TextField
           label="Radius"
-          type='number'
+          type="number"
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -72,7 +72,7 @@ const PointRadiusLatLonDd = props => {
         onBlur={() => setDdError(validateGeo('lon', lon))}
         addon="°"
       />
-      <ErrorComponent errorState={ddError}/>
+      <ErrorComponent errorState={ddError} />
       <Units
         value={radiusUnits}
         onChange={value => setState({ ['radiusUnits']: value })}
@@ -87,7 +87,7 @@ const PointRadiusLatLonDd = props => {
           }}
         />
       </Units>
-      <ErrorComponent errorState={radiusError}/>
+      <ErrorComponent errorState={radiusError} />
     </div>
   )
 }
@@ -161,7 +161,7 @@ const PointRadiusLatLonDms = props => {
           onChange={value => setState({ ['dmsLonDirection']: value })}
         />
       </DmsLongitude>
-      <ErrorComponent errorState={dmsError}/>
+      <ErrorComponent errorState={dmsError} />
       <Units
         value={radiusUnits}
         onChange={value => setState({ ['radiusUnits']: value })}
@@ -176,7 +176,7 @@ const PointRadiusLatLonDms = props => {
           }}
         />
       </Units>
-      <ErrorComponent errorState={radiusError}/>
+      <ErrorComponent errorState={radiusError} />
     </div>
   )
 }
@@ -204,7 +204,7 @@ const PointRadiusUsngMgrs = props => {
         onChange={value => setState({ ['usng']: value })}
         onBlur={() => setUsngError(validateGeo('usng', usng))}
       />
-      <ErrorComponent errorState={usngError}/>
+      <ErrorComponent errorState={usngError} />
       <Units
         value={radiusUnits}
         onChange={value => setState({ ['radiusUnits']: value })}
@@ -219,7 +219,7 @@ const PointRadiusUsngMgrs = props => {
           }}
         />
       </Units>
-      <ErrorComponent errorState={radiusError}/>
+      <ErrorComponent errorState={radiusError} />
     </div>
   )
 }
@@ -263,13 +263,12 @@ const PointRadiusUtmUps = props => {
         onChange={value => setState({ ['utmUpsEasting']: value })}
         onBlur={() =>
           setUtmError(
-            validateGeo(
-              'utmUpsEasting',
+            validateGeo('utmUpsEasting', {
               utmUpsEasting,
               utmUpsNorthing,
-              utmUpsZone,
-              utmUpsHemisphere
-            )
+              zoneNumber: utmUpsZone,
+              hemisphere: utmUpsHemisphere,
+            })
           )
         }
         addon="m"
@@ -282,13 +281,12 @@ const PointRadiusUtmUps = props => {
         onChange={value => setState({ ['utmUpsNorthing']: value })}
         onBlur={() =>
           setUtmError(
-            validateGeo(
-              'utmUpsNorthing',
+            validateGeo('utmUpsNorthing', {
               utmUpsEasting,
               utmUpsNorthing,
-              utmUpsZone,
-              utmUpsHemisphere
-            )
+              zoneNumber: utmUpsZone,
+              hemisphere: utmUpsHemisphere,
+            })
           )
         }
         addon="m"
@@ -298,13 +296,12 @@ const PointRadiusUtmUps = props => {
         onChange={value => setState({ ['utmUpsZone']: value })}
         onBlur={() =>
           setUtmError(
-            validateGeo(
-              'utmUpsZone',
+            validateGeo('utmUpsZone', {
               utmUpsEasting,
               utmUpsNorthing,
-              utmUpsZone,
-              utmUpsHemisphere
-            )
+              zoneNumber: utmUpsZone,
+              hemisphere: utmUpsHemisphere,
+            })
           )
         }
       />
@@ -313,17 +310,16 @@ const PointRadiusUtmUps = props => {
         onChange={value => setState({ ['utmUpsHemisphere']: value })}
         onBlur={() =>
           setUtmError(
-            validateGeo(
-              'utmUpsHemisphere',
+            validateGeo('utmUpsHemisphere', {
               utmUpsEasting,
               utmUpsNorthing,
-              utmUpsZone,
-              utmUpsHemisphere
-            )
+              zoneNumber: utmUpsZone,
+              hemisphere: utmUpsHemisphere,
+            })
           )
         }
       />
-      <ErrorComponent errorState={utmError}/>
+      <ErrorComponent errorState={utmError} />
       <Units
         value={radiusUnits}
         onChange={value => setState({ ['radiusUnits']: value })}
@@ -338,7 +334,7 @@ const PointRadiusUtmUps = props => {
           }}
         />
       </Units>
-      <ErrorComponent errorState={radiusError}/>
+      <ErrorComponent errorState={radiusError} />
     </div>
   )
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -75,16 +75,26 @@ const PointRadiusLatLonDd = props => {
       <ErrorComponent errorState={ddError} />
       <Units
         value={radiusUnits}
-        onChange={value => setState({ ['radiusUnits']: value })}
+        onChange={value => {
+          setState({ ['radiusUnits']: value })
+          setRadiusError(validateGeo('radius', { value: radius, units: value }))
+        }}
       >
         <TextField
           type="number"
           label="Radius"
           value={String(radius)}
           onChange={value => {
-            setRadiusError(validateGeo('radius', value))
             setState({ ['radius']: value })
           }}
+          onBlur={e =>
+            setRadiusError(
+              validateGeo('radius', {
+                value: e.target.value,
+                units: radiusUnits,
+              })
+            )
+          }
         />
       </Units>
       <ErrorComponent errorState={radiusError} />

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -211,6 +211,7 @@ const PointRadiusUsngMgrs = props => {
       >
         <TextField
           label="Radius"
+          type='number'
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
@@ -329,6 +330,7 @@ const PointRadiusUtmUps = props => {
       >
         <TextField
           label="Radius"
+          type='number'
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 const { Radio, RadioItem } = require('../radio')
 const TextField = require('../text-field')
 import {
@@ -32,6 +32,15 @@ const { Direction } = require('../../component/location-new/utils/dms-utils.js')
 const PointRadiusLatLonDd = props => {
   const { lat, lon, radius, radiusUnits, setState } = props
   const [ddError, setDdError] = useState(initialErrorStateWithDefault)
+  const [radiusError, setRadiusError] = useState(initialErrorState)
+
+  useEffect(() => {
+    if(props.drawing) {
+      setDdError(initialErrorStateWithDefault)
+      setRadiusError(initialErrorState)
+    }
+  }, [props.lat, props.lon, props.radius])
+
   function onChangeDd(key, value) {
     const { error, message, defaultValue } = validateGeo(key, value)
     if (defaultValue) {
@@ -41,7 +50,7 @@ const PointRadiusLatLonDd = props => {
       setState({[key]: value})
     }
   }
-  const [radiusError, setRadiusError] = useState(initialErrorState)
+
   return (
     <div>
       <TextField
@@ -94,6 +103,13 @@ const PointRadiusLatLonDms = props => {
   const [radiusError, setRadiusError] = useState(initialErrorState)
   const latitudeDirections = [Direction.North, Direction.South]
   const longitudeDirections = [Direction.East, Direction.West]
+
+  useEffect(() => {
+    if(props.drawing) {
+      setDmsError(initialErrorStateWithDefault)
+      setRadiusError(initialErrorState)
+    }
+  }, [props.dmsLat, props.dmsLon, props.radius])
 
   function validate(key, type, value) {
     const { error, message, defaultValue } = validateGeo(key, value)
@@ -161,6 +177,14 @@ const PointRadiusUsngMgrs = props => {
   const { usng, radius, radiusUnits, setState } = props
   const [usngError, setUsngError] = useState(initialErrorState)
   const [radiusError, setRadiusError] = useState(initialErrorState)
+
+  useEffect(() => {
+    if(props.drawing) {
+      setUsngError(initialErrorState)
+      setRadiusError(initialErrorState)
+    }
+  }, [props.usng, props.radius])
+
   return (
     <div>
       <TextField
@@ -200,6 +224,13 @@ const PointRadiusUtmUps = props => {
   } = props
   const [utmError, setUtmError] = useState(initialErrorState)
   const [radiusError, setRadiusError] = useState(initialErrorState)
+
+  useEffect(() => {
+    if(props.drawing) {
+      setUtmError(initialErrorState)
+      setRadiusError(initialErrorState)
+    }
+  }, [props.utmUpsEasting, props.utmUpsNorthing, props.utmUpsZone, props.utmUpsHemisphere, props.radius])
 
   return (
     <div>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -174,16 +174,26 @@ const PointRadiusLatLonDms = props => {
       <ErrorComponent errorState={dmsError} />
       <Units
         value={radiusUnits}
-        onChange={value => setState({ ['radiusUnits']: value })}
+        onChange={value => {
+          setState({ ['radiusUnits']: value })
+          setRadiusError(validateGeo('radius', { value: radius, units: value }))
+        }}
       >
         <TextField
           label="Radius"
           type="number"
           value={String(radius)}
           onChange={value => {
-            setRadiusError(validateGeo('radius', value))
             setState({ ['radius']: value })
           }}
+          onBlur={e =>
+            setRadiusError(
+              validateGeo('radius', {
+                value: e.target.value,
+                units: radiusUnits,
+              })
+            )
+          }
         />
       </Units>
       <ErrorComponent errorState={radiusError} />
@@ -217,7 +227,10 @@ const PointRadiusUsngMgrs = props => {
       <ErrorComponent errorState={usngError} />
       <Units
         value={radiusUnits}
-        onChange={value => setState({ ['radiusUnits']: value })}
+        onChange={value => {
+          setState({ ['radiusUnits']: value })
+          setRadiusError(validateGeo('radius', { value: radius, units: value }))
+        }}
       >
         <TextField
           label="Radius"
@@ -332,16 +345,26 @@ const PointRadiusUtmUps = props => {
       <ErrorComponent errorState={utmError} />
       <Units
         value={radiusUnits}
-        onChange={value => setState({ ['radiusUnits']: value })}
+        onChange={value => {
+          setState({ ['radiusUnits']: value })
+          setRadiusError(validateGeo('radius', { value: radius, units: value }))
+        }}
       >
         <TextField
           label="Radius"
           type="number"
           value={String(radius)}
           onChange={value => {
-            setRadiusError(validateGeo('radius', value))
             setState({ ['radius']: value })
           }}
+          onBlur={e =>
+            setRadiusError(
+              validateGeo('radius', {
+                value: e.target.value,
+                units: radiusUnits,
+              })
+            )
+          }
         />
       </Units>
       <ErrorComponent errorState={radiusError} />

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -12,90 +12,178 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-const React = require('react')
-
+import React, { useState } from 'react'
 const { Radio, RadioItem } = require('../radio')
 const TextField = require('../text-field')
-
+import {
+  getErrorComponent,
+  validateGeo,
+  initialErrorState,
+  initialErrorStateWithDefault,
+} from '../utils/validation'
 const { Units, Zone, Hemisphere, MinimumSpacing } = require('./common')
-
 const {
   DmsLatitude,
   DmsLongitude,
 } = require('../../component/location-new/geo-components/coordinates.js')
 const DirectionInput = require('../../component/location-new/geo-components/direction.js')
 const { Direction } = require('../../component/location-new/utils/dms-utils.js')
-import styled from 'styled-components'
 
-const ErrorBlock = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: center;
-  background: ${({ theme }) => theme.negativeColor};
-`
-
-const WarningIcon = styled.span`
-  padding: ${({ theme }) => theme.minimumSpacing};
-`
-
-const PointRadiusLatLon = props => {
-  const { lat, lon, radius, radiusUnits, cursor } = props
+const PointRadiusLatLonDd = props => {
+  const { lat, lon, radius, radiusUnits, setState } = props
+  const [ddError, setDdError] = useState(initialErrorStateWithDefault)
+  function onChangeDd(key, value) {
+    const { error, message, defaultValue } = validateGeo(key, value)
+    if (defaultValue) {
+      setDdError({ error, message, defaultValue })
+      setState(key, defaultValue)
+    } else {
+      setState(key, value)
+    }
+  }
+  const [radiusError, setRadiusError] = useState(initialErrorState)
   return (
     <div>
       <TextField
         type="number"
         label="Latitude"
-        value={lat}
-        onChange={cursor('lat')}
-        onBlur={props.callback}
+        value={lat !== undefined ? String(lat) : lat}
+        onChange={value => onChangeDd('lat', value)}
+        onBlur={() => setDdError(validateGeo('lat', lat))}
         addon="°"
       />
       <TextField
         type="number"
         label="Longitude"
-        value={lon}
-        onChange={cursor('lon')}
+        value={lon !== undefined ? String(lon) : lon}
+        onChange={value => onChangeDd('lon', value)}
+        onBlur={() => setDdError(validateGeo('lon', lon))}
         addon="°"
       />
-      <Units value={radiusUnits} onChange={cursor('radiusUnits')}>
+      {getErrorComponent(ddError)}
+      <Units
+        value={radiusUnits}
+        onChange={value => setState('radiusUnits', value)}
+      >
         <TextField
           type="number"
-          min="0"
           label="Radius"
-          value={radius}
-          onChange={cursor('radius')}
+          value={String(radius)}
+          onChange={value => {
+            setRadiusError(validateGeo('radius', value))
+            setState('radius', value)
+          }}
         />
       </Units>
+      {getErrorComponent(radiusError)}
     </div>
   )
 }
 
-const usngs = require('usng.js')
-const converter = new usngs.Converter()
+const PointRadiusLatLonDms = props => {
+  const {
+    dmsLat,
+    dmsLon,
+    dmsLatDirection,
+    dmsLonDirection,
+    radius,
+    radiusUnits,
+    setState,
+  } = props
+  const [dmsError, setDmsError] = useState(initialErrorStateWithDefault)
+  const [radiusError, setRadiusError] = useState(initialErrorState)
+  const latitudeDirections = [Direction.North, Direction.South]
+  const longitudeDirections = [Direction.East, Direction.West]
 
-const PointRadiusUsngMgrs = props => {
-  const { usng, radius, radiusUnits, cursor } = props
-  let error = false
-  try {
-    const result = converter.USNGtoLL(usng, true)
-    error = isNaN(result.lat) || isNaN(result.lon)
-  } catch (err) {
-    error = true
+  function validate(key, type, value) {
+    const { error, message, defaultValue } = validateGeo(key, value)
+    if (type === 'blur') {
+      setDmsError({
+        error: value !== undefined && value.length === 0,
+        message,
+        defaultValue,
+      })
+    } else if (defaultValue) {
+      setDmsError({
+        error,
+        message,
+        defaultValue,
+      })
+    }
+    defaultValue ? setState(key, defaultValue) : setState(key, value)
   }
+
   return (
     <div>
-      <TextField label="USNG / MGRS" value={usng} onChange={cursor('usng')} />
-      <Units value={radiusUnits} onChange={cursor('radiusUnits')}>
-        <TextField label="Radius" value={radius} onChange={cursor('radius')} />
+      <DmsLatitude
+        label="Latitude"
+        value={dmsLat}
+        onChange={(value, type) => validate('dmsLat', type, value)}
+      >
+        <DirectionInput
+          options={latitudeDirections}
+          value={dmsLatDirection}
+          onChange={value => setState('dmsLatDirection', value)}
+        />
+      </DmsLatitude>
+      <DmsLongitude
+        label="Longitude"
+        value={dmsLon}
+        onChange={(value, type) => validate('dmsLon', type, value)}
+      >
+        <DirectionInput
+          options={longitudeDirections}
+          value={dmsLonDirection}
+          onChange={value => setState('dmsLonDirection', value)}
+        />
+      </DmsLongitude>
+      {getErrorComponent(dmsError)}
+      <Units
+        value={radiusUnits}
+        onChange={value => setState('radiusUnits', value)}
+      >
+        <TextField
+          label="Radius"
+          type="number"
+          value={String(radius)}
+          onChange={value => {
+            setRadiusError(validateGeo('radius', value))
+            setState('radius', value)
+          }}
+        />
       </Units>
-      {error ? (
-        <ErrorBlock>
-          <WarningIcon className="fa fa-warning" />
-          <span>Invalid USNG / MGRS coords</span>
-        </ErrorBlock>
-      ) : null}
+      {getErrorComponent(radiusError)}
+    </div>
+  )
+}
+
+const PointRadiusUsngMgrs = props => {
+  const { usng, radius, radiusUnits, setState } = props
+  const [usngError, setUsngError] = useState(initialErrorState)
+  const [radiusError, setRadiusError] = useState(initialErrorState)
+  return (
+    <div>
+      <TextField
+        label="USNG / MGRS"
+        value={usng}
+        onChange={value => setState('usng', value)}
+        onBlur={() => setUsngError(validateGeo('usng', usng))}
+      />
+      {getErrorComponent(usngError)}
+      <Units
+        value={radiusUnits}
+        onChange={value => setState('radiusUnits', value)}
+      >
+        <TextField
+          label="Radius"
+          value={String(radius)}
+          onChange={value => {
+            setRadiusError(validateGeo('radius', value))
+            setState('radius', value)
+          }}
+        />
+      </Units>
+      {getErrorComponent(radiusError)}
     </div>
   )
 }
@@ -108,85 +196,106 @@ const PointRadiusUtmUps = props => {
     utmUpsHemisphere,
     radius,
     radiusUnits,
-    cursor,
+    setState,
   } = props
+  const [utmError, setUtmError] = useState(initialErrorState)
+  const [radiusError, setRadiusError] = useState(initialErrorState)
+
   return (
     <div>
       <TextField
         label="Easting"
-        value={utmUpsEasting}
-        onChange={cursor('utmUpsEasting')}
+        value={
+          utmUpsEasting !== undefined ? String(utmUpsEasting) : utmUpsEasting
+        }
+        onChange={value => setState('utmUpsEasting', value)}
+        onBlur={() =>
+          setUtmError(
+            validateGeo(
+              'utmUpsEasting',
+              utmUpsEasting,
+              utmUpsNorthing,
+              utmUpsZone,
+              utmUpsHemisphere
+            )
+          )
+        }
         addon="m"
       />
       <TextField
         label="Northing"
-        value={utmUpsNorthing}
-        onChange={cursor('utmUpsNorthing')}
+        value={
+          utmUpsNorthing !== undefined ? String(utmUpsNorthing) : utmUpsNorthing
+        }
+        onChange={value => setState('utmUpsNorthing', value)}
+        onBlur={() =>
+          setUtmError(
+            validateGeo(
+              'utmUpsNorthing',
+              utmUpsEasting,
+              utmUpsNorthing,
+              utmUpsZone,
+              utmUpsHemisphere
+            )
+          )
+        }
         addon="m"
       />
-      <Zone value={utmUpsZone} onChange={cursor('utmUpsZone')} />
+      <Zone
+        value={utmUpsZone}
+        onChange={value => setState('utmUpsZone', value)}
+        onBlur={() =>
+          setUtmError(
+            validateGeo(
+              'utmUpsZone',
+              utmUpsEasting,
+              utmUpsNorthing,
+              utmUpsZone,
+              utmUpsHemisphere
+            )
+          )
+        }
+      />
       <Hemisphere
         value={utmUpsHemisphere}
-        onChange={cursor('utmUpsHemisphere')}
+        onChange={value => setState('utmUpsHemisphere', value)}
+        onBlur={() =>
+          setUtmError(
+            validateGeo(
+              'utmUpsHemisphere',
+              utmUpsEasting,
+              utmUpsNorthing,
+              utmUpsZone,
+              utmUpsHemisphere
+            )
+          )
+        }
       />
-      <Units value={radiusUnits} onChange={cursor('radiusUnits')}>
-        <TextField label="Radius" value={radius} onChange={cursor('radius')} />
-      </Units>
-    </div>
-  )
-}
-
-const PointRadiusDms = props => {
-  const {
-    dmsLat,
-    dmsLon,
-    dmsLatDirection,
-    dmsLonDirection,
-    radius,
-    radiusUnits,
-    cursor,
-  } = props
-  const latitudeDirections = [Direction.North, Direction.South]
-  const longitudeDirections = [Direction.East, Direction.West]
-
-  return (
-    <div>
-      <DmsLatitude label="Latitude" value={dmsLat} onChange={cursor('dmsLat')}>
-        <DirectionInput
-          options={latitudeDirections}
-          value={dmsLatDirection}
-          onChange={cursor('dmsLatDirection')}
-        />
-      </DmsLatitude>
-      <DmsLongitude
-        label="Longitude"
-        value={dmsLon}
-        onChange={cursor('dmsLon')}
+      {getErrorComponent(utmError)}
+      <Units
+        value={radiusUnits}
+        onChange={value => setState('radiusUnits', value)}
       >
-        <DirectionInput
-          options={longitudeDirections}
-          value={dmsLonDirection}
-          onChange={cursor('dmsLonDirection')}
-        />
-      </DmsLongitude>
-      <Units value={radiusUnits} onChange={cursor('radiusUnits')}>
         <TextField
           label="Radius"
-          type="number"
-          value={radius}
-          onChange={cursor('radius')}
+          value={String(radius)}
+          onChange={value => {
+            setRadiusError(validateGeo('radius', value))
+            setState('radius', value)
+          }}
         />
       </Units>
+      {getErrorComponent(radiusError)}
     </div>
   )
 }
 
 const PointRadius = props => {
-  const { cursor, locationType } = props
+  const { setState, locationType } = props
 
   const inputs = {
-    latlon: PointRadiusLatLon,
-    dms: PointRadiusDms,
+    dd: PointRadiusLatLonDd,
+    dms: PointRadiusLatLonDms,
     usng: PointRadiusUsngMgrs,
     utmUps: PointRadiusUtmUps,
   }
@@ -195,8 +304,11 @@ const PointRadius = props => {
 
   return (
     <div>
-      <Radio value={locationType} onChange={cursor('locationType')}>
-        <RadioItem value="latlon">Lat / Lon (DD)</RadioItem>
+      <Radio
+        value={locationType}
+        onChange={value => setState('locationType', value)}
+      >
+        <RadioItem value="dd">Lat / Lon (DD)</RadioItem>
         <RadioItem value="dms">Lat / Lon (DMS)</RadioItem>
         <RadioItem value="usng">USNG / MGRS</RadioItem>
         <RadioItem value="utmUps">UTM / UPS</RadioItem>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -36,9 +36,9 @@ const PointRadiusLatLonDd = props => {
     const { error, message, defaultValue } = validateGeo(key, value)
     if (defaultValue) {
       setDdError({ error, message, defaultValue })
-      setState(key, defaultValue)
+      setState({[key]: defaultValue})
     } else {
-      setState(key, value)
+      setState({[key]: value})
     }
   }
   const [radiusError, setRadiusError] = useState(initialErrorState)
@@ -63,7 +63,7 @@ const PointRadiusLatLonDd = props => {
       {getErrorComponent(ddError)}
       <Units
         value={radiusUnits}
-        onChange={value => setState('radiusUnits', value)}
+        onChange={value => setState({ ['radiusUnits']: value })}
       >
         <TextField
           type="number"
@@ -71,7 +71,7 @@ const PointRadiusLatLonDd = props => {
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
-            setState('radius', value)
+            setState({['radius']: value})
           }}
         />
       </Units>
@@ -110,7 +110,7 @@ const PointRadiusLatLonDms = props => {
         defaultValue,
       })
     }
-    defaultValue ? setState(key, defaultValue) : setState(key, value)
+    defaultValue ? setState({[key]: defaultValue}) : setState({[key]: value})
   }
 
   return (
@@ -123,7 +123,7 @@ const PointRadiusLatLonDms = props => {
         <DirectionInput
           options={latitudeDirections}
           value={dmsLatDirection}
-          onChange={value => setState('dmsLatDirection', value)}
+          onChange={value => setState({['dmsLatDirection']: value})}
         />
       </DmsLatitude>
       <DmsLongitude
@@ -134,13 +134,13 @@ const PointRadiusLatLonDms = props => {
         <DirectionInput
           options={longitudeDirections}
           value={dmsLonDirection}
-          onChange={value => setState('dmsLonDirection', value)}
+          onChange={value => setState({['dmsLonDirection']: value})}
         />
       </DmsLongitude>
       {getErrorComponent(dmsError)}
       <Units
         value={radiusUnits}
-        onChange={value => setState('radiusUnits', value)}
+        onChange={value => setState({['radiusUnits']: value})}
       >
         <TextField
           label="Radius"
@@ -148,7 +148,7 @@ const PointRadiusLatLonDms = props => {
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
-            setState('radius', value)
+            setState({['radius']: value})
           }}
         />
       </Units>
@@ -166,20 +166,20 @@ const PointRadiusUsngMgrs = props => {
       <TextField
         label="USNG / MGRS"
         value={usng}
-        onChange={value => setState('usng', value)}
+        onChange={value => setState({['usng']: value})}
         onBlur={() => setUsngError(validateGeo('usng', usng))}
       />
       {getErrorComponent(usngError)}
       <Units
         value={radiusUnits}
-        onChange={value => setState('radiusUnits', value)}
+        onChange={value => setState({['radiusUnits']: value})}
       >
         <TextField
           label="Radius"
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
-            setState('radius', value)
+            setState({['radius']: value})
           }}
         />
       </Units>
@@ -208,7 +208,7 @@ const PointRadiusUtmUps = props => {
         value={
           utmUpsEasting !== undefined ? String(utmUpsEasting) : utmUpsEasting
         }
-        onChange={value => setState('utmUpsEasting', value)}
+        onChange={value => setState({['utmUpsEasting']: value })}
         onBlur={() =>
           setUtmError(
             validateGeo(
@@ -227,7 +227,7 @@ const PointRadiusUtmUps = props => {
         value={
           utmUpsNorthing !== undefined ? String(utmUpsNorthing) : utmUpsNorthing
         }
-        onChange={value => setState('utmUpsNorthing', value)}
+        onChange={value => setState({['utmUpsNorthing']: value})}
         onBlur={() =>
           setUtmError(
             validateGeo(
@@ -243,7 +243,7 @@ const PointRadiusUtmUps = props => {
       />
       <Zone
         value={utmUpsZone}
-        onChange={value => setState('utmUpsZone', value)}
+        onChange={value => setState({['utmUpsZone']: value})}
         onBlur={() =>
           setUtmError(
             validateGeo(
@@ -258,7 +258,7 @@ const PointRadiusUtmUps = props => {
       />
       <Hemisphere
         value={utmUpsHemisphere}
-        onChange={value => setState('utmUpsHemisphere', value)}
+        onChange={value => setState({['utmUpsHemisphere']: value})}
         onBlur={() =>
           setUtmError(
             validateGeo(
@@ -274,14 +274,14 @@ const PointRadiusUtmUps = props => {
       {getErrorComponent(utmError)}
       <Units
         value={radiusUnits}
-        onChange={value => setState('radiusUnits', value)}
+        onChange={value => setState({['radiusUnits']: value})}
       >
         <TextField
           label="Radius"
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
-            setState('radius', value)
+            setState({['radius']: value})
           }}
         />
       </Units>
@@ -306,7 +306,7 @@ const PointRadius = props => {
     <div>
       <Radio
         value={locationType}
-        onChange={value => setState('locationType', value)}
+        onChange={value => setState({['locationType']: value})}
       >
         <RadioItem value="dd">Lat / Lon (DD)</RadioItem>
         <RadioItem value="dms">Lat / Lon (DMS)</RadioItem>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -44,7 +44,7 @@ const PointRadiusLatLonDd = props => {
     [props.lat, props.lon, props.radius]
   )
 
-  function onChangeDd(key, value) {
+  function validateDd(key, value) {
     const { error, message, defaultValue } = validateGeo(key, value)
     if (defaultValue) {
       setDdError({ error, message, defaultValue })
@@ -60,7 +60,7 @@ const PointRadiusLatLonDd = props => {
         type="number"
         label="Latitude"
         value={lat !== undefined ? String(lat) : lat}
-        onChange={value => onChangeDd('lat', value)}
+        onChange={value => validateDd('lat', value)}
         onBlur={() => setDdError(validateGeo('lat', lat))}
         addon="°"
       />
@@ -68,7 +68,7 @@ const PointRadiusLatLonDd = props => {
         type="number"
         label="Longitude"
         value={lon !== undefined ? String(lon) : lon}
-        onChange={value => onChangeDd('lon', value)}
+        onChange={value => validateDd('lon', value)}
         onBlur={() => setDdError(validateGeo('lon', lon))}
         addon="°"
       />
@@ -117,7 +117,7 @@ const PointRadiusLatLonDms = props => {
     [props.dmsLat, props.dmsLon, props.radius]
   )
 
-  function validate(key, type, value) {
+  function validateDms(key, type, value) {
     const { error, message, defaultValue } = validateGeo(key, value)
     if (type === 'blur') {
       setDmsError({
@@ -142,7 +142,7 @@ const PointRadiusLatLonDms = props => {
       <DmsLatitude
         label="Latitude"
         value={dmsLat}
-        onChange={(value, type) => validate('dmsLat', type, value)}
+        onChange={(value, type) => validateDms('dmsLat', type, value)}
       >
         <DirectionInput
           options={latitudeDirections}
@@ -153,7 +153,7 @@ const PointRadiusLatLonDms = props => {
       <DmsLongitude
         label="Longitude"
         value={dmsLon}
-        onChange={(value, type) => validate('dmsLon', type, value)}
+        onChange={(value, type) => validateDms('dmsLon', type, value)}
       >
         <DirectionInput
           options={longitudeDirections}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/point-radius.js
@@ -34,20 +34,23 @@ const PointRadiusLatLonDd = props => {
   const [ddError, setDdError] = useState(initialErrorStateWithDefault)
   const [radiusError, setRadiusError] = useState(initialErrorState)
 
-  useEffect(() => {
-    if(props.drawing) {
-      setDdError(initialErrorStateWithDefault)
-      setRadiusError(initialErrorState)
-    }
-  }, [props.lat, props.lon, props.radius])
+  useEffect(
+    () => {
+      if (props.drawing) {
+        setDdError(initialErrorStateWithDefault)
+        setRadiusError(initialErrorState)
+      }
+    },
+    [props.lat, props.lon, props.radius]
+  )
 
   function onChangeDd(key, value) {
     const { error, message, defaultValue } = validateGeo(key, value)
     if (defaultValue) {
       setDdError({ error, message, defaultValue })
-      setState({[key]: defaultValue})
+      setState({ [key]: defaultValue })
     } else {
-      setState({[key]: value})
+      setState({ [key]: value })
     }
   }
 
@@ -80,7 +83,7 @@ const PointRadiusLatLonDd = props => {
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
-            setState({['radius']: value})
+            setState({ ['radius']: value })
           }}
         />
       </Units>
@@ -104,12 +107,15 @@ const PointRadiusLatLonDms = props => {
   const latitudeDirections = [Direction.North, Direction.South]
   const longitudeDirections = [Direction.East, Direction.West]
 
-  useEffect(() => {
-    if(props.drawing) {
-      setDmsError(initialErrorStateWithDefault)
-      setRadiusError(initialErrorState)
-    }
-  }, [props.dmsLat, props.dmsLon, props.radius])
+  useEffect(
+    () => {
+      if (props.drawing) {
+        setDmsError(initialErrorStateWithDefault)
+        setRadiusError(initialErrorState)
+      }
+    },
+    [props.dmsLat, props.dmsLon, props.radius]
+  )
 
   function validate(key, type, value) {
     const { error, message, defaultValue } = validateGeo(key, value)
@@ -126,7 +132,9 @@ const PointRadiusLatLonDms = props => {
         defaultValue,
       })
     }
-    defaultValue ? setState({[key]: defaultValue}) : setState({[key]: value})
+    defaultValue
+      ? setState({ [key]: defaultValue })
+      : setState({ [key]: value })
   }
 
   return (
@@ -139,7 +147,7 @@ const PointRadiusLatLonDms = props => {
         <DirectionInput
           options={latitudeDirections}
           value={dmsLatDirection}
-          onChange={value => setState({['dmsLatDirection']: value})}
+          onChange={value => setState({ ['dmsLatDirection']: value })}
         />
       </DmsLatitude>
       <DmsLongitude
@@ -150,13 +158,13 @@ const PointRadiusLatLonDms = props => {
         <DirectionInput
           options={longitudeDirections}
           value={dmsLonDirection}
-          onChange={value => setState({['dmsLonDirection']: value})}
+          onChange={value => setState({ ['dmsLonDirection']: value })}
         />
       </DmsLongitude>
       {getErrorComponent(dmsError)}
       <Units
         value={radiusUnits}
-        onChange={value => setState({['radiusUnits']: value})}
+        onChange={value => setState({ ['radiusUnits']: value })}
       >
         <TextField
           label="Radius"
@@ -164,7 +172,7 @@ const PointRadiusLatLonDms = props => {
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
-            setState({['radius']: value})
+            setState({ ['radius']: value })
           }}
         />
       </Units>
@@ -178,32 +186,35 @@ const PointRadiusUsngMgrs = props => {
   const [usngError, setUsngError] = useState(initialErrorState)
   const [radiusError, setRadiusError] = useState(initialErrorState)
 
-  useEffect(() => {
-    if(props.drawing) {
-      setUsngError(initialErrorState)
-      setRadiusError(initialErrorState)
-    }
-  }, [props.usng, props.radius])
+  useEffect(
+    () => {
+      if (props.drawing) {
+        setUsngError(initialErrorState)
+        setRadiusError(initialErrorState)
+      }
+    },
+    [props.usng, props.radius]
+  )
 
   return (
     <div>
       <TextField
         label="USNG / MGRS"
         value={usng}
-        onChange={value => setState({['usng']: value})}
+        onChange={value => setState({ ['usng']: value })}
         onBlur={() => setUsngError(validateGeo('usng', usng))}
       />
       {getErrorComponent(usngError)}
       <Units
         value={radiusUnits}
-        onChange={value => setState({['radiusUnits']: value})}
+        onChange={value => setState({ ['radiusUnits']: value })}
       >
         <TextField
           label="Radius"
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
-            setState({['radius']: value})
+            setState({ ['radius']: value })
           }}
         />
       </Units>
@@ -225,12 +236,21 @@ const PointRadiusUtmUps = props => {
   const [utmError, setUtmError] = useState(initialErrorState)
   const [radiusError, setRadiusError] = useState(initialErrorState)
 
-  useEffect(() => {
-    if(props.drawing) {
-      setUtmError(initialErrorState)
-      setRadiusError(initialErrorState)
-    }
-  }, [props.utmUpsEasting, props.utmUpsNorthing, props.utmUpsZone, props.utmUpsHemisphere, props.radius])
+  useEffect(
+    () => {
+      if (props.drawing) {
+        setUtmError(initialErrorState)
+        setRadiusError(initialErrorState)
+      }
+    },
+    [
+      props.utmUpsEasting,
+      props.utmUpsNorthing,
+      props.utmUpsZone,
+      props.utmUpsHemisphere,
+      props.radius,
+    ]
+  )
 
   return (
     <div>
@@ -239,7 +259,7 @@ const PointRadiusUtmUps = props => {
         value={
           utmUpsEasting !== undefined ? String(utmUpsEasting) : utmUpsEasting
         }
-        onChange={value => setState({['utmUpsEasting']: value })}
+        onChange={value => setState({ ['utmUpsEasting']: value })}
         onBlur={() =>
           setUtmError(
             validateGeo(
@@ -258,7 +278,7 @@ const PointRadiusUtmUps = props => {
         value={
           utmUpsNorthing !== undefined ? String(utmUpsNorthing) : utmUpsNorthing
         }
-        onChange={value => setState({['utmUpsNorthing']: value})}
+        onChange={value => setState({ ['utmUpsNorthing']: value })}
         onBlur={() =>
           setUtmError(
             validateGeo(
@@ -274,7 +294,7 @@ const PointRadiusUtmUps = props => {
       />
       <Zone
         value={utmUpsZone}
-        onChange={value => setState({['utmUpsZone']: value})}
+        onChange={value => setState({ ['utmUpsZone']: value })}
         onBlur={() =>
           setUtmError(
             validateGeo(
@@ -289,7 +309,7 @@ const PointRadiusUtmUps = props => {
       />
       <Hemisphere
         value={utmUpsHemisphere}
-        onChange={value => setState({['utmUpsHemisphere']: value})}
+        onChange={value => setState({ ['utmUpsHemisphere']: value })}
         onBlur={() =>
           setUtmError(
             validateGeo(
@@ -305,14 +325,14 @@ const PointRadiusUtmUps = props => {
       {getErrorComponent(utmError)}
       <Units
         value={radiusUnits}
-        onChange={value => setState({['radiusUnits']: value})}
+        onChange={value => setState({ ['radiusUnits']: value })}
       >
         <TextField
           label="Radius"
           value={String(radius)}
           onChange={value => {
             setRadiusError(validateGeo('radius', value))
-            setState({['radius']: value})
+            setState({ ['radius']: value })
           }}
         />
       </Units>
@@ -337,7 +357,7 @@ const PointRadius = props => {
     <div>
       <Radio
         value={locationType}
-        onChange={value => setState({['locationType']: value})}
+        onChange={value => setState({ ['locationType']: value })}
       >
         <RadioItem value="dd">Lat / Lon (DD)</RadioItem>
         <RadioItem value="dms">Lat / Lon (DMS)</RadioItem>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -15,7 +15,6 @@
 export {
   showErrorMessages,
   getFilterErrors,
-  getErrorComponent,
   ErrorComponent,
   validateGeo,
   initialErrorState,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -17,7 +17,6 @@ export {
   getFilterErrors,
   getErrorComponent,
   validateGeo,
-  validateLinePolygon,
   initialErrorState,
   initialErrorStateWithDefault,
 } from './validation'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -17,7 +17,7 @@ export {
   getFilterErrors,
   getErrorComponent,
   validateGeo,
-  validateListOfPoints,
+  validateLinePolygon,
   initialErrorState,
   initialErrorStateWithDefault,
 } from './validation'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -16,6 +16,7 @@ export {
   showErrorMessages,
   getFilterErrors,
   getErrorComponent,
+  ErrorComponent,
   validateGeo,
   initialErrorState,
   initialErrorStateWithDefault,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -12,4 +12,12 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-export { showErrorMessages, getFilterErrors } from './validation'
+export {
+  showErrorMessages,
+  getFilterErrors,
+  getErrorComponent,
+  validateGeo,
+  validateListOfPoints,
+  initialErrorState,
+  initialErrorStateWithDefault,
+} from './validation'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -85,6 +85,8 @@ export function validateGeo(key: string, value: any) {
     case 'line':
     case 'poly':
     case 'polygon':
+    case 'multiline':
+    case 'multipolygon':
       return validateLinePolygon(key, value)
     default:
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -382,19 +382,17 @@ function validateRadiusLineBuffer(key: string, value: any) {
   const label = key === 'radius' ? 'Radius ' : 'Buffer width '
   const buffer = DistanceUtils.getDistanceInMeters(value.value, value.units)
   if (key === 'polygonBufferWidth' || key === 'bufferWidth') {
-    if( buffer > 0 &&
-    buffer < 1
-  ) {
-    return {
-      error: true,
-      message:
-        label +
-        'must be 0, or at least ' +
-        DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
-        ' ' +
-        value.units,
+    if (buffer > 0 && buffer < 1) {
+      return {
+        error: true,
+        message:
+          label +
+          'must be 0, or at least ' +
+          DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
+          ' ' +
+          value.units,
+      }
     }
-  }
   } else if (buffer < 1) {
     return {
       error: true,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -171,23 +171,30 @@ function hasPointError(point: any[]) {
 
 function getGeometryErrors(filter: any): Set<string> {
   const geometry = filter.geojson && filter.geojson.geometry
+  const properties = filter.geojson.properties
   const bufferWidth =
-    filter.geojson.properties.buffer && filter.geojson.properties.buffer.width
+    properties.buffer && properties.buffer.width
   const errors = new Set<string>()
   if (!geometry) {
     return errors
   }
-  switch (filter.geojson.properties.type) {
+  switch (properties.type) {
     case 'Polygon':
-      if (
-        !geometry.coordinates[0].length ||
-        geometry.coordinates[0].length < 4
-      ) {
-        errors.add(
-          'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]'
-        )
-      }
-      break
+        if (!geometry.coordinates[0].length) {
+          errors.add(
+            'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]'
+          )
+        } else if (geometry.coordinates[0].length < 4) {
+          // check for MultiPolygon
+          geometry.coordinates[0].forEach((shape: number[]) => {
+          if(shape.length < 4) {
+            errors.add(
+            'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]'
+          )
+        }
+        })
+        }
+        break
     case 'LineString':
       if (!geometry.coordinates.length || geometry.coordinates.length < 2) {
         errors.add('Line coordinates must be in the form [[x,y],[x,y], ... ]')

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -381,9 +381,8 @@ function validateUtmUps(key: string, value: any) {
 function validateRadiusLineBuffer(key: string, value: any) {
   const label = key === 'radius' ? 'Radius ' : 'Buffer width '
   const buffer = DistanceUtils.getDistanceInMeters(value.value, value.units)
-  if (
-    (key === 'polygonBufferWidth' || key === 'bufferWidth') &&
-    buffer > 0 &&
+  if (key === 'polygonBufferWidth' || key === 'bufferWidth') {
+    if( buffer > 0 &&
     buffer < 1
   ) {
     return {
@@ -396,7 +395,7 @@ function validateRadiusLineBuffer(key: string, value: any) {
         value.units,
     }
   }
-  if (buffer < 1) {
+  } else if (buffer < 1) {
     return {
       error: true,
       message:

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -13,8 +13,22 @@
  *
  **/
 
+const React = require('react')
 import { InvalidSearchFormMessage } from '../../../component/announcement/CommonMessages'
+import styled from 'styled-components'
 const announcement = require('../../../component/announcement/index.jsx')
+const {
+  validateInput,
+} = require('../../../component/location-new/utils/dms-utils')
+const usngs = require('usng.js')
+const converter = new usngs.Converter()
+const northingOffset = 10000000
+const latitude = 'latitude'
+const longitude = 'longitude'
+interface ErrorState {
+  error: boolean
+  message: string
+}
 
 export function showErrorMessages(errors: any) {
   if (errors.length === 0) {
@@ -38,31 +52,326 @@ export function showErrorMessages(errors: any) {
 }
 
 export function getFilterErrors(filters: any) {
-  const errors: any[] = []
+  const errors = new Set()
+  let geometryErrors = new Set<string>()
   for (let i = 0; i < filters.length; i++) {
     const filter = filters[i]
-    const geometry = filter.geojson && filter.geojson.geometry
-    if (
-      geometry &&
-      geometry.type === 'Polygon' &&
-      geometry.coordinates[0].length < 4
-    ) {
-      errors.push({
-        title: 'Invalid geometry filter',
-        body:
-          'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]',
+    getGeometryErrors(filter).forEach(function(msg) {
+      geometryErrors.add(msg)
+    })
+  }
+  geometryErrors.forEach(function(err) {
+    errors.add({
+      title: 'Invalid geometry filter',
+      body: err,
+    })
+  })
+  return Array.from(errors)
+}
+
+export function validateGeo(
+  key: string,
+  value: string,
+  value1?: any,
+  value2?: any,
+  value3?: any
+) {
+  switch (key) {
+    case 'lat':
+      return validateDDLatLon(latitude, 90, value)
+    case 'lon':
+      return validateDDLatLon(longitude, 180, value)
+    case 'dmsLat':
+      return validateDmsLatLon(latitude, value)
+    case 'dmsLon':
+      return validateDmsLatLon(longitude, value)
+    case 'usng':
+      return validateUsng(value)
+    case 'utmUpsEasting':
+    case 'utmUpsNorthing':
+    case 'utmUpsZone':
+    case 'utmUpsHemisphere':
+      return validateUtmUps(key, value, value1, value2, value3)
+    case 'radius':
+    case 'lineWidth':
+      return validateRadiusLineBuffer(key, value)
+    default:
+  }
+}
+
+export function getErrorComponent(errorState: ErrorState) {
+  return errorState.error ? (
+    <Invalid>
+      <WarningIcon className="fa fa-warning" />
+      <span>{errorState.message}</span>
+    </Invalid>
+  ) : null
+}
+
+export function validateListOfPoints(coordinates: any[], mode: string) {
+  let message = ''
+  const isLine = mode.includes('line')
+  const numPoints = isLine ? 2 : 4
+  if (
+    !mode.includes('multi') &&
+    !coordinates.some(coords => coords.length > 2) &&
+    coordinates.length < numPoints
+  ) {
+    message = `Minimum of ${numPoints} points needed for ${
+      isLine ? 'Line' : 'Polygon'
+    }`
+  }
+  coordinates.forEach(coordinate => {
+    if (coordinate.length > 2) {
+      coordinate.forEach((coord: any) => {
+        if (hasPointError(coord))
+          message = JSON.stringify(coord) + ' is not a valid point.'
       })
+    } else {
+      if (mode.includes('multi')) {
+        message = `Switch to ${isLine ? 'Line' : 'Polygon'}`
+      } else if (hasPointError(coordinate)) {
+        message = JSON.stringify(coordinate) + ' is not a valid point.'
+      }
     }
-    if (
-      geometry &&
-      geometry.type === 'LineString' &&
-      geometry.coordinates.length < 2
-    ) {
-      errors.push({
-        title: 'Invalid geometry filter',
-        body: 'Line coordinates must be in the form [[x,y],[x,y], ... ]',
-      })
-    }
+  })
+  return { error: message.length > 0, message }
+}
+
+export const initialErrorState = {
+  error: false,
+  message: '',
+}
+
+export const initialErrorStateWithDefault = {
+  error: false,
+  message: '',
+  defaultValue: '',
+}
+
+function hasPointError(point: any[]) {
+  if (
+    point.length !== 2 ||
+    (Number.isNaN(Number.parseFloat(point[0])) &&
+      Number.isNaN(Number.parseFloat(point[1])))
+  ) {
+    return true
+  } else if (
+    point[0] > 180 ||
+    point[0] < -180 ||
+    point[1] > 90 ||
+    point[1] < -90
+  ) {
+    return true
+  }
+  return false
+}
+
+function getGeometryErrors(filter: any): Set<string> {
+  const geometry = filter.geojson && filter.geojson.geometry
+  const bufferWidth =
+    filter.geojson.properties.buffer && filter.geojson.properties.buffer.width
+  const errors = new Set<string>()
+  if (!geometry) {
+    return errors
+  }
+  switch (filter.geojson.properties.type) {
+    case 'Polygon':
+      if (geometry.coordinates[0].length < 4) {
+        errors.add(
+          'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]'
+        )
+      }
+      break
+    case 'LineString':
+      if (geometry.coordinates.length < 2) {
+        errors.add('Line coordinates must be in the form [[x,y],[x,y], ... ]')
+      }
+      if (!bufferWidth || bufferWidth == 0) {
+        errors.add('Line buffer width must be greater than 0.000001')
+      }
+      break
+    case 'Point':
+      if (!bufferWidth || bufferWidth < 0.000001) {
+        errors.add('Radius must be greater than 0.000001')
+      }
+      if (
+        geometry.coordinates.some(
+          (coord: any) => !coord || coord.toString().length == 0
+        )
+      ) {
+        errors.add('Coordinates must not be empty')
+      }
+      break
+    case 'BoundingBox':
+      const box = filter.geojson.properties
+      if (!box.east || !box.west || !box.north || !box.south) {
+        errors.add('Bounding box must have valid values')
+      }
+      break
   }
   return errors
 }
+
+function validateDDLatLon(label: string, defaultCoord: number, value: string) {
+  let message = ''
+  let defaultValue
+  if (value !== undefined && value.length === 0) {
+    message = getEmptyErrorMessage(label)
+    return { error: true, message, defaultValue }
+  }
+  if (Number(value) > defaultCoord || Number(value) < -1 * defaultCoord) {
+    defaultValue = Number(value) > 0 ? defaultCoord : -1 * defaultCoord
+    message = getDefaultingErrorMessage(value, label, defaultValue)
+    return { error: true, message, defaultValue }
+  }
+  return { error: false, message, defaultValue }
+}
+
+function validateDmsLatLon(label: string, value: string) {
+  let message = ''
+  let defaultValue
+  const validator = label === latitude ? 'dd°mm\'ss.s"' : 'ddd°mm\'ss.s"'
+  if (value !== undefined && value.length === 0) {
+    message = getEmptyErrorMessage(label)
+    return { error: true, message, defaultValue }
+  }
+  if (validateInput(value, validator) !== value) {
+    defaultValue = validateInput(value, validator)
+    message = getDefaultingErrorMessage(value, label, defaultValue)
+    return { error: true, message, defaultValue }
+  }
+  return { error: false, message, defaultValue }
+}
+
+function validateUsng(value: string) {
+  if (value === '') {
+    return { error: true, message: 'USNG / MGRS coordinates cannot be empty' }
+  }
+  const result = converter.USNGtoLL(value, true)
+  const isInvalid = Number.isNaN(result.lat) || Number.isNaN(result.lon)
+  return {
+    error: isInvalid,
+    message: isInvalid ? 'Invalid USNG / MGRS coordinates' : '',
+  }
+}
+
+function upsValidDistance(distance: number) {
+  return distance >= 800000 && distance <= 3200000
+}
+
+function validateLatLon(lat: string, lon: string) {
+  const latitude = parseFloat(lat)
+  const longitude = parseFloat(lon)
+  return latitude > -90 && latitude < 90 && longitude > -180 && longitude < 180
+}
+
+function validateUtmUps(
+  key: string,
+  utmUpsEasting: string,
+  utmUpsNorthing: string,
+  zoneNumber: any,
+  hemisphere: any
+) {
+  let error = { error: false, message: '' }
+  zoneNumber = Number.parseInt(zoneNumber)
+  // casting to Number() will return NaN if it's not a number, i.e. "3e".
+  //Except for empty string, which is why we have to do this check below
+  let easting = utmUpsEasting === '' ? NaN : Number(utmUpsEasting)
+  let northing = utmUpsNorthing === '' ? NaN : Number(utmUpsNorthing)
+  // isNaN will try to parse anything into a number
+  // have to check this because parseFloat will be able to parse things with letters, i.e. "12.3w"
+  if (!isNaN(easting)) {
+    easting = Number.parseFloat(utmUpsEasting)
+  }
+  if (!isNaN(northing)) {
+    northing = Number.parseFloat(utmUpsEasting)
+  }
+  const northernHemisphere = hemisphere.toUpperCase() === 'NORTHERN'
+  const isUps = zoneNumber === 0
+  const utmUpsParts = {
+    easting,
+    northing,
+    zoneNumber,
+    hemisphere,
+    northPole: northernHemisphere,
+  }
+  utmUpsParts.northing =
+    isUps || northernHemisphere ? northing : northing - northingOffset
+  const isNorthingInvalid =
+    isNaN(utmUpsParts.northing) && utmUpsNorthing !== undefined
+  const isEastingInvalid =
+    isNaN(utmUpsParts.easting) && utmUpsEasting !== undefined
+  let { lat, lon } = converter.UTMUPStoLL(utmUpsParts)
+  lon = lon % 360
+  if (lon < -180) {
+    lon = lon + 360
+  }
+  if (lon > 180) {
+    lon = lon - 360
+  }
+  // we want to validate using the validate lat lon method, but only if they're both defined
+  // if one or more is undefined, we want to return true
+  const isLatLonValid =
+    validateLatLon(lat, lon) ||
+    (utmUpsNorthing === undefined || utmUpsEasting === undefined)
+  if ((isNorthingInvalid && isEastingInvalid) || !isLatLonValid) {
+    error = { error: true, message: 'Invalid UTM/UPS coordinates' }
+  } else if (
+    key === 'utmUpsNorthing' &&
+    isNaN(utmUpsParts.northing) &&
+    utmUpsNorthing !== undefined
+  ) {
+    error = { error: true, message: 'Northing value is invalid' }
+  } else if (
+    key === 'utmUpsEasting' &&
+    isNaN(utmUpsParts.easting) &&
+    utmUpsEasting !== undefined
+  ) {
+    error = { error: true, message: 'Easting value is invalid' }
+  } else if (
+    isUps &&
+    (!upsValidDistance(northing) || !upsValidDistance(easting))
+  ) {
+    error = { error: true, message: 'Invalid UPS distance' }
+  }
+  return error
+}
+
+function validateRadiusLineBuffer(key: string, value: string) {
+  const label = key === 'lineWidth' ? 'Buffer ' : 'Radius '
+  if ((value !== undefined && value.length === 0) || Number(value) < 0.000001) {
+    return {
+      error: true,
+      message: label + 'cannot be less than 0.000001',
+    }
+  }
+  return { error: false, message: '' }
+}
+
+function getDefaultingErrorMessage(
+  value: string,
+  label: string,
+  defaultValue: number
+) {
+  return `${value.replace(
+    /_/g,
+    '0'
+  )} is not an acceptable ${label} value. Defaulting to ${defaultValue}`
+}
+
+function getEmptyErrorMessage(label: string) {
+  return `${label.replace(/^\w/, c => c.toUpperCase())} cannot be empty`
+}
+
+const Invalid = styled.div`
+  background-color: ${props => props.theme.negativeColor};
+  height: 100%;
+  display: block;
+  overflow: hidden;
+  color: white;
+`
+
+const WarningIcon = styled.span`
+  padding: ${({ theme }) => theme.minimumSpacing};
+`

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -381,13 +381,21 @@ function validateUtmUps(key: string, value: any) {
 function validateRadiusLineBuffer(key: string, value: any) {
   const label = key === 'radius' ? 'Radius ' : 'Buffer width '
   const buffer = DistanceUtils.getDistanceInMeters(value.value, value.units)
-  if ((key === 'polygonBufferWidth' || key === 'bufferWidth') && buffer > 0 && buffer < 1) {
+  if (
+    (key === 'polygonBufferWidth' || key === 'bufferWidth') &&
+    buffer > 0 &&
+    buffer < 1
+  ) {
     return {
       error: true,
       message:
         label +
-        'must be 0, ' + DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) + ' ' +
-        value.units + ' or greater than ' + DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
+        'must be 0, ' +
+        DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
+        ' ' +
+        value.units +
+        ' or greater than ' +
+        DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
         ' ' +
         value.units,
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -232,6 +232,9 @@ function getGeometryErrors(filter: any): Set<string> {
 }
 
 function validateLinePolygon(mode: string, currentValue: string) {
+  if (currentValue === undefined) {
+    return initialErrorState
+  }
   try {
     const parsedCoords = JSON.parse(currentValue)
     if (!is2DArray(parsedCoords)) {
@@ -255,7 +258,7 @@ function validateDDLatLon(label: string, value: string, defaultCoord: number) {
     message = getDefaultingErrorMessage(value, label, defaultValue)
     return { error: true, message, defaultValue }
   }
-  return { error: false, message, defaultValue }
+  return initialErrorStateWithDefault
 }
 
 function validateDmsLatLon(label: string, value: string) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -298,7 +298,7 @@ function validateUtmUps(
     easting = Number.parseFloat(utmUpsEasting)
   }
   if (!isNaN(northing)) {
-    northing = Number.parseFloat(utmUpsEasting)
+    northing = Number.parseFloat(utmUpsNorthing)
   }
   const northernHemisphere = hemisphere.toUpperCase() === 'NORTHERN'
   const isUps = zoneNumber === 0
@@ -330,16 +330,14 @@ function validateUtmUps(
   const isLatLonValid =
     !hasPointError([lon, lat]) ||
     (utmUpsNorthing === undefined || utmUpsEasting === undefined)
-  if ((isNorthingInvalid && isEastingInvalid) || !isLatLonValid) {
-    error = { error: true, message: 'Invalid UTM/UPS coordinates' }
-  } else if (
+   if (
     key === 'utmUpsNorthing' &&
-    isNorthingInvalid
+    isNorthingInvalid && !isEastingInvalid
   ) {
     error = { error: true, message: 'Northing value is invalid' }
   } else if (
     key === 'utmUpsEasting' &&
-    isEastingInvalid
+    isEastingInvalid && !isNorthingInvalid
   ) {
     error = { error: true, message: 'Easting value is invalid' }
   } else if (
@@ -347,6 +345,8 @@ function validateUtmUps(
     (!upsValidDistance(northing) || !upsValidDistance(easting))
   ) {
     error = { error: true, message: 'Invalid UPS distance' }
+  } else if ((isNorthingInvalid && isEastingInvalid) || !isLatLonValid) {
+    error = { error: true, message: 'Invalid UTM/UPS coordinates' }
   }
   return error
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -173,7 +173,7 @@ function getGeometryErrors(filter: any): Set<string> {
   }
   switch (properties.type) {
     case 'Polygon':
-      if (!geometry.coordinates[0].length) {
+      if (!Array.isArray(geometry.coordinates[0]) || !geometry.coordinates[0].length) {
         errors.add(
           'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]'
         )
@@ -189,7 +189,7 @@ function getGeometryErrors(filter: any): Set<string> {
       }
       break
     case 'LineString':
-      if (!geometry.coordinates.length || geometry.coordinates.length < 2) {
+      if (!Array.isArray(geometry.coordinates) || !geometry.coordinates.length || geometry.coordinates.length < 2) {
         errors.add('Line coordinates must be in the form [[x,y],[x,y], ... ]')
       }
       // Can't just check !bufferWidth because of the case of the string "0"

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -130,7 +130,7 @@ export function validateListOfPoints(coordinates: any[], mode: string) {
       })
     } else {
       if (mode.includes('multi')) {
-        // Handle the case where the user has selected a "multi" mode but 
+        // Handle the case where the user has selected a "multi" mode but
         // one or more shapes were invalid and therefore eliminated
         message = `Switch to ${isLine ? 'Line' : 'Polygon'}`
       } else if (hasPointError(coordinate)) {
@@ -176,7 +176,7 @@ function hasPointError(point: any[]) {
   if (
     point.length !== 2 ||
     Number.isNaN(Number.parseFloat(point[0])) ||
-      Number.isNaN(Number.parseFloat(point[1]))
+    Number.isNaN(Number.parseFloat(point[1]))
   ) {
     return true
   }
@@ -255,7 +255,7 @@ function validateDmsLatLon(label: string, value: string) {
     message = getEmptyErrorMessage(label)
     return { error: true, message, defaultValue }
   }
-  const dmsValidation = validateDmsInput(value, validator) 
+  const dmsValidation = validateDmsInput(value, validator)
   if (dmsValidation.error) {
     defaultValue = dmsValidation.defaultValue
     message = getDefaultingErrorMessage(value, label, defaultValue)
@@ -362,7 +362,7 @@ function validateRadiusLineBuffer(key: string, value: string) {
 const validateDmsInput = (input: any, placeHolder: string) => {
   if (input !== undefined && placeHolder === 'dd°mm\'ss.s"') {
     const corrected = getCorrectedDmsLatInput(input)
-    return { error: corrected !== input, defaultValue: corrected}
+    return { error: corrected !== input, defaultValue: corrected }
   } else if (input !== undefined && placeHolder === 'ddd°mm\'ss.s"') {
     const corrected = getCorrectedDmsLonInput(input)
     return { error: corrected !== input, defaultValue: corrected }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -270,6 +270,9 @@ function validateUsng(value: string) {
   if (value === '') {
     return { error: true, message: 'USNG / MGRS coordinates cannot be empty' }
   }
+  if (value === undefined) {
+    return { error: false, message: '' }
+  }
   const result = converter.USNGtoLL(value, true)
   const isInvalid = Number.isNaN(result.lat) || Number.isNaN(result.lon)
   return {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -82,6 +82,7 @@ export function validateGeo(key: string, value: any) {
       return validateUtmUps(key, value)
     case 'radius':
     case 'lineWidth':
+    case 'polygonBufferWidth':
       return validateRadiusLineBuffer(key, value)
     case 'line':
     case 'poly':
@@ -191,6 +192,13 @@ function getGeometryErrors(filter: any): Set<string> {
             )
           }
         })
+      }
+      const polyBufferValidation = validateRadiusLineBuffer('bufferWidth', {
+        value: buffer.width,
+        units: buffer.unit,
+      })
+      if (polyBufferValidation.error) {
+        errors.add(polyBufferValidation.message)
       }
       break
     case 'LineString':
@@ -371,8 +379,19 @@ function validateUtmUps(key: string, value: any) {
 }
 
 function validateRadiusLineBuffer(key: string, value: any) {
-  const label = key === 'lineWidth' ? 'Buffer width ' : 'Radius '
+  const label = key === 'radius' ? 'Radius ' : 'Buffer width ' 
   const buffer = DistanceUtils.getDistanceInMeters(value.value, value.units)
+  if (key === 'polygonBufferWidth' && buffer > 0 && buffer < 1) {
+      return {
+        error: true,
+        message:
+          label +
+          'must be greater than ' +
+          DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
+          ' ' +
+          value.units,
+      }
+  }
   if (buffer < 1) {
     return {
       error: true,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -110,15 +110,6 @@ export const ErrorComponent = props => {
   ) : null
 }
 
-export function getErrorComponent(errorState: ErrorState) {
-  return errorState.error ? (
-    <Invalid>
-      <WarningIcon className="fa fa-warning" />
-      <span>{errorState.message}</span>
-    </Invalid>
-  ) : null
-}
-
 export function validateListOfPoints(coordinates: any[], mode: string) {
   let message = ''
   const isLine = mode.includes('line')

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -350,7 +350,7 @@ function validateUtmUps(key: string, value: any) {
 }
 
 function validateRadiusLineBuffer(key: string, value: string) {
-  const label = key === 'lineWidth' ? 'Buffer ' : 'Radius '
+  const label = key === 'lineWidth' ? 'Buffer width ' : 'Radius '
   if ((value !== undefined && value.length === 0) || Number(value) <= 0) {
     return {
       error: true,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -199,12 +199,13 @@ function getGeometryErrors(filter: any): Set<string> {
       if (!geometry.coordinates.length || geometry.coordinates.length < 2) {
         errors.add('Line coordinates must be in the form [[x,y],[x,y], ... ]')
       }
-      if (!bufferWidth) {
+      // Can't just check !bufferWidth because of the case of the string "0"
+      if (bufferWidth === undefined || Number(bufferWidth) === 0) {
         errors.add('Line buffer width must be greater than 0')
       }
       break
     case 'Point':
-      if (!bufferWidth) {
+      if (bufferWidth === undefined || Number(bufferWidth) === 0) {
         errors.add('Radius must be greater than 0')
       }
       if (

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -328,7 +328,8 @@ function validateUtmUps(
   // if one or more is undefined, we want to return true
   const isLatLonValid =
     !hasPointError([lon, lat]) ||
-    (utmUpsNorthing === undefined || utmUpsEasting === undefined)
+    utmUpsNorthing === undefined || 
+    utmUpsEasting === undefined
   if (key === 'utmUpsNorthing' && isNorthingInvalid && !isEastingInvalid) {
     error = { error: true, message: 'Northing value is invalid' }
   } else if (
@@ -350,7 +351,7 @@ function validateUtmUps(
 
 function validateRadiusLineBuffer(key: string, value: string) {
   const label = key === 'lineWidth' ? 'Buffer ' : 'Radius '
-  if ((value !== undefined && value.length === 0) || Number(value) < 0.000001) {
+  if ((value !== undefined && value.length === 0) || Number(value) <= 0) {
     return {
       error: true,
       message: label + 'must be greater than 0',

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -95,6 +95,9 @@ export function validateGeo(
     case 'radius':
     case 'lineWidth':
       return validateRadiusLineBuffer(key, value)
+    case 'line':
+    case 'polygon':
+      return validateLinePolygon(key, value)
     default:
   }
 }
@@ -138,12 +141,12 @@ export function validateListOfPoints(coordinates: any[], mode: string) {
   return { error: message.length > 0, message }
 }
 
-export function validateLinePolygon(currentValue: string, mode: string) {
+function validateLinePolygon(mode: string, currentValue: string) {
   if (!is2DArray(currentValue)) {
     return { error: true, message: 'Not an acceptable value' }
   }
   try {
-    const pointsValid = validateListOfPoints(JSON.parse(currentValue), mode) 
+    const pointsValid = validateListOfPoints(JSON.parse(currentValue), mode)
     return pointsValid === undefined ? initialErrorState : pointsValid
   } catch (e) {
     return initialErrorState
@@ -198,7 +201,10 @@ function getGeometryErrors(filter: any): Set<string> {
   }
   switch (filter.geojson.properties.type) {
     case 'Polygon':
-      if (!geometry.coordinates[0].length || geometry.coordinates[0].length < 4) {
+      if (
+        !geometry.coordinates[0].length ||
+        geometry.coordinates[0].length < 4
+      ) {
         errors.add(
           'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]'
         )
@@ -311,7 +317,7 @@ function validateUtmUps(
   }
   utmUpsParts.northing =
     isUps || northernHemisphere ? northing : northing - northingOffset
-  // These checks are to ensure that we only mark a value as "invalid" 
+  // These checks are to ensure that we only mark a value as "invalid"
   // if the user has entered something already
   const isNorthingInvalid =
     isNaN(utmUpsParts.northing) && utmUpsNorthing !== undefined
@@ -330,14 +336,12 @@ function validateUtmUps(
   const isLatLonValid =
     !hasPointError([lon, lat]) ||
     (utmUpsNorthing === undefined || utmUpsEasting === undefined)
-   if (
-    key === 'utmUpsNorthing' &&
-    isNorthingInvalid && !isEastingInvalid
-  ) {
+  if (key === 'utmUpsNorthing' && isNorthingInvalid && !isEastingInvalid) {
     error = { error: true, message: 'Northing value is invalid' }
   } else if (
     key === 'utmUpsEasting' &&
-    isEastingInvalid && !isNorthingInvalid
+    isEastingInvalid &&
+    !isNorthingInvalid
   ) {
     error = { error: true, message: 'Easting value is invalid' }
   } else if (

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -193,12 +193,12 @@ function getGeometryErrors(filter: any): Set<string> {
         errors.add('Line coordinates must be in the form [[x,y],[x,y], ... ]')
       }
       // Can't just check !bufferWidth because of the case of the string "0"
-      if (bufferWidth === undefined || Number(bufferWidth) === 0) {
+      if (bufferWidth === undefined || Number(bufferWidth) <= 0) {
         errors.add('Line buffer width must be greater than 0')
       }
       break
     case 'Point':
-      if (bufferWidth === undefined || Number(bufferWidth) === 0) {
+      if (bufferWidth === undefined || Number(bufferWidth) <= 0) {
         errors.add('Radius must be greater than 0')
       }
       if (
@@ -339,6 +339,17 @@ function validateUtmUps(key: string, value: any) {
     return { error: true, message: 'Invalid UTM/UPS coordinates' }
   }
   return error
+}
+
+function validateRadiusLineBuffer(key: string, value: string) {
+  const label = key === 'lineWidth' ? 'Buffer ' : 'Radius '
+  if ((value !== undefined && value.length === 0) || Number(value) <= 0) {
+    return {
+      error: true,
+      message: label + 'must be greater than 0',
+    }
+  }
+  return { error: false, message: '' }
 }
 
 const validateDmsInput = (input: any, placeHolder: string) => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -100,6 +100,16 @@ export function validateGeo(
   }
 }
 
+export const ErrorComponent = props => {
+  const { errorState } = props
+  return errorState.error ? (
+    <Invalid>
+      <WarningIcon className="fa fa-warning" />
+      <span>{errorState.message}</span>
+    </Invalid>
+  ) : null
+}
+
 export function getErrorComponent(errorState: ErrorState) {
   return errorState.error ? (
     <Invalid>
@@ -139,17 +149,6 @@ export function validateListOfPoints(coordinates: any[], mode: string) {
     }
   })
   return { error: message.length > 0, message }
-}
-
-function validateLinePolygon(mode: string, currentValue: string) {
-  if (!is2DArray(currentValue)) {
-    return { error: true, message: 'Not an acceptable value' }
-  }
-  try {
-    return validateListOfPoints(JSON.parse(currentValue), mode)
-  } catch (e) {
-    return { error: true, message: 'Not an acceptable value' }
-  }
 }
 
 export const initialErrorState = {
@@ -230,6 +229,17 @@ function getGeometryErrors(filter: any): Set<string> {
       break
   }
   return errors
+}
+
+function validateLinePolygon(mode: string, currentValue: string) {
+  if (!is2DArray(currentValue)) {
+    return { error: true, message: 'Not an acceptable value' }
+  }
+  try {
+    return validateListOfPoints(JSON.parse(currentValue), mode)
+  } catch (e) {
+    return { error: true, message: 'Not an acceptable value' }
+  }
 }
 
 function validateDDLatLon(label: string, defaultCoord: number, value: string) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -381,13 +381,13 @@ function validateUtmUps(key: string, value: any) {
 function validateRadiusLineBuffer(key: string, value: any) {
   const label = key === 'radius' ? 'Radius ' : 'Buffer width '
   const buffer = DistanceUtils.getDistanceInMeters(value.value, value.units)
-  if (key === 'polygonBufferWidth' && buffer > 0 && buffer < 1) {
+  if ((key === 'polygonBufferWidth' || key === 'bufferWidth') && buffer > 0 && buffer < 1) {
     return {
       error: true,
       message:
         label +
-        'must be greater than ' +
-        DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
+        'must be 0, ' + DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) + ' ' +
+        value.units + ' or greater than ' + DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
         ' ' +
         value.units,
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -216,8 +216,8 @@ function getGeometryErrors(filter: any): Set<string> {
       }
       break
     case 'BoundingBox':
-      const box = filter.geojson.properties
-      if (!box.east || !box.west || !box.north || !box.south) {
+      const {east, west, north, south} = filter.geojson.properties
+      if ([east, west, north, south].some(direction => direction=== '' || direction === undefined)) {
         errors.add('Bounding box must have valid values')
       }
       break

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -292,24 +292,29 @@ function validateUtmUps(key: string, value: any) {
   // since we want to differentiate '' from 0
   let easting = utmUpsEasting === '' ? NaN : Number(utmUpsEasting)
   let northing = utmUpsNorthing === '' ? NaN : Number(utmUpsNorthing)
-  const isNorthingInvalid =
-      isNaN(northing) && utmUpsNorthing !== undefined
-  const isEastingInvalid =
-    isNaN(easting) && utmUpsEasting !== undefined
+  const isNorthingInvalid = isNaN(northing) && utmUpsNorthing !== undefined
+  const isEastingInvalid = isNaN(easting) && utmUpsEasting !== undefined
   if (!isNaN(easting)) {
     easting = Number.parseFloat(utmUpsEasting)
-  } else if(key === 'utmUpsEasting' && utmUpsEasting !== undefined && !isNorthingInvalid) {
+  } else if (
+    key === 'utmUpsEasting' &&
+    utmUpsEasting !== undefined &&
+    !isNorthingInvalid
+  ) {
     return { error: true, message: 'Easting value is invalid' }
   }
   if (!isNaN(northing)) {
     northing = Number.parseFloat(utmUpsNorthing)
-    northing = isUps || northernHemisphere ? northing : northing - NORTHING_OFFSET
-  } else if(key === 'utmUpsNorthing'  && utmUpsNorthing !== undefined && !isEastingInvalid ) {
+    northing =
+      isUps || northernHemisphere ? northing : northing - NORTHING_OFFSET
+  } else if (
+    key === 'utmUpsNorthing' &&
+    utmUpsNorthing !== undefined &&
+    !isEastingInvalid
+  ) {
     return { error: true, message: 'Northing value is invalid' }
   }
-  if(isUps &&
-    (!upsValidDistance(northing) || !upsValidDistance(easting))
-  ) {
+  if (isUps && (!upsValidDistance(northing) || !upsValidDistance(easting))) {
     return { error: true, message: 'Invalid UPS distance' }
   }
   const utmUpsParts = {
@@ -333,7 +338,7 @@ function validateUtmUps(key: string, value: any) {
   // if one or more is undefined, we want to return true
   const isLatLonValid =
     !hasPointError([lon, lat]) ||
-    utmUpsNorthing === undefined || 
+    utmUpsNorthing === undefined ||
     utmUpsEasting === undefined
   if ((isNorthingInvalid && isEastingInvalid) || !isLatLonValid) {
     return { error: true, message: 'Invalid UTM/UPS coordinates' }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -198,14 +198,14 @@ function getGeometryErrors(filter: any): Set<string> {
   }
   switch (filter.geojson.properties.type) {
     case 'Polygon':
-      if (geometry.coordinates[0].length < 4) {
+      if (!geometry.coordinates[0].length || geometry.coordinates[0].length < 4) {
         errors.add(
           'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]'
         )
       }
       break
     case 'LineString':
-      if (geometry.coordinates.length < 2) {
+      if (!geometry.coordinates.length || geometry.coordinates.length < 2) {
         errors.add('Line coordinates must be in the form [[x,y],[x,y], ... ]')
       }
       if (!bufferWidth || bufferWidth == 0) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -379,18 +379,18 @@ function validateUtmUps(key: string, value: any) {
 }
 
 function validateRadiusLineBuffer(key: string, value: any) {
-  const label = key === 'radius' ? 'Radius ' : 'Buffer width ' 
+  const label = key === 'radius' ? 'Radius ' : 'Buffer width '
   const buffer = DistanceUtils.getDistanceInMeters(value.value, value.units)
   if (key === 'polygonBufferWidth' && buffer > 0 && buffer < 1) {
-      return {
-        error: true,
-        message:
-          label +
-          'must be greater than ' +
-          DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
-          ' ' +
-          value.units,
-      }
+    return {
+      error: true,
+      message:
+        label +
+        'must be greater than ' +
+        DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
+        ' ' +
+        value.units,
+    }
   }
   if (buffer < 1) {
     return {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -390,11 +390,7 @@ function validateRadiusLineBuffer(key: string, value: any) {
       error: true,
       message:
         label +
-        'must be 0, ' +
-        DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
-        ' ' +
-        value.units +
-        ' or greater than ' +
+        'must be 0, or at least ' +
         DistanceUtils.getDistanceFromMeters(1, value.units).toPrecision(2) +
         ' ' +
         value.units,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -281,12 +281,6 @@ function upsValidDistance(distance: number) {
   return distance >= 800000 && distance <= 3200000
 }
 
-function validateLatLon(lat: string, lon: string) {
-  const latitude = parseFloat(lat)
-  const longitude = parseFloat(lon)
-  return latitude > -90 && latitude < 90 && longitude > -180 && longitude < 180
-}
-
 function validateUtmUps(
   key: string,
   utmUpsEasting: string,
@@ -331,23 +325,21 @@ function validateUtmUps(
   if (lon > 180) {
     lon = lon - 360
   }
-  // we want to validate using the validate lat lon method, but only if they're both defined
+  // we want to validate using the hasPointError method, but only if they're both defined
   // if one or more is undefined, we want to return true
   const isLatLonValid =
-    validateLatLon(lat, lon) ||
+    !hasPointError([lon, lat]) ||
     (utmUpsNorthing === undefined || utmUpsEasting === undefined)
   if ((isNorthingInvalid && isEastingInvalid) || !isLatLonValid) {
     error = { error: true, message: 'Invalid UTM/UPS coordinates' }
   } else if (
     key === 'utmUpsNorthing' &&
-    isNaN(utmUpsParts.northing) &&
-    utmUpsNorthing !== undefined
+    isNorthingInvalid
   ) {
     error = { error: true, message: 'Northing value is invalid' }
   } else if (
     key === 'utmUpsEasting' &&
-    isNaN(utmUpsParts.easting) &&
-    utmUpsEasting !== undefined
+    isEastingInvalid
   ) {
     error = { error: true, message: 'Easting value is invalid' }
   } else if (

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -143,10 +143,9 @@ export const initialErrorStateWithDefault = {
   defaultValue: '',
 }
 
-function is2DArray(coordinates: string) {
+function is2DArray(coordinates: any[]) {
   try {
-    const parsedCoords = JSON.parse(coordinates)
-    return Array.isArray(parsedCoords) && Array.isArray(parsedCoords[0])
+    return Array.isArray(coordinates) && Array.isArray(coordinates[0])
   } catch (e) {
     return false
   }
@@ -224,11 +223,12 @@ function getGeometryErrors(filter: any): Set<string> {
 }
 
 function validateLinePolygon(mode: string, currentValue: string) {
-  if (!is2DArray(currentValue)) {
-    return { error: true, message: 'Not an acceptable value' }
-  }
   try {
-    return validateListOfPoints(JSON.parse(currentValue), mode)
+    const parsedCoords = JSON.parse(currentValue)
+    if (!is2DArray(parsedCoords)) {
+      return { error: true, message: 'Not an acceptable value' }
+    }
+    return validateListOfPoints(parsedCoords, mode)
   } catch (e) {
     return { error: true, message: 'Not an acceptable value' }
   }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -22,10 +22,6 @@ const converter = new usngs.Converter()
 const NORTHING_OFFSET = 10000000
 const LATITUDE = 'latitude'
 const LONGITUDE = 'longitude'
-interface ErrorState {
-  error: boolean
-  message: string
-}
 
 export function showErrorMessages(errors: any) {
   if (errors.length === 0) {
@@ -100,7 +96,7 @@ export function validateGeo(
   }
 }
 
-export const ErrorComponent = props => {
+export const ErrorComponent = (props: any) => {
   const { errorState } = props
   return errorState.error ? (
     <Invalid>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -172,7 +172,10 @@ function getGeometryErrors(filter: any): Set<string> {
   const bufferWidth = properties.buffer && properties.buffer.width
   switch (properties.type) {
     case 'Polygon':
-      if (!Array.isArray(geometry.coordinates[0]) || !geometry.coordinates[0].length) {
+      if (
+        !Array.isArray(geometry.coordinates[0]) ||
+        !geometry.coordinates[0].length
+      ) {
         errors.add(
           'Polygon coordinates must be in the form [[x,y],[x,y],[x,y],[x,y], ... ]'
         )
@@ -188,7 +191,11 @@ function getGeometryErrors(filter: any): Set<string> {
       }
       break
     case 'LineString':
-      if (!Array.isArray(geometry.coordinates) || !geometry.coordinates.length || geometry.coordinates.length < 2) {
+      if (
+        !Array.isArray(geometry.coordinates) ||
+        !geometry.coordinates.length ||
+        geometry.coordinates.length < 2
+      ) {
         errors.add('Line coordinates must be in the form [[x,y],[x,y], ... ]')
       }
       // Can't just check !bufferWidth because of the case of the string "0"

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -165,12 +165,12 @@ function hasPointError(point: any[]) {
 
 function getGeometryErrors(filter: any): Set<string> {
   const geometry = filter.geojson && filter.geojson.geometry
-  const properties = filter.geojson.properties
-  const bufferWidth = properties.buffer && properties.buffer.width
   const errors = new Set<string>()
   if (!geometry) {
     return errors
   }
+  const properties = filter.geojson.properties
+  const bufferWidth = properties.buffer && properties.buffer.width
   switch (properties.type) {
     case 'Polygon':
       if (!Array.isArray(geometry.coordinates[0]) || !geometry.coordinates[0].length) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -96,6 +96,7 @@ export function validateGeo(
     case 'lineWidth':
       return validateRadiusLineBuffer(key, value)
     case 'line':
+    case 'poly':
     case 'polygon':
       return validateLinePolygon(key, value)
     default:

--- a/ui/packages/catalog-ui-search/src/main/webapp/test/mock-api/config.json
+++ b/ui/packages/catalog-ui-search/src/main/webapp/test/mock-api/config.json
@@ -67,7 +67,8 @@
     "sources.available": "All sources are currently up",
     "sources.title": "Sources",
     "sources.polling.error.message": "Unable to query server for list of active sources",
-    "sources.options.all": "All Sources"
+    "sources.options.all": "All Sources",
+    "form.title": "title"
   },
   "queryFeedbackEmailSubjectTemplate": "Query Feedback from {{username}}",
   "customBackgroundModal": "#252529",


### PR DESCRIPTION
#### What does this PR do?
This PR improves the validation/error handling/error displaying for anyGeo searches - specifically Line, Point-Radius, and Bounding Box.

For details on how the behavior has changed, please see this document:
[UX-changes_updated.pdf](https://github.com/codice/ddf/files/4246059/UX-changes_2_24.pdf)

It also refactors the way in which the state is set when values are changed by the user, and eliminates the `cursor` function from `location.js` entirely. This refactor involved moving the error components and their validation into each separate component (pulling shared logic into the `validation.tsx` file) rather than using the cursor function and the `LocationInput` component for most of the error handling. Generic validation logic that existed in `base.line.js` and 'location.js' were moved into the `validation.tsx` file.

___________________________________________
### UPDATE 2/24: 
Based on feedback from @bennuttle and @leo-sakh , The UX for radius and line buffer width has been changed. The minimum buffer has been changed to 1 meter (or its equivalent in the other units). Changes have been made to the inline error and toast message to reflect this minimum. 
Like the other inputs, we now do the validation in the `onBlur` function rather than the `onChange`, meaning the user will not see an error message until clicking out of the input box. If the user tries to search with an invalid radius or line buffer width, the search will be prevented.
I have updated the document above and the screenshots below to reflect this change. 

___________________________________________



## Known Issues
- ~Keyword: Can't change buffer width or units on the Polygon inside of the Keyword anyGeo search~ fixed 02/05
- ~Keyword: Console error when changing polygon value and clicking out~ fixed 02/05
- ~Keyword: Does not prevent a search when polygon is invalid~ exists previously, out of scope for this PR 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@hayleynorton @maryformanek @zta6 @andrewzimmer 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@bdeining 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Test that the new behavior is as defined here:
[UX-changes.pdf](https://github.com/codice/ddf/files/4156793/UX-changes.pdf)


#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5793 

#### Screenshots
<!--(if appropriate)-->
Here are some examples of the new behavior:
## Line
<img width="376" alt="Screen Shot 2020-02-24 at 11 22 23 AM" src="https://user-images.githubusercontent.com/25390369/75179812-23c1c100-56f8-11ea-97dd-2220913a6766.png">

<img width="502" alt="Screen Shot 2020-02-04 at 4 50 04 PM" src="https://user-images.githubusercontent.com/25390369/73797998-beb92200-476e-11ea-99b0-85d6c7b0f950.png">

## Point Radius
<img width="365" alt="Screen Shot 2020-02-24 at 11 23 06 AM" src="https://user-images.githubusercontent.com/25390369/75179847-350acd80-56f8-11ea-9371-c28d499fb1ea.png">

<img width="431" alt="Screen Shot 2020-02-04 at 3 02 51 PM" src="https://user-images.githubusercontent.com/25390369/73797957-9df0cc80-476e-11ea-89b7-deec12f9ce62.png">

<img width="447" alt="Screen Shot 2020-02-24 at 11 30 35 AM" src="https://user-images.githubusercontent.com/25390369/75180287-1bb65100-56f9-11ea-9991-c8be43d3f218.png">


## Bounding Box
<img width="559" alt="Screen Shot 2020-02-04 at 3 56 09 PM" src="https://user-images.githubusercontent.com/25390369/73797969-a34e1700-476e-11ea-85a0-09d75a2bac33.png">
<img width="558" alt="Screen Shot 2020-02-04 at 3 56 54 PM" src="https://user-images.githubusercontent.com/25390369/73797978-ac3ee880-476e-11ea-8bb5-dc980386d100.png">

## Search Errors
This is showing that when you have multiple errors of the same type, the error message that pops up will inform you about all of them only once (see how the `"Radius must be greater.." ` only shows once)

<img width="347" alt="Screen Shot 2020-02-24 at 11 31 58 AM" src="https://user-images.githubusercontent.com/25390369/75180378-5324fd80-56f9-11ea-9129-8f404f7e4d4b.png">

<img width="457" alt="Screen Shot 2020-02-24 at 11 32 04 AM" src="https://user-images.githubusercontent.com/25390369/75180385-54eec100-56f9-11ea-97b4-dcea5a2167d2.png">




#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
