### PR TITLE
[2.20.x] DDF-5849 make oidc token server connect and read timeouts configurable

### DIFF
--- a/platform/security/handler/security-handler-api/src/main/java/org/codice/ddf/security/handler/api/OidcHandlerConfiguration.java
+++ b/platform/security/handler/security-handler-api/src/main/java/org/codice/ddf/security/handler/api/OidcHandlerConfiguration.java
@@ -26,4 +26,8 @@ public interface OidcHandlerConfiguration {
   OidcLogoutActionBuilder getOidcLogoutActionBuilder();
 
   void testConnection();
+
+  int getConnectTimeout();
+
+  int getReadTimeout();
 }

--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcHandlerConfigurationImpl.java
@@ -37,6 +37,10 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
 
   public static final String DEFAULT_CALLBACK_URL = "https://localhost:8993/search";
 
+  private static final int DEFAULT_CONNECT_TIMEOUT = 5000;
+
+  private static final int DEFAULT_READ_TIMEOUT = 5000;
+
   public static final String IDP_TYPE_KEY = "idpType";
   public static final String CLIENT_ID_KEY = "clientId";
   public static final String REALM_KEY = "realm";
@@ -48,6 +52,8 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
   public static final String RESPONSE_TYPE_KEY = "responseType";
   public static final String RESPONSE_MODE_KEY = "responseMode";
   public static final String LOGOUT_URI_KEY = "logoutUri";
+  public static final String CONNECT_TIMEOUT_KEY = "connectTimeout";
+  public static final String READ_TIMEOUT_KEY = "readTimeout";
 
   private String idpType;
   private String clientId;
@@ -60,6 +66,8 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
   private String responseType;
   private String responseMode;
   private String logoutUri;
+  private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+  private int readTimeout = DEFAULT_READ_TIMEOUT;
 
   private OidcConfiguration oidcConfiguration;
 
@@ -80,6 +88,8 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     responseType = (String) properties.getOrDefault(RESPONSE_TYPE_KEY, responseType);
     responseMode = (String) properties.getOrDefault(RESPONSE_MODE_KEY, responseMode);
     logoutUri = (String) properties.getOrDefault(LOGOUT_URI_KEY, logoutUri);
