### PR TITLE
Enable longitude wrapping on the indexed Solr geo field

### DIFF
--- a/platform/solr/solr-schema/src/main/resources/solr/conf/schema.xml
+++ b/platform/solr/solr-schema/src/main/resources/solr/conf/schema.xml
@@ -119,7 +119,8 @@
                distanceUnits="degrees"
                format="WKT"
                autoIndex="true"
-               allowMultiOverlap="true" />
+               allowMultiOverlap="true"
+               normWrapLongitude="true" />
 
     <fieldType name="location" class="solr.LatLonPointSpatialField"/>
 


### PR DESCRIPTION
#### What does this PR do?
Running a DWITHIN query (i.e., a buffered geometry) near the antimeridian often results in a Solr error because the resulting geometry contains points outside the valid longitude range of [-180,180]. The SolrFilterDelegate uses JTS to calculate the buffered geometry but does not enforce the longitude range on the result so it is passed to Solr with out-of-range values. Enabling normWrapLongitude means that Solr will wrap longitudes outside of the range into it.

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdthomson
@pklinef

#### How should this be tested?
1. Ingest the following GeoJSON files:

`alaska1.json`
```javascript
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [179.980009, 51.602957]
  },
  "properties": {
    "title": "Alaska 1"
  }
}
```

`alaska2.json`
```javascript
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [-179.978792, 51.362968]
  },
  "properties": {
    "title": "Alaska 2"
  }
}
```

2. Open Intrigue and run a geo search using the following WKT and a buffer of 15 miles:
MULTIPOLYGON(((-180 51.7940888,-179.8836979 51.9764894,-180 52.138489,-180 52.0894509,-180 51.7940888)),((-179.4513774 51.2918677,-173.0657689 51.8281987,-171.9557873 52.3603655,-178.8839964 52.0470452,-179.4513774 51.2918677)),((-173.5039969 60.6549748,-172.9216783 60.0289185,-171.8049056 60.3105117,-172.8904444 60.9001351,-173.5039969 60.6549748)),((-172.294252 63.5601474,-169.7862804 62.7592245,-168.2265336 63.3083416,-171.6010169 64.0025856,-172.294252 63.5601474)),((-171.6265166 52.49595,-159.3508735 54.593299,-155.6733936 57.3599637,-153.7581681 56.346107,-151.5503749 58.9170441,-145.9713958 60.1919741,-138.4585092 58.8939167,-133.7160974 54.611912,-130.6156729 54.7074743,-130.003485 56.008075,-135.4791608 59.7980414,-137.5261144 58.9063722,-141.00198 60.3063692,-140.9961443 69.8886061,-156.6238242 71.5979656,-166.6489484 69.0136858,-162.3787034 66.4576525,-169.0162224 65.4807942,-161.2328826 63.8163309,-165.4597263 63.1438768,-166.5779936 61.628736,-165.4430729 60.7987078,-167.6371043 59.9593039,-158.0581693 57.7634245,-171.6265166 52.49595)),((-170.7729758 57.1768487,-170.3653916 56.8591585,-169.5509731 57.2040889,-170.1156906 57.4647136,-170.7729758 57.1768487)),((-170.1309102 56.6284401,-169.5725912 56.3483731,-169.0864518 56.6094894,-169.7280131 56.8307125,-170.1309102 56.6284401)),((-168.5515315 64.9822791,-168.0191526 64.7766628,-167.5609228 64.9940277,-168.0611278 65.1981204,-168.5515315 64.9822791)),((-157.7468595 55.792294,-157.3902403 55.5919363,-157.0336667 55.7924225,-157.3890126 55.9930271,-157.7468595 55.792294)),((-156.1288482 55.8456932,-155.5962747 55.5670199,-155.1772184 55.8333503,-155.5669043 56.1276229,-156.1288482 55.8456932)),((-146.7844719 59.405176,-146.3277496 59.2013377,-145.8345502 59.4540347,-146.3588623 59.7519229,-146.7844719 59.405176)),((172.1155062 52.9424044,173.6081696 52.1661839,174.8677707 52.6346755,173.1961114 53.2039662,172.1155062 52.9424044)),((175.5314355 52.3985671,175.9104381 52.1487823,176.3224511 52.3696531,175.8849487 52.6045536,175.5314355 52.3985671)),((176.887676 51.8928235,179.1652452 51.1704301,179.823363 51.3614575,178.6029564 52.201323,176.887676 51.8928235)),((179.166756 51.955404,179.7638419 51.6997153,180 52.1384488,179.5215506 52.2320046,179.166756 51.955404)))
This WKT was obtained from https://nominatim.openstreetmap.org/search.php?q=alaska&format=json&polygon_text=1&polygon_threshold=1.0. The 15-mile buffer ensures that the buffered geometry crosses the antimeridian. The two GeoJSON metacards above are located within the buffer area on either side of the antimeridian.
3. Verify both results are returned.

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.