### PR TITLE
[2.21.x] Add forwarded information to client-info

### DIFF
--- a/platform/platform-paxweb-jettyconfig/pom.xml
+++ b/platform/platform-paxweb-jettyconfig/pom.xml
@@ -138,17 +138,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.47</minimum>
+                                            <minimum>0.70</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.35</minimum>
+                                            <minimum>0.63</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.35</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/ClientInfoFilterTest.java
+++ b/platform/platform-paxweb-jettyconfig/src/test/java/org/codice/ddf/pax/web/jetty/ClientInfoFilterTest.java
@@ -24,13 +24,14 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletContext;
-import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import org.apache.shiro.util.ThreadContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,9 +53,21 @@ public class ClientInfoFilterTest {
 
   private static final String MOCK_CONTEXT_PATH = "/example/path";
 
-  @Mock private ServletContext mockServletContext;
+  private static final String MOCK_FORWARDED_HEADER = "for=192.0.2.60;proto=http;by=203.0.113.43";
 
-  @Mock private ServletRequest mockServletRequest;
+  private static final String MOCK_X_FORWARDED_FOR = "127.0.0.1";
+
+  private static final String MOCK_X_FORWARDED_HOST_HEADER = "www.example.com";
+
+  private static final String MOCK_X_FORWARDED_PORT_HEADER = "1234";
+
+  private static final String MOCK_X_FORWARDED_PROTO_HEADER = "https";
+
+  private static final String MOCK_X_FORWARDED_PREFIX_HEADER = "/api";
+
+  private static final String MOCK_X_FORWARDED_SSL_HEADER = "on";
+
+  @Mock private ServletContext mockServletContext;
 
   @Mock private ServletResponse mockServletResponse;
 
@@ -64,34 +77,41 @@ public class ClientInfoFilterTest {
 
   @Before
   public void setup() throws Exception {
-    when(mockServletRequest.getRemoteAddr()).thenReturn(MOCK_REMOTE_ADDRESS);
-    when(mockServletRequest.getRemoteHost()).thenReturn(MOCK_REMOTE_HOST);
-    when(mockServletRequest.getScheme()).thenReturn(MOCK_SCHEME);
-    when(mockServletRequest.getServletContext()).thenReturn(mockServletContext);
     when(mockServletContext.getContextPath()).thenReturn(MOCK_CONTEXT_PATH);
-
     clientInfoFilter = new ClientInfoFilter();
   }
 
   @Test
   public void testClientInfoPresentInMap() throws Exception {
+    HttpServletRequest httpServletRequest = mockFullClientInfo();
     doAnswer(invocationOnMock -> assertThatMapIsAccurate())
         .when(mockFilterChain)
-        .doFilter(mockServletRequest, mockServletResponse);
-    clientInfoFilter.doFilter(mockServletRequest, mockServletResponse, mockFilterChain);
+        .doFilter(httpServletRequest, mockServletResponse);
+    clientInfoFilter.doFilter(httpServletRequest, mockServletResponse, mockFilterChain);
     assertThatMapIsNull();
   }
 
   @Test(expected = RuntimeException.class)
   public void testClientInfoCleansUpOnException() throws Exception {
+    HttpServletRequest httpServletRequest = mockFullClientInfo();
     doThrow(RuntimeException.class)
         .when(mockFilterChain)
-        .doFilter(mockServletRequest, mockServletResponse);
+        .doFilter(httpServletRequest, mockServletResponse);
     try {
-      clientInfoFilter.doFilter(mockServletRequest, mockServletResponse, mockFilterChain);
+      clientInfoFilter.doFilter(httpServletRequest, mockServletResponse, mockFilterChain);
     } finally {
       assertThatMapIsNull();
     }
+  }
+
+  @Test
+  public void testForwardedHeadersAreOptional() throws Exception {
+    HttpServletRequest httpServletRequest = mockClientInfoMissingForwardedHeaders();
+    doAnswer(invocationOnMock -> assertMapWithoutForwardedHeaders())
+        .when(mockFilterChain)
+        .doFilter(httpServletRequest, mockServletResponse);
+    clientInfoFilter.doFilter(httpServletRequest, mockServletResponse, mockFilterChain);
+    assertThatMapIsNull();
   }
 
   private Object assertThatMapIsAccurate() throws Exception {
@@ -101,11 +121,57 @@ public class ClientInfoFilterTest {
     assertThat(clientInfoMap.get(SERVLET_REMOTE_HOST), is(MOCK_REMOTE_HOST));
     assertThat(clientInfoMap.get(SERVLET_SCHEME), is(MOCK_SCHEME));
     assertThat(clientInfoMap.get(SERVLET_CONTEXT_PATH), is(MOCK_CONTEXT_PATH));
+    assertThat(clientInfoMap.get("Forwarded"), is(MOCK_FORWARDED_HEADER));
+    assertThat(clientInfoMap.get("X-Forwarded-For"), is(MOCK_X_FORWARDED_FOR));
+    assertThat(clientInfoMap.get("X-Forwarded-Host"), is(MOCK_X_FORWARDED_HOST_HEADER));
+    assertThat(clientInfoMap.get("X-Forwarded-Port"), is(MOCK_X_FORWARDED_PORT_HEADER));
+    assertThat(clientInfoMap.get("X-Forwarded-Proto"), is(MOCK_X_FORWARDED_PROTO_HEADER));
+    assertThat(clientInfoMap.get("X-Forwarded-Prefix"), is(MOCK_X_FORWARDED_PREFIX_HEADER));
+    assertThat(clientInfoMap.get("X-Forwarded-Ssl"), is(MOCK_X_FORWARDED_SSL_HEADER));
+    assertThat(clientInfoMap.size(), is(11));
+    return null;
+  }
+
+  private Object assertMapWithoutForwardedHeaders() throws Exception {
+    Map<String, String> clientInfoMap = (Map<String, String>) ThreadContext.get(CLIENT_INFO_KEY);
+    assertThat(clientInfoMap, notNullValue());
+    assertThat(clientInfoMap.get(SERVLET_REMOTE_ADDR), is(MOCK_REMOTE_ADDRESS));
+    assertThat(clientInfoMap.get(SERVLET_REMOTE_HOST), is(MOCK_REMOTE_HOST));
+    assertThat(clientInfoMap.get(SERVLET_SCHEME), is(MOCK_SCHEME));
+    assertThat(clientInfoMap.get(SERVLET_CONTEXT_PATH), is(MOCK_CONTEXT_PATH));
+    assertThat(clientInfoMap.size(), is(4));
     return null;
   }
 
   private void assertThatMapIsNull() throws Exception {
     Map<String, String> clientInfoMap = (Map<String, String>) ThreadContext.get(CLIENT_INFO_KEY);
     assertThat(clientInfoMap, nullValue());
+  }
+
+  private HttpServletRequest mockFullClientInfo() {
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    when(httpServletRequest.getRemoteAddr()).thenReturn(MOCK_REMOTE_ADDRESS);
+    when(httpServletRequest.getRemoteHost()).thenReturn(MOCK_REMOTE_HOST);
+    when(httpServletRequest.getScheme()).thenReturn(MOCK_SCHEME);
+    when(httpServletRequest.getServletContext()).thenReturn(mockServletContext);
+    when(httpServletRequest.getHeader("Forwarded")).thenReturn(MOCK_FORWARDED_HEADER);
+    when(httpServletRequest.getHeader("X-Forwarded-For")).thenReturn(MOCK_X_FORWARDED_FOR);
+    when(httpServletRequest.getHeader("X-Forwarded-Host")).thenReturn(MOCK_X_FORWARDED_HOST_HEADER);
+    when(httpServletRequest.getHeader("X-Forwarded-Port")).thenReturn(MOCK_X_FORWARDED_PORT_HEADER);
+    when(httpServletRequest.getHeader("X-Forwarded-Proto"))
+        .thenReturn(MOCK_X_FORWARDED_PROTO_HEADER);
+    when(httpServletRequest.getHeader("X-Forwarded-Prefix"))
+        .thenReturn(MOCK_X_FORWARDED_PREFIX_HEADER);
+    when(httpServletRequest.getHeader("X-Forwarded-Ssl")).thenReturn(MOCK_X_FORWARDED_SSL_HEADER);
+    return httpServletRequest;
+  }
+
+  private HttpServletRequest mockClientInfoMissingForwardedHeaders() {
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    when(httpServletRequest.getRemoteAddr()).thenReturn(MOCK_REMOTE_ADDRESS);
+    when(httpServletRequest.getRemoteHost()).thenReturn(MOCK_REMOTE_HOST);
+    when(httpServletRequest.getScheme()).thenReturn(MOCK_SCHEME);
+    when(httpServletRequest.getServletContext()).thenReturn(mockServletContext);
+    return httpServletRequest;
   }
 }


### PR DESCRIPTION
#### What does this PR do?
- Adds proxy forwarded information to the client-info property, which will expose this information to the catalog framework through request properties.

#### Who is reviewing it? 
@figliold @mcalcote 

#### Select relevant component teams: 
@codice/security

#### Ask 2 committers to review/merge the PR and tag them here.
@figliold
@paouelle

#### How should this be tested?
1. Turn logging to DEBUG on `org.codice.ddf.pax.web.jetty`
2. Send CSW (or any other endpoint) containing with the new forwarded headers
3. Check logs for the map produced

#### Any background context you want to provide?
This change will allow a source to be created which can decide which host to federate too based on the original host the request was sent to.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
