### PR TITLE
DDF-5649 G-6176 routes exceptions back to client

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SortedQueryMonitor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SortedQueryMonitor.java
@@ -192,8 +192,12 @@ class SortedQueryMonitor implements Runnable {
 
           for (SourceProcessingDetails detailsOfSourceResponse :
               sourceResponse.getProcessingDetails()) {
-            detailsOfReturnResults.add(
-                new ProcessingDetailsImpl(detailsOfSourceResponse, sourceId));
+            if (detailsOfSourceResponse instanceof ProcessingDetails) {
+              detailsOfReturnResults.add((ProcessingDetails) detailsOfSourceResponse);
+            } else {
+              detailsOfReturnResults.add(
+                  new ProcessingDetailsImpl(detailsOfSourceResponse, sourceId));
+            }
           }
         }
       } catch (InterruptedException e) {

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SortedQueryMonitorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SortedQueryMonitorTest.java
@@ -272,8 +272,9 @@ public class SortedQueryMonitorTest {
     List<String> errorFromMalformedQuery =
         Collections.singletonList("We do not support this query.");
 
+    final Exception exception = new Exception("test exception");
     ProcessingDetails processingDetailsForMalformedQuery =
-        new ProcessingDetailsImpl(idOfTestSource, null, errorFromMalformedQuery);
+        new ProcessingDetailsImpl(idOfTestSource, exception, errorFromMalformedQuery);
     processingDetailsOfMockedSourceResponse.add(processingDetailsForMalformedQuery);
 
     List<String> nonspecificError = Collections.singletonList("Something went wrong.");
@@ -308,6 +309,9 @@ public class SortedQueryMonitorTest {
     assertThat(queryResponse.getProcessingDetails())
         .extracting(byName("warnings"))
         .containsOnly(errorFromMalformedQuery, nonspecificError);
+    assertThat(queryResponse.getProcessingDetails())
+        .extracting(byName("exception"))
+        .contains(exception);
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Adds logic to send any source exceptions contained in processing details back to the client

#### Who is reviewing it? 
@kentmorrissey 
@derekwilhelm 

#### Select relevant component teams: 
@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.
@pklinef 
@glenhein 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
