### PR TITLE
DDF-5962 Support querying quoted phrases with Solr

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -356,14 +356,8 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
     }
 
     String searchPhrase = QUOTE + escapeSpecialCharacters(literal) + QUOTE;
-    if (!(searchPhrase.contains(SOLR_WILDCARD_CHAR)
-            || searchPhrase.contains(SOLR_SINGLE_WILDCARD_CHAR))
-        && Metacard.ANY_TEXT.equals(propertyName)) {
+    if (Metacard.ANY_TEXT.equals(propertyName)) {
       return new SolrQuery(wildcardSolrQuery(searchPhrase, propertyName, true, true));
-    } else if (searchPhrase.contains(SOLR_WILDCARD_CHAR)
-        || searchPhrase.contains(SOLR_SINGLE_WILDCARD_CHAR)
-        || Metacard.ANY_TEXT.equals(propertyName)) {
-      return new SolrQuery(wildcardSolrQuery(searchPhrase, propertyName, true, false));
     } else {
       return new SolrQuery(mappedPropertyName + ":" + searchPhrase);
     }

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
@@ -1137,6 +1137,78 @@ public class SolrProviderQuery {
   }
 
   @Test
+  public void testPropertyIsLikeWithQuotedPhrases() throws Exception {
+    deleteAll(provider);
+
+    List<Metacard> list = new ArrayList<>();
+
+    MockMetacard metacard1 = new MockMetacard(Library.getFlagstaffRecord());
+    metacard1.setTitle("Mary");
+
+    list.add(metacard1);
+
+    MockMetacard metacard2 = new MockMetacard(Library.getTampaRecord());
+    metacard2.setTitle("Mary had a little");
+
+    list.add(metacard2);
+
+    MockMetacard metacard3 = new MockMetacard(Library.getShowLowRecord());
+    metacard3.setTitle("Mary had a little l!@#$%^&*()_mb");
+
+    list.add(metacard3);
+
+    create(list, provider);
+
+    queryAndVerifyCount(
+        2,
+        getFilterBuilder().attribute(Metacard.TITLE).is().like().text("\"Mary had*\""),
+        provider);
+
+    queryAndVerifyCount(
+        1,
+        getFilterBuilder().attribute(Metacard.TITLE).is().like().text("\"*ad a little\""),
+        provider);
+
+    queryAndVerifyCount(
+        1, getFilterBuilder().attribute(Metacard.TITLE).is().like().text("\"*little\""), provider);
+
+    queryAndVerifyCount(
+        2, getFilterBuilder().attribute(Metacard.TITLE).is().like().text("\"had a\""), provider);
+
+    queryAndVerifyCount(
+        2,
+        getFilterBuilder().attribute(Metacard.ANY_TEXT).is().like().text("\"Mary had*\""),
+        provider);
+
+    queryAndVerifyCount(
+        1,
+        getFilterBuilder().attribute(Metacard.ANY_TEXT).is().like().text("\"*ad a little\""),
+        provider);
+
+    queryAndVerifyCount(
+        1,
+        getFilterBuilder().attribute(Metacard.ANY_TEXT).is().like().text("\"*little\""),
+        provider);
+
+    queryAndVerifyCount(
+        2, getFilterBuilder().attribute(Metacard.ANY_TEXT).is().like().text("\"had a\""), provider);
+
+    /* Negative cases */
+
+    queryAndVerifyCount(
+        0, getFilterBuilder().attribute(Metacard.TITLE).is().like().text("\"*ad\""), provider);
+
+    queryAndVerifyCount(
+        0, getFilterBuilder().attribute(Metacard.TITLE).is().like().text("\"a had\""), provider);
+
+    queryAndVerifyCount(
+        0, getFilterBuilder().attribute(Metacard.ANY_TEXT).is().like().text("\"*ad\""), provider);
+
+    queryAndVerifyCount(
+        0, getFilterBuilder().attribute(Metacard.ANY_TEXT).is().like().text("\"a had\""), provider);
+  }
+
+  @Test
   public void testPropertyIsLike() throws Exception {
     deleteAll(provider);
 


### PR DESCRIPTION
#### What does this PR do?
Adds support to query quoted phrases with Solr.  See #5962 for more details.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@bellcc 
@derekwilhelm 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@Bdthomson 
@rzwiefel


#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Ingest a record with a field that contains spaces and/or punctuation. If you had a title like `This is the title`, you should be able to search on title and anyText and match with `"is the"`, `"*the title"`, and `"This is*"`.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #5962

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ n/a ] Documentation Updated
- [ n/a ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ n/a ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
