### PR TITLE
DDF-5875 Adds original tags to DeletedMetacard

### DIFF
--- a/catalog/core/catalog-core-versioning/versioning-api/src/main/java/ddf/catalog/core/versioning/DeletedMetacard.java
+++ b/catalog/core/catalog-core-versioning/versioning-api/src/main/java/ddf/catalog/core/versioning/DeletedMetacard.java
@@ -32,4 +32,6 @@ public interface DeletedMetacard extends Metacard {
   String DELETION_OF_ID = PREFIXER.apply("id");
 
   String LAST_VERSION_ID = PREFIXER.apply("version");
+
+  String DELETED_METACARD_TAGS = PREFIXER.apply("tags");
 }

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
@@ -15,16 +15,23 @@ package ddf.catalog.core.versioning.impl;
 
 import com.google.common.collect.ImmutableSet;
 import ddf.catalog.core.versioning.DeletedMetacard;
+import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -46,6 +53,9 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
     DESCRIPTORS.add(
         new AttributeDescriptorImpl(
             LAST_VERSION_ID, true, true, false, false, BasicTypes.STRING_TYPE));
+    DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            DELETED_METACARD_TAGS, true, true, false, true, BasicTypes.STRING_TYPE));
     METACARD_TYPE = new MetacardTypeImpl(PREFIX, DESCRIPTORS);
   }
 
@@ -63,6 +73,7 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
             metacardBeingDeleted.getMetacardType().getAttributeDescriptors()));
     this.setDeletionOfId(deletionOfId);
     this.setDeletedBy(deletedBy);
+    this.setDeletedMetacardTags(metacardBeingDeleted.getTags());
     this.setLastVersionId(lastVersionId);
     this.setTags(ImmutableSet.of(DELETED_TAG));
     this.setId(id);
@@ -109,5 +120,25 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
 
   public String getLastVersionId() {
     return requestString(LAST_VERSION_ID);
+  }
+
+  public void setDeletedMetacardTags(Set<String> tags) {
+    if (tags == null || tags.isEmpty()) {
+      setAttribute(DELETED_METACARD_TAGS, null);
+      return;
+    }
+    setAttribute(
+        new AttributeImpl(
+            DELETED_METACARD_TAGS, (List<Serializable>) new ArrayList<Serializable>(tags)));
+  }
+
+  public Set<String> getDeletedMetacardTags() {
+    Attribute deletedTags = getAttribute(DELETED_METACARD_TAGS);
+    if (deletedTags == null
+        || deletedTags.getValues() == null
+        || deletedTags.getValues().isEmpty()) {
+      return Collections.emptySet();
+    }
+    return deletedTags.getValues().stream().map(String::valueOf).collect(Collectors.toSet());
   }
 }

--- a/catalog/core/catalog-core-versioning/versioning-common/src/test/groovy/ddf/catalog/core/versioning/impl/DeletedMetacardImplSpec.groovy
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/test/groovy/ddf/catalog/core/versioning/impl/DeletedMetacardImplSpec.groovy
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.core.versioning.impl
+
+import ddf.catalog.core.versioning.DeletedMetacard
+import ddf.catalog.data.Metacard
+import ddf.catalog.data.impl.AttributeImpl
+import ddf.catalog.data.impl.MetacardImpl
+import org.apache.shiro.subject.Subject
+import org.apache.shiro.util.ThreadContext
+import spock.lang.Specification
+
+
+class DeletedMetacardImplSpec extends Specification {
+
+    void setup() {
+        ThreadContext.bind(Mock(Subject))
+
+    }
+
+    void cleanup() {
+        ThreadContext.unbindSubject()
+    }
+
+    def "Tags of metacard being deleted are stored in the deleted metacard"() {
+        setup:
+        def id = "OriginalMetacardId"
+        def title = "Title"
+        def tags = ['a-special-tag', 'a-second-special-tag'] as Set
+        Metacard metacard = new MetacardImpl().with {
+            setAttribute(ID, id)
+            setAttribute(TITLE, title)
+            setAttribute(new AttributeImpl(TAGS, new ArrayList<>(tags)))
+            return it
+        }
+
+        when: "deleted metacards are created from a metacard with specific tags"
+        def deletedMetacard = new DeletedMetacardImpl(
+                "DeletedMetacardId",
+                id,
+                "UserSubjectName",
+                "VersionMetacardId",
+                metacard)
+
+        then: "deleted metacards have those specific tags for searchability"
+        deletedMetacard.
+                getAttribute(DeletedMetacard.DELETED_METACARD_TAGS)?.
+                values?.
+                containsAll(tags)
+
+        when: "deleted metacard has no tags (which would be odd)"
+        Metacard metacardNoTags = new MetacardImpl().with {
+            setAttribute(ID, id)
+            setAttribute(TITLE, title)
+            return it
+        }
+
+        def deletedMetacardNoTags = new DeletedMetacardImpl(
+                "DeletedMetacardId",
+                id,
+                "UserSubjectName",
+                "VersionMetacardId",
+                metacardNoTags)
+        then: "nothing bad happens and there is no deleted_metacard_tags"
+        noExceptionThrown()
+        // Metacard interface does not dictate whether an empty set is "non existant" and will
+        // be treated as a delete aka not in the map and returns null or will be treated as a
+        // value and set as an empty attribute value
+        deletedMetacardNoTags.getAttribute(DeletedMetacard.DELETED_METACARD_TAGS) == null ||
+                deletedMetacardNoTags.
+                        getAttribute(DeletedMetacard.DELETED_METACARD_TAGS).
+                        values.
+                        isEmpty()
+    }
+
+
+}


### PR DESCRIPTION
#### What does this PR do?
 - You can now search for deleted metacards original tags by querying the field

#### How should this be tested?
Ensure nothing breaks, ensure you can query on DeletedMetacards original tags field `metacard.deleted.tags`

#### Any background context you want to provide?
- This is functionality that its sibling class (MetacardVersionImpl) has but this class never got for some reason. So this is something that probably should have been there but wasn't before. No hard schema changes so upgrade can be done with no migrations to continue working. 

#### What are the relevant tickets?
Fixes: #5875 

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Threat Dragon models
  - only adding additional metadata about what the original metacard was (eg, a workspace) no resource metadata is exposed.
- [x] Update / Add Unit Tests


#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
