### PR TITLE
DDF-6049 Move SecureWebSocketServlet into DDF

### DIFF
--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -528,6 +528,13 @@ org.ops4j.pax.web.default.realmname=DDF
         <bundle>mvn:ddf.security.servlet/security-servlet-whoami/${project.version}</bundle>
     </feature>
 
+    <feature name="security-servlet-web-socket" version="${project.version}"
+             description="Defines a secure web socket servlet type.">
+        <feature>security-core-impl</feature>
+        <feature>pax-http-whiteboard</feature>
+        <bundle>mvn:ddf.security.servlet/security-servlet-web-socket/${project.version}</bundle>
+    </feature>
+
     <feature name="security-handler-saml" version="${project.version}"
              description="SAML Web SSO client">
         <feature>security-core-api</feature>
@@ -590,6 +597,7 @@ org.ops4j.pax.web.default.realmname=DDF
         <feature>security-pdp-authz</feature>
         <feature>security-servlet-whoami</feature>
         <feature>security-servlet-session-expiry</feature>
+        <feature>security-servlet-web-socket</feature>
         <feature>security-realm-saml</feature>
         <feature>security-guest-realm</feature>
         <feature>security-claims-property</feature>

--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -530,7 +530,7 @@ org.ops4j.pax.web.default.realmname=DDF
 
     <feature name="security-servlet-web-socket" version="${project.version}"
              description="Defines a secure web socket servlet type.">
-        <feature>security-core-impl</feature>
+        <feature>security-core-api</feature>
         <feature>pax-http-whiteboard</feature>
         <bundle>mvn:ddf.security.servlet/security-servlet-web-socket/${project.version}</bundle>
     </feature>

--- a/platform/security/servlet/pom.xml
+++ b/platform/security/servlet/pom.xml
@@ -30,5 +30,6 @@
         <module>security-servlet-default-logout</module>
         <module>security-servlet-whoami</module>
         <module>security-servlet-session-expiry</module>
+        <module>security-servlet-web-socket</module>
     </modules>
 </project>

--- a/platform/security/servlet/security-servlet-web-socket/pom.xml
+++ b/platform/security/servlet/security-servlet-web-socket/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>security-servlet</artifactId>
+        <groupId>ddf.security.servlet</groupId>
+        <version>2.25.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>security-servlet-web-socket</artifactId>
+    <packaging>bundle</packaging>
+    <name>DDF :: Security :: Servlet :: Web Socket</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>gson-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-servlet</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/security/servlet/security-servlet-web-socket/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
+++ b/platform/security/servlet/security-servlet-web-socket/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.servlet.web.socket;
+
+import ddf.security.SecurityConstants;
+import ddf.security.Subject;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import javax.servlet.http.HttpSession;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SecureWebSocketServlet extends WebSocketServlet {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecureWebSocketServlet.class);
+
+  private final WebSocket ws;
+
+  private final ExecutorService executor;
+
+  public SecureWebSocketServlet(ExecutorService executor, WebSocket ws) {
+    this.ws = ws;
+    this.executor = executor;
+  }
+
+  @Override
+  public void destroy() {
+    executor.shutdown();
+  }
+
+  /*
+   Pass the TokenHolder into the WebSocket, in order to know when the user has logged out. Can't
+   pass the Session because Jetty won't let anything check session attributes unless there's a
+   request (excluding WebSocket requests) being actively fulfilled for that session.
+  */
+  @Override
+  public void configure(WebSocketServletFactory factory) {
+    factory.setCreator((req, resp) -> new SocketWrapper(executor, ws, req.getSession()));
+  }
+
+  @org.eclipse.jetty.websocket.api.annotations.WebSocket
+  public static class SocketWrapper {
+
+    private final WebSocket ws;
+
+    private final ExecutorService executor;
+
+    private final HttpSession httpSession;
+
+    SocketWrapper(ExecutorService executor, WebSocket ws, HttpSession httpSession) {
+      this.ws = ws;
+      this.executor = executor;
+      this.httpSession = httpSession;
+    }
+
+    private void runWithUser(Session session, Runnable runnable) {
+      Subject subject =
+          (Subject)
+              ((ServletUpgradeRequest) session.getUpgradeRequest())
+                  .getHttpServletRequest()
+                  .getAttribute(SecurityConstants.SECURITY_SUBJECT);
+
+      executor.submit(
+          () -> {
+            subject.execute(runnable);
+          });
+    }
+
+    @OnWebSocketConnect
+    public void onOpen(Session session) {
+      if (isUserLoggedIn()) {
+        runWithUser(session, () -> ws.onOpen(session));
+      } else {
+        onError(session, new WebSocketAuthenticationException("User not logged in."));
+      }
+    }
+
+    @OnWebSocketClose
+    public void onClose(Session session, int statusCode, String reason) {
+      runWithUser(session, () -> ws.onClose(session, statusCode, reason));
+    }
+
+    @OnWebSocketError
+    public void onError(Session session, Throwable ex) {
+      runWithUser(session, () -> ws.onError(session, ex));
+    }
+
+    @OnWebSocketMessage
+    public void onMessage(Session session, String message) {
+      if (isUserLoggedIn()) {
+        runWithUser(
+            session,
+            () -> {
+              try {
+                ws.onMessage(session, message);
+              } catch (IOException e) {
+                LOGGER.error("Failed to receive ws message.", e);
+              }
+            });
+      } else {
+        onError(session, new WebSocketAuthenticationException("User not logged in.", message));
+      }
+    }
+
+    private boolean isUserLoggedIn() {
+      if (httpSession == null) {
+        return false;
+      }
+
+      try {
+        httpSession.getCreationTime();
+        return true;
+      } catch (IllegalStateException ise) {
+        // the session is invalid
+        return false;
+      }
+    }
+  }
+}

