### PR TITLE
DDF-5920 Allows non-resource metacards to be restored

### DIFF
--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
@@ -226,11 +226,13 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
             source, getMetacardTypeBinary(source).orElseThrow(cannotDeserializeException));
     result.setId(id);
     result.setTags(getVersionTags(source));
-    try {
-      result.setResourceURI(
-          new URI(String.valueOf(source.getAttribute(VERSIONED_RESOURCE_URI).getValue())));
-    } catch (URISyntaxException e) {
-      LOGGER.debug("Could not replace the versioned resource URI, It might not be valid", e);
+    if (source.getAttribute(VERSIONED_RESOURCE_URI) != null) {
+      try {
+        result.setResourceURI(
+            new URI(String.valueOf(source.getAttribute(VERSIONED_RESOURCE_URI).getValue())));
+      } catch (URISyntaxException e) {
+        LOGGER.debug("Could not replace the versioned resource URI, It might not be valid", e);
+      }
     }
 
     sanitizeVersionAttributes(result);


### PR DESCRIPTION
#### What does this PR do?
Adds in a null check that breaks if a metacard isn't a resource (for example: it's a workspace)

#### Who is reviewing it? 
@rzwiefel @andrewkfiedler 

#### How should this be tested?
Verify that reverting resource metacards still work.


#### What are the relevant tickets?
Fixes: #5920 

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
