### PR TITLE
DDF-4883 removes ensure-solr-is-stopped executions

### DIFF
--- a/distribution/test/itests/test-itests-ddf-core/pom.xml
+++ b/distribution/test/itests/test-itests-ddf-core/pom.xml
@@ -171,7 +171,7 @@
                 <executions>
                     <execution>
                         <id>ensure-solr-is-stopped</id>
-                        <phase>pre-clean</phase>
+                        <phase>post-integration-test</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>

--- a/distribution/test/itests/test-itests-ddf-core/pom.xml
+++ b/distribution/test/itests/test-itests-ddf-core/pom.xml
@@ -170,27 +170,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>ensure-solr-is-stopped</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${solr.script.dir}${solr.script.file}</executable>
-                            <arguments>
-                                <argument>stop</argument>
-                                <argument>-p</argument>
-                                <argument>${solr.port}</argument>
-                            </arguments>
-                            <async>true</async>
-                            <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
-                            <successCodes>
-                                <successCode>0</successCode>
-                                <successCode>1</successCode>
-                            </successCodes>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>start-solr</id>
                         <phase>pre-integration-test</phase>
                         <goals>

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -415,27 +415,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>ensure-solr-is-stopped</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${solr.script.dir}${solr.script.file}</executable>
-                            <arguments>
-                                <argument>stop</argument>
-                                <argument>-p</argument>
-                                <argument>${solr.port}</argument>
-                            </arguments>
-                            <async>true</async>
-                            <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
-                            <successCodes>
-                                <successCode>0</successCode>
-                                <successCode>1</successCode>
-                            </successCodes>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>start-solr</id>
                         <phase>pre-integration-test</phase>
                         <goals>

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -416,7 +416,7 @@
                 <executions>
                     <execution>
                         <id>ensure-solr-is-stopped</id>
-                        <phase>pre-clean</phase>
+                        <phase>post-integration-test</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>


### PR DESCRIPTION
…. this was causing `mvn clean` to download a large number of dependencies

fixes #4883 
### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@ahoffer 
@bdeining 
#### Select relevant component teams: 
@codice/build 
#### Ask 2 committers to review/merge the PR and tag them here.
@AzGoalie
@bdeining

#### How should this be tested?
`mvn clean`
`mvn clean install` ensure solr is stopped after execution
it may be worth trying `mvn install` and `mvn clean install` with a running solr to see how it breaks

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
