### PR TITLE
[2.19.x] DDF-5829: Added plugin support to map.view; fixed OpenLayers minZoom

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -70,7 +70,7 @@ function setupTerrainProvider(viewer, terrainProvider) {
   viewer.scene.terrainProvider = customTerrainProvider
 }
 
-function createMap(insertionElement) {
+function createMap(insertionElement, maximumZoomDistance) {
   const layerPrefs = user.get('user>preferences>mapLayers')
   User.updateMapLayers(layerPrefs)
   const layerCollectionController = new CesiumLayerCollectionController({
@@ -95,6 +95,7 @@ function createMap(insertionElement) {
       baseLayerPicker: false, // Hide the base layer picker,
       imageryProvider: false, // prevent default imagery provider
       mapMode2D: 0,
+      ...maximumZoomDistance,
     },
   })
 
@@ -188,11 +189,12 @@ module.exports = function CesiumMap(
   selectionInterface,
   notificationEl,
   componentElement,
-  mapModel
+  mapModel,
+  zoomOptions
 ) {
   let overlays = {}
   let shapes = []
-  const map = createMap(insertionElement)
+  const map = createMap(insertionElement, zoomOptions && zoomOptions.cesium)
   const drawHelper = new DrawHelper(map)
   const billboardCollection = setupBillboard()
   const drawingTools = setupDrawingTools(map)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/cesium/map.cesium.js
@@ -70,7 +70,7 @@ function setupTerrainProvider(viewer, terrainProvider) {
   viewer.scene.terrainProvider = customTerrainProvider
 }
 
-function createMap(insertionElement, maximumZoomDistance) {
+function createMap(insertionElement, cameraOptions) {
   const layerPrefs = user.get('user>preferences>mapLayers')
   User.updateMapLayers(layerPrefs)
   const layerCollectionController = new CesiumLayerCollectionController({
@@ -95,7 +95,7 @@ function createMap(insertionElement, maximumZoomDistance) {
       baseLayerPicker: false, // Hide the base layer picker,
       imageryProvider: false, // prevent default imagery provider
       mapMode2D: 0,
-      ...maximumZoomDistance,
+      cameraOptions,
     },
   })
 
@@ -190,11 +190,11 @@ module.exports = function CesiumMap(
   notificationEl,
   componentElement,
   mapModel,
-  zoomOptions
+  cameraOptions
 ) {
   let overlays = {}
   let shapes = []
-  const map = createMap(insertionElement, zoomOptions && zoomOptions.cesium)
+  const map = createMap(insertionElement, cameraOptions && cameraOptions.cesium)
   const drawHelper = new DrawHelper(map)
   const billboardCollection = setupBillboard()
   const drawingTools = setupDrawingTools(map)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -42,6 +42,8 @@ const Gazetteer = require('../../../react-component/location/gazetteer.js')
 import MapSettings from '../../../react-component/map-settings'
 import MapInfo from '../../../react-component/map-info'
 
+import plugin from 'plugins/map.view'
+
 function findExtreme({ objArray, property, comparator }) {
   if (objArray.length === 0) {
     return undefined
@@ -134,7 +136,7 @@ const defaultHomeBoundingBox = {
   north: 52,
 }
 
-module.exports = Marionette.LayoutView.extend({
+const View = Marionette.LayoutView.extend({
   tagName: CustomElements.register('map'),
   template,
   regions: {
@@ -246,6 +248,10 @@ module.exports = Marionette.LayoutView.extend({
     this.setupRightClickMenu()
     this.setupMapInfo()
   },
+  /**
+   * Returns a map of zoom options for Open layers and Cesium map views
+   */
+  getZoomOptions() {},
   zoomToHome() {
     const home = [
       user
@@ -391,7 +397,8 @@ module.exports = Marionette.LayoutView.extend({
       this.options.selectionInterface,
       this.mapDrawingPopup.el,
       this.el,
-      this.mapModel
+      this.mapModel,
+      this.getZoomOptions()
     )
     this.setupCollections()
     this.setupListeners()
@@ -530,3 +537,5 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
 })
+
+module.exports = plugin(View)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -249,9 +249,9 @@ const View = Marionette.LayoutView.extend({
     this.setupMapInfo()
   },
   /**
-   * Returns a map of zoom options for Open layers and Cesium map views
+   * Returns a map of camera options (such as min/max zoom, etc) for Open layers and Cesium map views
    */
-  getZoomOptions() {},
+  getCameraOptions() {},
   zoomToHome() {
     const home = [
       user
@@ -398,7 +398,7 @@ const View = Marionette.LayoutView.extend({
       this.mapDrawingPopup.el,
       this.el,
       this.mapModel,
-      this.getZoomOptions()
+      this.getCameraOptions()
     )
     this.setupCollections()
     this.setupListeners()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -36,7 +36,7 @@ const User = require('../../../../js/model/User.js')
 const wreqr = require('../../../../js/wreqr.js')
 import { validateGeo } from '../../../../react-component/utils/validation'
 
-const DEFAULT_MAP_ZOOM_OPTIONS = { zoom: 3, minZoom: 1.9 }
+const DEFAULT_MAP_CAMERA_OPTIONS = { zoom: 3, minZoom: 1.9 }
 
 const defaultColor = '#3c6dd5'
 
@@ -49,7 +49,7 @@ const OpenLayerCollectionController = LayerCollectionController.extend({
 
 function createMap(
   insertionElement,
-  { zoom, minZoom } = DEFAULT_MAP_ZOOM_OPTIONS
+  cameraOptions = DEFAULT_MAP_CAMERA_OPTIONS
 ) {
   const layerPrefs = user.get('user>preferences>mapLayers')
   User.updateMapLayers(layerPrefs)
@@ -57,8 +57,7 @@ function createMap(
     collection: layerPrefs,
   })
   const map = layerCollectionController.makeMap({
-    zoom,
-    minZoom,
+    cameraOptions: cameraOptions,
     element: insertionElement,
   })
 
@@ -101,11 +100,14 @@ module.exports = function OpenlayersMap(
   notificationEl,
   componentElement,
   mapModel,
-  zoomOptions
+  cameraOptions
 ) {
   let overlays = {}
   let shapes = []
-  const map = createMap(insertionElement, zoomOptions && zoomOptions.openlayers)
+  const map = createMap(
+    insertionElement,
+    cameraOptions && cameraOptions.openlayers
+  )
   listenToResize()
   setupTooltip(map)
   const drawingTools = setupDrawingTools(map)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -36,6 +36,8 @@ const User = require('../../../../js/model/User.js')
 const wreqr = require('../../../../js/wreqr.js')
 import { validateGeo } from '../../../../react-component/utils/validation'
 
+const DEFAULT_MAP_ZOOM_OPTIONS = { zoom: 3, minZoom: 1.9 }
+
 const defaultColor = '#3c6dd5'
 
 const OpenLayerCollectionController = LayerCollectionController.extend({
@@ -45,15 +47,18 @@ const OpenLayerCollectionController = LayerCollectionController.extend({
   },
 })
 
-function createMap(insertionElement) {
+function createMap(
+  insertionElement,
+  { zoom, minZoom } = DEFAULT_MAP_ZOOM_OPTIONS
+) {
   const layerPrefs = user.get('user>preferences>mapLayers')
   User.updateMapLayers(layerPrefs)
   const layerCollectionController = new OpenLayerCollectionController({
     collection: layerPrefs,
   })
   const map = layerCollectionController.makeMap({
-    zoom: 3,
-    minZoom: 1.9,
+    zoom,
+    minZoom,
     element: insertionElement,
   })
 
@@ -95,11 +100,12 @@ module.exports = function OpenlayersMap(
   selectionInterface,
   notificationEl,
   componentElement,
-  mapModel
+  mapModel,
+  zoomOptions
 ) {
   let overlays = {}
   let shapes = []
-  const map = createMap(insertionElement)
+  const map = createMap(insertionElement, zoomOptions && zoomOptions.openlayers)
   listenToResize()
   setupTooltip(map)
   const drawingTools = setupDrawingTools(map)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -47,6 +47,8 @@ const Controller = CommonLayerController.extend({
     // must create cesium map after containing DOM is attached.
     this.map = new Cesium.Viewer(options.element, options.cesiumOptions)
     this.map.scene.requestRenderMode = true
+    this.map.scene.screenSpaceCameraController.maximumZoomDistance =
+      options.cesiumOptions.maximumZoomDistance
     this.layerOrder = []
 
     this.collection.forEach(function(model) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/controllers/cesium.layerCollection.controller.js
@@ -47,9 +47,13 @@ const Controller = CommonLayerController.extend({
     // must create cesium map after containing DOM is attached.
     this.map = new Cesium.Viewer(options.element, options.cesiumOptions)
     this.map.scene.requestRenderMode = true
-    this.map.scene.screenSpaceCameraController.maximumZoomDistance =
-      options.cesiumOptions.maximumZoomDistance
     this.layerOrder = []
+
+    if (options.cesiumOptions.cameraOptions)
+      Object.entries(options.cesiumOptions.cameraOptions).forEach(
+        entry =>
+          (this.map.scene.screenSpaceCameraController[entry[0]] = entry[1])
+      )
 
     this.collection.forEach(function(model) {
       if (model.get('show')) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
@@ -150,6 +150,7 @@ const Controller = CommonLayerController.extend({
       projection: ol.proj.get(properties.projection),
       center: ol.proj.transform([0, 0], 'EPSG:4326', properties.projection),
       zoom: options.zoom,
+      minZoom: options.minZoom,
     })
 
     const config = {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/controllers/ol.layerCollection.controller.js
@@ -149,8 +149,7 @@ const Controller = CommonLayerController.extend({
     const view = new ol.View({
       projection: ol.proj.get(properties.projection),
       center: ol.proj.transform([0, 0], 'EPSG:4326', properties.projection),
-      zoom: options.zoom,
-      minZoom: options.minZoom,
+      ...options.cameraOptions,
     })
 
     const config = {

--- a/ui/packages/catalog-ui-search/src/main/webapp/plugins/map.view.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/plugins/map.view.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+type MapViewZoomExtension = {
+  getZoomOptions: () => { [key: string]: string }
+}
+
+export default (mapView: any) => mapView as MapViewZoomExtension

--- a/ui/packages/catalog-ui-search/src/main/webapp/plugins/map.view.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/plugins/map.view.tsx
@@ -12,8 +12,8 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-type MapViewZoomExtension = {
-  getZoomOptions: () => { [key: string]: string }
+type MapViewCameraExtension = {
+  getCameraOptions: () => { [key: string]: {} }
 }
 
-export default (mapView: any) => mapView as MapViewZoomExtension
+export default (mapView: any) => mapView as MapViewCameraExtension


### PR DESCRIPTION
#### What does this PR do?
Adds ability to extend map (Cesium and OpenLayers) config functionality by downstream projects via 'plugin'

#### Who is reviewing it? 
@nsuvarna
@bennuttle 
@aj-brooks 
@AzGoalie 
@rymach 
@lavoywj 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@AzGoalie
@bdeining

#### How should this be tested?
Interact with both 2D and 3D maps in the UI to verify no regressions have been introduced.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5829

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
