### PR TITLE
[2.16.x] DDF-5946 Subject identity fix

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -811,7 +811,7 @@ public class MetacardApplication implements SparkApplication {
           Attribute attribute = metacard.getAttribute(Core.METACARD_OWNER);
           if (attribute != null
               && attribute.getValue() != null
-              && !attribute.getValue().equals(getSubjectEmail())) {
+              && !attribute.getValue().equals(getSubjectIdentifier())) {
             res.status(401);
             return util.getResponseWrapper(
                 ERROR_RESPONSE_TYPE, "Owner of note metacard is invalid!");
@@ -837,7 +837,7 @@ public class MetacardApplication implements SparkApplication {
           Attribute attribute = metacard.getAttribute(Core.METACARD_OWNER);
           if (attribute != null
               && attribute.getValue() != null
-              && !attribute.getValue().equals(getSubjectEmail())) {
+              && !attribute.getValue().equals(getSubjectIdentifier())) {
             res.status(401);
             return util.getResponseWrapper(
                 ERROR_RESPONSE_TYPE, "Owner of note metacard is invalid!");

--- a/platform/security/core/security-core-services/pom.xml
+++ b/platform/security/core/security-core-services/pom.xml
@@ -165,6 +165,11 @@
             <artifactId>util-uuidgenerator-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.security.sts</groupId>
+            <artifactId>security-sts-guestclaimshandler</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/platform/security/core/security-core-services/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/core/security-core-services/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -81,12 +81,17 @@
     <service id="sessionListenerService" ref="sessionListener"
              interface="javax.servlet.http.HttpSessionListener"/>
 
+    <reference id="guestClaimsConfig"
+      interface="org.codice.ddf.security.claims.guest.GuestClaimsConfig"
+      ext:proxy-method="classes"/>
+
     <bean id="subjectIdentityImpl"
           class="ddf.security.impl.SubjectIdentityImpl">
         <cm:managed-properties
                 persistent-id="ddf.security.SubjectIdentity"
                 update-strategy="container-managed"/>
         <property name="identityAttribute" value="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"/>
+        <property name="guestClaimsConfig" ref="guestClaimsConfig"/>
     </bean>
 
     <service id="subjectIdentity" ref="subjectIdentityImpl"

--- a/platform/security/core/security-core-services/src/test/java/ddf/security/impl/SubjectIdentityTest.java
+++ b/platform/security/core/security-core-services/src/test/java/ddf/security/impl/SubjectIdentityTest.java
@@ -23,7 +23,11 @@ import com.google.common.collect.ImmutableMap;
 import ddf.security.Subject;
 import ddf.security.SubjectUtils;
 import ddf.security.assertion.SecurityAssertion;
+import ddf.security.principal.GuestPrincipal;
+import java.net.URI;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,6 +35,7 @@ import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.session.mgt.SimpleSession;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.subject.SimplePrincipalCollection;
+import org.codice.ddf.security.claims.guest.GuestClaimsConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.core.xml.schema.XSString;
@@ -46,6 +51,7 @@ public class SubjectIdentityTest {
   @Before
   public void setUp() {
     subjectIdentity = new SubjectIdentityImpl();
+    subjectIdentity.setGuestClaimsConfig(getGuestClaimsConfig());
   }
 
   @Test
@@ -80,6 +86,48 @@ public class SubjectIdentityTest {
     assertThat(TEST_NAME, is(subjectIdentity.getUniqueIdentifier(subject)));
   }
 
+  @Test
+  public void testGuestClaimsRemoval() {
+    final String nameIdentifier = "user";
+    Map<String, List<String>> attrs =
+        ImmutableMap.of(
+            SubjectUtils.NAME_IDENTIFIER_CLAIM_URI, Arrays.asList("guest", nameIdentifier));
+    Subject subject = getSubjectWithAttributes(attrs);
+    subjectIdentity.setIdentityAttribute(SubjectUtils.NAME_IDENTIFIER_CLAIM_URI);
+    assertThat(subjectIdentity.getUniqueIdentifier(subject), is(nameIdentifier));
+  }
+
+  @Test
+  public void testGuestClaimsRemovalAsGuestSubject() {
+    Subject subject = getGuestSubject();
+    subjectIdentity.setIdentityAttribute(SubjectUtils.NAME_IDENTIFIER_CLAIM_URI);
+    assertThat(subjectIdentity.getUniqueIdentifier(subject), is("guest"));
+  }
+
+  private Subject getGuestSubject() {
+
+    Subject subject = mock(Subject.class);
+    PrincipalCollection pc = mock(PrincipalCollection.class);
+    SecurityAssertion assertion = mock(SecurityAssertion.class);
+    AttributeStatement as = mock(AttributeStatement.class);
+
+    Map<String, List<String>> guestClaims = new HashMap<>();
+    guestClaims.put(SubjectUtils.NAME_IDENTIFIER_CLAIM_URI, Collections.singletonList("guest"));
+    guestClaims.put(SubjectUtils.ROLE_CLAIM_URI, Collections.singletonList("guest"));
+    List<Attribute> attrs =
+        guestClaims.entrySet().stream().map(this::getAttribute).collect(Collectors.toList());
+    List<Object> principalList = Arrays.asList(mock(GuestPrincipal.class), assertion);
+
+    doReturn(pc).when(subject).getPrincipals();
+    doReturn(principalList).when(pc).asList();
+    doReturn(assertion).when(pc).oneByType(SecurityAssertion.class);
+    doReturn(ImmutableList.of(assertion)).when(pc).byType(SecurityAssertion.class);
+    doReturn(Collections.singletonList(as)).when(assertion).getAttributeStatements();
+    doReturn(attrs).when(as).getAttributes();
+
+    return subject;
+  }
+
   private Subject getSubjectWithAttributes(Map<String, List<String>> attributes) {
 
     Subject subject = mock(Subject.class);
@@ -91,12 +139,24 @@ public class SubjectIdentityTest {
         attributes.entrySet().stream().map(this::getAttribute).collect(Collectors.toList());
 
     doReturn(pc).when(subject).getPrincipals();
+    doReturn(Collections.singletonList(assertion)).when(pc).asList();
     doReturn(assertion).when(pc).oneByType(SecurityAssertion.class);
     doReturn(ImmutableList.of(assertion)).when(pc).byType(SecurityAssertion.class);
     doReturn(Collections.singletonList(as)).when(assertion).getAttributeStatements();
     doReturn(attrs).when(as).getAttributes();
 
     return subject;
+  }
+
+  private GuestClaimsConfig getGuestClaimsConfig() {
+    Map<URI, List<String>> guestClaims = new HashMap<>();
+    guestClaims.put(
+        URI.create(SubjectUtils.NAME_IDENTIFIER_CLAIM_URI), Collections.singletonList("guest"));
+    guestClaims.put(URI.create(SubjectUtils.ROLE_CLAIM_URI), Collections.singletonList("guest"));
+
+    GuestClaimsConfig guestClaimsConfig = mock(GuestClaimsConfig.class);
+    doReturn(guestClaims).when(guestClaimsConfig).getClaimsMap();
+    return guestClaimsConfig;
   }
 
   private Attribute getAttribute(Map.Entry<String, List<String>> attribute) {

--- a/platform/security/sts/security-sts-guestclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-guestclaimshandler/pom.xml
@@ -53,7 +53,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>httpclient,httpcore</Embed-Dependency>
-                        <Export-Package />
+<!--                        <Export-Package />-->
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/security/sts/security-sts-guestclaimshandler/pom.xml
+++ b/platform/security/sts/security-sts-guestclaimshandler/pom.xml
@@ -53,7 +53,6 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>httpclient,httpcore</Embed-Dependency>
-<!--                        <Export-Package />-->
                     </instructions>
                 </configuration>
             </plugin>

--- a/platform/security/sts/security-sts-guestclaimshandler/src/main/java/org/codice/ddf/security/claims/guest/GuestClaimsConfig.java
+++ b/platform/security/sts/security-sts-guestclaimshandler/src/main/java/org/codice/ddf/security/claims/guest/GuestClaimsConfig.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.claims.guest;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GuestClaimsConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GuestClaimsConfig.class);
+
+  private Map<URI, List<String>> claimsMap = new HashMap<>();
+
+  public void setAttributes(List<String> attributes) {
+    if (attributes != null) {
+      LOGGER.debug("Attribute value list was set.");
+      List<String> attrs = new ArrayList<>(attributes.size());
+      attrs.addAll(attributes);
+      initClaimsMap(attrs);
+    } else {
+      LOGGER.debug("Set attribute value list was null");
+    }
+  }
+
+  public Map<URI, List<String>> getClaimsMap() {
+    return Collections.unmodifiableMap(claimsMap);
+  }
+
+  private void initClaimsMap(List<String> attributes) {
+    for (String attr : attributes) {
+      String[] claimMapping = attr.split("=");
+      if (claimMapping.length == 2) {
+        try {
+          List<String> values = new ArrayList<>();
+          if (claimMapping[1].contains("|")) {
+            String[] valsArr = claimMapping[1].split("\\|");
+            Collections.addAll(values, valsArr);
+          } else {
+            values.add(claimMapping[1]);
+          }
+          claimsMap.put(new URI(claimMapping[0]), values);
+        } catch (URISyntaxException e) {
+          LOGGER.info(
+              "Claims mapping cannot be converted to a URI. This claim will be excluded: {}",
+              attr,
+              e);
+        }
+      } else {
+        LOGGER.warn("Invalid claims mapping entered for guest user: {}", attr);
+      }
+    }
+  }
+}

--- a/platform/security/sts/security-sts-guestclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/sts/security-sts-guestclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,9 +21,9 @@
         http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd"
            default-activation="lazy">
 
-    <bean class="org.codice.ddf.security.claims.guest.GuestClaimsHandler" id="guestHandler">
+    <bean class="org.codice.ddf.security.claims.guest.GuestClaimsConfig" id="guestClaimsConfig">
         <cm:managed-properties persistent-id="ddf.security.sts.guestclaims"
-                               update-strategy="container-managed"/>
+          update-strategy="container-managed"/>
         <!-- Default properties -->
         <property name="attributes">
             <array value-type="java.lang.String">
@@ -33,6 +33,11 @@
         </property>
     </bean>
 
+    <bean class="org.codice.ddf.security.claims.guest.GuestClaimsHandler" id="guestHandler">
+        <property name="guestClaimsConfig" ref="guestClaimsConfig"/>
+    </bean>
+
+    <service ref="guestClaimsConfig" interface="org.codice.ddf.security.claims.guest.GuestClaimsConfig"/>
     <service ref="guestHandler" interface="org.apache.cxf.sts.claims.ClaimsHandler"/>
 
 </blueprint>

--- a/platform/security/sts/security-sts-guestclaimshandler/src/test/java/org/codice/ddf/security/claims/guest/GuestClaimsHandlerTest.java
+++ b/platform/security/sts/security-sts-guestclaimshandler/src/test/java/org/codice/ddf/security/claims/guest/GuestClaimsHandlerTest.java
@@ -35,14 +35,16 @@ public class GuestClaimsHandlerTest {
 
   @Test
   public void testSettingClaimsMapList() throws URISyntaxException {
-    GuestClaimsHandler claimsHandler = new GuestClaimsHandler();
-    claimsHandler.setAttributes(
+    GuestClaimsConfig claimsConfig = new GuestClaimsConfig();
+    claimsConfig.setAttributes(
         Arrays.asList(
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier=Guest",
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress=Guest@guest.com",
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname=Guest"));
+    GuestClaimsHandler claimsHandler = new GuestClaimsHandler();
+    claimsHandler.setGuestClaimsConfig(claimsConfig);
 
-    Map<URI, List<String>> claimsMap = claimsHandler.getClaimsMap();
+    Map<URI, List<String>> claimsMap = claimsConfig.getClaimsMap();
 
     List<String> value =
         claimsMap.get(
@@ -57,10 +59,12 @@ public class GuestClaimsHandlerTest {
     value = claimsMap.get(new URI("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"));
     assertEquals("Guest", value.get(0));
 
-    claimsHandler = new GuestClaimsHandler();
-    claimsHandler.setAttributes(
+    claimsConfig = new GuestClaimsConfig();
+    claimsConfig.setAttributes(
         Arrays.asList(
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier=Guest,http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress=Guest@guest.com,http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname=Guest"));
+    claimsHandler = new GuestClaimsHandler();
+    claimsHandler.setGuestClaimsConfig(claimsConfig);
 
     value =
         claimsMap.get(
@@ -78,12 +82,14 @@ public class GuestClaimsHandlerTest {
 
   @Test
   public void testRetrieveClaims() throws URISyntaxException {
-    GuestClaimsHandler claimsHandler = new GuestClaimsHandler();
-    claimsHandler.setAttributes(
+    GuestClaimsConfig claimsConfig = new GuestClaimsConfig();
+    claimsConfig.setAttributes(
         Arrays.asList(
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier=Guest",
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress=Guest@guest.com|someguy@somesite.com|somedude@cool.com",
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname=Guest"));
+    GuestClaimsHandler claimsHandler = new GuestClaimsHandler();
+    claimsHandler.setGuestClaimsConfig(claimsConfig);
 
     ClaimCollection requestClaims = new ClaimCollection();
     Claim requestClaim = new Claim();
@@ -140,12 +146,14 @@ public class GuestClaimsHandlerTest {
 
   @Test
   public void testRetrieveClaimsWithAdditionalPropertyClaim() throws URISyntaxException {
-    GuestClaimsHandler claimsHandler = new GuestClaimsHandler();
-    claimsHandler.setAttributes(
+    GuestClaimsConfig claimsConfig = new GuestClaimsConfig();
+    claimsConfig.setAttributes(
         Arrays.asList(
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier=Guest",
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress=Guest@guest.com|someguy@somesite.com|somedude@cool.com",
             "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname=Guest"));
+    GuestClaimsHandler claimsHandler = new GuestClaimsHandler();
+    claimsHandler.setGuestClaimsConfig(claimsConfig);
 
     ClaimCollection requestClaims = new ClaimCollection();
     Claim requestClaim = new Claim();

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/annotation/annotation.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/annotation/annotation.view.js
@@ -37,7 +37,7 @@ module.exports = Marionette.LayoutView.extend({
     'click .footer-delete': 'handleDelete',
   },
   initialize(options) {
-    this._useremail = userInstance.get('user').get('email')
+    this._userId = userInstance.getUserId()
     this._parent = options.parent
   },
   handleDelete() {
@@ -105,7 +105,7 @@ module.exports = Marionette.LayoutView.extend({
   canModify() {
     this.$el.toggleClass(
       'is-modifiable',
-      this._useremail === this.model.attributes.owner
+      this._userId === this.model.attributes.owner
     )
   },
   toggleDeleting() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/editor/editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/editor/editor.view.js
@@ -101,7 +101,7 @@ module.exports = Marionette.LayoutView.extend({
     )
   },
   handleTypes() {
-    const username = user.get('user').get('userid')
+    const userId = user.getUserId()
     let isOwner = true
     const types = {}
     this.model.forEach(result => {
@@ -126,7 +126,7 @@ module.exports = Marionette.LayoutView.extend({
         .get('properties')
         .get('metacard.owner')
 
-      isOwner = isOwner && username === metacardOwner
+      isOwner = isOwner && userId === metacardOwner
     })
     this.$el.toggleClass('is-mixed', Object.keys(types).length > 1)
     this.$el.toggleClass('is-workspace', types.workspace !== undefined)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
@@ -18,8 +18,8 @@ module.exports = Backbone.Model.extend({
     return {
       title: '',
       description: '',
-      createdBy: user.getEmail(),
-      owner: user.getEmail(),
+      createdBy: user.getUserId(),
+      owner: user.getUserId(),
       createdOn: Date.now(),
       type: 'custom',
       id: undefined,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.js
@@ -20,14 +20,14 @@ const FormContainer = require('../../search-form/form-tab-container.view')
 
 const tabChildViewOptions = {
   'My Search Forms': {
-    filter: child => child.get('createdBy') === user.getEmail(),
+    filter: child => child.get('createdBy') === user.getUserId(),
     showNewForm: true,
   },
   'Shared Search Forms': {
     type: 'Shared',
     filter: child =>
       child.get('createdBy') !== 'system' &&
-      child.get('createdBy') !== user.getEmail() &&
+      child.get('createdBy') !== user.getUserId() &&
       user.canRead(child),
   },
   'System Search Forms': {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationStart.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationStart.js
@@ -28,7 +28,7 @@ function getWorkspacesOwnedByUser() {
     workspace =>
       user.isGuest()
         ? workspace.get('localStorage') === true
-        : workspace.get('metacard.owner') === user.get('user').get('email')
+        : workspace.get('metacard.owner') === user.getUserId()
   )
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/workspaces-items-container/workspaces-items-container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/container/workspaces-items-container/workspaces-items-container.tsx
@@ -38,13 +38,13 @@ function filterWorkspaces(workspaces: Backbone.Collection<Backbone.Model>) {
   return workspaces.filter((workspace: Backbone.Model) => {
     const localStorage = workspace.get('localStorage') || false
     const owner = workspace.get('metacard.owner')
-    const email = user.get('user').get('email')
+    const userId = user.getUserId()
 
     switch (preferences.get('homeFilter')) {
       case 'Not owned by me':
-        return !localStorage && email !== owner
+        return !localStorage && userId !== owner
       case 'Owned by me':
-        return localStorage || email === owner
+        return localStorage || userId === owner
       case 'Owned by anyone':
       default:
         return true

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/sharing/sharing.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/sharing/sharing.tsx
@@ -123,7 +123,7 @@ const render = (props: Props) => {
                   {item.category === Category.User ? (
                     <EditableLabelText
                       value={item.value}
-                      placeholder="user@example.com"
+                      placeholder="User ID"
                       showLabel={false}
                       onChange={value => handleChangeInput(i, value)}
                     />

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/workspace-interactions/workspace-interactions.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/presentation/workspace-interactions/workspace-interactions.tsx
@@ -99,8 +99,8 @@ const render = (props: Props) => {
       {!isShareable || isLocal ? null : (
         <MenuAction
           help="Brings up a view of the current
-        sharing settings for this workspace.  From there, you can change what permissions each role has on the workspace,
-         as well as give permissions to individuals by specifying their email."
+        sharing settings for this workspace. From there, you can change what permissions each role has on the workspace,
+         as well as give permissions to individuals by specifying their user ID."
           onClick={(_e, context) => {
             viewSharing()
             context.closeAndRefocus()

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/security/security.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/security/security.tsx
@@ -81,7 +81,7 @@ export class Security {
   private canAccess(user: any, accessLevel: Access) {
     return (
       this.res.owner === undefined ||
-      this.res.owner === user.getEmail() ||
+      this.res.owner === user.getUserId() ||
       this.getAccess(user) >= accessLevel
     )
   }
@@ -122,16 +122,16 @@ export class Security {
     return Access.None
   }
 
-  private getIndividualAccess(email: string) {
-    if (this.res.accessAdministrators.indexOf(email) > -1) {
+  private getIndividualAccess(userId: string) {
+    if (this.res.accessAdministrators.indexOf(userId) > -1) {
       return Access.Share
     }
 
-    if (this.res.accessIndividuals.indexOf(email) > -1) {
+    if (this.res.accessIndividuals.indexOf(userId) > -1) {
       return Access.Write
     }
 
-    if (this.res.accessIndividualsRead.indexOf(email) > -1) {
+    if (this.res.accessIndividualsRead.indexOf(userId) > -1) {
       return Access.Read
     }
 
@@ -140,7 +140,7 @@ export class Security {
 
   private getAccess(user: any): Access {
     return Math.max(
-      this.getIndividualAccess(user.getEmail()),
+      this.getIndividualAccess(user.getUserId()),
       ...user.getRoles().map((group: string) => this.getGroupAccess(group))
     )
   }
@@ -166,10 +166,10 @@ export class Security {
       this.res.accessIndividualsRead,
       this.res.accessAdministrators
     )
-      .map((username: string) => {
+      .map((userId: string) => {
         return {
-          value: username,
-          access: this.getIndividualAccess(username),
+          value: userId,
+          access: this.getIndividualAccess(userId),
         } as Entry
       })
       .sort(Security.compareFn)


### PR DESCRIPTION
#### What does this PR do?
Updates the UI to respect the Subject Identity configuration, rather than always using the email as the subject identity. It also updates the subject identity code to ignore guest claims if the user is logged in, so that they are not used as the subject identifier.

#### Who is reviewing it? 
@stustison @bakejeyner @blen-desta @garrettfreibott 

#### How should this be tested?
1. Create two non-admin accounts in DDF
2. Change the Subject Identity config in the Admin UI to use the `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` attribute instead of email.
3. Restart DDF
4. Verify the following:
* Metacard security attributes (the security.access-* attributes) use the name identifier instead of email.
* The workspaces page use the name identifier to indicate workspace ownership
* Workspace filtering works (Owned by Me, Not Owned by Me)
* Workspace sharing works
* Search form sharing works (top left hamburger > Search Forms)
* On load, Intrigue opens an existing workspace if there is one owned by the current user
* Query annotations use name identifier to indicate ownership, and only the owner can modify their notes. Also, make sure the owner can update and delete their notes
* The subject identifier is not "guest". It should always be the nameidentifier of the logged in user.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5946

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
