### PR TITLE
[2.23.x] DDF-5920 Allows non-resource metacards to be restored

### DIFF
--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/MetacardVersionImpl.java
@@ -226,11 +226,13 @@ public class MetacardVersionImpl extends MetacardImpl implements MetacardVersion
             source, getMetacardTypeBinary(source).orElseThrow(cannotDeserializeException));
     result.setId(id);
     result.setTags(getVersionTags(source));
-    try {
-      result.setResourceURI(
-          new URI(String.valueOf(source.getAttribute(VERSIONED_RESOURCE_URI).getValue())));
-    } catch (URISyntaxException e) {
-      LOGGER.debug("Could not replace the versioned resource URI, It might not be valid", e);
+    if (source.getAttribute(VERSIONED_RESOURCE_URI) != null) {
+      try {
+        result.setResourceURI(
+            new URI(String.valueOf(source.getAttribute(VERSIONED_RESOURCE_URI).getValue())));
+      } catch (URISyntaxException e) {
+        LOGGER.debug("Could not replace the versioned resource URI, It might not be valid", e);
+      }
     }
 
     sanitizeVersionAttributes(result);


### PR DESCRIPTION
Backport of: https://github.com/codice/ddf/pull/5921
@andrewkfiedler @rzwiefel 
@jordanwilking @stevenmalmgren 