### PR TITLE
DDF-5996 Simplifies the Web Context Policy Manager's authentication type configuration

### DIFF
--- a/distribution/ddf-common/src/main/resources/etc/web-context-policy-config.properties
+++ b/distribution/ddf-common/src/main/resources/etc/web-context-policy-config.properties
@@ -1,0 +1,12 @@
+# This file is used to configure different authentication types per context.
+# The list of default valid authentication types are: BASIC, PKI, SAML, and OIDC.
+# If the context does not have an authentication type defined and guest access is permitted through the Admin UI's
+# Web Context Policy Manager configuration, it will be open to guests.
+#
+# NOTE: A restart will be required for the changes to this file to be applied
+#
+# WARNING: If this file is used to configure authentication types, the authentication type configuration through the Admin UI will be ignored
+#
+# Example:
+#/=
+#/admin = PKI then BASIC

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -293,6 +293,10 @@ grant codeBase "file:/admin-core-impl/catalog-admin-poller-service/admin-core-jo
     permission java.io.FilePermission "${ddf.home.perm}etc${/}users.attributes", "read,write";
 }
 
+grant codeBase "file:/security-policy-context/platform-util" {
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}web-context-policy-config.properties", "read";
+}
+
 grant codeBase "file:/admin-core-jolokia/javax.servlet-api/org.apache.shiro.core/org.eclipse.jetty.io/org.eclipse.jetty.security/org.eclipse.jetty.server/org.eclipse.jetty.servlet/org.ops4j.pax.web.pax-web-extender-whiteboard/pax-web-jetty/platform-paxweb-jettyconfig/org.ops4j.pax.web.pax-web-runtime/org.apache.cxf.cxf-rt-transports-http/org.eclipse.jetty.servlet/org.eclipse.jetty.util/platform-filter-clientinfo/platform-filter-response/security-certificate-generator/security-filter-authorization/security-filter-login/security-filter-web-sso/org.eclipse.jetty.websocket.server" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}custom.system.properties", "read,write";

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/managed-service-factories.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/managed-service-factories.adoc
@@ -142,14 +142,8 @@ See the documentation for https://docs.oracle.com/javase/7/docs/api/java/lang/Lo
 .Sample configuration file
 [source,linenums]
 ----
