### PR TITLE
DDF-5907 - Fix spellcheck Showing Results For

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -260,7 +260,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         addDocsToResults(docs, results);
 
         if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
-          Collation collation = findQueryToResend(query, solrResponse);
+          Collation collation = getCollationToResend(query, solrResponse);
           query.set("q", collation.getCollationQueryString());
           query.set("spellcheck", false);
           QueryResponse solrResponseRequery = client.query(query, METHOD.POST);
@@ -316,7 +316,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         && CollectionUtils.isNotEmpty(solrResponse.getSpellCheckResponse().getCollatedResults());
   }
 
-  private Collation findQueryToResend(SolrQuery query, QueryResponse solrResponse) {
+  private Collation getCollationToResend(SolrQuery query, QueryResponse solrResponse) {
     long maxHits = Integer.MIN_VALUE;
     Collation bestCollation = null;
     for (Collation collation : solrResponse.getSpellCheckResponse().getCollatedResults()) {

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -280,8 +280,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
                       originals.add(correction.getOriginal());
                       corrections.add(correction.getCorrection());
                     });
-            responseProps.put(DID_YOU_MEAN_KEY, (Serializable) originals);
-            responseProps.put(SHOWING_RESULTS_FOR_KEY, (Serializable) corrections);
+            responseProps.put(DID_YOU_MEAN_KEY, new ArrayList<>(originals));
+            responseProps.put(SHOWING_RESULTS_FOR_KEY, new ArrayList<>(corrections));
           }
         }
       }

--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -270,8 +270,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
             totalHits = docs.getNumFound();
             addDocsToResults(docs, results);
 
-            List<String> originals = new ArrayList<>();
-            List<String> corrections = new ArrayList<>();
+            Set<String> originals = new HashSet<>();
+            Set<String> corrections = new HashSet<>();
             collation
                 .getMisspellingsAndCorrections()
                 .stream()


### PR DESCRIPTION
#### What does this PR do?
Fixes the bug where enabling spellcheck causes a NullPointerException due to missing spellcheck response in the modified query.
#### Who is reviewing it? 
@cantstoptheunk
@bellcc
@pklinef

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith
@andrewkfiedler

#### How should this be tested?
1. After full build and install, enable spellcheck in the admin console
2. Build the spellcheck dictionary index in Solr
3. Upload some data
4. Create a search that enables spellcheck and search for an incorrectly spelled word
5. Assuming the misspelled word provides a spellcheck hit:
  a) In the logs, there should no longer be a NullPointerException 
  b) The "Did you mean" and "Showing results for" capability on the UI will be populated

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5907 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
