### PR TITLE
[2.20.x] DDF-5907 - Fix Spellcheck Showing Results For capability

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -269,8 +269,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
             totalHits = docs.getNumFound();
             addDocsToResults(docs, results);
 
-            List<String> originals = new ArrayList<>();
-            List<String> corrections = new ArrayList<>();
+            Set<String> originals = new HashSet<>();
+            Set<String> corrections = new HashSet<>();
             collation
                 .getMisspellingsAndCorrections()
                 .stream()

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -260,7 +260,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         addDocsToResults(docs, results);
 
         if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
-          Collation collation = findQueryToResend(query, solrResponse);
+          Collation collation = getCollationToResend(query, solrResponse);
           query.set("q", collation.getCollationQueryString());
           QueryResponse solrResponseRequery = client.query(query, METHOD.POST);
           docs = solrResponseRequery.getResults();
@@ -315,7 +315,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         && CollectionUtils.isNotEmpty(solrResponse.getSpellCheckResponse().getCollatedResults());
   }
 
-  private Collation findQueryToResend(SolrQuery query, QueryResponse solrResponse) {
+  private Collation getCollationToResend(SolrQuery query, QueryResponse solrResponse) {
     long maxHits = Integer.MIN_VALUE;
     Collation bestCollation = null;
     for (Collation collation : solrResponse.getSpellCheckResponse().getCollatedResults()) {

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -279,8 +279,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
                       originals.add(correction.getOriginal());
                       corrections.add(correction.getCorrection());
                     });
-            responseProps.put(DID_YOU_MEAN_KEY, (Serializable) originals);
-            responseProps.put(SHOWING_RESULTS_FOR_KEY, (Serializable) corrections);
+            responseProps.put(DID_YOU_MEAN_KEY, new ArrayList<>(originals));
+            responseProps.put(SHOWING_RESULTS_FOR_KEY, new ArrayList<>(corrections));
           }
         }
       }

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -260,7 +260,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         addDocsToResults(docs, results);
 
         if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
-          query.set("q", findQueryToResend(query, solrResponse));
+          Collation collation = findQueryToResend(query, solrResponse);
+          query.set("q", collation.getCollationQueryString());
           QueryResponse solrResponseRequery = client.query(query, METHOD.POST);
           docs = solrResponseRequery.getResults();
           if (docs != null && docs.size() > originalQueryResultsSize) {
@@ -268,11 +269,18 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
             totalHits = docs.getNumFound();
             addDocsToResults(docs, results);
 
-            responseProps.put(
-                DID_YOU_MEAN_KEY, (Serializable) getSearchTermFieldValues(solrResponse));
-            responseProps.put(
-                SHOWING_RESULTS_FOR_KEY,
-                (Serializable) getSearchTermFieldValues(solrResponseRequery));
+            List<String> originals = new ArrayList<>();
+            List<String> corrections = new ArrayList<>();
+            collation
+                .getMisspellingsAndCorrections()
+                .stream()
+                .forEach(
+                    correction -> {
+                      originals.add(correction.getOriginal());
+                      corrections.add(correction.getCorrection());
+                    });
+            responseProps.put(DID_YOU_MEAN_KEY, (Serializable) originals);
+            responseProps.put(SHOWING_RESULTS_FOR_KEY, (Serializable) corrections);
           }
         }
       }
@@ -294,16 +302,6 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     return new SourceResponseImpl(request, responseProps, results, totalHits);
   }
 
-  private List<String> getSearchTermFieldValues(QueryResponse solrResponse) {
-    Set<String> fieldValues = solrResponse.getSpellCheckResponse().getSuggestionMap().keySet();
-    removeResourceFieldValue(fieldValues);
-    return new ArrayList<>(fieldValues);
-  }
-
-  private void removeResourceFieldValue(Set<String> fieldValues) {
-    fieldValues.remove(RESOURCE_ATTRIBUTE);
-  }
-
   private Boolean userSpellcheckIsOn(QueryRequest request) {
     Boolean userSpellcheckChoice = false;
     if (request.getProperties().get("spellcheck") != null) {
@@ -317,16 +315,16 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         && CollectionUtils.isNotEmpty(solrResponse.getSpellCheckResponse().getCollatedResults());
   }
 
-  private String findQueryToResend(SolrQuery query, QueryResponse solrResponse) {
+  private Collation findQueryToResend(SolrQuery query, QueryResponse solrResponse) {
     long maxHits = Integer.MIN_VALUE;
-    String queryToResend = query.get("q");
+    Collation bestCollation = null;
     for (Collation collation : solrResponse.getSpellCheckResponse().getCollatedResults()) {
       if (maxHits < collation.getNumberOfHits()) {
         maxHits = collation.getNumberOfHits();
-        queryToResend = collation.getCollationQueryString();
+        bestCollation = collation;
       }
     }
-    return queryToResend;
+    return bestCollation;
   }
 
   private void addDocsToResults(SolrDocumentList docs, List<Result> results)


### PR DESCRIPTION
#### What does this PR do?
Fixes the bug where enabling spellcheck causes a NullPointerException due to missing spellcheck response in the modified query.
#### Who is reviewing it? 
@cantstoptheunk 
@bellcc 
@pklinef 

#### Select relevant component teams: 
@codice/solr 


#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith 
@andrewkfiedler 

#### How should this be tested?
1. After full build and install, enable spellcheck in the admin console
2. Build the spellcheck dictionary index in Solr
3. Upload some data
4. Create a search that enables spellcheck and search for an incorrectly spelled word
5. Assuming the misspelled word provides a spellcheck hit:
  a) In the logs, there should no longer be a NullPointerException
  b) The "Did you mean" and "Showing results for" capability on the UI will be populated

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5907 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
