### PR TITLE
[2.19.x] DDF-5724 G-2115 fixes issue with basic search form when there are no facets

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-basic/query-basic.view.js
@@ -543,7 +543,10 @@ module.exports = Marionette.LayoutView.extend({
     }
 
     const types = this.basicType.currentView.model.getValue()[0]
-    const specificTypes = this.basicTypeSpecific.currentView.model.getValue()[0]
+    const specificTypes =
+      this.basicTypeSpecific.currentView.model !== undefined
+        ? this.basicTypeSpecific.currentView.model.getValue()[0]
+        : []
     if (types === 'specific' && specificTypes.length !== 0) {
       const filterAttributeIsSupported = filter => filter !== null
       const typeFilter = {


### PR DESCRIPTION
#### What does this PR do?
Fixes issue with basic search form when there are no facets
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@bdthomson
@jrnorth
#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Build / Install / Configure the Catalog UI to use a facet that will return nothing and verify one can still issue a query from the basic search form
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