+    connectTimeout = (int) properties.getOrDefault(CONNECT_TIMEOUT_KEY, connectTimeout);
+    readTimeout = (int) properties.getOrDefault(READ_TIMEOUT_KEY, readTimeout);
 
     // TODO - Remove if fragment response_mode is supported
     if (IMPLICIT_FLOWS.contains(new ResponseType(responseType))) {
@@ -97,6 +107,8 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
     oidcConfiguration.setUseNonce(useNonce);
     oidcConfiguration.setLogoutUrl(logoutUri);
     oidcConfiguration.setWithState(true);
+    oidcConfiguration.setConnectTimeout(connectTimeout);
+    oidcConfiguration.setReadTimeout(readTimeout);
 
     try {
       testConnection();
@@ -145,6 +157,16 @@ public class OidcHandlerConfigurationImpl implements OidcHandlerConfiguration {
   public void testConnection() {
     getOidcConfiguration();
     getOidcClient(DEFAULT_CALLBACK_URL);
+  }
+
+  @Override
+  public int getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  @Override
+  public int getReadTimeout() {
+    return readTimeout;
   }
 
   @VisibleForTesting

--- a/platform/security/handler/security-handler-oidc/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/handler/security-handler-oidc/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -42,6 +42,12 @@
             </cm:property>
             <cm:property name="responseType" value="code"/>
             <cm:property name="responseMode" value="form_post"/>
+            <cm:property name="connectTimeout">
+                <value type="java.lang.Integer">5000</value>
+            </cm:property>
+            <cm:property name="readTimeout">
+                <value type="java.lang.Integer">5000</value>
+            </cm:property>
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -61,6 +67,8 @@
                 </entry>
                 <entry key="responseType" value="${responseType}"/>
                 <entry key="responseMode" value="${responseMode}"/>
+                <entry key="connectTimeout" value="${connectTimeout}"/>
+                <entry key="readTimeout" value="${readTimeout}"/>
             </map>
         </property>
     </bean>

--- a/platform/security/handler/security-handler-oidc/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/handler/security-handler-oidc/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -62,6 +62,12 @@
         <Option label="form_post" value="form_post"/>
     </AD>
 
+    <AD name="Network Connect Timeout" id="connectTimeout" type="Integer" default="5000"
+        description="Network connect timeout in milliseconds for connecting to the OIDC token server."/>
+
+    <AD name="Network Read Timeout" id="readTimeout" type="Integer" default="5000"
+        description="Network read timeout in milliseconds for reading from the OIDC token server."/>
+
   </OCD>
 
     <Designate pid="org.codice.ddf.security.handler.api.OidcHandlerConfiguration">

--- a/platform/security/security-oidc-realm/src/main/java/org/codice/ddf/security/oidc/realm/OidcCredentialsResolver.java
+++ b/platform/security/security-oidc-realm/src/main/java/org/codice/ddf/security/oidc/realm/OidcCredentialsResolver.java
@@ -57,12 +57,20 @@ public class OidcCredentialsResolver extends OidcAuthenticator {
 
   private OidcTokenValidator oidcTokenValidator;
   private OIDCProviderMetadata metadata;
+  private int connectTimeout;
+  private int readTimeout;
 
   public OidcCredentialsResolver(
-      OidcConfiguration oidcConfiguration, OidcClient oidcClient, OIDCProviderMetadata metadata) {
+      OidcConfiguration oidcConfiguration,
+      OidcClient oidcClient,
+      OIDCProviderMetadata metadata,
+      int connectTimeout,
+      int readTimeout) {
     super(oidcConfiguration, oidcClient);
     this.metadata = metadata;
     oidcTokenValidator = new OidcTokenValidator(oidcConfiguration, metadata);
+    this.connectTimeout = connectTimeout;
+    this.readTimeout = readTimeout;
   }
 
   /* This methods job is to try and get an id token from a
@@ -150,8 +158,8 @@ public class OidcCredentialsResolver extends OidcAuthenticator {
     final TokenRequest request =
         new TokenRequest(metadata.getTokenEndpointURI(), getClientAuthentication(), grant);
     HTTPRequest tokenHttpRequest = request.toHTTPRequest();
-    tokenHttpRequest.setConnectTimeout(configuration.getConnectTimeout());
-    tokenHttpRequest.setReadTimeout(configuration.getReadTimeout());
+    tokenHttpRequest.setConnectTimeout(connectTimeout);
+    tokenHttpRequest.setReadTimeout(readTimeout);
 
     final HTTPResponse httpResponse = tokenHttpRequest.send();
     LOGGER.debug(

--- a/platform/security/security-oidc-realm/src/main/java/org/codice/ddf/security/oidc/realm/OidcRealm.java
+++ b/platform/security/security-oidc-realm/src/main/java/org/codice/ddf/security/oidc/realm/OidcRealm.java
@@ -85,9 +85,12 @@ public class OidcRealm extends AuthenticatingRealm {
     OIDCProviderMetadata oidcProviderMetadata = oidcConfiguration.findProviderMetadata();
     WebContext webContext = (WebContext) oidcAuthenticationToken.getContext();
     OidcClient oidcClient = oidcHandlerConfiguration.getOidcClient(webContext.getFullRequestURL());
+    int connectTimeout = oidcHandlerConfiguration.getConnectTimeout();
+    int readTimeout = oidcHandlerConfiguration.getReadTimeout();
 
     OidcCredentialsResolver oidcCredentialsResolver =
-        new OidcCredentialsResolver(oidcConfiguration, oidcClient, oidcProviderMetadata);
+        new OidcCredentialsResolver(
+            oidcConfiguration, oidcClient, oidcProviderMetadata, connectTimeout, readTimeout);
 
     oidcCredentialsResolver.resolveIdToken(credentials, webContext);
 


### PR DESCRIPTION
#### What does this PR do?

Abbreviated review of https://github.com/codice/ddf/pull/5858

Make the OIDC token server connect and read timeouts admin configurable. A downstream project is operating in an environment where the default timeouts were too short.

The connect and read timeouts are configured separately. But let me know if it would be preferred to have a single "network timeout" that is used for both connecting and reading.

There is a static method (getOidcTokens) that is being used by downstream projects. In order to not break those projects, I left a deprecated version of the method that uses the original timeout values. 

#### Who is reviewing it? 
@rzwiefel 
@pklinef 

#### Select relevant component teams: 
@codice/security 
@codice/ui (because ddf-ui uses the deprecrated method)

#### Ask 2 committers to review/merge the PR and tag them here.
@jrnorth
@bdthomson

#### How should this be tested?

I don't have a good way to simulate the slow network environment from the downstream project. My idea is to set a breakpoint in OidcCredentialsResolver:222 and see that the configured values for the connect and read timeouts are being passed to the underlying library that executes the token request.

I had to build a ddf-ui pr to get the ui to build and deploy with this snapshot version of ddf. I used https://github.com/codice/ddf-ui/pull/101. A had to change ddf version number in its pom to 2.23.0-SNAPSHOT.

In order to test, you will need a keycloak instance. This isn't required to test that the timeouts are being used, but to make sure that OIDC authentication wasn't broken in some other manner.

1) download and unzip keycloak 7.0.1: https://www.keycloak.org/archive/downloads-7.0.1.html
2) start keycloak: <keycloak_dir>/bin/standalone.sh
3) Browse to http://localhost:8080/auth
4) Enter desired admin credentials. I use admin/admin.
5) Log into keycloak with admin user.
6) Create a new realm called "DDF".
7) Create a new client called "ddf-client". Set the root url field to https://localhost:8993/.
8) Create a test user with the CLI: <keycloak_dir>/bin/add-user-keycloak.sh -r DDF -u user1 -p user1 
9)build and install ddf/ddf-ui.
10) In DDF->Admin->Security->OIDC Handler, set the client to "ddf-client", set the realm to "DDF", change the keycloak urls to be http instead of https and change their port number to 8080, set the connect and read timeouts (in milliseconds) to 15000 and 17000, respectively.
11) Change Web Context Policy Manager to use OIDC for the root path.
12) Set a breakpoint for OidcCredentialsResolver:222. 
13) Using a private browser window (prevents weirdness with old cookies), go the https://localhost:8993/search/catalog. You should be presented with a keycloak login page. Enter user1/user1.
14) Your breakpoint should hit. Confirm that the connect timeout is 15000 and the read timeout is 17000. Continue execution.
15) You should be logged into DDF! 
16) What you do with DDF at this point is your business. I'm not one to pry.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: # https://github.com/codice/ddf/issues/5849

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
