### PR TITLE
[2.19.x] DDF-UI-111 Fixed drawn geometries and result geometries over anti-meridian

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/geometry.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/geometry.view.js
@@ -80,20 +80,18 @@ const GeometryView = Marionette.ItemView.extend({
   },
   adjustPoints(type, coordinates) {
     coordinates.forEach((coord, index) => {
-      if(index + 1 < coordinates.length) {
-        let negative = false
+      if (index + 1 < coordinates.length) {
         const east = Number(coordinates[index + 1][0])
         const west = Number(coordinates[index][0])
-        if(east - west < -180) {
-          negative = true
+        if (east - west < -180) {
           coordinates[index + 1][0] = east + 360
-        } else if(!negative && east - west > 180) {
+        } else if (east - west > 180) {
           coordinates[index][0] = west + 360
         }
       }
     })
     // If the geo is a polygon, ensure that the first and last coordinate are the same
-    if(type.includes('Polygon')) {
+    if (type.includes('Polygon')) {
       coordinates[0][0] = coordinates[coordinates.length - 1][0]
     }
     return coordinates
@@ -108,11 +106,13 @@ const GeometryView = Marionette.ItemView.extend({
           polygon = this.adjustPoints(geometry.type, polygon)
           this.handlePoint(polygon[0])
           this.handleLine(polygon)
-          //this.handlePolygon(polygon);
         })
         break
       case 'LineString':
-        geometry.coordinates = this.adjustPoints(geometry.type, geometry.coordinates)
+        geometry.coordinates = this.adjustPoints(
+          geometry.type,
+          geometry.coordinates
+        )
         this.handlePoint(geometry.coordinates[0])
         this.handleLine(geometry.coordinates)
         break
@@ -134,7 +134,6 @@ const GeometryView = Marionette.ItemView.extend({
             polygon = this.adjustPoints(geometry.type, polygon)
             this.handlePoint(polygon[0])
             this.handleLine(polygon)
-            //this.handlePolygon(polygon);
           })
         })
         break
@@ -162,19 +161,6 @@ const GeometryView = Marionette.ItemView.extend({
   handleLine(line) {
     this.geometry.push(
       this.options.map.addLine(line, {
-        id: this.model.id,
-        color: this.model.get('metacard').get('color'),
-        title: this.model
-          .get('metacard')
-          .get('properties')
-          .get('title'),
-        view: this,
-      })
-    )
-  },
-  handlePolygon(polygon) {
-    this.geometry = this.geometry.concat(
-      this.options.map.addPolygon(polygon, {
         id: this.model.id,
         color: this.model.get('metacard').get('color'),
         title: this.model

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -85,14 +85,12 @@ Draw.LineView = Marionette.View.extend({
   adjustPoints(coordinates) {
     // Structure of coordinates is [x, y, x, y, ... ]
     coordinates.forEach((coord, index) => {
-      if(index + 2 < coordinates.length) {
-        let negative = false
+      if (index + 2 < coordinates.length) {
         const east = Number(coordinates[index + 2])
         const west = Number(coordinates[index])
-        if(east - west < -180) {
-          negative = true
+        if (east - west < -180) {
           coordinates[index + 2] = east + 360
-        } else if(!negative && east - west > 180) {
+        } else if (east - west > 180) {
           coordinates[index] = west + 360
         }
       }

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.line.js
@@ -82,6 +82,24 @@ Draw.LineView = Marionette.View.extend({
     })
   },
 
+  adjustPoints(coordinates) {
+    // Structure of coordinates is [x, y, x, y, ... ]
+    coordinates.forEach((coord, index) => {
+      if(index + 2 < coordinates.length) {
+        let negative = false
+        const east = Number(coordinates[index + 2])
+        const west = Number(coordinates[index])
+        if(east - west < -180) {
+          negative = true
+          coordinates[index + 2] = east + 360
+        } else if(!negative && east - west > 180) {
+          coordinates[index] = west + 360
+        }
+      }
+    })
+    return coordinates
+  },
+
   modelToPolygon(model) {
     const polygon = model.get('line')
     const setArr = _.uniq(polygon)
@@ -97,7 +115,7 @@ Draw.LineView = Marionette.View.extend({
 
   updatePrimitive(model) {
     const polygon = this.modelToPolygon(model)
-    // make sure the current model has width and height before drawing
+    // Make sure the current model has width and height before drawing
     if (
       polygon !== undefined &&
       !validateGeo('line', JSON.stringify(polygon.getCoordinates())).error
@@ -115,7 +133,7 @@ Draw.LineView = Marionette.View.extend({
 
   drawBorderedPolygon(rectangle) {
     if (!rectangle) {
-      // handles case where model changes to empty vars and we don't want to draw anymore
+      // Handles case where model changes to empty vars and we don't want to draw anymore
       return
     }
     const lineWidth =
@@ -124,6 +142,7 @@ Draw.LineView = Marionette.View.extend({
         this.model.get('lineUnits')
       ) || 1
 
+    rectangle.A = this.adjustPoints(rectangle.A)
     const turfLine = Turf.lineString(
       translateFromOpenlayersCoordinates(rectangle.getCoordinates())
     )

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/widgets/openlayers.polygon.js
@@ -120,21 +120,19 @@ Draw.PolygonView = Marionette.View.extend({
       // Structure of geometry is [coordinatePair, coordinatePair, ... ]
       geometry.forEach((coordinatePair, innerIndex) => {
         // Structure of coordinatePair is [x, y]
-        if(innerIndex + 1 < geometry.length) {
-          let negative = false
+        if (innerIndex + 1 < geometry.length) {
           const east = Number(geometry[innerIndex + 1][0])
           const west = Number(geometry[innerIndex][0])
-          if(east - west < -180) {
-            negative = true
+          if (east - west < -180) {
             geometries[outerIndex][innerIndex + 1][0] = east + 360
-          } else if(!negative && east - west > 180) {
+          } else if (east - west > 180) {
             geometries[outerIndex][innerIndex][0] = west + 360
           }
         }
-
       })
       // Ensure that the first and last coordinate are the same
-      geometries[outerIndex][0][0] = geometries[outerIndex][geometry.length - 1][0]
+      geometries[outerIndex][0][0] =
+        geometries[outerIndex][geometry.length - 1][0]
     })
     return geometries
   },
@@ -185,7 +183,10 @@ Draw.PolygonView = Marionette.View.extend({
     ]
 
     // Structure of coordinates is [geometries, geometries, ... ]
-    coordinates.forEach((geometries, index) => coordinates[index] = this.adjustPoints(geometries))
+    coordinates.forEach(
+      (geometries, index) =>
+        (coordinates[index] = this.adjustPoints(geometries))
+    )
 
     if (this.vectorLayer) {
       this.map.removeLayer(this.vectorLayer)


### PR DESCRIPTION
#### What does this PR do?
Before, if you drew a geometry over the anti-meridian (180 degrees longitude) on the 2D map, the query would return the correct results (within the originally drawn geometry) but the map would show a geometry that would fit within the constraints of the map (see "before" gifs below). This did not happen on the 3D map.

Also, results whose location geometries were over the anti-meridian would render within the constraints of the map as well.
#### Who is reviewing it? 
@andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@millerw8
#### How should this be tested?
See gifs below, verify you see the behavior from the "after" gif for drawn geometries
For result geometries, edit the location attribute with WKTs that cross the antimeridian. Verify that they rendering correctly on the 2D map
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #codice/ddf-ui#111
G-1595
#### Screenshots
##### Drawn geometries
Bounding Box before (this change occurs only upon search/save)
![antimeridian-min](https://user-images.githubusercontent.com/39737329/76033103-a9afea00-5ef8-11ea-884b-60a18ba262fd.gif)
Bounding Box after
![antimeridianfixed-min](https://user-images.githubusercontent.com/39737329/76033555-bc76ee80-5ef9-11ea-900a-5b8a14bede53.gif)
Polygon before (this change occurs immediately after the drawing is complete)
![Recording #69-min](https://user-images.githubusercontent.com/39737329/76442533-b6b05b80-6386-11ea-82f7-8c81f9f18bda.gif)
Polygon after
![Recording #73-min](https://user-images.githubusercontent.com/39737329/76799198-b9e88480-6796-11ea-9764-1607664cfbc1.gif)
Line before (also occurs immediately after drawing is complete)
![Recording #70-min](https://user-images.githubusercontent.com/39737329/76443005-61c11500-6387-11ea-9924-cacf26f50b6b.gif)
Line after
![Recording #74-min](https://user-images.githubusercontent.com/39737329/76799388-05029780-6797-11ea-984a-8b3ebfec2eff.gif)
##### Result geometries
Based on the result's location WKT, it should appear on the map like this:
![image](https://user-images.githubusercontent.com/39737329/76443675-705bfc00-6388-11ea-9f06-1d7b3ee6abf9.png)
But it was appearing here instead:
![image](https://user-images.githubusercontent.com/39737329/76443800-9f726d80-6388-11ea-8d70-6d26db02812f.png)
Now it appears in the correct location:
![image](https://user-images.githubusercontent.com/39737329/76798866-0a131700-6796-11ea-86b2-50972f2dc374.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
