### PR TITLE
[2.19.x] DDF-96 Start with default value in result forms

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
@@ -53,24 +53,28 @@ module.exports = Marionette.LayoutView.extend({
   },
   setupAttributeSpecific() {
     let excludedList = metacardDefinitions.getMetacardStartingTypes()
+    const allowedValues = _.filter(
+      metacardDefinitions.sortedMetacardTypes,
+      type => !metacardDefinitions.isHiddenTypeExceptThumbnail(type.id)
+    )
+      .filter(type => !properties.isHidden(type.id))
+      .filter(type => !excludedList.hasOwnProperty(type.id))
+      .map(metacardType => ({
+        label: metacardType.alias || metacardType.id,
+        value: metacardType.id,
+      }))
     this.basicAttributeSpecific.show(
       new PropertyView({
         model: new Property({
           enumFiltering: true,
           showValidationIssues: true,
           enumMulti: true,
-          enum: _.filter(
-            metacardDefinitions.sortedMetacardTypes,
-            type => !metacardDefinitions.isHiddenTypeExceptThumbnail(type.id)
-          )
-            .filter(type => !properties.isHidden(type.id))
-            .filter(type => !excludedList.hasOwnProperty(type.id))
-            .map(metacardType => ({
-              label: metacardType.alias || metacardType.id,
-              value: metacardType.id,
-            })),
+          enum: allowedValues,
           values: this.model.get('descriptors'),
-          value: [this.model.get('descriptors')],
+          value:
+            [this.model.get('descriptors')].size > 0
+              ? [this.model.get('descriptors')]
+              : [[allowedValues[0] && allowedValues[0].label]],
           id: 'Attributes',
         }),
       })


### PR DESCRIPTION
#### What does this PR do?
Selects the first attribute as the default when creating a new result form. 
#### Who is reviewing it? 
@bennuttle 
@leo-sakh 
@nsuvarna 
@lavoywj 
@AzGoalie 
@maryformanek 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@gordocanchola 
@lambeaux


#### How should this be tested?
1. Start DDF, and install the standard profile
2. Create a new result form. Check that there is an attribute selected by default
3. Check that you can change the attribute, and successfully save the form.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #https://github.com/codice/ddf-ui/issues/96
#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
