### PR TITLE
[2.19.x] DDF-UI-131 allow for customization of how 2D map pans to results

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -15,6 +15,7 @@
 /* global require, window */
 
 import wrapNum from '../../../../react-component/utils/wrap-num/wrap-num.tsx'
+import plugin from 'plugins/map.openlayers.js'
 
 const $ = require('jquery')
 const _ = require('underscore')
@@ -94,148 +95,168 @@ function offMap([longitude, latitude]) {
   return latitude < -90 || latitude > 90
 }
 
-module.exports = function OpenlayersMap(
-  insertionElement,
-  selectionInterface,
-  notificationEl,
-  componentElement,
-  mapModel,
-  cameraOptions
-) {
-  let overlays = {}
-  let shapes = []
-  const map = createMap(
+// The extension argument is a function used in panToExtent
+// It allows for customization of the way the map pans to results
+const OpenlayersMap = extension =>
+  function(
     insertionElement,
-    cameraOptions && cameraOptions.openlayers
-  )
-  listenToResize()
-  setupTooltip(map)
-  const drawingTools = setupDrawingTools(map)
+    selectionInterface,
+    notificationEl,
+    componentElement,
+    mapModel,
+    cameraOptions
+  ) {
+    let overlays = {}
+    let shapes = []
+    const map = createMap(
+      insertionElement,
+      cameraOptions && cameraOptions.openlayers
+    )
+    listenToResize()
+    setupTooltip(map)
+    const drawingTools = setupDrawingTools(map)
 
-  function setupTooltip(map) {
-    map.on('pointermove', e => {
-      const point = unconvertPointCoordinate(e.coordinate)
-      if (!offMap(point)) {
-        mapModel.updateMouseCoordinates({
-          lat: point[1],
-          lon: point[0],
-        })
-      } else {
-        mapModel.clearMouseCoordinates()
-      }
-    })
-  }
-
-  function setupDrawingTools(map) {
-    return {
-      bbox: new DrawBBox.Controller({
-        map,
-        notificationEl,
-      }),
-      circle: new DrawCircle.Controller({
-        map,
-        notificationEl,
-      }),
-      polygon: new DrawPolygon.Controller({
-        map,
-        notificationEl,
-      }),
-      line: new DrawLine.Controller({
-        map,
-        notificationEl,
-      }),
+    function setupTooltip(map) {
+      map.on('pointermove', e => {
+        const point = unconvertPointCoordinate(e.coordinate)
+        if (!offMap(point)) {
+          mapModel.updateMouseCoordinates({
+            lat: point[1],
+            lon: point[0],
+          })
+        } else {
+          mapModel.clearMouseCoordinates()
+        }
+      })
     }
-  }
 
-  function resizeMap() {
-    map.updateSize()
-  }
-
-  function listenToResize() {
-    wreqr.vent.on('resize', resizeMap)
-  }
-
-  function unlistenToResize() {
-    wreqr.vent.off('resize', resizeMap)
-  }
-
-  const exposedMethods = _.extend({}, Map, {
-    drawLine(model) {
-      drawingTools.line.draw(model)
-    },
-    drawBbox(model) {
-      drawingTools.bbox.draw(model)
-    },
-    drawCircle(model) {
-      drawingTools.circle.draw(model)
-    },
-    drawPolygon(model) {
-      drawingTools.polygon.draw(model)
-    },
-    destroyDrawingTools() {
-      drawingTools.line.destroy()
-      drawingTools.polygon.destroy()
-      drawingTools.circle.destroy()
-      drawingTools.bbox.destroy()
-    },
-    onLeftClick(callback) {
-      $(map.getTargetElement()).on('click', e => {
-        const boundingRect = map.getTargetElement().getBoundingClientRect()
-        callback(e, {
-          mapTarget: determineIdFromPosition(
-            [e.clientX - boundingRect.left, e.clientY - boundingRect.top],
-            map
-          ),
-        })
-      })
-    },
-    onRightClick(callback) {
-      $(map.getTargetElement()).on('contextmenu', e => {
-        callback(e)
-      })
-    },
-    onMouseMove(callback) {
-      $(map.getTargetElement()).on('mousemove', e => {
-        const boundingRect = map.getTargetElement().getBoundingClientRect()
-        callback(e, {
-          mapTarget: determineIdFromPosition(
-            [e.clientX - boundingRect.left, e.clientY - boundingRect.top],
-            map
-          ),
-        })
-      })
-    },
-    onCameraMoveStart(callback) {
-      map.on('movestart', callback)
-    },
-    onCameraMoveEnd(callback) {
-      map.on('moveend', callback)
-    },
-    doPanZoom(coords) {
-      const that = this
-      that.zoomOut({ duration: 1000 }, () => {
-        setTimeout(() => {
-          that.zoomToExtent(coords, { duration: 2000 })
-        }, 0)
-      })
-    },
-    zoomOut(opts, next) {
-      next()
-    },
-    zoomToSelected() {
-      if (selectionInterface.getSelectedResults().length === 1) {
-        this.panToResults(selectionInterface.getSelectedResults())
+    function setupDrawingTools(map) {
+      return {
+        bbox: new DrawBBox.Controller({
+          map,
+          notificationEl,
+        }),
+        circle: new DrawCircle.Controller({
+          map,
+          notificationEl,
+        }),
+        polygon: new DrawPolygon.Controller({
+          map,
+          notificationEl,
+        }),
+        line: new DrawLine.Controller({
+          map,
+          notificationEl,
+        }),
       }
-    },
-    panToResults(results) {
-      const coordinates = _.flatten(
-        results.map(result => result.getPoints()),
-        true
-      )
-      this.panToExtent(coordinates)
-    },
-    panToExtent(coords) {
-      if (coords.constructor === Array && coords.length > 0) {
+    }
+
+    function resizeMap() {
+      map.updateSize()
+    }
+
+    function listenToResize() {
+      wreqr.vent.on('resize', resizeMap)
+    }
+
+    function unlistenToResize() {
+      wreqr.vent.off('resize', resizeMap)
+    }
+
+    const exposedMethods = _.extend({}, Map, {
+      drawLine(model) {
+        drawingTools.line.draw(model)
+      },
+      drawBbox(model) {
+        drawingTools.bbox.draw(model)
+      },
+      drawCircle(model) {
+        drawingTools.circle.draw(model)
+      },
+      drawPolygon(model) {
+        drawingTools.polygon.draw(model)
+      },
+      destroyDrawingTools() {
+        drawingTools.line.destroy()
+        drawingTools.polygon.destroy()
+        drawingTools.circle.destroy()
+        drawingTools.bbox.destroy()
+      },
+      onLeftClick(callback) {
+        $(map.getTargetElement()).on('click', e => {
+          const boundingRect = map.getTargetElement().getBoundingClientRect()
+          callback(e, {
+            mapTarget: determineIdFromPosition(
+              [e.clientX - boundingRect.left, e.clientY - boundingRect.top],
+              map
+            ),
+          })
+        })
+      },
+      onRightClick(callback) {
+        $(map.getTargetElement()).on('contextmenu', e => {
+          callback(e)
+        })
+      },
+      onMouseMove(callback) {
+        $(map.getTargetElement()).on('mousemove', e => {
+          const boundingRect = map.getTargetElement().getBoundingClientRect()
+          callback(e, {
+            mapTarget: determineIdFromPosition(
+              [e.clientX - boundingRect.left, e.clientY - boundingRect.top],
+              map
+            ),
+          })
+        })
+      },
+      onCameraMoveStart(callback) {
+        map.on('movestart', callback)
+      },
+      onCameraMoveEnd(callback) {
+        map.on('moveend', callback)
+      },
+      doPanZoom(coords) {
+        const that = this
+        that.zoomOut({ duration: 1000 }, () => {
+          setTimeout(() => {
+            that.zoomToExtent(coords, { duration: 2000 })
+          }, 0)
+        })
+      },
+      zoomOut(opts, next) {
+        next()
+      },
+      zoomToSelected() {
+        if (selectionInterface.getSelectedResults().length === 1) {
+          this.panToResults(selectionInterface.getSelectedResults())
+        }
+      },
+      panToResults(results) {
+        const coordinates = _.flatten(
+          results.map(result => result.getPoints()),
+          true
+        )
+        this.panToExtent(coordinates)
+      },
+      panToExtent(coords) {
+        if (coords.constructor === Array && coords.length > 0) {
+          const lineObject = coords.map(coordinate =>
+            convertPointCoordinate(coordinate)
+          )
+
+          const extent =
+            extension && extension instanceof Function
+              ? extension(Openlayers.extent.boundingExtent(lineObject), map)
+              : Openlayers.extent.boundingExtent(lineObject)
+
+          map.getView().fit(extent, {
+            size: map.getSize(),
+            maxZoom: map.getView().getZoom(),
+            duration: 500,
+          })
+        }
+      },
+      zoomToExtent(coords, opts = {}) {
         const lineObject = coords.map(coordinate =>
           convertPointCoordinate(coordinate)
         )
@@ -244,435 +265,419 @@ module.exports = function OpenlayersMap(
 
         map.getView().fit(extent, {
           size: map.getSize(),
-          maxZoom: map.getView().getZoom(),
           duration: 500,
+          ...opts,
         })
-      }
-    },
-    zoomToExtent(coords, opts = {}) {
-      const lineObject = coords.map(coordinate =>
-        convertPointCoordinate(coordinate)
-      )
-
-      const extent = Openlayers.extent.boundingExtent(lineObject)
-
-      map.getView().fit(extent, {
-        size: map.getSize(),
-        duration: 500,
-        ...opts,
-      })
-    },
-    zoomToBoundingBox({ north, east, south, west }) {
-      this.zoomToExtent([[west, south], [east, north]])
-    },
-    limit(value, min, max) {
-      return Math.min(Math.max(value, min), max)
-    },
-    getBoundingBox() {
-      const extent = map.getView().calculateExtent(map.getSize())
-      let longitudeEast = wrapNum(extent[2], -180, 180)
-      const longitudeWest = wrapNum(extent[0], -180, 180)
-      //add 360 degrees to longitudeEast to accommodate bounding boxes that span across the anti-meridian
-      if (longitudeEast < longitudeWest) {
-        longitudeEast += 360
-      }
-      return {
-        north: this.limit(extent[3], -90, 90),
-        east: longitudeEast,
-        south: this.limit(extent[1], -90, 90),
-        west: longitudeWest,
-      }
-    },
-    overlayImage(model) {
-      const metacardId = model.get('properties').get('id')
-      this.removeOverlay(metacardId)
-
-      const coords = model.getPoints('location')
-      const array = _.map(coords, coord => convertPointCoordinate(coord))
-
-      const polygon = new Openlayers.geom.Polygon([array])
-      const extent = polygon.getExtent()
-      const projection = Openlayers.proj.get(properties.projection)
-
-      const overlayLayer = new Openlayers.layer.Image({
-        source: new Openlayers.source.ImageStatic({
-          url: model.get('currentOverlayUrl'),
-          projection,
-          imageExtent: extent,
-        }),
-      })
-
-      map.addLayer(overlayLayer)
-      overlays[metacardId] = overlayLayer
-    },
-    removeOverlay(metacardId) {
-      if (overlays[metacardId]) {
-        map.removeLayer(overlays[metacardId])
-        delete overlays[metacardId]
-      }
-    },
-    removeAllOverlays() {
-      for (const overlay in overlays) {
-        if (overlays.hasOwnProperty(overlay)) {
-          map.removeLayer(overlays[overlay])
+      },
+      zoomToBoundingBox({ north, east, south, west }) {
+        this.zoomToExtent([[west, south], [east, north]])
+      },
+      limit(value, min, max) {
+        return Math.min(Math.max(value, min), max)
+      },
+      getBoundingBox() {
+        const extent = map.getView().calculateExtent(map.getSize())
+        let longitudeEast = wrapNum(extent[2], -180, 180)
+        const longitudeWest = wrapNum(extent[0], -180, 180)
+        //add 360 degrees to longitudeEast to accommodate bounding boxes that span across the anti-meridian
+        if (longitudeEast < longitudeWest) {
+          longitudeEast += 360
         }
-      }
-      overlays = {}
-    },
-    getCartographicCenterOfClusterInDegrees(cluster) {
-      return utility.calculateCartographicCenterOfGeometriesInDegrees(
-        cluster.get('results').map(result => result)
-      )
-    },
-    getWindowLocationsOfResults(results) {
-      return results.map(result => {
-        const openlayersCenterOfGeometry = utility.calculateOpenlayersCenterOfGeometry(
-          result
+        return {
+          north: this.limit(extent[3], -90, 90),
+          east: longitudeEast,
+          south: this.limit(extent[1], -90, 90),
+          west: longitudeWest,
+        }
+      },
+      overlayImage(model) {
+        const metacardId = model.get('properties').get('id')
+        this.removeOverlay(metacardId)
+
+        const coords = model.getPoints('location')
+        const array = _.map(coords, coord => convertPointCoordinate(coord))
+
+        const polygon = new Openlayers.geom.Polygon([array])
+        const extent = polygon.getExtent()
+        const projection = Openlayers.proj.get(properties.projection)
+
+        const overlayLayer = new Openlayers.layer.Image({
+          source: new Openlayers.source.ImageStatic({
+            url: model.get('currentOverlayUrl'),
+            projection,
+            imageExtent: extent,
+          }),
+        })
+
+        map.addLayer(overlayLayer)
+        overlays[metacardId] = overlayLayer
+      },
+      removeOverlay(metacardId) {
+        if (overlays[metacardId]) {
+          map.removeLayer(overlays[metacardId])
+          delete overlays[metacardId]
+        }
+      },
+      removeAllOverlays() {
+        for (const overlay in overlays) {
+          if (overlays.hasOwnProperty(overlay)) {
+            map.removeLayer(overlays[overlay])
+          }
+        }
+        overlays = {}
+      },
+      getCartographicCenterOfClusterInDegrees(cluster) {
+        return utility.calculateCartographicCenterOfGeometriesInDegrees(
+          cluster.get('results').map(result => result)
         )
-        const center = map.getPixelFromCoordinate(openlayersCenterOfGeometry)
-        if (center) {
-          return center
-        } else {
-          return undefined
-        }
-      })
-    },
-    /*
+      },
+      getWindowLocationsOfResults(results) {
+        return results.map(result => {
+          const openlayersCenterOfGeometry = utility.calculateOpenlayersCenterOfGeometry(
+            result
+          )
+          const center = map.getPixelFromCoordinate(openlayersCenterOfGeometry)
+          if (center) {
+            return center
+          } else {
+            return undefined
+          }
+        })
+      },
+      /*
             Adds a billboard point utilizing the passed in point and options.
             Options are a view to relate to, and an id, and a color.
         */
-    addPointWithText(point, options) {
-      const pointObject = convertPointCoordinate(point)
-      const feature = new Openlayers.Feature({
-        geometry: new Openlayers.geom.Point(pointObject),
-      })
-      feature.setId(options.id)
-
-      feature.setStyle(
-        new Openlayers.style.Style({
-          image: new Openlayers.style.Icon({
-            img: DrawingUtility.getCircleWithText({
-              fillColor: options.color,
-              text: options.id.length,
-            }),
-            imgSize: [44, 44],
-          }),
+      addPointWithText(point, options) {
+        const pointObject = convertPointCoordinate(point)
+        const feature = new Openlayers.Feature({
+          geometry: new Openlayers.geom.Point(pointObject),
         })
-      )
+        feature.setId(options.id)
 
-      const vectorSource = new Openlayers.source.Vector({
-        features: [feature],
-      })
+        feature.setStyle(
+          new Openlayers.style.Style({
+            image: new Openlayers.style.Icon({
+              img: DrawingUtility.getCircleWithText({
+                fillColor: options.color,
+                text: options.id.length,
+              }),
+              imgSize: [44, 44],
+            }),
+          })
+        )
 
-      const vectorLayer = new Openlayers.layer.Vector({
-        source: vectorSource,
-        zIndex: 1,
-      })
+        const vectorSource = new Openlayers.source.Vector({
+          features: [feature],
+        })
 
-      map.addLayer(vectorLayer)
+        const vectorLayer = new Openlayers.layer.Vector({
+          source: vectorSource,
+          zIndex: 1,
+        })
 
-      return vectorLayer
-    },
-    /*
+        map.addLayer(vectorLayer)
+
+        return vectorLayer
+      },
+      /*
           Adds a billboard point utilizing the passed in point and options.
           Options are a view to relate to, and an id, and a color.
         */
-    addPoint(point, options) {
-      const pointObject = convertPointCoordinate(point)
-      const feature = new Openlayers.Feature({
-        geometry: new Openlayers.geom.Point(pointObject),
-        name: options.title,
-      })
-      feature.setId(options.id)
-
-      let x = 39,
-        y = 40
-      if (options.size) {
-        x = options.size.x
-        y = options.size.y
-      }
-      feature.setStyle(
-        new Openlayers.style.Style({
-          image: new Openlayers.style.Icon({
-            img: DrawingUtility.getPin({
-              fillColor: options.color,
-              icon: options.icon,
-            }),
-            imgSize: [x, y],
-            anchor: [x / 2, 0],
-            anchorOrigin: 'bottom-left',
-            anchorXUnits: 'pixels',
-            anchorYUnits: 'pixels',
-          }),
+      addPoint(point, options) {
+        const pointObject = convertPointCoordinate(point)
+        const feature = new Openlayers.Feature({
+          geometry: new Openlayers.geom.Point(pointObject),
+          name: options.title,
         })
-      )
+        feature.setId(options.id)
 
-      const vectorSource = new Openlayers.source.Vector({
-        features: [feature],
-      })
+        let x = 39,
+          y = 40
+        if (options.size) {
+          x = options.size.x
+          y = options.size.y
+        }
+        feature.setStyle(
+          new Openlayers.style.Style({
+            image: new Openlayers.style.Icon({
+              img: DrawingUtility.getPin({
+                fillColor: options.color,
+                icon: options.icon,
+              }),
+              imgSize: [x, y],
+              anchor: [x / 2, 0],
+              anchorOrigin: 'bottom-left',
+              anchorXUnits: 'pixels',
+              anchorYUnits: 'pixels',
+            }),
+          })
+        )
 
-      const vectorLayer = new Openlayers.layer.Vector({
-        source: vectorSource,
-        zIndex: 1,
-      })
+        const vectorSource = new Openlayers.source.Vector({
+          features: [feature],
+        })
 
-      map.addLayer(vectorLayer)
+        const vectorLayer = new Openlayers.layer.Vector({
+          source: vectorSource,
+          zIndex: 1,
+        })
 
-      return vectorLayer
-    },
-    /*
+        map.addLayer(vectorLayer)
+
+        return vectorLayer
+      },
+      /*
           Adds a polyline utilizing the passed in line and options.
           Options are a view to relate to, and an id, and a color.
         */
-    addLine(line, options) {
-      const lineObject = line.map(coordinate =>
-        convertPointCoordinate(coordinate)
-      )
+      addLine(line, options) {
+        const lineObject = line.map(coordinate =>
+          convertPointCoordinate(coordinate)
+        )
 
-      const feature = new Openlayers.Feature({
-        geometry: new Openlayers.geom.LineString(lineObject),
-        name: options.title,
-      })
-      feature.setId(options.id)
+        const feature = new Openlayers.Feature({
+          geometry: new Openlayers.geom.LineString(lineObject),
+          name: options.title,
+        })
+        feature.setId(options.id)
 
-      const styles = [
-        new Openlayers.style.Style({
-          stroke: new Openlayers.style.Stroke({
-            color: 'white',
-            width: 8,
+        const styles = [
+          new Openlayers.style.Style({
+            stroke: new Openlayers.style.Stroke({
+              color: 'white',
+              width: 8,
+            }),
           }),
-        }),
-        new Openlayers.style.Style({
-          stroke: new Openlayers.style.Stroke({
-            color: options.color || defaultColor,
-            width: 4,
+          new Openlayers.style.Style({
+            stroke: new Openlayers.style.Stroke({
+              color: options.color || defaultColor,
+              width: 4,
+            }),
           }),
-        }),
-      ]
+        ]
 
-      feature.setStyle(styles)
+        feature.setStyle(styles)
 
-      const vectorSource = new Openlayers.source.Vector({
-        features: [feature],
-      })
+        const vectorSource = new Openlayers.source.Vector({
+          features: [feature],
+        })
 
-      const vectorLayer = new Openlayers.layer.Vector({
-        source: vectorSource,
-      })
+        const vectorLayer = new Openlayers.layer.Vector({
+          source: vectorSource,
+        })
 
-      map.addLayer(vectorLayer)
+        map.addLayer(vectorLayer)
 
-      return vectorLayer
-    },
-    /*
+        return vectorLayer
+      },
+      /*
           Adds a polygon fill utilizing the passed in polygon and options.
           Options are a view to relate to, and an id.
         */
-    addPolygon(polygon, options) {},
-    /*
+      addPolygon(polygon, options) {},
+      /*
          Updates a passed in geometry to reflect whether or not it is selected.
          Options passed in are color and isSelected.
          */
-    updateCluster(geometry, options) {
-      if (geometry.constructor === Array) {
-        geometry.forEach(innerGeometry => {
-          this.updateCluster(innerGeometry, options)
-        })
-      } else {
-        const feature = geometry.getSource().getFeatures()[0]
-        const geometryInstance = feature.getGeometry()
-        if (geometryInstance.constructor === Openlayers.geom.Point) {
-          geometry.setZIndex(options.isSelected ? 2 : 1)
-          feature.setStyle(
-            new Openlayers.style.Style({
-              image: new Openlayers.style.Icon({
-                img: DrawingUtility.getCircleWithText({
-                  fillColor: options.color,
-                  strokeColor: options.outline,
-                  text: options.count,
-                  textColor: options.textFill,
+      updateCluster(geometry, options) {
+        if (geometry.constructor === Array) {
+          geometry.forEach(innerGeometry => {
+            this.updateCluster(innerGeometry, options)
+          })
+        } else {
+          const feature = geometry.getSource().getFeatures()[0]
+          const geometryInstance = feature.getGeometry()
+          if (geometryInstance.constructor === Openlayers.geom.Point) {
+            geometry.setZIndex(options.isSelected ? 2 : 1)
+            feature.setStyle(
+              new Openlayers.style.Style({
+                image: new Openlayers.style.Icon({
+                  img: DrawingUtility.getCircleWithText({
+                    fillColor: options.color,
+                    strokeColor: options.outline,
+                    text: options.count,
+                    textColor: options.textFill,
+                  }),
+                  imgSize: [44, 44],
                 }),
-                imgSize: [44, 44],
+              })
+            )
+          } else if (
+            geometryInstance.constructor === Openlayers.geom.LineString
+          ) {
+            const styles = [
+              new Openlayers.style.Style({
+                stroke: new Openlayers.style.Stroke({
+                  color: 'rgba(255,255,255, .1)',
+                  width: 8,
+                }),
               }),
-            })
-          )
-        } else if (
-          geometryInstance.constructor === Openlayers.geom.LineString
-        ) {
-          const styles = [
-            new Openlayers.style.Style({
-              stroke: new Openlayers.style.Stroke({
-                color: 'rgba(255,255,255, .1)',
-                width: 8,
+              new Openlayers.style.Style({
+                stroke: new Openlayers.style.Stroke({
+                  color: 'rgba(0,0,0, .1)',
+                  width: 4,
+                }),
               }),
-            }),
-            new Openlayers.style.Style({
-              stroke: new Openlayers.style.Stroke({
-                color: 'rgba(0,0,0, .1)',
-                width: 4,
-              }),
-            }),
-          ]
-          feature.setStyle(styles)
+            ]
+            feature.setStyle(styles)
+          }
         }
-      }
-    },
-    /*
+      },
+      /*
           Updates a passed in geometry to reflect whether or not it is selected.
           Options passed in are color and isSelected.
         */
-    updateGeometry(geometry, options) {
-      if (geometry.constructor === Array) {
-        geometry.forEach(innerGeometry => {
-          this.updateGeometry(innerGeometry, options)
-        })
-      } else {
-        const feature = geometry.getSource().getFeatures()[0]
-        const geometryInstance = feature.getGeometry()
-        if (geometryInstance.constructor === Openlayers.geom.Point) {
-          let x = 39,
-            y = 40
-          if (options.size) {
-            x = options.size.x
-            y = options.size.y
-          }
-          geometry.setZIndex(options.isSelected ? 2 : 1)
-          feature.setStyle(
-            new Openlayers.style.Style({
-              image: new Openlayers.style.Icon({
-                img: DrawingUtility.getPin({
-                  fillColor: options.color,
-                  strokeColor: options.isSelected ? 'black' : 'white',
-                  icon: options.icon,
+      updateGeometry(geometry, options) {
+        if (geometry.constructor === Array) {
+          geometry.forEach(innerGeometry => {
+            this.updateGeometry(innerGeometry, options)
+          })
+        } else {
+          const feature = geometry.getSource().getFeatures()[0]
+          const geometryInstance = feature.getGeometry()
+          if (geometryInstance.constructor === Openlayers.geom.Point) {
+            let x = 39,
+              y = 40
+            if (options.size) {
+              x = options.size.x
+              y = options.size.y
+            }
+            geometry.setZIndex(options.isSelected ? 2 : 1)
+            feature.setStyle(
+              new Openlayers.style.Style({
+                image: new Openlayers.style.Icon({
+                  img: DrawingUtility.getPin({
+                    fillColor: options.color,
+                    strokeColor: options.isSelected ? 'black' : 'white',
+                    icon: options.icon,
+                  }),
+                  imgSize: [x, y],
+                  anchor: [x / 2, 0],
+                  anchorOrigin: 'bottom-left',
+                  anchorXUnits: 'pixels',
+                  anchorYUnits: 'pixels',
                 }),
-                imgSize: [x, y],
-                anchor: [x / 2, 0],
-                anchorOrigin: 'bottom-left',
-                anchorXUnits: 'pixels',
-                anchorYUnits: 'pixels',
+              })
+            )
+          } else if (
+            geometryInstance.constructor === Openlayers.geom.LineString
+          ) {
+            const styles = [
+              new Openlayers.style.Style({
+                stroke: new Openlayers.style.Stroke({
+                  color: options.isSelected ? 'black' : 'white',
+                  width: 8,
+                }),
               }),
-            })
-          )
-        } else if (
-          geometryInstance.constructor === Openlayers.geom.LineString
-        ) {
-          const styles = [
-            new Openlayers.style.Style({
-              stroke: new Openlayers.style.Stroke({
-                color: options.isSelected ? 'black' : 'white',
-                width: 8,
+              new Openlayers.style.Style({
+                stroke: new Openlayers.style.Stroke({
+                  color: options.color || defaultColor,
+                  width: 4,
+                }),
               }),
-            }),
-            new Openlayers.style.Style({
-              stroke: new Openlayers.style.Stroke({
-                color: options.color || defaultColor,
-                width: 4,
-              }),
-            }),
-          ]
-          feature.setStyle(styles)
+            ]
+            feature.setStyle(styles)
+          }
         }
-      }
-    },
-    /*
+      },
+      /*
          Updates a passed in geometry to be hidden
          */
-    hideGeometry(geometry) {
-      geometry.setVisible(false)
-    },
-    /*
+      hideGeometry(geometry) {
+        geometry.setVisible(false)
+      },
+      /*
          Updates a passed in geometry to be shown
          */
-    showGeometry(geometry) {
-      geometry.setVisible(true)
-    },
-    removeGeometry(geometry) {
-      map.removeLayer(geometry)
-    },
-    showPolygonShape(locationModel) {
-      const polygon = new DrawPolygon.PolygonView({
-        model: locationModel,
-        map,
-      })
-      shapes.push(polygon)
-    },
-    showCircleShape(locationModel) {
-      const circle = new DrawCircle.CircleView({
-        model: locationModel,
-        map,
-      })
-      shapes.push(circle)
-    },
-    showLineShape(locationModel) {
-      const line = new DrawLine.LineView({
-        model: locationModel,
-        map,
-      })
-      shapes.push(line)
-    },
-    showMultiLineShape(locationModel) {
-      let lineObject = locationModel.get('multiline')
-      if (validateGeo('multiline', JSON.stringify(lineObject)).error) {
-        return
-      }
-      lineObject = lineObject.map(line =>
-        line.map(coords => convertPointCoordinate(coords))
-      )
+      showGeometry(geometry) {
+        geometry.setVisible(true)
+      },
+      removeGeometry(geometry) {
+        map.removeLayer(geometry)
+      },
+      showPolygonShape(locationModel) {
+        const polygon = new DrawPolygon.PolygonView({
+          model: locationModel,
+          map,
+        })
+        shapes.push(polygon)
+      },
+      showCircleShape(locationModel) {
+        const circle = new DrawCircle.CircleView({
+          model: locationModel,
+          map,
+        })
+        shapes.push(circle)
+      },
+      showLineShape(locationModel) {
+        const line = new DrawLine.LineView({
+          model: locationModel,
+          map,
+        })
+        shapes.push(line)
+      },
+      showMultiLineShape(locationModel) {
+        let lineObject = locationModel
+          .get('multiline')
+          .map(line => line.map(coords => convertPointCoordinate(coords)))
 
-      let feature = new Openlayers.Feature({
-        geometry: new Openlayers.geom.MultiLineString(lineObject),
-      })
+        let feature = new Openlayers.Feature({
+          geometry: new Openlayers.geom.MultiLineString(lineObject),
+        })
 
-      feature.setId(locationModel.cid)
+        feature.setId(locationModel.cid)
 
-      const styles = [
-        new Openlayers.style.Style({
-          stroke: new Openlayers.style.Stroke({
-            color: locationModel.get('color') || defaultColor,
-            width: 4,
+        const styles = [
+          new Openlayers.style.Style({
+            stroke: new Openlayers.style.Stroke({
+              color: locationModel.get('color') || defaultColor,
+              width: 4,
+            }),
           }),
-        }),
-      ]
+        ]
 
-      feature.setStyle(styles)
+        feature.setStyle(styles)
 
-      return this.createVectorLayer(locationModel, feature)
-    },
-    createVectorLayer(locationModel, feature) {
-      let vectorSource = new Openlayers.source.Vector({
-        features: [feature],
-      })
+        return this.createVectorLayer(locationModel, feature)
+      },
+      createVectorLayer(locationModel, feature) {
+        let vectorSource = new Openlayers.source.Vector({
+          features: [feature],
+        })
 
-      let vectorLayer = new Openlayers.layer.Vector({
-        source: vectorSource,
-      })
+        let vectorLayer = new Openlayers.layer.Vector({
+          source: vectorSource,
+        })
 
-      map.addLayer(vectorLayer)
-      overlays[locationModel.cid] = vectorLayer
+        map.addLayer(vectorLayer)
+        overlays[locationModel.cid] = vectorLayer
 
-      return vectorLayer
-    },
-    destroyShape(cid) {
-      const shapeIndex = shapes.findIndex(shape => cid === shape.model.cid)
-      if (shapeIndex >= 0) {
-        shapes[shapeIndex].destroy()
-        shapes.splice(shapeIndex, 1)
-      }
-    },
-    destroyShapes() {
-      shapes.forEach(shape => {
-        shape.destroy()
-      })
-      shapes = []
-    },
-    getOpenLayersMap() {
-      return map
-    },
-    destroy() {
-      this.destroyDrawingTools()
-      unlistenToResize()
-    },
-  })
+        return vectorLayer
+      },
+      destroyShape(cid) {
+        const shapeIndex = shapes.findIndex(shape => cid === shape.model.cid)
+        if (shapeIndex >= 0) {
+          shapes[shapeIndex].destroy()
+          shapes.splice(shapeIndex, 1)
+        }
+      },
+      destroyShapes() {
+        shapes.forEach(shape => {
+          shape.destroy()
+        })
+        shapes = []
+      },
+      getOpenLayersMap() {
+        return map
+      },
+      destroy() {
+        this.destroyDrawingTools()
+        unlistenToResize()
+      },
+    })
 
-  return exposedMethods
-}
+    return exposedMethods
+  }
+
+module.exports = plugin(OpenlayersMap)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/openlayers/map.openlayers.js
@@ -618,9 +618,13 @@ const OpenlayersMap = extension =>
         shapes.push(line)
       },
       showMultiLineShape(locationModel) {
-        let lineObject = locationModel
-          .get('multiline')
-          .map(line => line.map(coords => convertPointCoordinate(coords)))
+        let lineObject = locationModel.get('multiline')
+        if (validateGeo('multiline', JSON.stringify(lineObject)).error) {
+          return
+        }
+        lineObject = lineObject.map(line =>
+          line.map(coords => convertPointCoordinate(coords))
+        )
 
         let feature = new Openlayers.Feature({
           geometry: new Openlayers.geom.MultiLineString(lineObject),

--- a/ui/packages/catalog-ui-search/src/main/webapp/plugins/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/plugins/map.openlayers.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+module.exports = v => v(null)

--- a/ui/packages/catalog-ui-search/src/main/webapp/plugins/map.openlayers.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/plugins/map.openlayers.js
@@ -12,4 +12,5 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
+// Invoke the function with null in order to maintain existing functionality
 module.exports = v => v(null)


### PR DESCRIPTION
#### What does this PR do?
This PR adds an `extension` argument to `OpenlayersMap` to allow for customization of how the 2D map pans to results. The `extension` argument is utilized in `panToExtent` if it exists and is a function. In the plugin, `null` is passed as the argument so that the `extent`, and therefore the way the 2D map pans to results is unaffected.

Thanks @leo-sakh for helping with this!
#### Who is reviewing it? 
@andrewzimmer @cassandrabailey293 @leo-sakh @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@millerw8 
@shaundmorris 
#### How should this be tested?
- Upload a couple images and edit their locations so that they're on the edges of the map (i.e. one in Russia, one in Alaska)
- Open the 2D map
- Select each result in the results panel and verify that the way the map pans to each result has not changed and that at no point does it pan off of the singular map image
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #codice/ddf-ui#131
G-4596
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
