### PR TITLE
[2.19.x] Disable attributes that are not supported by selected sources

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -97,7 +97,7 @@ module.exports = Marionette.LayoutView.extend({
         isFormBuilder: this.options.isFormBuilder || false,
         suggester: this.options.suggester,
         includedAttributes: this.options.includedAttributes,
-        settingsModel: this.options.settingsModel,
+        supportedAttributes: this.options.supportedAttributes,
       })
     )
     this.handleEditing()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -98,7 +98,6 @@ module.exports = Marionette.LayoutView.extend({
         suggester: this.options.suggester,
         includedAttributes: this.options.includedAttributes,
         settingsModel: this.options.settingsModel,
-
       })
     )
     this.handleEditing()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -97,6 +97,8 @@ module.exports = Marionette.LayoutView.extend({
         isFormBuilder: this.options.isFormBuilder || false,
         suggester: this.options.suggester,
         includedAttributes: this.options.includedAttributes,
+        settingsModel: this.options.settingsModel,
+
       })
     )
     this.handleEditing()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
@@ -56,6 +56,7 @@ module.exports = Marionette.CollectionView.extend({
       isFormBuilder: this.options.isFormBuilder || false,
       suggester: this.options.suggester,
       includedAttributes: this.options.includedAttributes,
+      settingsModel: this.options.settingsModel,
     }
   },
   initialize() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.collection.view.js
@@ -56,7 +56,7 @@ module.exports = Marionette.CollectionView.extend({
       isFormBuilder: this.options.isFormBuilder || false,
       suggester: this.options.suggester,
       includedAttributes: this.options.includedAttributes,
-      settingsModel: this.options.settingsModel,
+      supportedAttributes: this.options.supportedAttributes,
     }
   },
   initialize() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -47,7 +47,7 @@ module.exports = Marionette.LayoutView.extend({
       type: attribute,
       comparator,
       value: [value],
-      settingsModel
+      settingsModel,
     })
   },
   turnOnEditing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -46,7 +46,7 @@ module.exports = Marionette.LayoutView.extend({
     this.model.set({
       type: attribute,
       comparator,
-      value: [value]
+      value: [value],
     })
   },
   turnOnEditing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -31,7 +31,7 @@ module.exports = Marionette.LayoutView.extend({
         editing={this.$el.hasClass('is-editing')}
         onRemove={() => this.delete()}
         onChange={state => this.onChange(state)}
-        settingsModel={this.options.settingsModel}
+        supportedAttributes={this.options.supportedAttributes}
       />
     )
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -31,6 +31,7 @@ module.exports = Marionette.LayoutView.extend({
         editing={this.$el.hasClass('is-editing')}
         onRemove={() => this.delete()}
         onChange={state => this.onChange(state)}
+        settingsModel={this.options.settingsModel}
       />
     )
   },
@@ -41,11 +42,12 @@ module.exports = Marionette.LayoutView.extend({
     this.model.destroy()
   },
   onChange(state) {
-    const { attribute, comparator, value } = state
+    const { attribute, comparator, value, settingsModel } = state
     this.model.set({
       type: attribute,
       comparator,
       value: [value],
+      settingsModel
     })
   },
   turnOnEditing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter/filter.view.js
@@ -42,12 +42,11 @@ module.exports = Marionette.LayoutView.extend({
     this.model.destroy()
   },
   onChange(state) {
-    const { attribute, comparator, value, settingsModel } = state
+    const { attribute, comparator, value } = state
     this.model.set({
       type: attribute,
       comparator,
-      value: [value],
-      settingsModel,
+      value: [value]
     })
   },
   turnOnEditing() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -34,7 +34,6 @@ const fetchSuggestions = memoize(async attr => {
   })
 
   const suggestions = json.facets[attr]
-
   if (suggestions === undefined) {
     return []
   }
@@ -91,7 +90,6 @@ module.exports = Marionette.LayoutView.extend({
         isFormBuilder: this.options.isFormBuilder || false,
       })
     )
-
     let filter
     if (this.model.get('filterTree') !== undefined) {
       filter = this.model.get('filterTree')
@@ -118,6 +116,13 @@ module.exports = Marionette.LayoutView.extend({
         this.showAdvanced(filter)
       },
     })
+    this.listenTo(
+      this.querySettings.currentView.model,
+      'change:src',
+      function() {
+        this.showAdvanced(this.queryAdvanced.currentView.getFilters())
+      }
+    )
   },
   onDestroy() {
     unregister(this.action)
@@ -135,9 +140,9 @@ module.exports = Marionette.LayoutView.extend({
         filter,
         isForm: this.options.isForm || false,
         isFormBuilder: this.options.isFormBuilder || false,
+        settingsModel: this.querySettings.currentView.model
       })
     )
-
     this.queryAdvanced.currentView.turnOffEditing()
     this.edit()
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -140,7 +140,8 @@ module.exports = Marionette.LayoutView.extend({
         filter,
         isForm: this.options.isForm || false,
         isFormBuilder: this.options.isFormBuilder || false,
-        settingsModel: this.querySettings.currentView.model.attributes.src,
+        supportedAttributes: this.querySettings.currentView.model.attributes
+          .src,
       })
     )
     this.queryAdvanced.currentView.turnOffEditing()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -140,7 +140,7 @@ module.exports = Marionette.LayoutView.extend({
         filter,
         isForm: this.options.isForm || false,
         isFormBuilder: this.options.isFormBuilder || false,
-        settingsModel: this.querySettings.currentView.model.attributes.src
+        settingsModel: this.querySettings.currentView.model.attributes.src,
       })
     )
     this.queryAdvanced.currentView.turnOffEditing()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -140,7 +140,7 @@ module.exports = Marionette.LayoutView.extend({
         filter,
         isForm: this.options.isForm || false,
         isFormBuilder: this.options.isFormBuilder || false,
-        settingsModel: this.querySettings.currentView.model
+        settingsModel: this.querySettings.currentView.model.attributes.src
       })
     )
     this.queryAdvanced.currentView.turnOffEditing()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -32,7 +32,6 @@ const ResultForm = require('../result-form/result-form.js')
 import * as React from 'react'
 import RadioComponent from '../../react-component/input-wrappers/radio'
 import { showErrorMessages } from '../../react-component/utils/validation'
-
 module.exports = plugin(
   Marionette.LayoutView.extend({
     template,
@@ -158,6 +157,7 @@ module.exports = plugin(
           model: this._srcDropdownModel,
         })
       )
+
       this.settingsSrc.currentView.turnOffEditing()
     },
     setupSpellcheck() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -157,7 +157,6 @@ module.exports = plugin(
           model: this._srcDropdownModel,
         })
       )
-
       this.settingsSrc.currentView.turnOffEditing()
     },
     setupSpellcheck() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
