### PR TITLE
[2.19.x] DDF-5815 fix result form action dropdown

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-forms.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-forms.view.js
@@ -31,7 +31,7 @@ module.exports = SearchFormViews.extend({
           title: 'Error',
           message:
             'You have read-only permission on result form ' +
-            this.model.get('name') +
+            this.model.get('title') +
             '.',
           type: 'error',
         },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -59,10 +59,6 @@
   > .interaction-share {
     display: none;
   }
-
-  > .interaction-edit {
-    display: none;
-  }
 }
 
 @{customElementNamespace}search-form-interactions.is-not-shareable-template {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -45,10 +45,6 @@
   > .interaction-default {
     display: none;
   }
-
-  > .interaction-edit {
-    display: none;
-  }
 }
 
 @{customElementNamespace}search-form-interactions.is-system-template {
@@ -57,6 +53,10 @@
   }
 
   > .interaction-share {
+    display: none;
+  }
+
+  > .interaction-edit {
     display: none;
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -185,7 +185,13 @@ export default Marionette.LayoutView.extend({
     return { createdOn: Common.getMomentDate(createdOn), ...json }
   },
   onRender() {
-    if (this.model.get('type') === 'new-result') {
+    const type = this.model.get('type')
+    if (
+      type === 'new-result' ||
+      (type === 'result' &&
+        (!user.canWrite(this.model) ||
+          this.model.get('createdBy') === 'system'))
+    ) {
       this.$el.addClass('is-static')
     } else {
       this.searchFormActions.show(

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -185,13 +185,11 @@ export default Marionette.LayoutView.extend({
     return { createdOn: Common.getMomentDate(createdOn), ...json }
   },
   onRender() {
-    const type = this.model.get('type')
-    if (
-      type === 'new-result' ||
-      (type === 'result' &&
-        (!user.canWrite(this.model) ||
-          this.model.get('createdBy') === 'system'))
-    ) {
+    const newResult = this.model.get('type') === 'new-result'
+    const noActions =
+      this.model.get('type') === 'result' &&
+      (!user.canWrite(this.model) || this.model.get('createdBy') === 'system')
+    if (newResult || noActions) {
       this.$el.addClass('is-static')
     } else {
       this.searchFormActions.show(


### PR DESCRIPTION
#### What does this PR do?
Hides result form actions (vertical ellipsis) when no actions are present
re adds edit as a result form action

#### Who is reviewing it? 
@zta6 @hayleynorton @cassandrabailey293 

#### Select relevant component teams: 
@codice/ui

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@bdthomson

#### How should this be tested?
- build / install
- ingest system search form, verify there are no actions available
- verify edit action is available for editable result forms

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5815 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
