### PR TITLE
[2.23.x] DDF-UI-112 allow intersects query for line

### DIFF
--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
@@ -31,6 +31,7 @@ import org.geotools.temporal.object.DefaultInstant;
 import org.geotools.temporal.object.DefaultPeriodDuration;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
@@ -492,6 +493,9 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
       openSearchFilterVisitorObject.addGeometrySearch(polygon);
     } else if (geometryExpression instanceof MultiPolygon) {
       Geometry polygon = ((MultiPolygon) geometryExpression);
+      openSearchFilterVisitorObject.addGeometrySearch(polygon);
+    } else if (geometryExpression instanceof LineString) {
+      Geometry polygon = ((LineString) geometryExpression);
       openSearchFilterVisitorObject.addGeometrySearch(polygon);
     } else {
       LOGGER.debug("Unsupported filter constraint");

--- a/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
+++ b/catalog/opensearch/catalog-opensearch-source/src/main/java/org/codice/ddf/opensearch/source/OpenSearchFilterVisitor.java
@@ -32,6 +32,7 @@ import org.geotools.temporal.object.DefaultPeriodDuration;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
@@ -496,6 +497,9 @@ public class OpenSearchFilterVisitor extends DefaultFilterVisitor {
       openSearchFilterVisitorObject.addGeometrySearch(polygon);
     } else if (geometryExpression instanceof LineString) {
       Geometry polygon = ((LineString) geometryExpression);
+      openSearchFilterVisitorObject.addGeometrySearch(polygon);
+    } else if (geometryExpression instanceof MultiLineString) {
+      Geometry polygon = ((MultiLineString) geometryExpression);
       openSearchFilterVisitorObject.addGeometrySearch(polygon);
     } else {
       LOGGER.debug("Unsupported filter constraint");


### PR DESCRIPTION
Backend portion of the 2.23.x Forward-port of https://github.com/codice/ddf/pull/5889
_____________________________________________________________________
#### What does this PR do?
Allows a line to have a zero-buffer. Solves https://github.com/codice/ddf-ui/issues/112

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@hayleynorton @andrewzimmer @zta6 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@bdeining 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

- Advanced search - anyGeo
- Select Line
- Draw a line and verify that it doesn't automatically change the buffer width to 1
- Verify that you can search with nothing (and/or 0) in the buffer width input, and that the outgoing cql uses INTERSECTS instead of DWITHIN
- Verify that searching with a buffer width greater than 1 meter is allowed and that the outgoing cql uses DWITHIN
- Verify that searching with a buffer width of greater than 0 but less than 1 meter displays an inline error message "Buffer width must be 0 or at least 1 meter".  similar message should display when clicking search (the search should be prevented). Error message should change based on which units you have selected
- Verify no regression with Line searches

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes:  https://github.com/codice/ddf-ui/issues/112

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