@@ -28,7 +28,7 @@ const FilterAttributeDropdown = ({
   includedAttributes,
   editing,
   value,
-  settingsModel,
+  supportedAttributes,
 }) => {
   return (
     <Root>
@@ -37,7 +37,7 @@ const FilterAttributeDropdown = ({
           value={value}
           suggestions={getFilteredAttributeList(includedAttributes)}
           onChange={onChange}
-          settingsModel={settingsModel}
+          supportedAttributes={supportedAttributes}
         />
       ) : (
         value

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
@@ -28,7 +28,9 @@ const FilterAttributeDropdown = ({
   includedAttributes,
   editing,
   value,
+  settingsModel,
 }) => {
+  console.log(settingsModel)
   return (
     <Root>
       {editing ? (
@@ -36,6 +38,7 @@ const FilterAttributeDropdown = ({
           value={value}
           suggestions={getFilteredAttributeList(includedAttributes)}
           onChange={onChange}
+          settingsModel={settingsModel}
         />
       ) : (
         value

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
@@ -30,7 +30,6 @@ const FilterAttributeDropdown = ({
   value,
   settingsModel,
 }) => {
-  console.log(settingsModel)
   return (
     <Root>
       {editing ? (

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -98,7 +98,7 @@ class Filter extends React.Component {
           includedAttributes={this.props.includedAttributes}
           editing={this.props.editing}
           onChange={this.updateAttribute}
-          settingsModel={this.getListofSupportedAttributes()}
+          supportedAttributes={this.getListofSupportedAttributes()}
         />
         <FilterComparator
           comparator={this.state.comparator}
@@ -125,22 +125,14 @@ class Filter extends React.Component {
     this.props.onChange(this.state)
   }
   getListofSupportedAttributes = () => {
-    // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
-    const settingsModel = this.props.settingsModel
-    // if settingsModel is not passed down from another parent Component (other than advanced) return empty list
-    if (!settingsModel) {
+    // if no source is selected and supportedAttributes is present from parent component we want to present all attributes as available
+    const supportedAttributes = this.props.supportedAttributes
+    // if supportedAttributes is not passed down from another parent Component (other than advanced) return empty list
+    if (!supportedAttributes || supportedAttributes.length == 0) {
       return []
     }
-
-    if (settingsModel.length == 0) {
-      return []
-    }
-    if (settingsModel.includes('GIMS_GIN')) {
-      return ['ext.alternate-identifier-qualifier']
-    }
-
     let allSupportedAttributes = sources.models
-      .filter(source => settingsModel.includes(source.id))
+      .filter(source => supportedAttributes.includes(source.id))
       .map(sourceSelected => sourceSelected.attributes.supportedAttributes)
       .flat()
     return allSupportedAttributes

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -133,7 +133,12 @@ class Filter extends React.Component {
     }
     return sources.models
       .filter(source => supportedAttributes.includes(source.id))
-      .map(sourceSelected => sourceSelected.attributes.supportedAttributes)
+      .map(
+        sourceSelected =>
+          sourceSelected.attributes.supportedAttributes
+            ? sourceSelected.attributes.supportedAttributes
+            : []
+      )
       .flat()
   }
   updateSuggestions = async () => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -126,7 +126,7 @@ class Filter extends React.Component {
   }
   getListofSupportedAttributes = () => {
     // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
-    let settingsModel = this.props.settingsModel
+    const settingsModel = this.props.settingsModel
     // if settingsModel is not passed down from another parent Component (other than advanced) return empty list
     if (!settingsModel) {
       return []

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -81,21 +81,6 @@ class Filter extends React.Component {
   componentDidMount() {
     this.updateSuggestions()
   }
-  getListofSupportedAttributes = settingsModel => {
-    // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
-    if (settingsModel.length == 0) {
-      return []
-    }
-    if (settingsModel.includes('GIMS_GIN')) {
-      return ['ext.alternate-identifier-qualifier']
-    }
-
-    let allSupportedAttributes = sources.models
-      .filter(source => settingsModel.includes(source.id))
-      .map(sourceSelected => sourceSelected.attributes.supportedAttributes)
-      .flat()
-    return allSupportedAttributes
-  }
   render() {
     return (
       <Root>
@@ -113,9 +98,7 @@ class Filter extends React.Component {
           includedAttributes={this.props.includedAttributes}
           editing={this.props.editing}
           onChange={this.updateAttribute}
-          settingsModel={this.getListOfSupportedAttributes(
-            this.props.settingsModel
-          )}
+          settingsModel={this.getListofSupportedAttributes()}
         />
         <FilterComparator
           comparator={this.state.comparator}
@@ -141,7 +124,22 @@ class Filter extends React.Component {
     this.updateSuggestions()
     this.props.onChange(this.state)
   }
+  getListofSupportedAttributes = () => {
+    // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
+    let settingsModel = this.props.settingsModel
+    if (settingsModel.length == 0) {
+      return []
+    }
+    if (settingsModel.includes('GIMS_GIN')) {
+      return ['ext.alternate-identifier-qualifier']
+    }
 
+    let allSupportedAttributes = sources.models
+      .filter(source => settingsModel.includes(source.id))
+      .map(sourceSelected => sourceSelected.attributes.supportedAttributes)
+      .flat()
+    return allSupportedAttributes
+  }
   updateSuggestions = async () => {
     const { attribute } = this.state
     let suggestions = []

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -127,6 +127,11 @@ class Filter extends React.Component {
   getListofSupportedAttributes = () => {
     // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
     let settingsModel = this.props.settingsModel
+    // if settingsModel is not paased down from another parentConponent (other than advanced) return emoty list
+    if (!settingsModel) {
+      return []
+    }
+
     if (settingsModel.length == 0) {
       return []
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -81,19 +81,20 @@ class Filter extends React.Component {
   componentDidMount() {
     this.updateSuggestions()
   }
-  getListofSupportedAttributes = (settingsModel) => {
-    // if no source is selected and settingsModel is present from parent component we want to present all attributes as available 
+  getListofSupportedAttributes = settingsModel => {
+    // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
     if (settingsModel.length == 0) {
-        return [];
+      return []
     }
     if (settingsModel.includes('GIMS_GIN')) {
       return ['ext.alternate-identifier-qualifier']
     }
 
-    let allSupportedAttributes = sources.models.filter(source => settingsModel.includes(source.id))
-    .map(sourceSelected => sourceSelected.attributes.supportedAttributes)
-    .flat();
-    return allSupportedAttributes;
+    let allSupportedAttributes = sources.models
+      .filter(source => settingsModel.includes(source.id))
+      .map(sourceSelected => sourceSelected.attributes.supportedAttributes)
+      .flat()
+    return allSupportedAttributes
   }
   render() {
     return (

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -83,7 +83,7 @@ class Filter extends React.Component {
   }
   getListofSupportedAttributes = (settingsModel) => {
     // if no source is selected and settingsModel is present from parent component we want to present all attributes as available 
-    if(settingsModel.length == 0){
+    if (settingsModel.length == 0) {
         return [];
     }
     if (settingsModel.includes('GIMS_GIN')) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -23,7 +23,7 @@ import FilterAttribute from './filter-attribute'
 import FilterComparator from './filter-comparator'
 import FilterInput from './filter-input'
 import { getAttributeType } from './filterHelper'
-
+const sources = require('../../component/singletons/sources-instance')
 const Root = styled.div`
   width: auto;
   height: 100%;
@@ -57,7 +57,6 @@ const FilterRemove = styled(Button)`
   line-height: ${({ theme }) => theme.minimumButtonSize};
   display: ${({ editing }) => (editing ? 'inline-block' : 'none')};
 `
-
 class Filter extends React.Component {
   constructor(props) {
     super(props)
@@ -82,7 +81,20 @@ class Filter extends React.Component {
   componentDidMount() {
     this.updateSuggestions()
   }
+  getListofSupportedAttributes = (settingsModel) => {
+    // if no source is selected and settingsModel is present from parent component we want to present all attributes as available 
+    if(settingsModel.length == 0){
+        return [];
+    }
+    if (settingsModel.includes('GIMS_GIN')) {
+      return ['ext.alternate-identifier-qualifier']
+    }
 
+    let allSupportedAttributes = sources.models.filter(source => settingsModel.includes(source.id))
+    .map(sourceSelected => sourceSelected.attributes.supportedAttributes)
+    .flat();
+    return allSupportedAttributes;
+  }
   render() {
     return (
       <Root>
@@ -100,7 +112,7 @@ class Filter extends React.Component {
           includedAttributes={this.props.includedAttributes}
           editing={this.props.editing}
           onChange={this.updateAttribute}
-          settingsModel={this.props.settingsModel}
+          settingsModel={this.getListofSupportedAttributes(this.props.settingsModel)}
         />
         <FilterComparator
           comparator={this.state.comparator}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -100,6 +100,7 @@ class Filter extends React.Component {
           includedAttributes={this.props.includedAttributes}
           editing={this.props.editing}
           onChange={this.updateAttribute}
+          settingsModel={this.props.settingsModel}
         />
         <FilterComparator
           comparator={this.state.comparator}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -112,7 +112,9 @@ class Filter extends React.Component {
           includedAttributes={this.props.includedAttributes}
           editing={this.props.editing}
           onChange={this.updateAttribute}
-          settingsModel={this.getListofSupportedAttributes(this.props.settingsModel)}
+          settingsModel={this.getListOfSupportedAttributes(
+            this.props.settingsModel
+          )}
         />
         <FilterComparator
           comparator={this.state.comparator}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -131,11 +131,10 @@ class Filter extends React.Component {
     if (!supportedAttributes || supportedAttributes.length == 0) {
       return []
     }
-    let allSupportedAttributes = sources.models
+    return sources.models
       .filter(source => supportedAttributes.includes(source.id))
       .map(sourceSelected => sourceSelected.attributes.supportedAttributes)
       .flat()
-    return allSupportedAttributes
   }
   updateSuggestions = async () => {
     const { attribute } = this.state

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -127,7 +127,7 @@ class Filter extends React.Component {
   getListofSupportedAttributes = () => {
     // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
     let settingsModel = this.props.settingsModel
-    // if settingsModel is not paased down from another parentConponent (other than advanced) return emoty list
+    // if settingsModel is not passed down from another parent Component (other than advanced) return empty list
     if (!settingsModel) {
       return []
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -20,6 +20,7 @@ import TextField from '../../text-field'
 import styled from 'styled-components'
 import { getFilteredSuggestions, inputMatchesSuggestions } from './enumHelper'
 import PropTypes from 'prop-types'
+const properties = require('catalog-ui-search/src/main/webapp/js/properties.js')
 const TextWrapper = styled.div`
   padding: ${({ theme }) => theme.minimumSpacing};
 `
@@ -33,9 +34,13 @@ border-color: red
 `
 
 const isAttributeDisabled = (allSupportedAttributes, currValue) => {
+  //if the parent component does not pass down the attributes then return false
+  if (!allSupportedAttributes) {
+    return false
+  }
   return (
     allSupportedAttributes.length > 0 &&
-    allSupportedAttributes.indexOf(currValue) == -1
+    allSupportedAttributes.indexOf(currValue.value) == -1
   )
 }
 
@@ -49,7 +54,6 @@ const EnumInput = ({
 }) => {
   const [input, setInput] = useState('')
   const selected = suggestions.find(suggestion => suggestion.value === value)
-
   const filteredSuggestions = getFilteredSuggestions(
     input,
     suggestions,
@@ -57,7 +61,7 @@ const EnumInput = ({
   )
 
   const displayInput = !inputMatchesSuggestions(input, suggestions, matchCase)
-
+  const SOURCES = properties.i18n['sources'] || 'source(s)'
   const attributeDropdown = (
     <Dropdown label={(selected && selected.label) || value}>
       <TextWrapper>
@@ -77,13 +81,13 @@ const EnumInput = ({
           return (
             <EnumMenuItem
               title={
-                isAttributeDisabled(settingsModel, suggestion.value)
-                  ? 'Attribute is unsupported by the content store(s) selected'
+                isAttributeDisabled(settingsModel, suggestion)
+                  ? `Attribute is unsupported by the ${SOURCES} selected`
                   : ''
               }
               key={suggestion.value}
               value={suggestion.value}
-              disabled={isAttributeDisabled(settingsModel, suggestion.value)}
+              disabled={isAttributeDisabled(settingsModel, suggestion)}
             >
               {suggestion.label}
             </EnumMenuItem>
@@ -92,17 +96,16 @@ const EnumInput = ({
       </Menu>
     </Dropdown>
   )
-
   return (
     <div>
-      {isAttributeDisabled(settingsModel, selected.value) ? (
+      {isAttributeDisabled(settingsModel, selected) ? (
         <div>
           <UnsupportedAttribute title="Attribute is unsupported by the content store(s) selected">
             {attributeDropdown}
           </UnsupportedAttribute>
           <div style={{ color: 'red' }}>
             {' '}
-            This selection does not work with the content store selected{' '}
+            This selection does not work with the {SOURCES} selected{' '}
           </div>
         </div>
       ) : (

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -15,33 +15,58 @@
 import React, { useState } from 'react'
 
 import Dropdown from '../../dropdown'
-import { Menu, MenuItemDisabled } from '../../menu'
+import { Menu, MenuItem } from '../../menu'
 import TextField from '../../text-field'
 import styled from 'styled-components'
 import { getFilteredSuggestions, inputMatchesSuggestions } from './enumHelper'
 import PropTypes from 'prop-types'
+import { Button } from '../../presentation/button'
 const properties = require('catalog-ui-search/src/main/webapp/js/properties.js')
 const TextWrapper = styled.div`
   padding: ${({ theme }) => theme.minimumSpacing};
 `
+const SOURCES = properties.i18n['sources'] || 'source(s)'
 const EnumMenuItem = props => (
-  <MenuItemDisabled {...props} style={{ paddingLeft: '1.5rem' }} />
+  <span
+  title={
+    isAttributeDisabled(props.settingsModel, props.value)
+      ? `Attribute is unsupported by the ${SOURCES} selected`
+      : '' 
+  }>
+    <MenuItem {...props} style={{ paddingLeft: '1.5rem' }} />
+  </span>
 )
 
+const StyledEnumButton = styled.button`
+display : flex
+color: ${props => props.theme.primaryColor};
+`
 const UnsupportedAttribute = styled.div`
 border-style: solid
 border-color: red
 `
+
 
 const isAttributeDisabled = (allSupportedAttributes, currValue) => {
   //if the parent component does not pass down the attributes then return false
   if (!allSupportedAttributes) {
     return false
   }
+  console.log(currValue);
   return (
     allSupportedAttributes.length > 0 &&
     allSupportedAttributes.indexOf(currValue.value) == -1
   )
+}
+
+const addDisabledPropToSuggestions = (allSupportedAttributes,filteredSuggestions) => {
+
+      return  filteredSuggestions.map((suggestion) => {
+          let disabledStatus  = isAttributeDisabled(allSupportedAttributes,suggestion);
+          suggestion.disabled = disabledStatus;
+          return suggestion;
+      },allSupportedAttributes);
+
 }
 
 const EnumInput = ({
@@ -59,9 +84,10 @@ const EnumInput = ({
     suggestions,
     matchCase
   )
-
   const displayInput = !inputMatchesSuggestions(input, suggestions, matchCase)
-  const SOURCES = properties.i18n['sources'] || 'source(s)'
+  console.log(filteredSuggestions);
+  let test = addDisabledPropToSuggestions(settingsModel,filteredSuggestions);
+  console.log(test)
   const attributeDropdown = (
     <Dropdown label={(selected && selected.label) || value}>
       <TextWrapper>
@@ -79,18 +105,15 @@ const EnumInput = ({
           )}
         {filteredSuggestions.map(suggestion => {
           return (
-            <EnumMenuItem
-              title={
-                isAttributeDisabled(settingsModel, suggestion)
-                  ? `Attribute is unsupported by the ${SOURCES} selected`
-                  : ''
-              }
-              key={suggestion.value}
-              value={suggestion.value}
-              disabled={isAttributeDisabled(settingsModel, suggestion)}
-            >
-              {suggestion.label}
-            </EnumMenuItem>
+            
+              <EnumMenuItem
+                key={suggestion.value}
+                value={suggestion.value}
+                settingsModel={settingsModel}
+                disabled={suggestion.disabled}
+              >
+                {suggestion.label}
+              </EnumMenuItem>
           )
         })}
       </Menu>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -97,7 +97,7 @@ const EnumInput = ({
   
   return (
     <div>
-      {isAttributeDisabled(settingsModel,selected.value) ? (
+      {isAttributeDisabled(settingsModel, selected.value) ? (
         <div>
           <UnsupportedAttribute title="Attribute is unsupported by the content store(s) selected">
             {attributeDropdown}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -85,7 +85,7 @@ const EnumInput = ({
               }
               key={suggestion.value}
               value={suggestion.value}
-              disabled={isAttributeDisabled(settingsModel,suggestion.value)}
+              disabled={isAttributeDisabled(settingsModel, suggestion.value)}
             >
               {suggestion.label}
             </EnumMenuItem>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -79,7 +79,7 @@ const EnumInput = ({
           return (
             <EnumMenuItem
               title={
-                isAttributeDisabled(settingsModel,suggestion.value)
+                isAttributeDisabled(settingsModel, suggestion.value)
                   ? 'Attribute is unsupported by the content store(s) selected'
                   : ''
               }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -33,7 +33,7 @@ border-style: solid
 border-color: red
 `
 
-const isAttributeDisabled = (AllSupportedAttributes, currValue) => {
+const isAttributeDisabled = (allSupportedAttributes, currValue) => {
   //All attributes are supported
   if (AllSupportedAttributes.length == 0) {
     return false

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -60,6 +60,10 @@ const isAttributeUnsupported = (currValue, settingsModel) => {
     )
 
     let AllSupportedAttributes = sourceModelsSelected.map(sourceSelected => {
+      if (sourceSelected.id == 'GIMS_GIN') {
+        return ['ext.alternate-identifier-qualifier']
+      }
+
       return sourceSelected.attributes.supportedAttributes
     })
 
@@ -72,7 +76,7 @@ const isAttributeUnsupportedHelper = (settingsModel, suggestion) => {
   //if settingsModel is passed down from a parent component , proceed to check if the attribute is unsupported
   return (
     settingsModel &&
-    isAttributeUnsupported(suggestion.value, settingsModel.attributes.src)
+    isAttributeUnsupported(suggestion.value, settingsModel)
   )
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -13,20 +13,68 @@
  *
  **/
 import React, { useState } from 'react'
+
 import Dropdown from '../../dropdown'
-import { Menu, MenuItem } from '../../menu'
+import { Menu, MenuItemDisabled } from '../../menu'
 import TextField from '../../text-field'
 import styled from 'styled-components'
 import { getFilteredSuggestions, inputMatchesSuggestions } from './enumHelper'
 import PropTypes from 'prop-types'
-
+const sources = require('../../../component/singletons/sources-instance')
 const TextWrapper = styled.div`
   padding: ${({ theme }) => theme.minimumSpacing};
 `
-
 const EnumMenuItem = props => (
-  <MenuItem {...props} style={{ paddingLeft: '1.5rem' }} />
+  <MenuItemDisabled {...props} style={{ paddingLeft: '1.5rem' }} />
 )
+
+const UnsupportedAttribute = styled.div`
+border-style: solid
+border-color: red
+`
+
+const isAttributeDisabled = (AllSupportedAttributes, currValue) => {
+  //All attributes are supported
+  if (AllSupportedAttributes.length == 0) {
+    return false
+  }
+  //If attribute is supported  dont disable the option
+  if (AllSupportedAttributes.indexOf(currValue) >= 0) {
+    return false
+  }
+  //attribute was not found in the supported list therefore disable the option
+  return true
+}
+const isAttributeUnsupported = (currValue, settingsModel) => {
+  // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
+  if (settingsModel != undefined && settingsModel.length == 0) {
+        return false;
+  } else {
+    // if settingsModel is not available treat it as all attributes are supported
+    if (settingsModel == undefined) {
+      return false;
+    }
+
+    let sourceModelsSelected = sources.models.filter(source =>
+      settingsModel.includes(source.id)
+    )
+
+    let AllSupportedAttributes = sourceModelsSelected.map(sourceSelected => {
+      return sourceSelected.attributes.supportedAttributes
+    })
+
+    AllSupportedAttributes = AllSupportedAttributes.flat()
+    return isAttributeDisabled(AllSupportedAttributes, currValue)
+  }
+}
+
+const isAttributeUnsupportedHelper = (settingsModel, suggestion) => {
+  //if settingsModel is passed down from a parent component , proceed to check if the attribute is unsupported
+  return (
+    settingsModel &&
+    isAttributeUnsupported(suggestion.value, settingsModel.attributes.src)
+  )
+}
 
 const EnumInput = ({
   allowCustom,
@@ -34,16 +82,20 @@ const EnumInput = ({
   onChange,
   suggestions,
   value,
+  settingsModel,
 }) => {
   const [input, setInput] = useState('')
   const selected = suggestions.find(suggestion => suggestion.value === value)
+
   const filteredSuggestions = getFilteredSuggestions(
     input,
     suggestions,
     matchCase
   )
+
   const displayInput = !inputMatchesSuggestions(input, suggestions, matchCase)
-  return (
+
+  const attributeDropdown = (
     <Dropdown label={(selected && selected.label) || value}>
       <TextWrapper>
         <TextField
@@ -53,14 +105,23 @@ const EnumInput = ({
           onChange={setInput}
         />
       </TextWrapper>
-      <Menu value={value} onChange={onChange}>
+      <Menu value={value} onChange={onChange} class="fa">
         {allowCustom &&
           displayInput && (
             <EnumMenuItem value={input}>{input} (custom)</EnumMenuItem>
           )}
         {filteredSuggestions.map(suggestion => {
           return (
-            <EnumMenuItem key={suggestion.value} value={suggestion.value}>
+            <EnumMenuItem
+              title={
+                isAttributeUnsupportedHelper(settingsModel, suggestion)
+                  ? 'Attribute is unsupported by the content store(s) selected'
+                  : ''
+              }
+              key={suggestion.value}
+              value={suggestion.value}
+              disabled={isAttributeUnsupportedHelper(settingsModel, suggestion)}
+            >
               {suggestion.label}
             </EnumMenuItem>
           )
@@ -68,8 +129,25 @@ const EnumInput = ({
       </Menu>
     </Dropdown>
   )
+  
+  return (
+    <div>
+      {isAttributeUnsupportedHelper(settingsModel, selected) ? (
+        <div>
+          <UnsupportedAttribute title="Attribute is unsupported by the content store(s) selected">
+            {attributeDropdown}
+          </UnsupportedAttribute>
+          <div style={{ color: 'red' }}>
+            {' '}
+            This selection does not work with the content store selected{' '}
+          </div>
+        </div>
+      ) : (
+        <div>{attributeDropdown}</div>
+      )}
+    </div>
+  )
 }
-
 EnumInput.propTypes = {
   /** The current selected value. */
   value: PropTypes.string,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -20,7 +20,6 @@ import TextField from '../../text-field'
 import styled from 'styled-components'
 import { getFilteredSuggestions, inputMatchesSuggestions } from './enumHelper'
 import PropTypes from 'prop-types'
-import { Button } from '../../presentation/button'
 const properties = require('catalog-ui-search/src/main/webapp/js/properties.js')
 const TextWrapper = styled.div`
   padding: ${({ theme }) => theme.minimumSpacing};
@@ -28,45 +27,41 @@ const TextWrapper = styled.div`
 const SOURCES = properties.i18n['sources'] || 'source(s)'
 const EnumMenuItem = props => (
   <span
-  title={
-    isAttributeDisabled(props.settingsModel, props.value)
-      ? `Attribute is unsupported by the ${SOURCES} selected`
-      : '' 
-  }>
+    title={
+      isAttributeDisabled(props.settingsModel, props.value)
+        ? `Attribute is unsupported by the ${SOURCES} selected`
+        : ''
+    }
+  >
     <MenuItem {...props} style={{ paddingLeft: '1.5rem' }} />
   </span>
 )
 
-const StyledEnumButton = styled.button`
-display : flex
-color: ${props => props.theme.primaryColor};
-`
 const UnsupportedAttribute = styled.div`
 border-style: solid
 border-color: red
 `
-
 
 const isAttributeDisabled = (allSupportedAttributes, currValue) => {
   //if the parent component does not pass down the attributes then return false
   if (!allSupportedAttributes) {
     return false
   }
-  console.log(currValue);
   return (
     allSupportedAttributes.length > 0 &&
     allSupportedAttributes.indexOf(currValue.value) == -1
   )
 }
 
-const addDisabledPropToSuggestions = (allSupportedAttributes,filteredSuggestions) => {
-
-      return  filteredSuggestions.map((suggestion) => {
-          let disabledStatus  = isAttributeDisabled(allSupportedAttributes,suggestion);
-          suggestion.disabled = disabledStatus;
-          return suggestion;
-      },allSupportedAttributes);
-
+const addDisabledPropToSuggestions = (
+  allSupportedAttributes,
+  filteredSuggestions
+) => {
+  return filteredSuggestions.map(suggestion => {
+    let disabledStatus = isAttributeDisabled(allSupportedAttributes, suggestion)
+    suggestion.disabled = disabledStatus
+    return suggestion
+  }, allSupportedAttributes)
 }
 
 const EnumInput = ({
@@ -85,9 +80,7 @@ const EnumInput = ({
     matchCase
   )
   const displayInput = !inputMatchesSuggestions(input, suggestions, matchCase)
-  console.log(filteredSuggestions);
-  let test = addDisabledPropToSuggestions(settingsModel,filteredSuggestions);
-  console.log(test)
+  addDisabledPropToSuggestions(settingsModel, filteredSuggestions)
   const attributeDropdown = (
     <Dropdown label={(selected && selected.label) || value}>
       <TextWrapper>
@@ -105,15 +98,14 @@ const EnumInput = ({
           )}
         {filteredSuggestions.map(suggestion => {
           return (
-            
-              <EnumMenuItem
-                key={suggestion.value}
-                value={suggestion.value}
-                settingsModel={settingsModel}
-                disabled={suggestion.disabled}
-              >
-                {suggestion.label}
-              </EnumMenuItem>
+            <EnumMenuItem
+              key={suggestion.value}
+              value={suggestion.value}
+              settingsModel={settingsModel}
+              disabled={suggestion.disabled}
+            >
+              {suggestion.label}
+            </EnumMenuItem>
           )
         })}
       </Menu>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -34,16 +34,8 @@ border-color: red
 `
 
 const isAttributeDisabled = (allSupportedAttributes, currValue) => {
-  //All attributes are supported
-  if (allSupportedAttributes.length == 0) {
-    return false
-  }
-  //If attribute is supported  dont disable the option
-  if (allSupportedAttributes.indexOf(currValue) >= 0) {
-    return false
-  }
-  //attribute was not found in the supported list therefore disable the option
-  return true
+  
+  return allSupportedAttributes.length > 0 && allSupportedAttributes.indexOf(currValue) == -1;
 }
 
 const EnumInput = ({

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -25,15 +25,9 @@ const TextWrapper = styled.div`
   padding: ${({ theme }) => theme.minimumSpacing};
 `
 const SOURCES = properties.i18n['sources'] || 'source(s)'
-const UNSUPPORTED_ATTRIBUTE_TITLE = `Attribute is unsupported by the ${SOURCES} selected`;
+const UNSUPPORTED_ATTRIBUTE_TITLE = `Attribute is unsupported by the ${SOURCES} selected`
 const EnumMenuItem = props => (
-  <span
-    title={
-      props.disabled
-        ? UNSUPPORTED_ATTRIBUTE_TITLE
-        : ''
-    }
-  >
+  <span title={props.disabled ? UNSUPPORTED_ATTRIBUTE_TITLE : ''}>
     <MenuItem {...props} style={{ paddingLeft: '1.5rem' }} />
   </span>
 )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -28,7 +28,7 @@ const SOURCES = properties.i18n['sources'] || 'source(s)'
 const EnumMenuItem = props => (
   <span
     title={
-      isAttributeDisabled(props.supportedAttributes, props.value)
+      props.disabled
         ? `Attribute is unsupported by the ${SOURCES} selected`
         : ''
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -25,11 +25,12 @@ const TextWrapper = styled.div`
   padding: ${({ theme }) => theme.minimumSpacing};
 `
 const SOURCES = properties.i18n['sources'] || 'source(s)'
+const UNSUPPORTED_ATTRIBUTE_TITLE = `Attribute is unsupported by the ${SOURCES} selected`;
 const EnumMenuItem = props => (
   <span
     title={
       props.disabled
-        ? `Attribute is unsupported by the ${SOURCES} selected`
+        ? UNSUPPORTED_ATTRIBUTE_TITLE
         : ''
     }
   >
@@ -115,7 +116,7 @@ const EnumInput = ({
     <div>
       {isAttributeDisabled(supportedAttributes, selected) ? (
         <div>
-          <UnsupportedAttribute title="Attribute is unsupported by the content store(s) selected">
+          <UnsupportedAttribute title={UNSUPPORTED_ATTRIBUTE_TITLE}>
             {attributeDropdown}
           </UnsupportedAttribute>
           <div style={{ color: 'red' }}>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -35,49 +35,15 @@ border-color: red
 
 const isAttributeDisabled = (allSupportedAttributes, currValue) => {
   //All attributes are supported
-  if (AllSupportedAttributes.length == 0) {
+  if (allSupportedAttributes.length == 0) {
     return false
   }
   //If attribute is supported  dont disable the option
-  if (AllSupportedAttributes.indexOf(currValue) >= 0) {
+  if (allSupportedAttributes.indexOf(currValue) >= 0) {
     return false
   }
   //attribute was not found in the supported list therefore disable the option
   return true
-}
-const isAttributeUnsupported = (currValue, settingsModel) => {
-  // if no source is selected and settingsModel is present from parent component we want to present all attributes as available
-  if (settingsModel != undefined && settingsModel.length == 0) {
-        return false;
-  } else {
-    // if settingsModel is not available treat it as all attributes are supported
-    if (settingsModel == undefined) {
-      return false;
-    }
-
-    let sourceModelsSelected = sources.models.filter(source =>
-      settingsModel.includes(source.id)
-    )
-
-    let AllSupportedAttributes = sourceModelsSelected.map(sourceSelected => {
-      if (sourceSelected.id == 'GIMS_GIN') {
-        return ['ext.alternate-identifier-qualifier']
-      }
-
-      return sourceSelected.attributes.supportedAttributes
-    })
-
-    AllSupportedAttributes = AllSupportedAttributes.flat()
-    return isAttributeDisabled(AllSupportedAttributes, currValue)
-  }
-}
-
-const isAttributeUnsupportedHelper = (settingsModel, suggestion) => {
-  //if settingsModel is passed down from a parent component , proceed to check if the attribute is unsupported
-  return (
-    settingsModel &&
-    isAttributeUnsupported(suggestion.value, settingsModel)
-  )
 }
 
 const EnumInput = ({
@@ -118,13 +84,13 @@ const EnumInput = ({
           return (
             <EnumMenuItem
               title={
-                isAttributeUnsupportedHelper(settingsModel, suggestion)
+                isAttributeDisabled(settingsModel,suggestion.value)
                   ? 'Attribute is unsupported by the content store(s) selected'
                   : ''
               }
               key={suggestion.value}
               value={suggestion.value}
-              disabled={isAttributeUnsupportedHelper(settingsModel, suggestion)}
+              disabled={isAttributeDisabled(settingsModel,suggestion.value)}
             >
               {suggestion.label}
             </EnumMenuItem>
@@ -136,7 +102,7 @@ const EnumInput = ({
   
   return (
     <div>
-      {isAttributeUnsupportedHelper(settingsModel, selected) ? (
+      {isAttributeDisabled(settingsModel,selected.value) ? (
         <div>
           <UnsupportedAttribute title="Attribute is unsupported by the content store(s) selected">
             {attributeDropdown}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -20,7 +20,6 @@ import TextField from '../../text-field'
 import styled from 'styled-components'
 import { getFilteredSuggestions, inputMatchesSuggestions } from './enumHelper'
 import PropTypes from 'prop-types'
-const sources = require('../../../component/singletons/sources-instance')
 const TextWrapper = styled.div`
   padding: ${({ theme }) => theme.minimumSpacing};
 `
@@ -34,7 +33,6 @@ border-color: red
 `
 
 const isAttributeDisabled = (allSupportedAttributes, currValue) => {
-  
   return (
     allSupportedAttributes.length > 0 &&
     allSupportedAttributes.indexOf(currValue) == -1
@@ -94,7 +92,7 @@ const EnumInput = ({
       </Menu>
     </Dropdown>
   )
-  
+
   return (
     <div>
       {isAttributeDisabled(settingsModel, selected.value) ? (

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -68,7 +68,7 @@ const EnumInput = ({
           onChange={setInput}
         />
       </TextWrapper>
-      <Menu value={value} onChange={onChange} class="fa">
+      <Menu value={value} onChange={onChange}>
         {allowCustom &&
           displayInput && (
             <EnumMenuItem value={input}>{input} (custom)</EnumMenuItem>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -28,7 +28,7 @@ const SOURCES = properties.i18n['sources'] || 'source(s)'
 const EnumMenuItem = props => (
   <span
     title={
-      isAttributeDisabled(props.settingsModel, props.value)
+      isAttributeDisabled(props.supportedAttributes, props.value)
         ? `Attribute is unsupported by the ${SOURCES} selected`
         : ''
     }
@@ -70,7 +70,7 @@ const EnumInput = ({
   onChange,
   suggestions,
   value,
-  settingsModel,
+  supportedAttributes,
 }) => {
   const [input, setInput] = useState('')
   const selected = suggestions.find(suggestion => suggestion.value === value)
@@ -80,7 +80,7 @@ const EnumInput = ({
     matchCase
   )
   const displayInput = !inputMatchesSuggestions(input, suggestions, matchCase)
-  addDisabledPropToSuggestions(settingsModel, filteredSuggestions)
+  addDisabledPropToSuggestions(supportedAttributes, filteredSuggestions)
   const attributeDropdown = (
     <Dropdown label={(selected && selected.label) || value}>
       <TextWrapper>
@@ -101,7 +101,7 @@ const EnumInput = ({
             <EnumMenuItem
               key={suggestion.value}
               value={suggestion.value}
-              settingsModel={settingsModel}
+              supportedAttributes={supportedAttributes}
               disabled={suggestion.disabled}
             >
               {suggestion.label}
@@ -113,7 +113,7 @@ const EnumInput = ({
   )
   return (
     <div>
-      {isAttributeDisabled(settingsModel, selected) ? (
+      {isAttributeDisabled(supportedAttributes, selected) ? (
         <div>
           <UnsupportedAttribute title="Attribute is unsupported by the content store(s) selected">
             {attributeDropdown}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/inputs/enum-input/enum-input.js
@@ -35,7 +35,10 @@ border-color: red
 
 const isAttributeDisabled = (allSupportedAttributes, currValue) => {
   
-  return allSupportedAttributes.length > 0 && allSupportedAttributes.indexOf(currValue) == -1;
+  return (
+    allSupportedAttributes.length > 0 &&
+    allSupportedAttributes.indexOf(currValue) == -1
+  )
 }
 
 const EnumInput = ({

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/index.tsx
@@ -13,4 +13,4 @@
  *
  **/
 
-export { Menu, MenuItem, MenuItemDisabled } from './menu'
+export { Menu, MenuItem } from './menu'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/index.tsx
@@ -12,4 +12,5 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-export { Menu, MenuItem } from './menu'
+
+export { Menu, MenuItem, MenuItemDisabled } from './menu'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
@@ -50,10 +50,6 @@ const foreground = (props: any) => {
     return readableColor(props.theme.backgroundDropdown)
   }
 }
-
-const test = (active: any, disabled: any) => {
-  return active && !disabled ? after : ''
-}
 const ItemRoot = styled.div<{
   active: boolean
   disabled: boolean
@@ -81,7 +77,7 @@ ${({ theme, active, disabled }) =>
     ? `box-shadow: inset 0px 0px 0px 1px  ${theme.primaryColor};`
     : ''}
 ${({ selected }) => (selected ? 'font-weight: bold;' : '')}
-${({ selected, disabled }) => test(selected, disabled)}
+${({ selected, disabled }) => (selected && !disabled ? after : '')}
 background: ${props =>
   props.active && !props.disabled ? background(props) : 'inherit'};
 color: ${props => (props.disabled ? 'lightgrey' : foreground)};

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
@@ -51,29 +51,38 @@ const foreground = (props: any) => {
   }
 }
 
-const ItemRoot = styled.div<{ active: boolean; selected: boolean }>`
-  position: relative;
-  padding: 0px ${({ theme }) => theme.minimumSpacing};
-  padding-right: ${({ theme }) => theme.minimumButtonSize};
-  box-sizing: border-box;
-  height: ${({ theme }) => theme.minimumButtonSize};
-  line-height: ${({ theme }) => theme.minimumButtonSize};
-  cursor: pointer;
-  -webkit-touch-callout: none; /* iOS Safari */
-  -webkit-user-select: none; /* Safari */
-  -khtml-user-select: none; /* Konqueror HTML */
-  -moz-user-select: none; /* Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  ${({ theme, active }) =>
-    active ? `box-shadow: inset 0px 0px 0px 1px  ${theme.primaryColor};` : ''}
-  ${({ selected }) => (selected ? 'font-weight: bold;' : '')}
-  ${({ selected }) => (selected ? after : '')}
-  background: ${props => (props.active ? background(props) : 'inherit')};
-  color: ${foreground};
+const test = (active : any, disabled: any) => {
+
+return active && !disabled ? after : ''
+
+}
+const ItemRoot = styled.div<{ active: boolean; disabled: boolean ; selected : boolean }>`
+position: relative;
+padding: 0px ${({ theme }) => theme.minimumSpacing};
+padding-right: ${({ theme }) => theme.minimumButtonSize};
+box-sizing: border-box;
+height: ${({ theme }) => theme.minimumButtonSize};
+line-height: ${({ theme }) => theme.minimumButtonSize};
+cursor: pointer;
+-webkit-touch-callout: none; /* iOS Safari */
+-webkit-user-select: none; /* Safari */
+-khtml-user-select: none; /* Konqueror HTML */
+-moz-user-select: none; /* Firefox */
+-ms-user-select: none; /* Internet Explorer/Edge */
+user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
+white-space: nowrap;
+overflow: hidden;
+text-overflow: ellipsis;
+${({ disabled }) => disabled ? 'pointer-events : none' : ''}
+${({ theme, active, disabled }) =>
+  active && !disabled
+    ? `box-shadow: inset 0px 0px 0px 1px  ${theme.primaryColor};`
+    : ''}
+${({ selected }) => (selected ? 'font-weight: bold;' : '')}
+${({ selected , disabled }) => (test(selected , disabled))}
+background: ${props =>
+  props.active && !props.disabled ? background(props) : 'inherit'};
+color: ${props => (props.disabled ? 'lightgrey' : foreground)};
 `
 
 const DocumentListener = (props: any) => {
@@ -225,14 +234,15 @@ type MenuItemProps = {
   children?: any
   /** Optional styles for root element. */
   style?: object
-  onClick?: any
   selected?: any
+  onClick?: any
   active?: any
+  disabled?: any
   onHover?: any
 }
 
 export const MenuItem = (props: MenuItemProps) => {
-  const { value, children, selected, onClick, active, onHover, style } = props
+  const { value, children, selected,onClick, active, onHover, style , disabled} = props
   return (
     <ItemRoot
       selected={selected}
@@ -242,84 +252,11 @@ export const MenuItem = (props: MenuItemProps) => {
       onFocus={() => onHover(value)}
       tabIndex={0}
       onClick={() => onClick(value)}
+      disabled={disabled}
     >
       {children || value}
     </ItemRoot>
   )
 }
-
-type MenutItemPropsDisabled = {
-  /** A value to represent the current Item */
-  value?: any
-  /**
-   * Children to display for menu item.
-   *
-   * @default value
-   */
-  children?: any
-  /** Optional styles for root element. */
-  style?: object
-  onClick?: any
-  selected?: any
-  active?: any
-  onHover?: any
-  disabled?: any
-  title?: any
-}
-
-const ItemRootDisabled = styled.option<{ active: boolean; disabled: boolean }>`
-  position: relative;
-  padding: 0px ${({ theme }) => theme.minimumSpacing};
-  padding-right: ${({ theme }) => theme.minimumButtonSize};
-  box-sizing: border-box;
-  height: ${({ theme }) => theme.minimumButtonSize};
-  line-height: ${({ theme }) => theme.minimumButtonSize};
-  cursor: pointer;
-  -webkit-touch-callout: none; /* iOS Safari */
-  -webkit-user-select: none; /* Safari */
-  -khtml-user-select: none; /* Konqueror HTML */
-  -moz-user-select: none; /* Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  ${({ theme, active, disabled }) =>
-    active && !disabled
-      ? `box-shadow: inset 0px 0px 0px 1px  ${theme.primaryColor};`
-      : ''}
-  ${({ active }) => (active ? 'font-weight: bold;' : '')}
-  ${({ active, disabled }) => (active && !disabled ? after : '')}
-  background: ${props =>
-    props.active && !props.disabled ? background(props) : 'inherit'};
-  color: ${props => (props.disabled ? 'lightgrey' : foreground)};
-`
-export const MenuItemDisabled = (props: MenutItemPropsDisabled) => {
-  const {
-    value,
-    children,
-    onClick,
-    active,
-    onHover,
-    style,
-    disabled,
-    title,
-  } = props
-  return (
-    <ItemRootDisabled
-      disabled={disabled}
-      active={active}
-      style={style}
-      onMouseEnter={() => onHover(value)}
-      onFocus={() => onHover(value)}
-      tabIndex={0}
-      onClick={() => onClick(value)}
-      title={title}
-    >
-      {children || value}
-    </ItemRootDisabled>
-  )
-}
-
 // @ts-ignore
 MenuItem.displayName = 'MenuItem'

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
@@ -51,12 +51,14 @@ const foreground = (props: any) => {
   }
 }
 
-const test = (active : any, disabled: any) => {
-
-return active && !disabled ? after : ''
-
+const test = (active: any, disabled: any) => {
+  return active && !disabled ? after : ''
 }
-const ItemRoot = styled.div<{ active: boolean; disabled: boolean ; selected : boolean }>`
+const ItemRoot = styled.div<{
+  active: boolean
+  disabled: boolean
+  selected: boolean
+}>`
 position: relative;
 padding: 0px ${({ theme }) => theme.minimumSpacing};
 padding-right: ${({ theme }) => theme.minimumButtonSize};
@@ -73,13 +75,13 @@ user-select: none; /* Non-prefixed version, currently supported by Chrome and Op
 white-space: nowrap;
 overflow: hidden;
 text-overflow: ellipsis;
-${({ disabled }) => disabled ? 'pointer-events : none' : ''}
+${({ disabled }) => (disabled ? 'pointer-events : none' : '')}
 ${({ theme, active, disabled }) =>
   active && !disabled
     ? `box-shadow: inset 0px 0px 0px 1px  ${theme.primaryColor};`
     : ''}
 ${({ selected }) => (selected ? 'font-weight: bold;' : '')}
-${({ selected , disabled }) => (test(selected , disabled))}
+${({ selected, disabled }) => test(selected, disabled)}
 background: ${props =>
   props.active && !props.disabled ? background(props) : 'inherit'};
 color: ${props => (props.disabled ? 'lightgrey' : foreground)};
@@ -242,7 +244,16 @@ type MenuItemProps = {
 }
 
 export const MenuItem = (props: MenuItemProps) => {
-  const { value, children, selected,onClick, active, onHover, style , disabled} = props
+  const {
+    value,
+    children,
+    selected,
+    onClick,
+    active,
+    onHover,
+    style,
+    disabled,
+  } = props
   return (
     <ItemRoot
       selected={selected}

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/menu/menu.tsx
@@ -233,7 +233,6 @@ type MenuItemProps = {
 
 export const MenuItem = (props: MenuItemProps) => {
   const { value, children, selected, onClick, active, onHover, style } = props
-
   return (
     <ItemRoot
       selected={selected}
@@ -246,6 +245,79 @@ export const MenuItem = (props: MenuItemProps) => {
     >
       {children || value}
     </ItemRoot>
+  )
+}
+
+type MenutItemPropsDisabled = {
+  /** A value to represent the current Item */
+  value?: any
+  /**
+   * Children to display for menu item.
+   *
+   * @default value
+   */
+  children?: any
+  /** Optional styles for root element. */
+  style?: object
+  onClick?: any
+  selected?: any
+  active?: any
+  onHover?: any
+  disabled?: any
+  title?: any
+}
+
+const ItemRootDisabled = styled.option<{ active: boolean; disabled: boolean }>`
+  position: relative;
+  padding: 0px ${({ theme }) => theme.minimumSpacing};
+  padding-right: ${({ theme }) => theme.minimumButtonSize};
+  box-sizing: border-box;
+  height: ${({ theme }) => theme.minimumButtonSize};
+  line-height: ${({ theme }) => theme.minimumButtonSize};
+  cursor: pointer;
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -khtml-user-select: none; /* Konqueror HTML */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  ${({ theme, active, disabled }) =>
+    active && !disabled
+      ? `box-shadow: inset 0px 0px 0px 1px  ${theme.primaryColor};`
+      : ''}
+  ${({ active }) => (active ? 'font-weight: bold;' : '')}
+  ${({ active, disabled }) => (active && !disabled ? after : '')}
+  background: ${props =>
+    props.active && !props.disabled ? background(props) : 'inherit'};
+  color: ${props => (props.disabled ? 'lightgrey' : foreground)};
+`
+export const MenuItemDisabled = (props: MenutItemPropsDisabled) => {
+  const {
+    value,
+    children,
+    onClick,
+    active,
+    onHover,
+    style,
+    disabled,
+    title,
+  } = props
+  return (
+    <ItemRootDisabled
+      disabled={disabled}
+      active={active}
+      style={style}
+      onMouseEnter={() => onHover(value)}
+      onFocus={() => onHover(value)}
+      tabIndex={0}
+      onClick={() => onClick(value)}
+      title={title}
+    >
+      {children || value}
+    </ItemRootDisabled>
   )
 }
 


### PR DESCRIPTION
#### What does this PR do?

Disables attributes from the dropdown when a source with supportedAttributes is selected. Display a warning below the dropdown that the currently selected attribute is not available to be selected in the dropdown

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 
@codice/ui 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
TBD
#### Any background context you want to provide?
TBD
These changes were done in catalog-ui-search which is now removed from master a forward port to ddf-ui will be necessary
#### What are the relevant tickets?
Fixes: #____
#### Screenshots
<!--(if appropriate)-->
TBD
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
