### PR TITLE
DDF-6058 Store date that metacard was deleted

### DIFF
--- a/catalog/core/catalog-core-versioning/versioning-api/src/main/java/ddf/catalog/core/versioning/DeletedMetacard.java
+++ b/catalog/core/catalog-core-versioning/versioning-api/src/main/java/ddf/catalog/core/versioning/DeletedMetacard.java
@@ -34,4 +34,6 @@ public interface DeletedMetacard extends Metacard {
   String LAST_VERSION_ID = PREFIXER.apply("version");
 
   String DELETED_METACARD_TAGS = PREFIXER.apply("tags");
+
+  String METACARD_DELETED_DATE = PREFIXER.apply("date");
 }

--- a/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
+++ b/catalog/core/catalog-core-versioning/versioning-common/src/main/java/ddf/catalog/core/versioning/impl/DeletedMetacardImpl.java
@@ -27,6 +27,7 @@ import ddf.catalog.data.impl.MetacardTypeImpl;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -56,6 +57,9 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
     DESCRIPTORS.add(
         new AttributeDescriptorImpl(
             DELETED_METACARD_TAGS, true, true, false, true, BasicTypes.STRING_TYPE));
+    DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            METACARD_DELETED_DATE, true, true, false, false, BasicTypes.DATE_TYPE));
     METACARD_TYPE = new MetacardTypeImpl(PREFIX, DESCRIPTORS);
   }
 
@@ -77,6 +81,7 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
     this.setLastVersionId(lastVersionId);
     this.setTags(ImmutableSet.of(DELETED_TAG));
     this.setId(id);
+    this.setDeletedDate(new Date());
   }
 
   public static boolean isNotDeleted(@Nullable Metacard metacard) {
@@ -140,5 +145,9 @@ public class DeletedMetacardImpl extends MetacardImpl implements DeletedMetacard
       return Collections.emptySet();
     }
     return deletedTags.getValues().stream().map(String::valueOf).collect(Collectors.toSet());
+  }
+
+  public void setDeletedDate(Date date) {
+    setAttribute(METACARD_DELETED_DATE, date);
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Stores the date that the metacard was deleted on deleted metacards. 

#### Who is reviewing it? 
@derekwilhelm 
@rececoffin 

#### Select relevant component teams: 
@codice/core-apis 
@codice/data 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@jlcsmith 
@rzwiefel

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Ingest a metacard. 
2. Delete that metacard. 
3. Verify that the deleted metacard contains the date that it was deleted on. 

#### Any background context you want to provide?
None

#### What are the relevant tickets?
Fixes: #6058 

#### Screenshots
None

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
