### PR TITLE
DDF-5924 remove persistence type enforcement

### DIFF
--- a/platform/persistence/platform-persistence-commands/src/main/java/org/codice/ddf/persistence/commands/AbstractStoreCommand.java
+++ b/platform/persistence/platform-persistence-commands/src/main/java/org/codice/ddf/persistence/commands/AbstractStoreCommand.java
@@ -15,7 +15,6 @@ package org.codice.ddf.persistence.commands;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
@@ -24,7 +23,6 @@ import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.codice.ddf.persistence.PersistenceException;
 import org.codice.ddf.persistence.PersistentStore;
-import org.codice.ddf.persistence.PersistentStore.PersistenceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,16 +62,7 @@ public abstract class AbstractStoreCommand implements Action {
   public Object execute() {
 
     try {
-
-      if (PersistenceType.hasType(type)) {
-        storeCommand();
-      } else {
-        console.println(
-            "Type passed in was not correct. Must be one of "
-                + Arrays.toString(PersistenceType.values())
-                + ".");
-      }
-
+      storeCommand();
     } catch (PersistenceException pe) {
       console.println(
           "Encountered an error when trying to perform the command. Check log for more details.");

--- a/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentStore.java
+++ b/platform/persistence/platform-persistence-core-api/src/main/java/org/codice/ddf/persistence/PersistentStore.java
@@ -16,8 +16,6 @@ package org.codice.ddf.persistence;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public interface PersistentStore {
 
@@ -38,13 +36,6 @@ public interface PersistentStore {
 
     PersistenceType(final String type) {
       this.type = type;
-    }
-
-    public static boolean hasType(String type) {
-      return Stream.of(PersistenceType.values())
-          .map(PersistenceType::toString)
-          .collect(Collectors.toList())
-          .contains(type);
     }
 
     @Override


### PR DESCRIPTION
#### What does this PR do?
Addressing issue https://github.com/codice/ddf/issues/5924

This persistence type check is a self inflicting restriction. The PersistentStoreImpl allows any type to establish a new solr core/collection.

For import, if persistence core is not found, create a new core and store result
For export, if persistence core is not found, return empty result

able to import/export any persistence core

#### Who is reviewing it? 
@millerw8 
@bdeining 

#### Select relevant component teams: 

@codice/solr 


#### Ask 2 committers to review/merge the PR and tag them here.


#### How should this be tested?
build profile:install standard
store:list -t metacard_cache
results found: xx (before this PR, this will fail)
store:list -t alerts
result found: xx
store:list -t abc
results found: 0


#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
