### PR TITLE
[2.21.x] DDF-5946 Update Intrigue to respect Subject Identity configuration

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/MetacardApplication.java
@@ -812,7 +812,7 @@ public class MetacardApplication implements SparkApplication {
           Attribute attribute = metacard.getAttribute(Core.METACARD_OWNER);
           if (attribute != null
               && attribute.getValue() != null
-              && !attribute.getValue().equals(getSubjectEmail())) {
+              && !attribute.getValue().equals(getSubjectIdentifier())) {
             res.status(401);
             return util.getResponseWrapper(
                 ERROR_RESPONSE_TYPE, "Owner of note metacard is invalid!");
@@ -838,7 +838,7 @@ public class MetacardApplication implements SparkApplication {
           Attribute attribute = metacard.getAttribute(Core.METACARD_OWNER);
           if (attribute != null
               && attribute.getValue() != null
-              && !attribute.getValue().equals(getSubjectEmail())) {
+              && !attribute.getValue().equals(getSubjectIdentifier())) {
             res.status(401);
             return util.getResponseWrapper(
                 ERROR_RESPONSE_TYPE, "Owner of note metacard is invalid!");

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/annotation/annotation.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/annotation/annotation.view.js
@@ -37,7 +37,7 @@ module.exports = Marionette.LayoutView.extend({
     'click .footer-delete': 'handleDelete',
   },
   initialize(options) {
-    this._useremail = userInstance.get('user').get('email')
+    this._userId = userInstance.getUserId()
     this._parent = options.parent
   },
   handleDelete() {
@@ -105,7 +105,7 @@ module.exports = Marionette.LayoutView.extend({
   canModify() {
     this.$el.toggleClass(
       'is-modifiable',
-      this._useremail === this.model.attributes.owner
+      this._userId === this.model.attributes.owner
     )
   },
   toggleDeleting() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/editor/editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/editor/editor.view.js
@@ -101,7 +101,7 @@ module.exports = Marionette.LayoutView.extend({
     )
   },
   handleTypes() {
-    const username = user.get('user').get('userid')
+    const userId = user.getUserId()
     let isOwner = true
     const types = {}
     this.model.forEach(result => {
@@ -122,7 +122,7 @@ module.exports = Marionette.LayoutView.extend({
         .get('properties')
         .get('metacard.owner')
 
-      isOwner = isOwner && username === metacardOwner
+      isOwner = isOwner && userId === metacardOwner
     })
     this.$el.toggleClass('is-mixed', Object.keys(types).length > 1)
     this.$el.toggleClass('is-workspace', types.workspace !== undefined)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.js
@@ -21,8 +21,8 @@ module.exports = Backbone.Model.extend({
     return {
       title: '',
       description: '',
-      createdBy: user.getEmail(),
-      owner: user.getEmail(),
+      createdBy: user.getUserId(),
+      owner: user.getUserId(),
       createdOn: Date.now(),
       type: 'custom',
       id: undefined,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/tabs/search-form/tabs.search-form.js
@@ -26,14 +26,14 @@ const formsTitle = properties.i18n['forms.title'] || 'Forms'
 
 const tabChildViewOptions = {
   [`My Search ${formsTitle}`]: {
-    filter: child => child.get('createdBy') === user.getEmail(),
+    filter: child => child.get('createdBy') === user.getUserId(),
     showNewForm: true,
   },
   [`Shared Search ${formsTitle}`]: {
     type: 'Shared',
     filter: child =>
       child.get('createdBy') !== 'system' &&
-      child.get('createdBy') !== user.getEmail() &&
+      child.get('createdBy') !== user.getUserId() &&
       user.canRead(child),
   },
   [`System Search ${formsTitle}`]: {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationStart.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/ApplicationStart.js
@@ -32,7 +32,7 @@ function getWorkspacesOwnedByUser() {
     workspace =>
       user.isGuest()
         ? workspace.get('localStorage') === true
-        : workspace.get('metacard.owner') === user.get('user').get('email')
+        : workspace.get('metacard.owner') === user.getUserId()
   )
 }
 

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/sharing/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/sharing/presentation.tsx
@@ -126,7 +126,7 @@ const render = (props: Props) => {
                   {item.category === Category.User ? (
                     <EditableLabelText
                       value={item.value}
-                      placeholder="user id"
+                      placeholder="User ID"
                       showLabel={false}
                       onChange={value => handleChangeInput(i, value)}
                     />

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/sharing/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/sharing/presentation.tsx
@@ -126,7 +126,7 @@ const render = (props: Props) => {
                   {item.category === Category.User ? (
                     <EditableLabelText
                       value={item.value}
-                      placeholder="user@example.com"
+                      placeholder="user id"
                       showLabel={false}
                       onChange={value => handleChangeInput(i, value)}
                     />

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/security/security.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/security/security.tsx
@@ -95,7 +95,7 @@ export class Security {
   private canAccess(user: any, accessLevel: Access) {
     return (
       this.res.owner === undefined ||
-      this.res.owner === user.getEmail() ||
+      this.res.owner === user.getUserId() ||
       this.getAccess(user) >= accessLevel
     )
   }
@@ -136,16 +136,16 @@ export class Security {
     return Access.None
   }
 
-  private getIndividualAccess(email: string) {
-    if (this.res.accessAdministrators.indexOf(email) > -1) {
+  private getIndividualAccess(userId: string) {
+    if (this.res.accessAdministrators.indexOf(userId) > -1) {
       return Access.Share
     }
 
-    if (this.res.accessIndividuals.indexOf(email) > -1) {
+    if (this.res.accessIndividuals.indexOf(userId) > -1) {
       return Access.Write
     }
 
-    if (this.res.accessIndividualsRead.indexOf(email) > -1) {
+    if (this.res.accessIndividualsRead.indexOf(userId) > -1) {
       return Access.Read
     }
 
@@ -154,7 +154,7 @@ export class Security {
 
   private getAccess(user: any): Access {
     return Math.max(
-      this.getIndividualAccess(user.getEmail()),
+      this.getIndividualAccess(user.getUserId()),
       ...user.getRoles().map((group: string) => this.getGroupAccess(group))
     )
   }
@@ -180,10 +180,10 @@ export class Security {
       this.res.accessIndividualsRead,
       this.res.accessAdministrators
     )
-      .map((username: string) => {
+      .map((userId: string) => {
         return {
-          value: username,
-          access: this.getIndividualAccess(username),
+          value: userId,
+          access: this.getIndividualAccess(userId),
         } as Entry
       })
       .sort(Security.compareFn)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/presentation.tsx
@@ -105,7 +105,7 @@ const render = (props: Props) => {
         <MenuAction
           help="Brings up a view of the current
         sharing settings for this workspace.  From there, you can change what permissions each role has on the workspace,
-         as well as give permissions to individuals by specifying their email."
+         as well as give permissions to individuals by specifying their user id."
           onClick={(_e, context) => {
             viewSharing()
             context.closeAndRefocus()

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspaces-items/container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspaces-items/container.tsx
@@ -41,13 +41,13 @@ function filterWorkspaces(workspaces: Backbone.Collection<Backbone.Model>) {
   return workspaces.filter((workspace: Backbone.Model) => {
     const localStorage = workspace.get('localStorage') || false
     const owner = workspace.get('metacard.owner')
-    const email = user.get('user').get('email')
+    const userId = user.getUserId()
 
     switch (preferences.get('homeFilter')) {
       case 'Not owned by me':
-        return !localStorage && email !== owner
+        return !localStorage && userId !== owner
       case 'Owned by me':
-        return localStorage || email === owner
+        return localStorage || userId === owner
       case 'Owned by anyone':
       default:
         return true


### PR DESCRIPTION
#### What does this PR do?
Removes all hardcoded uses of email as the subject identity. Now Intrigue uses the attribute set in the Subject Identity configuration.

#### Who is reviewing it? 
@stustison @brendan-hofmann @beyelerb 

#### Select relevant component teams: 
<!--
@codice/ui 
-->

#### How should this be tested?
1. Create two non-admin accounts in DDF
2. Change the Subject Identity config in the Admin UI to use the `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` attribute instead of email.
3. Restart DDF
4. Verify the following:
* Metacard security attributes (the security.access-* attributes) use the name identifier instead of email.
* The workspaces page use the name identifier to indicate workspace ownership
* Workspace filtering works (Owned by Me, Not Owned by Me)
* Workspace sharing works
* Search form sharing works (top left hamburger > Search Forms)
* On load, Intrigue opens an existing workspace if there is one owned by the current user
* Query annotations use name identifier to indicate ownership, and only the owner can modify their notes.
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5946

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
