### PR TITLE
[2.19.x] DDF-UI-145 default result form

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
         stage('Validate Poms') {
             steps {
                 retry(3) {
-                    checkout scm
+                    checkout([$class: 'GitSCM', branches: [[name: "refs/heads/${BRANCH_NAME}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'WipeWorkspace'], [$class: 'LocalBranch', localBranch: "${BRANCH_NAME}"], [$class: 'CloneOption', timeout: 30, shallow: true]], submoduleCfg: [], userRemoteConfigs: scm.userRemoteConfigs ])
                 }
                 withMaven(maven: 'M3', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
                     sh 'mvn clean install -DskipStatic=true -DskipTests=true -B -pl $POMFIX $DISABLE_DOWNLOAD_PROGRESS_OPTS'

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/data/QueryTemplateMetacard.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/data/QueryTemplateMetacard.java
@@ -123,6 +123,8 @@ public class QueryTemplateMetacard extends MetacardImpl {
     String detailLevel = safeGet(json, DETAIL_LEVEL, String.class);
     if (detailLevel != null) {
       setAttribute(DETAIL_LEVEL, detailLevel);
+    } else {
+      setAttribute(DETAIL_LEVEL, "");
     }
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -54,6 +54,9 @@ module.exports = Marionette.LayoutView.extend({
     this.listenTo(user.getQuerySettings(), 'change:template', querySettings =>
       this.updateCurrentQuery(querySettings)
     )
+    this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', querySettings =>
+    this.updateCurrentQuery(querySettings)
+  )
     this.model = new Query.Model(this.getDefaultQuery())
     this.listenTo(this.model, 'resetToDefaults change:type', this.reshow)
     this.listenTo(this.model, 'change:filterTree', this.reshow)
@@ -69,6 +72,12 @@ module.exports = Marionette.LayoutView.extend({
     }
     const searchForm = new SearchForm(currentQuerySettings.get('template'))
     const sharedAttributes = searchForm.transformToQueryStructure()
+    if(currentQuerySettings.get('defaultResultFormId')) {
+      sharedAttributes['detail-level'] = ''
+      this.model.set({
+        defaultResultFormId: currentQuerySettings.get('defaultResultFormId')
+      })
+    }
     this.model.set({
       type: currentQuerySettings.get('type'),
       ...sharedAttributes,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -54,11 +54,6 @@ module.exports = Marionette.LayoutView.extend({
     this.listenTo(user.getQuerySettings(), 'change:template', querySettings =>
       this.updateCurrentQuery(querySettings)
     )
-    this.listenTo(
-      user.getQuerySettings(),
-      'change:defaultResultFormId',
-      querySettings => this.updateCurrentQuery(querySettings)
-    )
     this.model = new Query.Model(this.getDefaultQuery())
     this.listenTo(this.model, 'resetToDefaults change:type', this.reshow)
     this.listenTo(this.model, 'change:filterTree', this.reshow)
@@ -74,11 +69,6 @@ module.exports = Marionette.LayoutView.extend({
     }
     const searchForm = new SearchForm(currentQuerySettings.get('template'))
     const sharedAttributes = searchForm.transformToQueryStructure()
-    if (currentQuerySettings.get('defaultResultFormId')) {
-      user.getQuerySettings().set({
-        defaultResultFormId: currentQuerySettings.get('defaultResultFormId'),
-      })
-    }
     this.model.set({
       type: currentQuerySettings.get('type'),
       ...sharedAttributes,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -75,8 +75,7 @@ module.exports = Marionette.LayoutView.extend({
     const searchForm = new SearchForm(currentQuerySettings.get('template'))
     const sharedAttributes = searchForm.transformToQueryStructure()
     if (currentQuerySettings.get('defaultResultFormId')) {
-      sharedAttributes['detail-level'] = ''
-      this.model.set({
+      user.getQuerySettings().set({
         defaultResultFormId: currentQuerySettings.get('defaultResultFormId'),
       })
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -54,9 +54,11 @@ module.exports = Marionette.LayoutView.extend({
     this.listenTo(user.getQuerySettings(), 'change:template', querySettings =>
       this.updateCurrentQuery(querySettings)
     )
-    this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', querySettings =>
-    this.updateCurrentQuery(querySettings)
-  )
+    this.listenTo(
+      user.getQuerySettings(),
+      'change:defaultResultFormId',
+      querySettings => this.updateCurrentQuery(querySettings)
+    )
     this.model = new Query.Model(this.getDefaultQuery())
     this.listenTo(this.model, 'resetToDefaults change:type', this.reshow)
     this.listenTo(this.model, 'change:filterTree', this.reshow)
@@ -72,10 +74,10 @@ module.exports = Marionette.LayoutView.extend({
     }
     const searchForm = new SearchForm(currentQuerySettings.get('template'))
     const sharedAttributes = searchForm.transformToQueryStructure()
-    if(currentQuerySettings.get('defaultResultFormId')) {
+    if (currentQuerySettings.get('defaultResultFormId')) {
       sharedAttributes['detail-level'] = ''
       this.model.set({
-        defaultResultFormId: currentQuerySettings.get('defaultResultFormId')
+        defaultResultFormId: currentQuerySettings.get('defaultResultFormId'),
       })
     }
     this.model.set({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
@@ -89,6 +89,9 @@ module.exports = Marionette.LayoutView.extend({
   },
   showForm(form) {
     const options = form.options || {}
+    if (this.model.get('detail-level') === undefined) {
+      this.model.set('detail-level', 'allFields')
+    }
     this.queryContent.show(
       new form.view({
         model: this.model,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -96,7 +96,7 @@ module.exports = plugin(
       let detailLevelProperty = new Property({
         label: 'Result Form',
         enum: resultTemplates,
-        value: [ defaultResultForm && defaultResultForm.value || this.model.get('detail-level') ||
+        value: [ this.model.get('detail-level') || defaultResultForm && defaultResultForm.value ||
             (resultTemplates &&
               resultTemplates[lastIndex] &&
               resultTemplates[lastIndex].value),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -69,9 +69,8 @@ module.exports = plugin(
         'change:added',
         this.handleFormUpdate
       )
-      this.listenTo(user.getQuerySettings(),
-      'change:defaultResultFormId',
-     () => this.renderResultForms(this.resultFormCollection.filteredList)
+      this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', () =>
+        this.renderResultForms(this.resultFormCollection.filteredList)
       )
     },
     handleFormUpdate(newForm) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -29,6 +29,7 @@ const Common = require('../../js/Common.js')
 const properties = require('../../js/properties.js')
 const plugin = require('plugins/query-settings')
 const ResultForm = require('../result-form/result-form.js')
+const user = require('../singletons/user-instance.js')
 import * as React from 'react'
 import RadioComponent from '../../react-component/input-wrappers/radio'
 import { showErrorMessages } from '../../react-component/utils/validation'
@@ -68,6 +69,10 @@ module.exports = plugin(
         'change:added',
         this.handleFormUpdate
       )
+      this.listenTo(user.getQuerySettings(),
+      'change:defaultResultFormId',
+     () => this.renderResultForms(this.resultFormCollection.filteredList)
+      )
     },
     handleFormUpdate(newForm) {
       this.renderResultForms(this.resultFormCollection.filteredList)
@@ -93,7 +98,7 @@ module.exports = plugin(
       resultTemplates = _.uniq(resultTemplates, 'id')
       let lastIndex = resultTemplates.length - 1
       let defaultResultForm = resultTemplates.find(
-        form => form.id === this.model.get('defaultResultFormId')
+        form => form.id === user.getQuerySettings().get('defaultResultFormId')
       )
       let detailLevelProperty = new Property({
         label: 'Result Form',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -92,11 +92,11 @@ module.exports = plugin(
       })
       resultTemplates = _.uniq(resultTemplates, 'id')
       let lastIndex = resultTemplates.length - 1
+      let defaultResultForm = resultTemplates.find((form) => form.id === this.model.get('defaultResultFormId'))
       let detailLevelProperty = new Property({
         label: 'Result Form',
         enum: resultTemplates,
-        value: [
-          this.model.get('detail-level') ||
+        value: [ defaultResultForm && defaultResultForm.value || this.model.get('detail-level') ||
             (resultTemplates &&
               resultTemplates[lastIndex] &&
               resultTemplates[lastIndex].value),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -99,15 +99,13 @@ module.exports = plugin(
       let defaultResultForm = resultTemplates.find(
         form => form.id === user.getQuerySettings().get('defaultResultFormId')
       )
+      const propertyValue = this.model.get('detail-level') === undefined ? (resultTemplates && resultTemplates[lastIndex] && resultTemplates[lastIndex].value) : (this.model.get('detail-level') ||
+      (defaultResultForm && defaultResultForm.value))
       let detailLevelProperty = new Property({
         label: 'Result Form',
         enum: resultTemplates,
         value: [
-          this.model.get('detail-level') ||
-            (defaultResultForm && defaultResultForm.value) ||
-            (resultTemplates &&
-              resultTemplates[lastIndex] &&
-              resultTemplates[lastIndex].value),
+          propertyValue,
         ],
         showValidationIssues: false,
         id: 'Result Form',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -99,14 +99,17 @@ module.exports = plugin(
       let defaultResultForm = resultTemplates.find(
         form => form.id === user.getQuerySettings().get('defaultResultFormId')
       )
-      const propertyValue = this.model.get('detail-level') === undefined ? (resultTemplates && resultTemplates[lastIndex] && resultTemplates[lastIndex].value) : (this.model.get('detail-level') ||
-      (defaultResultForm && defaultResultForm.value))
+      const propertyValue =
+        this.model.get('detail-level') === undefined
+          ? resultTemplates &&
+            resultTemplates[lastIndex] &&
+            resultTemplates[lastIndex].value
+          : this.model.get('detail-level') ||
+            (defaultResultForm && defaultResultForm.value)
       let detailLevelProperty = new Property({
         label: 'Result Form',
         enum: resultTemplates,
-        value: [
-          propertyValue,
-        ],
+        value: [propertyValue],
         showValidationIssues: false,
         id: 'Result Form',
       })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -100,12 +100,11 @@ module.exports = plugin(
         form => form.id === user.getQuerySettings().get('defaultResultFormId')
       )
       const propertyValue =
-        this.model.get('detail-level') === undefined
-          ? resultTemplates &&
-            resultTemplates[lastIndex] &&
-            resultTemplates[lastIndex].value
-          : this.model.get('detail-level') ||
-            (defaultResultForm && defaultResultForm.value)
+        this.model.get('detail-level') ||
+        (defaultResultForm && defaultResultForm.value) ||
+        (resultTemplates &&
+          resultTemplates[lastIndex] &&
+          resultTemplates[lastIndex].value)
       let detailLevelProperty = new Property({
         label: 'Result Form',
         enum: resultTemplates,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -92,11 +92,15 @@ module.exports = plugin(
       })
       resultTemplates = _.uniq(resultTemplates, 'id')
       let lastIndex = resultTemplates.length - 1
-      let defaultResultForm = resultTemplates.find((form) => form.id === this.model.get('defaultResultFormId'))
+      let defaultResultForm = resultTemplates.find(
+        form => form.id === this.model.get('defaultResultFormId')
+      )
       let detailLevelProperty = new Property({
         label: 'Result Form',
         enum: resultTemplates,
-        value: [ this.model.get('detail-level') || defaultResultForm && defaultResultForm.value ||
+        value: [
+          this.model.get('detail-level') ||
+            (defaultResultForm && defaultResultForm.value) ||
             (resultTemplates &&
               resultTemplates[lastIndex] &&
               resultTemplates[lastIndex].value),

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -41,10 +41,6 @@
   > .interaction-clear {
     display: none;
   }
-
-  > .interaction-default {
-    display: none;
-  }
 }
 
 @{customElementNamespace}search-form-interactions.is-system-template {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.less
@@ -37,12 +37,6 @@
   }
 }
 
-@{customElementNamespace}search-form-interactions.is-result-form-template {
-  > .interaction-clear {
-    display: none;
-  }
-}
-
 @{customElementNamespace}search-form-interactions.is-system-template {
   > .interaction-trash {
     display: none;

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -116,10 +116,6 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
       user.getQuerySettings().isDefaultTemplate(this.model)
     )
     this.$el.toggleClass(
-      'is-result-form-template',
-      this.model.get('type') === 'result'
-    )
-    this.$el.toggleClass(
       'is-system-template',
       this.model.get('createdBy') === 'system'
     )

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -202,10 +202,16 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
   },
   handleMakeDefault() {
     this.model.set('default', true)
-    user.getQuerySettings().set({
-      type: 'custom',
-      template: this.model.toJSON(),
-    })
+    if(this.model.get('type') === 'result') {
+      user.getQuerySettings().set({
+        defaultResultFormId: this.model.get('id'),
+      })
+    } else {
+      user.getQuerySettings().set({
+        type: 'custom',
+        template: this.model.toJSON(),
+      })
+    }
     user.savePreferences()
     this.messageNotifier(
       'Success',
@@ -215,10 +221,16 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
   },
   handleClearDefault() {
     this.model.set('default', false)
-    user.getQuerySettings().set({
-      template: undefined,
-      type: 'text',
-    })
+    if(this.model.get('type') === 'result') {
+      user.getQuerySettings().set({
+        defaultResultFormId: undefined,
+      })
+    } else {
+      user.getQuerySettings().set({
+        template: undefined,
+        type: 'text',
+      })
+    }
     user.savePreferences()
     this.messageNotifier(
       'Success',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -204,7 +204,7 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
     this.model.set('default', true)
     if(this.model.get('type') === 'result') {
       user.getQuerySettings().set({
-        defaultResultFormId: this.model.get('id')
+        defaultResultFormId: this.model.get('id'),
       })
     } else {
       user.getQuerySettings().set({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -198,7 +198,7 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
   },
   handleMakeDefault() {
     this.model.set('default', true)
-    if(this.model.get('type') === 'result') {
+    if (this.model.get('type') === 'result') {
       user.getQuerySettings().set({
         defaultResultFormId: this.model.get('id'),
       })
@@ -217,7 +217,7 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
   },
   handleClearDefault() {
     this.model.set('default', false)
-    if(this.model.get('type') === 'result') {
+    if (this.model.get('type') === 'result') {
       user.getQuerySettings().set({
         defaultResultFormId: undefined,
       })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -204,7 +204,7 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
     this.model.set('default', true)
     if(this.model.get('type') === 'result') {
       user.getQuerySettings().set({
-        defaultResultFormId: this.model.get('id'),
+        defaultResultFormId: this.model.get('id')
       })
     } else {
       user.getQuerySettings().set({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -182,6 +182,7 @@ export default Marionette.LayoutView.extend({
   initialize() {
     this.listenTo(this.model, 'change:type', this.changeView)
     this.listenTo(user.getQuerySettings(), 'change:template', this.render)
+    this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', this.render)
   },
   serializeData() {
     const { createdOn, ...json } = this.model.toJSON()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -149,8 +149,8 @@ export default Marionette.LayoutView.extend({
         />
       )
     } else if (props.type == 'result') {
-      const isDefault = user.getQuerySettings().get('defaultResultFormId') === props.id
-      debugger
+      const isDefault =
+        user.getQuerySettings().get('defaultResultFormId') === props.id
       return (
         <RelativeWrapper>
           <FormTitle data-help={props.title}>{props.title}</FormTitle>
@@ -182,7 +182,11 @@ export default Marionette.LayoutView.extend({
   initialize() {
     this.listenTo(this.model, 'change:type', this.changeView)
     this.listenTo(user.getQuerySettings(), 'change:template', this.render)
-    this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', this.render)
+    this.listenTo(
+      user.getQuerySettings(),
+      'change:defaultResultFormId',
+      this.render
+    )
   },
   serializeData() {
     const { createdOn, ...json } = this.model.toJSON()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -149,9 +149,12 @@ export default Marionette.LayoutView.extend({
         />
       )
     } else if (props.type == 'result') {
+      const isDefault = user.getQuerySettings().get('defaultResultFormId') === props.id
+      debugger
       return (
         <RelativeWrapper>
           <FormTitle data-help={props.title}>{props.title}</FormTitle>
+          {isDefault ? <DefaultIcon className="fa fa-star" /> : null}
           <FormContents>{props.createdOn}</FormContents>
           <Author title={props.createdBy}>
             <span className="fa fa-cloud" />

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -33,6 +33,9 @@ module.exports = Backbone.Model.extend({
     }
   },
   isTemplate(template) {
+    if (this.get('defaultResultFormId') === template.id) {
+      return true
+    }
     if (this.get('template') !== undefined) {
       return this.get('template').id === template.id
     } else {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -43,6 +43,6 @@ module.exports = Backbone.Model.extend({
     }
   },
   isDefaultTemplate(template) {
-    return this.isTemplate(template) && this.get('template').default
+    return this.isTemplate(template) && this.get('template') && this.get('template').default
   },
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -43,6 +43,10 @@ module.exports = Backbone.Model.extend({
     }
   },
   isDefaultTemplate(template) {
-    return this.isTemplate(template) && this.get('template') && this.get('template').default
+    return (
+      this.isTemplate(template) &&
+      this.get('template') &&
+      this.get('template').default
+    )
   },
 })


### PR DESCRIPTION
#### What does this PR do?
Adds the ability to set a default result form. 

Setting a result form as default means that it will show up automatically in these cases:
1. When you create a basic or advanced search in your workspace
2. When you create a new search form in the search form editor

If you set a result form to default, but you already have a default search form that does not have that result form, you will NOT see the default result form when you search. You will see the result form associated with your default search form. 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer @hayleynorton @zta6 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. build/profile install
2. create two result forms if you don't already have them
3. Verify that the dropdown has the "Set Default" option
4. Set one as the default
5. Verify that the result form you set as default appears in the basic and advanced search (make sure you don't have a default search form set)
6. Verify that the result form you set as default appears when you're creating a new search form
7. Create two search forms, one with one of your result forms, and another with no result form specified ("All Fields")
8. Verify that when you set these search forms to default, the default result form doesn't show up in the Basic and Advanced search. Rather, the result form you set ON the search from should show up. 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: https://github.com/codice/ddf-ui/issues/145

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