-authenticationTypes=[ \
-  "/\=", \
-  "/admin\=basic", \
-  "/system\=basic", \
-  "/sources\=basic", \
-  "/security-config\=basic", \
-  "/search\=basic", \
-  ]
+webAuthenticationTypes="basic"
+endpointAuthenticationTypes=""
 sessionAccess=B"true"
 guestAccess=B"true"
 realms=[ \

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/configuring-oidc.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/configuring-oidc.adoc
@@ -26,7 +26,7 @@ Once connected, the Web Context Policy Manager needs to be updated. to do so,
 
 . Under the *Configuration* tab in the *${ddf-security}* application
 . Select the *Web Context Policy Manager*.
-. Under `Authentication Types`, add the context type of the endpoint you wish to protect with OIDC. For example `/search=OIDC`.
+. Under `Authentication Types for Web Pages` and `Authentication Types for Endpoints` add OIDC.
 
 ===== OAuth 2.0
 

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/no-idp.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/no-idp.adoc
@@ -19,4 +19,4 @@ To configure ${branding} to not use a SAML Identity Provider (IdP),
 .. Select the *${ddf-security}* application.
 .. Select the *Configuration* tab.
 .. Select *Web Context Policy Manager*
-.. Under *Authentication Types*, remove the SAML authentication type from all context paths.
+.. Under *Authentication Types for Web Pages* and *Authentication Types for Endpoints*, remove the SAML authentication type.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/securing-admin-console.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/securing-admin-console.adoc
@@ -19,8 +19,7 @@ To set access restrictions on the ${admin-console}, consult the organization's s
 . Select the *Configuration* tab.
 . Select the *Web Context Policy Manager*.
 .. A dialogue will pop up that allows you to edit ${branding} access restrictions.
-.. Once you have configured your <<{reference-prefix}org.codice.ddf.security.policy.context.impl.PolicyManager,realms>> in your security infrastructure, you can associate them with ${branding} contexts.
-.. If your infrastructure supports multiple <<{reference-prefix}org.codice.ddf.security.policy.context.impl.PolicyManager,authentication methods>>, they may be specified on a per-context basis.
+.. If your infrastructure supports multiple <<{reference-prefix}org.codice.ddf.security.policy.context.impl.PolicyManager,authentication methods>>, you may specify them here.
 .. Role requirements may be enforced by configuring the <<{reference-prefix}org.codice.ddf.security.policy.context.impl.PolicyManager,required attributes>> for a given context.
 .. The <<{reference-prefix}org.codice.ddf.security.policy.context.impl.PolicyManager,white listed contexts>> allows child contexts to be excluded from the authentication constraints of their parents.
 

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/securing-idp-sp.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/securing-idp-sp.adoc
@@ -80,5 +80,5 @@ Set the authentication types in the `WebContextPolicyManager` to SAML.
 . Under *Authentication Types for Web Pages* and *Authentication Types for Endpoints*, set the SAML authentication type_ as necessary.
 
 Other authentication types can also be used in conjunction with the SAML type.
-For example, if you wanted to secure the entire system with the IDP, but still allow legacy clients that don't understand the SAML ECP specification to connect, you could set *Authentication Types for Web Pages* and *Authentication Types for Endpoints* to `SAML|PKI`.
+For example, if you wanted to secure the entire system with the IDP, but still allow PKI authentication for legacy clients that don't understand the SAML ECP specification, you could set *Authentication Types for Web Pages* and *Authentication Types for Endpoints* to `PKI|SAML`.
 With that configuration, any clients that failed to connect using either the SAML 2.0 Web SSO Profile or the SAML ECP spec would fall back to 2-way TLS for authentication.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/securing-idp-sp.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/securing-idp-sp.adoc
@@ -77,10 +77,8 @@ Set the authentication types in the `WebContextPolicyManager` to SAML.
 . Select the *${ddf-security}* application.
 . Select the *Configuration* tab.
 . Select *Web Context Policy Manager*
-. Under *Authentication Types*, set the SAML authentication type_ as necessary.
-For example:
-- `/search=SAML`
+. Under *Authentication Types for Web Pages* and *Authentication Types for Endpoints*, set the SAML authentication type_ as necessary.
 
 Other authentication types can also be used in conjunction with the SAML type.
-For example, if you wanted to secure the entire system with the IDP, but still allow legacy clients that don't understand the SAML ECP specification to connect, you could set `/=SAML|PKI`.
+For example, if you wanted to secure the entire system with the IDP, but still allow legacy clients that don't understand the SAML ECP specification to connect, you could set *Authentication Types for Web Pages* and *Authentication Types for Endpoints* to `SAML|PKI`.
 With that configuration, any clients that failed to connect using either the SAML 2.0 Web SSO Profile or the SAML ECP spec would fall back to 2-way TLS for authentication.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/web-context-policy-manager.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/web-context-policy-manager.adoc
@@ -10,9 +10,9 @@
 The Web Context Policy Manager defines all security policies for REST endpoints within ${branding}.
 It defines:
 
-* the realms a context should authenticate against.
-* the type of authentication that a context requires.
-* any user attributes required for authorization.
+* the type of authentication for web pages (such as /admin and /search) and endpoints (context paths that start with /services)
+* any user attributes required for authorization
+* a list of whitelisted contexts
 
 See <<{reference-prefix}org.codice.ddf.security.policy.context.impl.PolicyManager, Web Context Policy Manager Configurations>> for detailed descriptions of all fields.
 
@@ -27,13 +27,32 @@ Note that the `SAML` and `OIDC` authentication types require session storage to 
 
 === Authentication Types
 
-As you add REST endpoints, you may need to add different types of authentication through the Web Context Policy Manager.
-
-Any web context that allows or requires specific authentication types should be added here with the following format:
+Through the Web Context Policy Manager, authentication types for ${branding} may be configured with the following format:
 
 ----
-/<CONTEXT>=<AUTH_TYPE>|<AUTH_TYPE|...
+<AUTH_TYPE>|<AUTH_TYPE|...
 ----
+
+Authentication types can be configured separately for:
+* web pages (these are all context paths that do not start with `/services` such as `/admin` and `/search`)
+* endpoints (these are all context paths that start with `/services`)
+
+Configuring separate authentication types for web pages or endpoints is supported through the `web-context-policy-config.properties` configuration file.
+* Navigate to `${home_directory}/etc/`
+* Edit the `web-context-policy-config.properties` file
+* Restart ${branding}
+
+The `web-context-policy-config.properties` file format is:
+
+----
+/<CONTEXT>=<AUTH_TYPE> then <AUTH_TYPE then ...
+----
+
+[WARNING]
+====
+If the file-based configuration is used, the *authentication type* configuration for web pages and endpoints in the ${admin-console} is ignored.
+All other configurations in the Web Context Policy Manager such as Guest Access, Required Attributes, and White Listed Contexts will *not* be ignored.
+====
 
 .Default Types of Authentication
 [cols="1,4" options="header"]
@@ -64,10 +83,10 @@ Non-Terminating authentication types are authentication types where, once hit, m
 If the client supports the non-terminating authentication type's method of obtaining credentials, it either allows or forbids access to the system.
 However if the client does not support the non-terminating authentication type's method of obtaining credentials, the system will continue to the next configured authentication type.
 
-`BASIC` is the only terminating authentication type.
-Every other authentication type is non-terminating.
+`PKI` is the only non-terminating authentication type.
+`BASIC`, `OIDC`, and `SAML` are terminating authentication types.
 
-For example: assume a context is protected by the non-terminating `SAML` authorization type.
+For example: assume ${branding} is protected by the terminating `SAML` authorization type.
 The system first checks to see if the client supports the acquisition of SAML credentials.
 
 - If the connecting client is a browser, the system can acquire SAML credentials.
@@ -75,10 +94,9 @@ The system first checks to see if the client supports the acquisition of SAML cr
 - If the connecting client is a machine that does not support SAML ECP, the system cannot acquire SAML credentials.
 
 If the system can acquire SAML credentials from the client, the system will attempt to acquire said credentials and either allow or forbid access.
-If the system cannot acquire SAML credentials from the client, the system will continue to the next configured authentication type.
+If the system cannot acquire SAML credentials from the client, the system will forbid access.
 
-Contrarily, assume a context is protected by the terminating `BASIC` authentication type.
-Once this authentication type is hit, the system either allows or forbids access to the system, without checking if the client supports the acquisition of BASIC credentials.
+Otherwise, if ${branding} is protected by the non-terminating `PKI` authorization type and the system cannot acquire PKI certificates from the client, the system will continue to the next configured authentication type.
 
 === Required Attributes
 

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/web-context-policy-manager.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/web-context-policy-manager.adoc
@@ -37,7 +37,7 @@ Authentication types can be configured separately for:
 * web pages (these are all context paths that do not start with `/services` such as `/admin` and `/search`)
 * endpoints (these are all context paths that start with `/services`)
 
-Configuring separate authentication types for web pages or endpoints is supported through the `web-context-policy-config.properties` configuration file.
+Configuring separate authentication types for specific contexts is supported through the `web-context-policy-config.properties` configuration file.
 * Navigate to `${home_directory}/etc/`
 * Edit the `web-context-policy-config.properties` file
 * Restart ${branding}

--- a/distribution/docs/src/main/resources/content/_managing/_securing/disallowing-login-wo-certs.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_securing/disallowing-login-wo-certs.adoc
@@ -13,8 +13,7 @@ ${branding} can be configured to prevent login without a valid PKI certificate.
 * Select *${ddf-security}*.
 * Select *Web Context Policy Manager*.
 * Add a policy for each context requiring restriction.
-** For example: `/search=PKI` will disallow login without certificates to the Search UI.
-** The format for the policy should be: `/<CONTEXT>=PKI`
+** For example, just configuring `PKI` as the authentication type for web pages will disallow login without certificates to ${branding}.
 * Click *Save*.
 
 [NOTE]

--- a/distribution/docs/src/main/resources/content/_managing/_securing/managing-crl.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_securing/managing-crl.adoc
@@ -57,7 +57,7 @@ Enabling CRL revocation or modifying the CRL file will require a restart of ${br
 . (Replace <CRL_FILENAME> with the file path or URL of the CRL file used in previous step.)
 
 Adding this property will also enable CRL revocation for any context policy implementing PKI authentication.
-For example, adding an authentication policy in the Web Context Policy Manager of `/search=PKI` will disable basic authentication and require a certificate for the search UI.
+For example, setting PKI as the authentication type for web pages in the Web Context Policy Manager will disable basic authentication and require a certificate.
 If a certificate is not in the CRL, it will be allowed through, otherwise it will get a 401 error.
 If no certificate is provided, and guest access is enabled on the web context policy, guest access will be granted.
 
@@ -80,7 +80,7 @@ A local CRL file will be created and the `encryption.properties` and `signature.
 The PKIHandler implements CRL revocation, so any web context that is configured to use PKI authentication will also use CRL revocation if revocation is enabled.
 
 . After enabling revocation (see above), open the *Web Context Policy Manager*.
-. Add or modify a Web Context to use PKI in authentication. For example, enabling CRL for the search ui endpoint would require adding an authorization policy of `/search=PKI`
+. Add or modify the *Authentication Types for Web Pages* and *Authentication Types for Endpoints* configurations to use PKI.
 . If guest access is also required, check the `Allow Guest Access` box in the policy.
 
 With guest access, a user with a revoked certificate will be given a 401 error, but users without a certificate will be able to access the web context as the guest user.

--- a/distribution/docs/src/main/resources/content/_reference/_tables/PolicyManager.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/PolicyManager.adoc
@@ -37,11 +37,18 @@
 |true
 |true
 
-|Authentication Types
-|authenticationTypes
+|Authentication Types for Web Pages
+|webAuthenticationTypes
 |String
-|List of authentication types required for each context. List of default valid authentication types are: BASIC, PKI, SAML, and OIDC. Example: /context=AUTH1|AUTH2|AUTH3
-|/=,/admin=PKI|BASIC
+|List of authentication types required for all web pages (these are all context paths except /services). List of valid authentication types are: BASIC, PKI, SAML, and OIDC. Example: AUTH1|AUTH2|AUTH3
+|PKI|BASIC
+|true
+
+|Authentication Types for Endpoints
+|endpointAuthenticationTypes
+|String
+|List of authentication types required for all endpoints (these are context paths that start with /services). List of valid authentication types are: BASIC, PKI, SAML, and OIDC. Example: AUTH1|AUTH2|AUTH3
+|PKI|BASIC
 |true
 
 |Required Attributes

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/AbstractIntegrationTest.java
@@ -400,6 +400,7 @@ public abstract class AbstractIntegrationTest {
       basePort = getBasePort();
       getServiceManager().startFeature(true, getDefaultRequiredApps());
       getServiceManager().waitForAllBundles();
+      getSecurityPolicy().configureRestForGuest();
       getCatalogBundle().waitForCatalogProvider();
 
       getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query?_wadl");

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -1230,7 +1230,7 @@ public class TestFederation extends AbstractIntegrationTest {
   @Test
   public void testRetrievalReliablility() throws Exception {
     try {
-      getSecurityPolicy().configureWebContextPolicy("/=basic,/solr=PKI|basic", null, null);
+      getSecurityPolicy().configureWebContextPolicy("PKI|BASIC", "PKI|BASIC", null, null);
 
       String filename = "product2.txt";
       String metacardId = generateUniqueMetacardId();
@@ -1608,7 +1608,7 @@ public class TestFederation extends AbstractIntegrationTest {
   public void testCancelDownload() throws Exception {
     try {
       getCatalogBundle().setupCaching(true);
-      getSecurityPolicy().configureWebContextPolicy("/=basic,/solr=PKI|basic", null, null);
+      getSecurityPolicy().configureWebContextPolicy("PKI|BASIC", "PKI|BASIC", null, null);
 
       String filename = testName + ".txt";
       String metacardId = generateUniqueMetacardId();
@@ -1732,7 +1732,7 @@ public class TestFederation extends AbstractIntegrationTest {
   @Test
   public void testProductDownloadWithTwoUsers() throws Exception {
     try {
-      getSecurityPolicy().configureWebContextPolicy("/=basic,/solr=PKI|basic", null, null);
+      getSecurityPolicy().configureWebContextPolicy("PKI|BASIC", "PKI|BASIC", null, null);
 
       String filename1 = "product4.txt";
       String metacardId1 = generateUniqueMetacardId();
@@ -1836,7 +1836,7 @@ public class TestFederation extends AbstractIntegrationTest {
   public void testSingleUserDownloadSameProductSyncAndAsync() throws Exception {
     try {
       getCatalogBundle().setupCaching(true);
-      getSecurityPolicy().configureWebContextPolicy("/=basic,/solr=PKI|basic", null, null);
+      getSecurityPolicy().configureWebContextPolicy("PKI|BASIC", "PKI|BASIC", null, null);
 
       String filename = "product4.txt";
       String metacardId = generateUniqueMetacardId();
@@ -1882,7 +1882,7 @@ public class TestFederation extends AbstractIntegrationTest {
   public void testSingleUserDownloadSameProductAsync() throws Exception {
     try {
       getCatalogBundle().setupCaching(true);
-      getSecurityPolicy().configureWebContextPolicy("/=basic,/solr=PKI|basic", null, null);
+      getSecurityPolicy().configureWebContextPolicy("PKI|BASIC", "PKI|BASIC", null, null);
 
       String filename = "product4.txt";
       String metacardId = generateUniqueMetacardId();

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestOidc.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestOidc.java
@@ -97,7 +97,7 @@ import org.osgi.service.cm.Configuration;
 @ExamReactorStrategy(PerSuite.class)
 public class TestOidc extends AbstractIntegrationTest {
 
-  private static final String OIDC_AUTH_TYPES = "/=OIDC,/solr=SAML|PKI|basic";
+  private static final String OIDC_AUTH_TYPES = "OIDC";
 
   private static final DynamicUrl LOGOUT_REQUEST_URL =
       new DynamicUrl(SERVICE_ROOT, "/logout/actions");
@@ -181,7 +181,8 @@ public class TestOidc extends AbstractIntegrationTest {
       getServiceManager().waitForHttpEndpoint(WHO_AM_I_URL.getUrl());
       getServiceManager().waitForHttpEndpoint(SERVICE_ROOT + "/catalog/query");
       oldPolicyManagerProps =
-          getSecurityPolicy().configureWebContextPolicy(OIDC_AUTH_TYPES, null, null);
+          getSecurityPolicy()
+              .configureWebContextPolicy(OIDC_AUTH_TYPES, OIDC_AUTH_TYPES, null, null);
 
       // start stub server
       server = new StubServer(Integer.parseInt(IDP_PORT.getPort())).run();

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/platform/TestSecurity.java
@@ -745,10 +745,11 @@ public class TestSecurity extends AbstractIntegrationTest {
   }
 
   @Test
-  public void testAdminConfigPolicyCreateAndModifyConfiguration() {
+  public void testAdminConfigPolicyCreateAndModifyConfiguration() throws Exception {
 
     // create config CreateFactoryConfiguration
 
+    configureRestForBasic();
     String createFactoryConfigPermittedResponse =
         sendPermittedRequest(
             "/admin/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/createFactoryConfiguration/testCreateFactoryPid");

--- a/platform/security/policy/security-policy-context/pom.xml
+++ b/platform/security/policy/security-policy-context/pom.xml
@@ -70,7 +70,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.87</minimum>
+                                            <minimum>0.86</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
@@ -80,7 +80,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.63</minimum>
+                                            <minimum>0.68</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,7 +13,10 @@
  **/
 -->
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.2.0">
+
+    <ext:property-placeholder/>
 
     <bean id="policyMgr" class="org.codice.ddf.security.policy.context.impl.PolicyManager"
           init-method="configure">
@@ -21,12 +24,8 @@
                 persistent-id="org.codice.ddf.security.policy.context.impl.PolicyManager"
                 update-strategy="component-managed" update-method="setPolicies"/>
 
-        <property name="authenticationTypes">
-            <array value-type="java.lang.String">
-                <value>/=</value>
-                <value>/admin=PKI|BASIC</value>
-            </array>
-        </property>
+        <property name="webAuthenticationTypes" value="PKI|BASIC"/>
+        <property name="endpointAuthenticationTypes" value="PKI|BASIC"/>
         <property name="guestAccess" value="true" />
         <property name="sessionAccess" value="true" />
         <property name="requiredAttributes">
@@ -62,6 +61,7 @@
         <property name="traversalDepth">
             <value>20</value>
         </property>
+        <property name="policyFilePath" value="${ddf.etc}/web-context-policy-config.properties"/>
     </bean>
 
     <service ref="policyMgr"

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -32,10 +32,15 @@
             description="Allow for session cookies to be used. Note that the SAML and OIDC authentication types require session storage to be enabled."
             default="true"/>
 
-        <AD description="List of authentication types required for each context. List of default valid authentication types are: BASIC, PKI, SAML, and OIDC. Example: /context=AUTH1|AUTH2|AUTH3"
-            name="Authentication Types" id="authenticationTypes" cardinality="100"
+        <AD description="List of authentication types required for all web pages (these are all context paths except /services). List of valid authentication types are: BASIC, PKI, SAML, and OIDC. Example: AUTH1|AUTH2|AUTH3"
+            name="Authentication Types for Web Pages" id="webAuthenticationTypes"
             type="String"
-            default="/=,/admin=PKI|BASIC"/>
+            default="PKI|BASIC"/>
+
+        <AD description="List of authentication types required for all endpoints (these are context paths that start with /services). List of valid authentication types are: BASIC, PKI, SAML, and OIDC. Example: AUTH1|AUTH2|AUTH3"
+            name="Authentication Types for Endpoints" id="endpointAuthenticationTypes"
+            type="String"
+            default="PKI|BASIC"/>
 
         <AD description="List of attributes required for each Web Context. Example: /context={role=role1;type=type1}"
             name="Required Attributes" id="requiredAttributes" cardinality="100"

--- a/platform/security/policy/security-policy-context/src/test/resources/web-context-policy-config.properties
+++ b/platform/security/policy/security-policy-context/src/test/resources/web-context-policy-config.properties
@@ -1,0 +1,10 @@
+# This file is used to configure different authentication types per context.
+# The list of default valid authentication types are: BASIC, PKI, SAML, and OIDC.
+# Example:
+/ = SAML then BASIC
+/search = SAML then BASIC
+/admin = SAML then BASIC
+/foo = BASIC
+/unprotected =
+/unprotected2 =
+/services = PKI


### PR DESCRIPTION
#### What does this PR do?
Simplifies the Web Context Policy Manager's authentication type configuration by:
- Removing the authentication type configuration per context
- Adding a single auth type config for all web pages  
- Adding another auth type config for all endpoints
- Keeping the option to configure multiple auth types per context as a file-based configuration

#### Who is reviewing it? 
@bakejeyner
@garrettfreibott  
@ricklarsen 
@SmithJosh 
@stustison 

#### Select relevant component teams: 
@codice/security 

#### How should this be tested?
- Test that changes to the web and endpoint authentication types works as expected
- Test the current (soon to be old) was of configuring auth types is still supported and works
To see how to do these and test the documentation see the docs on how to accomplish ☝️ 

#### What are the relevant tickets?
Fixes: #5996 

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
