### PR TITLE
[2.21.x] Update policies and interceptors

### DIFF
--- a/catalog/security/catalog-security-policyplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/security/catalog-security-policyplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,22 +18,22 @@
                                update-strategy="container-managed" />
         <property name="createPermissions">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
         <property name="updatePermissions">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
         <property name="deletePermissions">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
         <property name="readPermissions">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
     </bean>

--- a/catalog/security/catalog-security-policyplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/security/catalog-security-policyplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,22 +18,22 @@
                                update-strategy="container-managed" />
         <property name="createPermissions">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
         <property name="updatePermissions">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
         <property name="deletePermissions">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
         <property name="readPermissions">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
     </bean>

--- a/catalog/security/catalog-security-policyplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/security/catalog-security-policyplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -16,6 +16,7 @@
     <bean id="ingestPlugin" class="org.codice.ddf.catalog.security.CatalogPolicy">
         <cm:managed-properties persistent-id="org.codice.ddf.catalog.security.CatalogPolicy"
                                update-strategy="container-managed" />
+        <!-- An empty value on permissions so there are no restrictions on who can perform the operations -->
         <property name="createPermissions">
             <array>
                 <value></value>

--- a/catalog/security/catalog-security-policyplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/security/catalog-security-policyplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -19,19 +19,19 @@
 
         <AD description="Roles/attributes required for the create operations. Example: role=role1,role2"
             name="Create Required Attributes" id="createPermissions" required="true" type="String" cardinality="1000"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+            default=""/>
 
         <AD description="Roles/attributes required for the update operation. Example: role=role1,role2"
             name="Update Required Attributes" id="updatePermissions" required="true" type="String" cardinality="1000"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+            default=""/>
 
         <AD description="Roles/attributes required for the delete operation. Example: role=role1,role2"
             name="Delete Required Attributes" id="deletePermissions" required="true" type="String" cardinality="1000"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+            default=""/>
 
         <AD description="Roles/attributes required for the read operations (query and resource). Example: role=role1,role2"
             name="Read Required Attributes" id="readPermissions" required="true" type="String" cardinality="1000"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+            default=""/>
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.security.CatalogPolicy">

--- a/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,12 +20,12 @@
                 update-strategy="container-managed"/>
         <property name="createPermissions">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
         <property name="updatePermissions">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
     </bean>

--- a/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,6 +18,7 @@
         <cm:managed-properties
                 persistent-id="org.codice.ddf.catalog.security.ResourceUriPolicy"
                 update-strategy="container-managed"/>
+        <!-- An empty value on permissions so there are no restrictions on who can perform the operations -->
         <property name="createPermissions">
             <array>
                 <value></value>

--- a/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,12 +20,12 @@
                 update-strategy="container-managed"/>
         <property name="createPermissions">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
         <property name="updatePermissions">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
     </bean>

--- a/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -20,12 +20,12 @@
         <AD description="Allow users to provide a resource URI when creating a metacard"
             name="Permit Resource URI on Creation" id="createPermissions" required="true"
             type="String" cardinality="1000"
-            default=""/>/>
+            default=""/>
 
         <AD description="Allow users to provide a resource URI when updating a metacard"
             name="Permit Resource URI on Update" id="updatePermissions" required="true"
             type="String" cardinality="1000"
-            default=""/>/>
+            default=""/>
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.security.ResourceUriPolicy">

--- a/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/security/catalog-security-resourceplugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -20,12 +20,12 @@
         <AD description="Allow users to provide a resource URI when creating a metacard"
             name="Permit Resource URI on Creation" id="createPermissions" required="true"
             type="String" cardinality="1000"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>/>
+            default=""/>/>
 
         <AD description="Allow users to provide a resource URI when updating a metacard"
             name="Permit Resource URI on Update" id="updatePermissions" required="true"
             type="String" cardinality="1000"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>/>
+            default=""/>/>
     </OCD>
 
     <Designate pid="org.codice.ddf.catalog.security.ResourceUriPolicy">

--- a/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,22 +26,22 @@
         </property>
         <property name="createAccessPolicyStrings">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
         <property name="updateAccessPolicyStrings">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
         <property name="deleteAccessPolicyStrings">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
         <property name="readAccessPolicyStrings">
             <array>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest</value>
+                <value>""</value>
             </array>
         </property>
     </bean>

--- a/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,6 +24,7 @@
                 </value>
             </array>
         </property>
+        <!-- An empty value on access policies so there are no restrictions on who can perform the operations -->
         <property name="createAccessPolicyStrings">
             <array>
                 <value></value>

--- a/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,22 +26,22 @@
         </property>
         <property name="createAccessPolicyStrings">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
         <property name="updateAccessPolicyStrings">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
         <property name="deleteAccessPolicyStrings">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
         <property name="readAccessPolicyStrings">
             <array>
-                <value>""</value>
+                <value></value>
             </array>
         </property>
     </bean>

--- a/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-policy-plugin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -20,22 +20,22 @@
         <AD description="Roles/attributes required for create operations on registry entries. Example: {role=role1;type=type1}"
             name="Registry Create Attributes" id="createAccessPolicyStrings" required="true"
             type="String" cardinality="100"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+            default=""/>
 
         <AD description="Roles/attributes required for update operations on registry entries. Example: {role=role1;type=type1}"
             name="Registry Update Attributes" id="updateAccessPolicyStrings" required="true"
             type="String" cardinality="100"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+            default=""/>
 
         <AD description="Roles/attributes required for delete operations on registry entries. Example: {role=role1;type=type1}"
             name="Registry Delete Attributes" id="deleteAccessPolicyStrings" required="true"
             type="String" cardinality="100"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+            default=""/>
 
         <AD description="Roles/attributes required for reading registry entries. Example: {role=role1;type=type1}"
             name="Registry Read Attributes" id="readAccessPolicyStrings" required="true"
             type="String" cardinality="100"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=guest"/>