--- a/platform/security/servlet/security-servlet-web-socket/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
+++ b/platform/security/servlet/security-servlet-web-socket/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
@@ -47,11 +47,6 @@ public class SecureWebSocketServlet extends WebSocketServlet {
     executor.shutdown();
   }
 
-  /*
-   Pass the TokenHolder into the WebSocket, in order to know when the user has logged out. Can't
-   pass the Session because Jetty won't let anything check session attributes unless there's a
-   request (excluding WebSocket requests) being actively fulfilled for that session.
-  */
   @Override
   public void configure(WebSocketServletFactory factory) {
     factory.setCreator((req, resp) -> new SocketWrapper(executor, ws, req.getSession()));

--- a/platform/security/servlet/security-servlet-web-socket/src/main/java/org/codice/ddf/security/servlet/web/socket/WebSocket.java
+++ b/platform/security/servlet/security-servlet-web-socket/src/main/java/org/codice/ddf/security/servlet/web/socket/WebSocket.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.servlet.web.socket;
+
+import java.io.IOException;
+import org.eclipse.jetty.websocket.api.Session;
+
+/** WebSocket is a thin wrapper over the org.eclipse.jetty.websocket.api.annotations. */
+public interface WebSocket {
+  void onOpen(Session session);
+
+  void onClose(Session session, int statusCode, String reason);
+
+  void onError(Session session, Throwable ex);
+
+  void onMessage(Session session, String message) throws IOException;
+}

--- a/platform/security/servlet/security-servlet-web-socket/src/main/java/org/codice/ddf/security/servlet/web/socket/WebSocketAuthenticationException.java
+++ b/platform/security/servlet/security-servlet-web-socket/src/main/java/org/codice/ddf/security/servlet/web/socket/WebSocketAuthenticationException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.security.servlet.web.socket;
+
+/** An exception to represent a security-related error in the {@link SecureWebSocketServlet}. */
+public class WebSocketAuthenticationException extends RuntimeException {
+  private final String wsMessage;
+
+  WebSocketAuthenticationException(String message) {
+    this(message, null);
+  }
+
+  WebSocketAuthenticationException(String message, String wsMessage) {
+    super(message);
+    this.wsMessage = wsMessage;
+  }
+
+  public String getWsMessage() {
+    return wsMessage;
+  }
+}


### PR DESCRIPTION
[DDF-UI Pull Request](https://github.com/codice/ddf-ui/pull/219)

#### What does this PR do?
Moves the `SecureWebSocketServlet` into DDF and changes the way the web sockets checks to see if a user is logged in. The web sockets now store a reference to the http session (which contains the login information), and when that session is invalid it means the user has logged out.

#### Who is reviewing it? 
@SmithJosh 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@blen-desta 
@garrettfreibott 
@stustison 

#### How should this be tested?
Feel free to contact me with any questions.

Setup:
1. Install the standard profile.
1. Build and install [this DDF-UI](https://github.com/codice/ddf-ui/pull/219). **Make sure that ddf.version in the DDF-UI root pom matches this version of DDF.**

Test w/ Basic:
1. Login to the admin console with basic credentials.
1. Navigate to `System -> Configuration -> Catalog UI Search` and check `Enable Web Sockets`.
1. *In a new tab* login to intrigue with basic credentials.
1. Ingest some things.
1. Execute a query and verify results.
1. In the admin console tab, logout of the admin account. The goal here is to logout of the admin account with the intrigue tab still open and ready.
1. In the intrigue tab, re-execute the query. The query should fail. (Further executions may succeed due to the user being re-signed in with cached credentials, that is expected behavior)
1. Refreshing the intrigue tab should make you re-enter credentials and querying should work as expected.

(Extra Credit) Test w/ OIDC:
1. Start up keycloak and set it up a client for DDF to OIDC.
1. Login to DDF's admin console.
1. Modify the OIDC Handler configuration to contain the proper information to connect with keycoak.
1. Modify the Web Context Policy Manager to use OIDC for Web Pages and Endpoints.
1. Logout.
1. Login to intrigue.
1. Execute a query and verify results.
1. *In a new tab* login to a web page (i.e. the admin console or intrigue) and logout. The goal here is to logout of the admin account with the intrigue tab still open and ready.
1. In the intrigue tab, re-execute the query. The query should fail. Further executions of the query should also fail.
1. Refreshing the intrigue tab should make you re-enter credentials and querying should work as expected.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6049

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
