### PR TITLE
[2.20.x] DDF-5538 - Add InjectedAttributes to DynamicSchemaResolver field cache

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
@@ -214,6 +214,10 @@ public class DynamicSchemaResolver {
         .forEach(field -> dynamicSchemaResolver.fieldsCache.add(field));
   }
 
+  public void addAdditionalFields(List<AttributeDescriptor> additionalFields) {
+    additionalFields.stream().forEach(this::addToFieldsCache);
+  }
+
   @SuppressWarnings("WeakerAccess" /* access needed by blueprint */)
   public void addMetacardType(MetacardType metacardType) {
     metacardType.getAttributeDescriptors().forEach(this::addToFieldsCache);

--- a/catalog/solr/catalog-solr-provider/pom.xml
+++ b/catalog/solr/catalog-solr-provider/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>Saxon-HE</artifactId>
             <version>${lux.saxon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${osgi.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/solr/catalog-solr-provider/src/main/java/ddf/catalog/solr/provider/InjectedAttributeListener.java
+++ b/catalog/solr/catalog-solr-provider/src/main/java/ddf/catalog/solr/provider/InjectedAttributeListener.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.solr.provider;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeRegistry;
+import ddf.catalog.data.InjectableAttribute;
+import ddf.catalog.source.solr.DynamicSchemaResolver;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * OSGI <code>ServiceListener</code> implementation that listens for <code>InjectableAttribute
+ * </code>s that are registered in the OSGI service registry. Upon notification that a new attribute
+ * has been registered, this listener will update its <code>DynamicSchemaResolver</code> with the
+ * additional <code>AttributeDescriptor</code> that was added to the <code>AttributeRegistry</code>.
+ */
+public class InjectedAttributeListener implements ServiceListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InjectedAttributeListener.class);
+
+  private BundleContext context;
+  private DynamicSchemaResolver resolver;
+  private AttributeRegistry attributeRegistry;
+
+  public InjectedAttributeListener(
+      DynamicSchemaResolver resolver, AttributeRegistry attributeRegistry) {
+    this.resolver = resolver;
+    this.attributeRegistry = attributeRegistry;
+  }
+
+  public void init() {
+    Bundle bundle = FrameworkUtil.getBundle(this.getClass());
+    context = bundle.getBundleContext();
+    try {
+      String filter = "(objectClass=" + InjectableAttribute.class.getName() + ")";
+      context.addServiceListener(this, filter);
+
+      Collection<ServiceReference<InjectableAttribute>> alreadyRegistered =
+          context.getServiceReferences(InjectableAttribute.class, null);
+      alreadyRegistered
+          .stream()
+          .map(context::getService)
+          .filter(Objects::nonNull)
+          .map(InjectableAttribute::attribute)
+          .forEach(this::registerAttribute);
+    } catch (InvalidSyntaxException e) {
+      LOGGER.warn("Unable to register listener for injected attributes", e);
+    }
+  }
+
+  public void close() {
+    if (context != null) {
+      context.removeServiceListener(this);
+    }
+  }
+
+  public void serviceChanged(ServiceEvent event) {
+    ServiceReference serviceRef = event.getServiceReference();
+    Object service = context.getService(serviceRef);
+    if (service instanceof InjectableAttribute) {
+      if (event.getType() == ServiceEvent.REGISTERED) {
+        registerAttribute(((InjectableAttribute) service).attribute());
+      }
+    }
+  }
+
+  private void registerAttribute(String attributeName) {
+    Optional<AttributeDescriptor> descriptor = attributeRegistry.lookup(attributeName);
+    if (descriptor.isPresent()) {
+      AttributeDescriptor ad = descriptor.get();
+      LOGGER.debug(
+          "Registering attribute {} of type {}",
+          ad.getName(),
+          ad.getType().getAttributeFormat().name());
+      resolver.addAdditionalFields(Arrays.asList(ad));
+    }
+  }
+}

--- a/catalog/solr/catalog-solr-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/solr/catalog-solr-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,6 +20,15 @@
 
 	<bean id="dynamicSchemaResolver" class="ddf.catalog.source.solr.DynamicSchemaResolver"/>
 
+	<reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
+
+	<bean id="injectedAttributeListener"
+		  class="ddf.catalog.solr.provider.InjectedAttributeListener"
+		  init-method="init" destroy-method="close">
+		<argument ref="dynamicSchemaResolver"/>
+		<argument ref="attributeRegistry"/>
+	</bean>
+
 	<reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
 		<reference-listener bind-method="addMetacardType" ref="dynamicSchemaResolver"/>
 	</reference-list>


### PR DESCRIPTION
#### What does this PR do?
ABBREVIATED REVIEW 
Back port PR for DDF-5538 into 2.20.x
Original PR: #5807 

#### Who is reviewing it? 
@glenhein 
@rzwiefel 
@pklinef 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler 
@jlcsmith 

#### How should this be tested?
The original problem can be reproduced by first installing a master build. Add a json definition file to `etc/definitions` that will inject an attribute into any/all metacard types (e.g. `ext.alt-source`). Then, using the karaf console, run `catalog:search --cql '"ext.alt-source" IS NULL'`. You should see an exception in the logs with the message `Anonymous Field Property does not exist. ext.alt-source`.

With this PR, you should no longer see the exception.

#### Any background context you want to provide?

This is affecting downstream projects. Part of the issue was solved with #5536
This was fixed in the master branch but needs to be back ported to 2.20.x

#### What are the relevant tickets?
Fixes: #5538 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
