### PR TITLE
[2.19.x] DDF-6035 G-8076 Fix result forms

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -28,8 +28,8 @@ const SortItemCollectionView = require('../sort/sort.view.js')
 const Common = require('../../js/Common.js')
 const properties = require('../../js/properties.js')
 const plugin = require('plugins/query-settings')
-const ResultForm = require('../result-form/result-form.js')
 const user = require('../singletons/user-instance.js')
+const ResultFormCollection = require('../result-form/result-form-collection-instance')
 import * as React from 'react'
 import RadioComponent from '../../react-component/input-wrappers/radio'
 import { showErrorMessages } from '../../react-component/utils/validation'
@@ -63,18 +63,15 @@ module.exports = plugin(
         'change:sortField change:sortOrder change:src change:federation',
         Common.safeCallback(this.onBeforeShow)
       )
-      this.resultFormCollection = ResultForm.getResultCollection()
+      this.resultFormCollection = ResultFormCollection.getCollection();
       this.listenTo(
         this.resultFormCollection,
-        'change:added',
-        this.handleFormUpdate
+        'change',
+        this.renderResultForms
       )
       this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', () =>
         this.renderResultForms(this.resultFormCollection.filteredList)
       )
-    },
-    handleFormUpdate(newForm) {
-      this.renderResultForms(this.resultFormCollection.filteredList)
     },
     onBeforeShow() {
       this.setupSpellcheck()
@@ -82,32 +79,39 @@ module.exports = plugin(
       this.setupSortFieldDropdown()
       this.setupSrcDropdown()
       this.turnOnEditing()
-      this.renderResultForms(this.resultFormCollection.filteredList)
+      this.renderResultForms()
       this.setupExtensions()
     },
-    renderResultForms(resultTemplates) {
-      resultTemplates = resultTemplates ? resultTemplates : []
-      resultTemplates.push({
+    renderResultForms() {
+      let resultFormsCollection = ResultFormCollection.getCollection() || []
+      let resultForms = resultFormsCollection.map(resultTemplate => {
+        const resultFormJson = resultTemplate.toJSON()
+        return {
+        ...resultFormJson,
+        label: resultFormJson.title,
+        value: resultFormJson.title,
+      }});
+      resultForms.push({
         label: 'All Fields',
         value: 'allFields',
         id: 'All Fields',
         descriptors: [],
         description: 'All Fields',
       })
-      resultTemplates = _.uniq(resultTemplates, 'id')
-      let lastIndex = resultTemplates.length - 1
-      let defaultResultForm = resultTemplates.find(
+      resultForms = _.uniq(resultForms, 'id')
+      let lastIndex = resultForms.length - 1
+      let defaultResultForm = resultForms.find(
         form => form.id === user.getQuerySettings().get('defaultResultFormId')
       )
       const propertyValue =
         this.model.get('detail-level') ||
         (defaultResultForm && defaultResultForm.value) ||
-        (resultTemplates &&
-          resultTemplates[lastIndex] &&
-          resultTemplates[lastIndex].value)
+        (resultForms &&
+          resultForms[lastIndex] &&
+          resultForms[lastIndex].value)
       let detailLevelProperty = new Property({
         label: 'Result Form',
-        enum: resultTemplates,
+        enum: resultForms,
         value: [propertyValue],
         showValidationIssues: false,
         id: 'Result Form',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -63,12 +63,8 @@ module.exports = plugin(
         'change:sortField change:sortOrder change:src change:federation',
         Common.safeCallback(this.onBeforeShow)
       )
-      this.resultFormCollection = ResultFormCollection.getCollection();
-      this.listenTo(
-        this.resultFormCollection,
-        'change',
-        this.renderResultForms
-      )
+      this.resultFormCollection = ResultFormCollection.getCollection()
+      this.listenTo(this.resultFormCollection, 'change', this.renderResultForms)
       this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', () =>
         this.renderResultForms(this.resultFormCollection.filteredList)
       )
@@ -87,10 +83,11 @@ module.exports = plugin(
       let resultForms = resultFormsCollection.map(resultTemplate => {
         const resultFormJson = resultTemplate.toJSON()
         return {
-        ...resultFormJson,
-        label: resultFormJson.title,
-        value: resultFormJson.title,
-      }});
+          ...resultFormJson,
+          label: resultFormJson.title,
+          value: resultFormJson.title,
+        }
+      })
       resultForms.push({
         label: 'All Fields',
         value: 'allFields',
@@ -106,9 +103,7 @@ module.exports = plugin(
       const propertyValue =
         this.model.get('detail-level') ||
         (defaultResultForm && defaultResultForm.value) ||
-        (resultForms &&
-          resultForms[lastIndex] &&
-          resultForms[lastIndex].value)
+        (resultForms && resultForms[lastIndex] && resultForms[lastIndex].value)
       let detailLevelProperty = new Property({
         label: 'Result Form',
         enum: resultForms,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -63,10 +63,10 @@ module.exports = plugin(
         'change:sortField change:sortOrder change:src change:federation',
         Common.safeCallback(this.onBeforeShow)
       )
-      this.resultFormCollection = ResultFormCollection.getCollection()
-      this.listenTo(this.resultFormCollection, 'change', this.renderResultForms)
+      this.resultForms = ResultFormCollection.getCollection()
+      this.listenTo(this.resultForms, 'change', this.renderResultForms)
       this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', () =>
-        this.renderResultForms(this.resultFormCollection.filteredList)
+        this.renderResultForms()
       )
     },
     onBeforeShow() {
@@ -79,8 +79,8 @@ module.exports = plugin(
       this.setupExtensions()
     },
     renderResultForms() {
-      let resultFormsCollection = ResultFormCollection.getCollection() || []
-      let resultForms = resultFormsCollection.map(resultTemplate => {
+      // Each item in a dropdown needs a label and value so we add those here
+      let resultFormsForDropdown = this.resultForms.map(resultTemplate => {
         const resultFormJson = resultTemplate.toJSON()
         return {
           ...resultFormJson,
@@ -88,25 +88,27 @@ module.exports = plugin(
           value: resultFormJson.title,
         }
       })
-      resultForms.push({
+      resultFormsForDropdown.push({
         label: 'All Fields',
         value: 'allFields',
         id: 'All Fields',
         descriptors: [],
         description: 'All Fields',
       })
-      resultForms = _.uniq(resultForms, 'id')
-      let lastIndex = resultForms.length - 1
-      let defaultResultForm = resultForms.find(
+      resultFormsForDropdown = _.uniq(resultFormsForDropdown, 'id')
+      let lastIndex = resultFormsForDropdown.length - 1
+      let defaultResultForm = resultFormsForDropdown.find(
         form => form.id === user.getQuerySettings().get('defaultResultFormId')
       )
       const propertyValue =
         this.model.get('detail-level') ||
         (defaultResultForm && defaultResultForm.value) ||
-        (resultForms && resultForms[lastIndex] && resultForms[lastIndex].value)
+        (resultFormsForDropdown &&
+          resultFormsForDropdown[lastIndex] &&
+          resultFormsForDropdown[lastIndex].value)
       let detailLevelProperty = new Property({
         label: 'Result Form',
-        enum: resultForms,
+        enum: resultFormsForDropdown,
         value: [propertyValue],
         showValidationIssues: false,
         id: 'Result Form',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.collection.js
@@ -37,7 +37,6 @@ module.exports = Backbone.AssociatedModel.extend({
   model: ResultForm,
   defaults: {
     doneLoading: false,
-    added: false,
     resultForms: [],
   },
   initialize() {
@@ -69,21 +68,6 @@ module.exports = Backbone.AssociatedModel.extend({
   ],
   addResultForms() {
     if (!this.isDestroyed) {
-      this.filteredList = _.map(resultTemplates, resultForm => ({
-        label: resultForm.title,
-        value: resultForm.title,
-        id: resultForm.id,
-        descriptors: resultForm.descriptors,
-        description: resultForm.description,
-        owner: resultForm.owner,
-        created: resultForm.created,
-        creator: resultForm.creator,
-        createdBy: resultForm.creator,
-        accessGroups: resultForm.accessGroups,
-        accessIndividuals: resultForm.accessIndividuals,
-        accessAdministrators: resultForm.accessAdministrators,
-      }))
-
       resultTemplates.forEach((value, index) => {
         this.addResultForm(
           new ResultForm({
@@ -113,9 +97,6 @@ module.exports = Backbone.AssociatedModel.extend({
   getDoneLoading() {
     return this.get('doneLoading')
   },
-  toggleUpdate() {
-    this.set('added', !this.get('added'))
-  },
   doneLoading() {
     this.set('doneLoading', true)
   },
@@ -123,13 +104,6 @@ module.exports = Backbone.AssociatedModel.extend({
     return this.get('resultForms')
   },
   deleteCachedTemplateById(id) {
-    if (this.filteredList) {
-      this.filteredList = _.filter(
-        this.filteredList,
-        template => template.id !== id
-      )
-      this.toggleUpdate()
-    }
     if (resultTemplates) {
       resultTemplates = _.filter(
         resultTemplates,

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
@@ -73,7 +73,7 @@ module.exports = Marionette.LayoutView.extend({
           enum: allowedValues,
           values: this.model.get('descriptors'),
           value:
-            [this.model.get('descriptors')].size > 0
+            [this.model.get('descriptors')].length > 0
               ? [this.model.get('descriptors')]
               : [[allowedValues[0] && allowedValues[0].label]],
           id: 'Attributes',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/row.view.js
@@ -14,6 +14,7 @@
  **/
 import * as React from 'react'
 import { ItemCheckbox } from '../../selection-checkbox/item-checkbox'
+import MarionetteRegionContainer from '../../../react-component/marionette-region-container'
 
 const Marionette = require('marionette')
 const CustomElements = require('../../../js/CustomElements.js')
@@ -29,9 +30,6 @@ module.exports = Marionette.LayoutView.extend({
   tagName: CustomElements.register('result-row'),
   events: {
     'click .result-download': 'triggerDownload',
-  },
-  regions: {
-    resultThumbnail: '.is-thumbnail',
   },
   attributes() {
     return {
@@ -57,43 +55,58 @@ module.exports = Marionette.LayoutView.extend({
               }`}
               data-value={`${property.value}`}
             >
-              <div>
-                {property.value.map(value => {
-                  return (
-                    <span data-value={`${value}`} title={`${alias}: ${value}`}>
-                      {value.toString().substring(0, 4) === 'http' ? (
-                        <a
-                          href={`${value}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
+              {property.property === 'thumbnail' ? (
+                <MarionetteRegionContainer
+                  view={HoverPreviewDropdown}
+                  viewOptions={{
+                    model: new DropdownModel(),
+                    modelForComponent: this.model,
+                  }}
+                />
+              ) : (
+                <React.Fragment>
+                  <div>
+                    {property.value.map(value => {
+                      return (
+                        <span
+                          data-value={`${value}`}
+                          title={`${alias}: ${value}`}
                         >
-                          {HandleBarsHelpers.getAlias(property.property)}
-                        </a>
-                      ) : (
-                        `${value}`
-                      )}
-                    </span>
-                  )
-                })}
-              </div>
-              <div className="for-bold">
-                {property.value.map(value => (
-                  <span data-value={`${value}`}>
-                    {value.toString().substring(0, 4) === 'http' ? (
-                      <a
-                        href={`${value}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {HandleBarsHelpers.getAlias(property.property)}
-                      </a>
-                    ) : (
-                      `${value}`
-                    )}
-                    :{value}
-                  </span>
-                ))}
-              </div>
+                          {value.toString().substring(0, 4) === 'http' ? (
+                            <a
+                              href={`${value}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {HandleBarsHelpers.getAlias(property.property)}
+                            </a>
+                          ) : (
+                            `${value}`
+                          )}
+                        </span>
+                      )
+                    })}
+                  </div>
+                  <div className="for-bold">
+                    {property.value.map(value => (
+                      <span data-value={`${value}`}>
+                        {value.toString().substring(0, 4) === 'http' ? (
+                          <a
+                            href={`${value}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {HandleBarsHelpers.getAlias(property.property)}
+                          </a>
+                        ) : (
+                          `${value}`
+                        )}
+                        :{value}
+                      </span>
+                    ))}
+                  </div>
+                </React.Fragment>
+              )}
             </td>
           )
         })}
@@ -139,25 +152,6 @@ module.exports = Marionette.LayoutView.extend({
   onRender() {
     this.checkIfLinks()
     this.$el.attr(this.attributes())
-    this.handleResultThumbnail()
-  },
-  handleResultThumbnail() {
-    if (
-      this.model
-        .get('metacard')
-        .get('properties')
-        .get('thumbnail') &&
-      !this.isHidden('thumbnail')
-    ) {
-      if (this.resultThumbnail.$el) {
-        this.resultThumbnail.show(
-          new HoverPreviewDropdown({
-            model: new DropdownModel(),
-            modelForComponent: this.model,
-          })
-        )
-      }
-    }
   },
   checkIfLinks() {
     this.$el.toggleClass(


### PR DESCRIPTION
#### What does this PR do?
Fixes the following issues with result forms:
- Newly created result forms were not able to be used in queries until after a refresh.
- While editing existing forms, the attributes were not being populated correctly.
- The table visualization would throw an error if the `thumbnail` attribute was not included in the attributes of the result form

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@brianfelix 
@Lambeaux 
@kentmorrissey 
@brhumphe 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@bdeining

#### How should this be tested?
##### Testing that newly created result forms can be used without a refresh
1. Go to `Result Forms` page in Intrigue
2. Create a new result form
3. Navigate to the `Workspaces` page from the hamburger menu without refreshing the page
4. Create a new query and open the `Result Forms` dropdown
5. Notice the new result form is available in the list without a refresh

##### Testing that the attributes of existing forms are populated correctly while editing
1. Go to `Result Forms` page in Intrigue
2. Create a new result form with some attributes
3. Click on the result form that was created from the card view
4. Verify that the attributes shown were the ones that were selected in step 2
5. Refresh the page
6. Again verify that the attributes shown were the ones that were selected in step 2

##### Testing that table visualization renders with or without the `thumbnail` attribute
1. Go to `Result Forms` page in Intrigue
2. Create a new result form with some attributes other than `thumbnail`
3. Go to the `Workspaces` page and run a query with the result form that was created
4. Verify the table renders correctly without a `Thumbnail` column
5. Go back to the `Result Forms` page and add the `thumbnail` attribute to the form created in step 2
6. Run the query again and verify the table renders correctly with the `Thumbnail` column

##### Any other regression testing
1. Ensure result forms are still able to be marked as default
2. Test using a result form with a search form
3. Other things I didn't think of
#### What are the relevant tickets?
Fixes: #6035 
