### PR TITLE
[2.20.x] DDF-5614 create CachePutPlugin interface and update SolrCache to call registered plugins

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -703,5 +703,10 @@
             <artifactId>catalog-rest-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.plugin</groupId>
+            <artifactId>cache-plugin-defaultmetacardtags</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -83,6 +83,7 @@
         </bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-defaultvalues/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.core/catalog-core-metacardtype/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.plugin/cache-plugin-defaultmetacardtags/${project.version}</bundle>
     </feature>
 
     <feature name="catalog-core-attachment" version="${project.version}"

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/CachePutPlugin.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/CachePutPlugin.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.cache;
+
+import ddf.catalog.data.Metacard;
+import java.util.Optional;
+
+public interface CachePutPlugin {
+
+  /**
+   * Modify (optional) a metacard prior to being put into the cache. Implementations are not
+   * required to return the same metacard instance. Return {@link Optional#empty()} if the metacard
+   * should not be put into the cache.
+   *
+   * @param metacard the metacard to be modified
+   * @return the modifed metacard or Optional.empty()
+   */
+  Optional<Metacard> process(Metacard metacard);
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheBulkProcessor.java
@@ -76,7 +76,7 @@ public class CacheBulkProcessor {
               List<Metacard> metacards = new ArrayList<>(metacardsToCache.values());
               for (Collection<Metacard> batch : Lists.partition(metacards, batchSize)) {
                 LOGGER.debug("Caching a batch of {} metacards", batch.size());
-                cache.create(batch);
+                cache.put(batch);
 
                 for (Metacard metacard : batch) {
                   metacardsToCache.remove(metacard.getId());

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheCommitPhaser.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CacheCommitPhaser.java
@@ -61,7 +61,7 @@ class CacheCommitPhaser extends Phaser {
     // block next phase
     this.register();
     // add results to cache
-    cache.create(getMetacards(results));
+    cache.put(getMetacards(results));
     // unblock phase and wait for all other parties to unblock phase
     this.awaitAdvance(this.arriveAndDeregister());
   }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -379,7 +379,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
     }
 
     LOGGER.debug("Updating metacard(s) in cache.");
-    cache.create(metacards);
+    cache.put(metacards);
     LOGGER.debug("Updating metacard(s) in cache complete.");
 
     return input;

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/SolrCache.java
@@ -16,6 +16,7 @@ package ddf.catalog.cache.solr.impl;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.annotations.VisibleForTesting;
+import ddf.catalog.cache.CachePutPlugin;
 import ddf.catalog.cache.SolrCacheMBean;
 import ddf.catalog.data.ContentType;
 import ddf.catalog.data.Metacard;
@@ -40,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -82,6 +84,15 @@ public class SolrCache implements SolrCacheMBean {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SolrCache.class);
 
+  private static final CachePutPlugin REQUIRED_ATTRIBUTES_PUT_PLUGIN =
+      metacard -> {
+        if (StringUtils.isNotBlank(metacard.getSourceId())
+            && StringUtils.isNotBlank(metacard.getId())) {
+          return Optional.of(metacard);
+        }
+        return Optional.empty();
+      };
+
   private final SolrClient client;
 
   private final SolrMetacardClient metacardClient;
@@ -96,6 +107,8 @@ public class SolrCache implements SolrCacheMBean {
 
   private long expirationAgeInMinutes = TimeUnit.DAYS.toMinutes(7);
 
+  private final List<CachePutPlugin> cachePutPlugins;
+
   /**
    * Constructor.
    *
@@ -109,27 +122,34 @@ public class SolrCache implements SolrCacheMBean {
       FilterAdapter adapter,
       SolrClientFactory solrClientFactory,
       SolrFilterDelegateFactory solrFilterDelegateFactory,
-      DynamicSchemaResolver dynamicSchemaResolver) {
+      DynamicSchemaResolver dynamicSchemaResolver,
+      List<CachePutPlugin> cachePutPlugins) {
     this(
         adapter,
         solrClientFactory.newClient(METACARD_CACHE_CORE_NAME),
         solrFilterDelegateFactory,
-        dynamicSchemaResolver);
-  }
-
-  @VisibleForTesting
-  SolrCache(SolrClient client, CacheSolrMetacardClient metacardClient) {
-    this(client, metacardClient, SolrCache::createScheduler);
+        dynamicSchemaResolver,
+        cachePutPlugins);
   }
 
   @VisibleForTesting
   SolrCache(
       SolrClient client,
       CacheSolrMetacardClient metacardClient,
-      Supplier<ScheduledExecutorService> schedulerCreator) {
+      List<CachePutPlugin> cachePutPlugins) {
+    this(client, metacardClient, SolrCache::createScheduler, cachePutPlugins);
+  }
+
+  @VisibleForTesting
+  SolrCache(
+      SolrClient client,
+      CacheSolrMetacardClient metacardClient,
+      Supplier<ScheduledExecutorService> schedulerCreator,
+      List<CachePutPlugin> cachePutPlugins) {
     this.client = client;
     this.metacardClient = metacardClient;
     this.schedulerCreator = schedulerCreator;
+    this.cachePutPlugins = cachePutPlugins;
     configureCacheExpirationScheduler();
     configureMBean();
   }
@@ -140,11 +160,13 @@ public class SolrCache implements SolrCacheMBean {
       FilterAdapter adapter,
       SolrClient client,
       SolrFilterDelegateFactory solrFilterDelegateFactory,
-      DynamicSchemaResolver dynamicSchemaResolver) {
+      DynamicSchemaResolver dynamicSchemaResolver,
+      List<CachePutPlugin> cachePutPlugins) {
     this(
         client,
         new CacheSolrMetacardClient(
-            client, adapter, solrFilterDelegateFactory, dynamicSchemaResolver));
+            client, adapter, solrFilterDelegateFactory, dynamicSchemaResolver),
+        cachePutPlugins);
   }
 
   /**
@@ -169,21 +191,15 @@ public class SolrCache implements SolrCacheMBean {
     return metacardClient.query(request);
   }
 
-  public void create(Collection<Metacard> metacards) {
+  public void put(Collection<Metacard> metacards) {
     if (CollectionUtils.isEmpty(metacards)) {
       return;
     }
 
-    List<Metacard> updatedMetacards = new ArrayList<>();
-    for (Metacard metacard : metacards) {
-      if (metacard != null) {
-        if (StringUtils.isNotBlank(metacard.getSourceId())
-            && StringUtils.isNotBlank(metacard.getId())) {
-          updatedMetacards.add(metacard);
-        }
-      } else {
-        LOGGER.debug("metacard in result was null");
-      }
+    List<Metacard> updatedMetacards = applyCachePutPlugins(metacards);
+
+    if (CollectionUtils.isEmpty(updatedMetacards)) {
+      return;
     }
 
     try {
@@ -225,6 +241,31 @@ public class SolrCache implements SolrCacheMBean {
 
   public void setExpirationAgeInMinutes(long expirationAgeInMinutes) {
     this.expirationAgeInMinutes = expirationAgeInMinutes;
+  }
+
+  private List<Metacard> applyCachePutPlugins(Collection<Metacard> metacards) {
+    List<Metacard> updatedMetacards = new ArrayList<>();
+    for (Metacard metacard : metacards) {
+      if (metacard != null) {
+        applyCachePutPlugins(metacard).ifPresent(updatedMetacards::add);
+      } else {
+        LOGGER.debug("metacard in result was null");
+      }
+    }
+    return updatedMetacards;
+  }
+
+  private Optional<Metacard> applyCachePutPlugins(Metacard metacard) {
+    Optional<Metacard> updatedMetacard = REQUIRED_ATTRIBUTES_PUT_PLUGIN.process(metacard);
+    if (updatedMetacard.isPresent()) {
+      for (CachePutPlugin cachePutPlugin : cachePutPlugins) {
+        updatedMetacard = cachePutPlugin.process(updatedMetacard.get());
+        if (!updatedMetacard.isPresent()) {
+          return updatedMetacard;
+        }
+      }
+    }
+    return updatedMetacard;
   }
 
   private void configureCacheExpirationScheduler() {

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/fedstrategy.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/fedstrategy.xml
@@ -41,7 +41,9 @@
         <reference-listener bind-method="addMetacardType" ref="dynamicSchemaResolver"/>
     </reference-list>
 
-    <bean id="solrCatalogCache" class="ddf.catalog.cache.solr.impl.SolrCache"
+    <bean id="solrCatalogCache"
+          depends-on="cachePutSortedList"
+          class="ddf.catalog.cache.solr.impl.SolrCache"
           destroy-method="shutdown">
         <cm:managed-properties persistent-id="ddf.catalog.solr.provider.SolrCacheProvider"
                                update-strategy="container-managed"/>
@@ -51,6 +53,7 @@
             <bean class="ddf.catalog.source.solr.SolrFilterDelegateFactoryImpl"/>
         </argument>
         <argument ref="dynamicSchemaResolver"/>
+        <argument ref="cachePutSortedList"/>
     </bean>
 
     <bean id="cacheQueryFactory" class="ddf.catalog.cache.solr.impl.CacheQueryFactory">

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/plugins.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/blueprint/plugins.xml
@@ -109,6 +109,12 @@
                             unbind-method="unbindPlugin" ref="accessSortedList"/>
     </reference-list>
 
+    <reference-list id="cachePutPlugins" interface="ddf.catalog.cache.CachePutPlugin"
+                    availability="optional">
+        <reference-listener bind-method="bindPlugin"
+                            unbind-method="unbindPlugin" ref="cachePutSortedList"/>
+    </reference-list>
+
     <bean id="preCreateStorageSortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
     <bean id="postCreateStorageSortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
     <bean id="preUpdateStorageSortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
@@ -124,5 +130,6 @@
     <bean id="preAuthSortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
     <bean id="policySortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
     <bean id="accessSortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
+    <bean id="cachePutSortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
 
 </blueprint>

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CacheBulkProcessorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CacheBulkProcessorTest.java
@@ -69,7 +69,7 @@ public class CacheBulkProcessorTest {
     cacheBulkProcessor.add(mockResults);
     waitForPendingMetacardsToCache();
 
-    verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
+    verify(mockSolrCache, times(1)).put(capturedMetacards.capture());
     assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
   }
 
@@ -81,7 +81,7 @@ public class CacheBulkProcessorTest {
     cacheBulkProcessor.add(mockResults);
     waitForPendingMetacardsToCache();
 
-    verify(mockSolrCache, times(1)).create(capturedMetacards.capture());
+    verify(mockSolrCache, times(1)).put(capturedMetacards.capture());
     assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
   }
 
@@ -89,7 +89,7 @@ public class CacheBulkProcessorTest {
   public void nullResult() throws Exception {
     cacheBulkProcessor.add(Collections.singletonList((Result) null));
 
-    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    verify(mockSolrCache, never()).put(anyCollectionOf(Metacard.class));
   }
 
   @Test
@@ -99,7 +99,7 @@ public class CacheBulkProcessorTest {
 
     cacheBulkProcessor.add(Collections.singletonList(mockResult));
 
-    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    verify(mockSolrCache, never()).put(anyCollectionOf(Metacard.class));
   }
 
   @Test
@@ -107,7 +107,7 @@ public class CacheBulkProcessorTest {
     cacheBulkProcessor.setMaximumBacklogSize(0);
     cacheBulkProcessor.add(getMockResults(10));
 
-    verify(mockSolrCache, never()).create(anyCollectionOf(Metacard.class));
+    verify(mockSolrCache, never()).put(anyCollectionOf(Metacard.class));
   }
 
   @Test
@@ -115,13 +115,13 @@ public class CacheBulkProcessorTest {
     doThrow(new RuntimeException())
         .doNothing()
         .when(mockSolrCache)
-        .create(anyCollectionOf(Metacard.class));
+        .put(anyCollectionOf(Metacard.class));
     List<Result> mockResults = getMockResults(10);
 
     cacheBulkProcessor.add(mockResults);
     waitForPendingMetacardsToCache();
 
-    verify(mockSolrCache, atLeast(2)).create(capturedMetacards.capture());
+    verify(mockSolrCache, atLeast(2)).put(capturedMetacards.capture());
     for (Collection<Metacard> metacards : capturedMetacards.getAllValues()) {
       assertThat(metacards).containsAll(getMetacards(mockResults));
     }
@@ -142,7 +142,7 @@ public class CacheBulkProcessorTest {
     cacheBulkProcessor.add(mockResults);
     waitForPendingMetacardsToCache();
 
-    verify(mockSolrCache).create(capturedMetacards.capture());
+    verify(mockSolrCache).put(capturedMetacards.capture());
     assertThat(capturedMetacards.getValue()).containsAll(getMetacards(mockResults));
   }
 

--- a/catalog/plugin/cache-plugin-defaultmetacardtags/pom.xml
+++ b/catalog/plugin/cache-plugin-defaultmetacardtags/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugin</artifactId>
+        <groupId>ddf.catalog.plugin</groupId>
+        <version>2.20.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cache-plugin-defaultmetacardtags</artifactId>
+    <name>DDF :: Cache :: Put Plugin :: Default Metacard Tags</name>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-standardframework</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                        </Export-Package>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.99</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.99</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.99</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/plugin/cache-plugin-defaultmetacardtags/src/main/java/org/codice/ddf/cache/plugin/metacardtags/DefaultMetacardTagsPlugin.java
+++ b/catalog/plugin/cache-plugin-defaultmetacardtags/src/main/java/org/codice/ddf/cache/plugin/metacardtags/DefaultMetacardTagsPlugin.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.cache.plugin.metacardtags;
+
+import ddf.catalog.cache.CachePutPlugin;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.Core;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultMetacardTagsPlugin implements CachePutPlugin {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMetacardTagsPlugin.class);
+
+  @Override
+  public Optional<Metacard> process(Metacard metacard) {
+    if (isMetacardTagsSet(metacard)) {
+      LOGGER.trace(
+          "The metacard {} already has the {} attribute. Therefore, not modifying the metacard.",
+          metacard.getId(),
+          Core.METACARD_TAGS);
+      return Optional.of(metacard);
+    }
+
+    LOGGER.trace(
+        "Setting the attribute {} with the value \"{}\" on metacard {}.",
+        Core.METACARD_TAGS,
+        Metacard.DEFAULT_TAG,
+        metacard.getId());
+    metacard.setAttribute(new AttributeImpl(Core.METACARD_TAGS, Metacard.DEFAULT_TAG));
+
+    return Optional.of(metacard);
+  }
+
+  private boolean isMetacardTagsSet(Metacard metacard) {
+    return !metacard.getTags().isEmpty();
+  }
+}

--- a/catalog/plugin/cache-plugin-defaultmetacardtags/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/cache-plugin-defaultmetacardtags/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,20 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="plugin" class="org.codice.ddf.cache.plugin.metacardtags.DefaultMetacardTagsPlugin"/>
+
+    <service ref="plugin" interface="ddf.catalog.cache.CachePutPlugin"/>
+
+</blueprint>

--- a/catalog/plugin/cache-plugin-defaultmetacardtags/src/test/java/org/codice/ddf/cache/plugin/metacardtags/DefaultMetacardTagsPluginTest.java
+++ b/catalog/plugin/cache-plugin-defaultmetacardtags/src/test/java/org/codice/ddf/cache/plugin/metacardtags/DefaultMetacardTagsPluginTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.cache.plugin.metacardtags;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Core;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class DefaultMetacardTagsPluginTest {
+
+  private DefaultMetacardTagsPlugin setDefaultMetacardTags;
+
+  private Metacard metacard;
+
+  @Before
+  public void setup() {
+    metacard = mock(Metacard.class);
+    setDefaultMetacardTags = new DefaultMetacardTagsPlugin();
+  }
+
+  @Test
+  public void testMetacardWithTags() {
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getValues()).thenReturn(Collections.singletonList("aTag"));
+
+    when(metacard.getTags()).thenReturn(Collections.singleton("aTag"));
+
+    Optional<Metacard> result = setDefaultMetacardTags.process(metacard);
+
+    assertThat(result.isPresent(), is(true));
+
+    verify(metacard, never()).setAttribute(any());
+  }
+
+  @Test
+  public void testMetacardWithoutTags() {
+
+    Optional<Metacard> result = setDefaultMetacardTags.process(metacard);
+
+    assertThat(result.isPresent(), is(true));
+
+    ArgumentCaptor<Attribute> captor = ArgumentCaptor.forClass(Attribute.class);
+
+    verify(metacard, times(1)).setAttribute(captor.capture());
+
+    assertThat(captor.getValue().getName(), is(Core.METACARD_TAGS));
+    assertThat(captor.getValue().getValue(), is(Metacard.DEFAULT_TAG));
+  }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -42,5 +42,6 @@
         <module>catalog-plugin-security-audit</module>
         <module>catalog-plugin-gazetteer</module>
         <module>catalog-plugin-facet-attribute-access</module>
+        <module>cache-plugin-defaultmetacardtags</module>
     </modules>
 </project>


### PR DESCRIPTION

#### What does this PR do?

Backport of https://github.com/codice/ddf/pull/5615/

Adds a CachePutPlugin and updates SolrCache to utilize the plugin. This plugin is called for every metacard being put into the solr cache. The plugin provides the opportunity to modify metacards before being put into the cache, or to indicate that the metacard should not be put into the cache.

This PR also provides an implementation of the CachePutPlugin that sets metacard tags attribute to "resource" if the metacard does not have a metacard tags.

#### Who is reviewing it? 
@pklinef
@jlcsmith
@jrnorth

#### Select relevant component teams: 
@codice/core-apis
@codice/data
@codice/solr

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@Bdthomson

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

Follow steps in original PR.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
