### PR TITLE
[2.20.x] Use SelectionInterface in metacardOverwrite

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/metacard-overwrite/metacard-overwrite.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/metacard-overwrite/metacard-overwrite.view.js
@@ -13,7 +13,6 @@
  *
  **/
 
-const store = require('../../js/store.js')
 const ConfirmationView = require('../confirmation/confirmation.view.js')
 const Dropzone = require('dropzone')
 const OverwritesInstance = require('../singletons/overwrites-instance.js')
@@ -211,7 +210,7 @@ class MetacardOverwrite extends React.Component {
   constructor(props) {
     super(props)
     this.state = defaultState
-    this.model = store.getSelectedResults().first()
+    this.model = props.selectionInterface.getSelectedResults().first()
     this.dropzoneElement = React.createRef()
   }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/metacard/tabs-metacard.js
@@ -27,7 +27,11 @@ import MetacardQuality from '../../../react-component/metacard-quality'
 import MetacardHistory from '../../../react-component/metacard-history'
 
 const MetacardOverwriteView = Marionette.LayoutView.extend({
-  template: () => <MetacardOverwrite />,
+  template() {
+    return (
+      <MetacardOverwrite selectionInterface={this.options.selectionInterface} />
+    )
+  },
 })
 
 const MetacardArchiveView = Marionette.LayoutView.extend({


### PR DESCRIPTION
#### What does this PR do?
Port of https://github.com/codice/ddf-ui/pull/91
Updates metacard overwrite to use selection interface, allowing this to be reused downstream or in other routes

#### Who is reviewing it? 
@willwill96 @Bdthomson @andrewkfiedler 

#### How should this be tested?
Test metacard overwrite, see that it still works as expected 

#### What are the relevant tickets?
Fixes: #5881 

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