+            default=""/>
 
         <AD description="Roles/attributes required for an admin to bypass all filtering/access controls. Example: {role=role1;type=type1}"
             name="Registry Admin Attributes" id="registryBypassPolicyStrings" required="true"

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorActionsTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorActionsTest.java
@@ -15,6 +15,7 @@ package ddf.security.pep.interceptor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -63,9 +64,7 @@ public class PepInterceptorActionsTest {
 
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getToken()).thenReturn(mockSecurityToken);
-    when(mockSecurityToken.getToken()).thenReturn(null);
-
-    when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+    when(mockSecurityManager.getSubject(any())).thenReturn(mockSubject);
 
     QName op = new QName("urn:catalog:query", "search", "ns1");
     QName port = new QName("urn:catalog:query", "query-port", "ns1");
@@ -106,9 +105,7 @@ public class PepInterceptorActionsTest {
 
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getToken()).thenReturn(mockSecurityToken);
-    when(mockSecurityToken.getToken()).thenReturn(null);
-
-    when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+    when(mockSecurityManager.getSubject(any())).thenReturn(mockSubject);
 
     QName op = new QName("http://catalog/query/", "Search", "ns1");
     QName port = new QName("http://catalog/query/", "QueryPort", "ns1");
@@ -149,9 +146,7 @@ public class PepInterceptorActionsTest {
 
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getToken()).thenReturn(mockSecurityToken);
-    when(mockSecurityToken.getToken()).thenReturn(null);
-
-    when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+    when(mockSecurityManager.getSubject(any())).thenReturn(mockSubject);
 
     MessageInfo mockMessageInfo = mock(MessageInfo.class);
     when(messageWithAction.get(MessageInfo.class.getName())).thenReturn(mockMessageInfo);
@@ -187,9 +182,7 @@ public class PepInterceptorActionsTest {
 
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getToken()).thenReturn(mockSecurityToken);
-    when(mockSecurityToken.getToken()).thenReturn(null);
-
-    when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+    when(mockSecurityManager.getSubject(any())).thenReturn(mockSubject);
 
     Exchange mockExchange = mock(Exchange.class);
     BindingOperationInfo mockBOI = mock(BindingOperationInfo.class);
@@ -227,9 +220,7 @@ public class PepInterceptorActionsTest {
 
     // SecurityLogger is already stubbed out
     when(mockSecurityAssertion.getToken()).thenReturn(mockSecurityToken);
-    when(mockSecurityToken.getToken()).thenReturn(null);
-
-    when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+    when(mockSecurityManager.getSubject(any())).thenReturn(mockSubject);
 
     Exchange mockExchange = mock(Exchange.class);
     BindingOperationInfo mockBOI = mock(BindingOperationInfo.class);

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
@@ -30,7 +30,6 @@ import org.apache.cxf.binding.soap.model.SoapOperationInfo;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.model.BindingOperationInfo;
-import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.codice.ddf.security.handler.api.SessionToken;
 import org.junit.Test;
 

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
@@ -14,6 +14,7 @@
 package ddf.security.pep.interceptor;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -30,6 +31,7 @@ import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.codice.ddf.security.handler.api.SessionToken;
 import org.junit.Test;
 
 public class PepInterceptorValidSubjectTest {
@@ -44,15 +46,12 @@ public class PepInterceptorValidSubjectTest {
     interceptor.setSecurityManager(mockSecurityManager);
 
     Message messageWithValidSecurityAssertion = mock(Message.class);
-    SecurityToken mockSecurityToken = mock(SecurityToken.class);
+    SessionToken mockSecurityToken = mock(SessionToken.class);
     Subject mockSubject = mock(Subject.class);
     assertNotNull(mockSecurityAssertion);
 
     // SecurityLogger is already stubbed out
-    when(mockSecurityAssertion.getToken()).thenReturn(mockSecurityToken);
-    when(mockSecurityToken.getToken()).thenReturn(null);
-
-    when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+    when(mockSecurityManager.getSubject(any())).thenReturn(mockSubject);
 
     QName op = new QName("urn:catalog:query", "search", "ns1");
     QName port = new QName("urn:catalog:query", "query-port", "ns1");

--- a/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
+++ b/platform/security/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/PepInterceptorValidSubjectTest.java
@@ -50,6 +50,7 @@ public class PepInterceptorValidSubjectTest {
     assertNotNull(mockSecurityAssertion);
 
     // SecurityLogger is already stubbed out
+    when(mockSecurityAssertion.getToken()).thenReturn(mockSecurityToken);
     when(mockSecurityManager.getSubject(any())).thenReturn(mockSubject);
 
     QName op = new QName("urn:catalog:query", "search", "ns1");


### PR DESCRIPTION
#### What does this PR do?
This PR removes the requirement for a guest user to be able to do CRUD operations, as well as changes to the PEPAuthInterceptor that allow for SessionToken creation for requests that do not have an authentication token.

#### Who is reviewing it? 
@rfding 
@mdang8 
@josephthweatt 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard
@stustison

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
