### PR TITLE
DDF-5893 Fixes commands attempting to use references in their constructor

### DIFF
--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/DumpCommand.java
@@ -201,9 +201,7 @@ public class DumpCommand extends CqlCommands {
   )
   String zipFileName;
 
-  public DumpCommand() {
-    this.signer = new DigitalSignature(security);
-  }
+  public DumpCommand() {}
 
   public DumpCommand(DigitalSignature signer) {
     this.signer = signer;
@@ -211,6 +209,9 @@ public class DumpCommand extends CqlCommands {
 
   @Override
   protected final Object executeWithSubject() throws Exception {
+    if (signer == null) {
+      signer = new DigitalSignature(security);
+    }
     if (FilenameUtils.getExtension(dirPath).equals("") && !dirPath.endsWith(File.separator)) {
       dirPath += File.separator;
     }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ExportCommand.java
@@ -178,9 +178,7 @@ public class ExportCommand extends CqlCommands {
   )
   boolean unsafe = false;
 
-  public ExportCommand() {
-    this.signer = new DigitalSignature(security);
-  }
+  public ExportCommand() {}
 
   public ExportCommand(
       FilterBuilder filterBuilder,
@@ -195,6 +193,9 @@ public class ExportCommand extends CqlCommands {
 
   @Override
   protected Object executeWithSubject() throws Exception {
+    if (signer == null) {
+      signer = new DigitalSignature(security);
+    }
     Filter filter = getFilter();
     transformer =
         getServiceByFilter(

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/IngestCommand.java
@@ -256,9 +256,7 @@ public class IngestCommand extends CatalogCommands {
 
   private Optional<InputTransformer> transformer = null;
 
-  public IngestCommand() {
-    this.verifier = new DigitalSignature(security);
-  }
+  public IngestCommand() {}
 
   public IngestCommand(DigitalSignature verifier) {
     this.verifier = verifier;
@@ -266,6 +264,9 @@ public class IngestCommand extends CatalogCommands {
 
   @Override
   protected Object executeWithSubject() throws Exception {
+    if (this.verifier == null) {
+      this.verifier = new DigitalSignature(security);
+    }
     if (batchSize * multithreaded > MAX_QUEUE_SIZE) {
       throw new IngestException(
           String.format("batchsize * multithreaded cannot be larger than %d.", MAX_QUEUE_SIZE));


### PR DESCRIPTION

#### What does this PR do?
fixes commands that use Security interface

#### Who is reviewing it? 
anyone

#### How should this be tested?
Ensure catalog commands that use security work (eg, ingest)

#### Any background context you want to provide?
`@Reference` fields are not actually injected until _after_ object construction , so attempting to use them in the constructor means they will be null still. You must use them after object is init'ed.
#### What are the relevant tickets?
Fixes: #5893

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
