### PR TITLE
[2.19.x] DDF-6022 Make DDF to return suggested values for each attribute in k-v pairs o…

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AcronymizedValidationReportImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AcronymizedValidationReportImpl.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.validation.impl.report;
+
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AcronymizedValidationReportImpl extends AttributeValidationReportImpl {
+
+  private final Set<Map<String, String>> suggestedValues = new HashSet<>();
+
+  public AcronymizedValidationReportImpl() {
+    super();
+  }
+
+  /**
+   * Adds a suggested attribute value to the report.
+   *
+   * @param acronym a suggested attribute value to add to the report
+   * @throws IllegalArgumentException if {@code value} is null
+   */
+  @Override
+  public void addSuggestedValue(final String acronym, final String meaning) {
+    Preconditions.checkArgument(acronym != null, "The suggested acronym cannot be null.");
+    Preconditions.checkArgument(meaning != null, "The suggested meaning cannot be null.");
+
+    Map<String, String> suggestedValue = new HashMap<>();
+    suggestedValue.put("label", acronym + " (" + meaning + ")");
+    suggestedValue.put("value", acronym);
+    suggestedValues.add(suggestedValue);
+  }
+
+  /**
+   * Adds a a set of attribute values to the report.
+   *
+   * @param values a set of suggested attribute values to add to the report, cannot be null or empty
+   * @throws IllegalArgumentException if {@code value} is null or empty
+   */
+  @Override
+  public void addSuggestedValues(Set<Map<String, String>> values) {
+    Preconditions.checkArgument(values != null, "The suggested values cannot be null.");
+    Preconditions.checkArgument(!values.isEmpty(), "The suggested values cannot be empty.");
+
+    suggestedValues.addAll(values);
+  }
+
+  @Override
+  public Set<Map<String, String>> getSuggestedValues() {
+    return Collections.unmodifiableSet(suggestedValues);
+  }
+}

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AttributeValidationReportImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/validation/impl/report/AttributeValidationReportImpl.java
@@ -17,13 +17,15 @@ import com.google.common.base.Preconditions;
 import ddf.catalog.validation.report.AttributeValidationReport;
 import ddf.catalog.validation.violation.ValidationViolation;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class AttributeValidationReportImpl implements AttributeValidationReport {
   private final Set<ValidationViolation> attributeValidationViolations = new HashSet<>();
 
-  private final Set<String> suggestedValues = new HashSet<>();
+  private final Set<Map<String, String>> suggestedValues = new HashSet<>();
 
   /**
    * Adds a {@link ValidationViolation} to the report.
@@ -45,9 +47,24 @@ public class AttributeValidationReportImpl implements AttributeValidationReport 
    */
   public void addViolations(Set<ValidationViolation> violations) {
     Preconditions.checkArgument(violations != null, "The violation list cannot be null.");
-    Preconditions.checkArgument(violations.size() > 0, "The violation list cannot be empty.");
+    Preconditions.checkArgument(!violations.isEmpty(), "The violation list cannot be empty.");
 
     attributeValidationViolations.addAll(violations);
+  }
+
+  /**
+   * Adds a suggested attribute value to the report.
+   *
+   * @param value a suggested attribute value to add to the report
+   * @throws IllegalArgumentException if {@code value} is null
+   */
+  public void addSuggestedValue(final String label, final String value) {
+    Preconditions.checkArgument(value != null, "The suggested value cannot be null.");
+
+    Map<String, String> suggestedValue = new HashMap<>();
+    suggestedValue.put("label", label);
+    suggestedValue.put("value", value);
+    suggestedValues.add(suggestedValue);
   }
 
   /**
@@ -59,7 +76,10 @@ public class AttributeValidationReportImpl implements AttributeValidationReport 
   public void addSuggestedValue(final String value) {
     Preconditions.checkArgument(value != null, "The suggested value cannot be null.");
 
-    suggestedValues.add(value);
+    Map<String, String> suggestedValue = new HashMap<>();
+    suggestedValue.put("label", value);
+    suggestedValue.put("value", value);
+    suggestedValues.add(suggestedValue);
   }
 
   /**
@@ -68,9 +88,9 @@ public class AttributeValidationReportImpl implements AttributeValidationReport 
    * @param values a set of suggested attribute values to add to the report, cannot be null or empty
    * @throws IllegalArgumentException if {@code value} is null or empty
    */
-  public void addSuggestedValues(Set<String> values) {
+  public void addSuggestedValues(Set<Map<String, String>> values) {
     Preconditions.checkArgument(values != null, "The suggested values cannot be null.");
-    Preconditions.checkArgument(values.size() > 0, "The suggested values cannot be empty.");
+    Preconditions.checkArgument(!values.isEmpty(), "The suggested values cannot be empty.");
 
     suggestedValues.addAll(values);
   }
@@ -81,7 +101,7 @@ public class AttributeValidationReportImpl implements AttributeValidationReport 
   }
 
   @Override
-  public Set<String> getSuggestedValues() {
+  public Set<Map<String, String>> getSuggestedValues() {
     return Collections.unmodifiableSet(suggestedValues);
   }
 }

--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/report/AttributeValidationReport.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/validation/report/AttributeValidationReport.java
@@ -14,6 +14,7 @@
 package ddf.catalog.validation.report;
 
 import ddf.catalog.validation.violation.ValidationViolation;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -39,5 +40,5 @@ public interface AttributeValidationReport {
    *
    * @return the set of suggested values or an empty set if there are none
    */
-  Set<String> getSuggestedValues();
+  Set<Map<String, String>> getSuggestedValues();
 }

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/ISO3CountryCodeValidator.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/ISO3CountryCodeValidator.java
@@ -16,16 +16,17 @@ package ddf.catalog.validation.impl.validator;
 import com.google.common.base.Preconditions;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.validation.AttributeValidator;
-import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
+import ddf.catalog.validation.impl.report.AcronymizedValidationReportImpl;
 import ddf.catalog.validation.impl.violation.ValidationViolationImpl;
 import ddf.catalog.validation.report.AttributeValidationReport;
 import ddf.catalog.validation.violation.ValidationViolation;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.codice.countrycode.standard.CountryCode;
 import org.codice.countrycode.standard.StandardProvider;
 import org.codice.countrycode.standard.StandardRegistryImpl;
 
@@ -40,7 +41,7 @@ public class ISO3CountryCodeValidator implements AttributeValidator {
 
   private final boolean ignoreCase;
 
-  private final Set<String> countryCodes;
+  private final Map<String, String> countryCodes;
 
   public ISO3CountryCodeValidator(final boolean ignoreCase) {
     this.ignoreCase = ignoreCase;
@@ -57,8 +58,7 @@ public class ISO3CountryCodeValidator implements AttributeValidator {
         standardProvider
             .getStandardEntries()
             .stream()
-            .map(cc -> cc.getAsFormat("alpha3"))
-            .collect(Collectors.toSet());
+            .collect(Collectors.toMap(cc -> cc.getAsFormat("alpha3"), CountryCode::getName));
   }
 
   /**
@@ -78,7 +78,7 @@ public class ISO3CountryCodeValidator implements AttributeValidator {
   }
 
   private AttributeValidationReport buildReport(Attribute attribute) {
-    AttributeValidationReportImpl report = new AttributeValidationReportImpl();
+    AcronymizedValidationReportImpl report = new AcronymizedValidationReportImpl();
 
     attribute
         .getValues()
@@ -86,7 +86,7 @@ public class ISO3CountryCodeValidator implements AttributeValidator {
         .filter(String.class::isInstance)
         .map(String.class::cast)
         .map(ignoreCase ? String::toUpperCase : String::toString)
-        .filter(s -> !countryCodes.contains(s))
+        .filter(s -> !countryCodes.containsKey(s))
         .map(
             s ->
                 new ValidationViolationImpl(

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
@@ -22,6 +22,7 @@ import ddf.catalog.validation.violation.ValidationViolation;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
@@ -84,7 +85,7 @@ public class MatchAnyValidator implements AttributeValidator {
 
       Set<ValidationViolation> validationViolations =
           attributeValidationReport.getAttributeValidationViolations();
-      Set<String> suggestedValues = attributeValidationReport.getSuggestedValues();
+      Set<Map<String, String>> suggestedValues = attributeValidationReport.getSuggestedValues();
 
       result.addViolations(validationViolations);
 

--- a/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/EnumerationValidatorTest.java
+++ b/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/EnumerationValidatorTest.java
@@ -58,7 +58,14 @@ public class EnumerationValidatorTest {
   public void testSuggestedValues() {
     final Optional<AttributeValidationReport> reportOptional =
         getReport(false, new AttributeImpl("test", "something"));
-    assertThat(reportOptional.get().getSuggestedValues(), containsInAnyOrder(ENUMERATED_VALUES));
+    assertThat(
+        reportOptional
+            .get()
+            .getSuggestedValues()
+            .stream()
+            .map(pair -> pair.get("label"))
+            .collect(Collectors.toSet()),
+        containsInAnyOrder(ENUMERATED_VALUES));
   }
 
   private Optional<AttributeValidationReport> getReport(

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/validation/AttributeValidationResponse.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/validation/AttributeValidationResponse.java
@@ -14,15 +14,16 @@
 package org.codice.ddf.catalog.ui.metacard.validation;
 
 import ddf.catalog.validation.violation.ValidationViolation;
+import java.util.Map;
 import java.util.Set;
 
 public class AttributeValidationResponse {
   private Set<ValidationViolation> violations;
 
-  private Set<String> suggestedValues;
+  private Set<Map<String, String>> suggestedValues;
 
   public AttributeValidationResponse(
-      Set<ValidationViolation> violations, Set<String> suggestedValues) {
+      Set<ValidationViolation> violations, Set<Map<String, String>> suggestedValues) {
     this.violations = violations;
     this.suggestedValues = suggestedValues;
   }
@@ -35,11 +36,11 @@ public class AttributeValidationResponse {
     this.violations = violations;
   }
 
-  public Set<String> getSuggestedValues() {
+  public Set<Map<String, String>> getSuggestedValues() {
     return suggestedValues;
   }
 
-  public void setSuggestedValues(Set<String> suggestedValues) {
+  public void setSuggestedValues(Set<Map<String, String>> suggestedValues) {
     this.suggestedValues = suggestedValues;
   }
 }

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/validation/Validator.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/metacard/validation/Validator.java
@@ -103,7 +103,7 @@ public class Validator {
                 })
             .orElse(new HashSet<>());
 
-    Set<String> suggestedValues = new HashSet<>();
+    Set<Map<String, String>> suggestedValues = new HashSet<>();
     Set<ValidationViolation> violations = new HashSet<>();
     for (AttributeValidator validator : attributeValidators) {
       Optional<AttributeValidationReport> validationReport =

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/singletons/metacard-definitions.js
@@ -26,9 +26,15 @@ function transformEnumResponse(metacardTypes, response) {
         case 'DATE':
           result[key] = value.map(subval => {
             if (subval) {
-              return moment(subval).toISOString()
+              return {
+                label: moment(subval).toISOString(),
+                value: moment(subval).toISOString(),
+              }
             }
-            return subval
+            return {
+              label: subval,
+              value: subval,
+            }
           })
           break
         case 'LONG':
@@ -38,10 +44,16 @@ function transformEnumResponse(metacardTypes, response) {
         case 'SHORT': //needed until enum response correctly returns numbers as numbers
           result[key] = value.map((
             subval //handle cases of unnecessary number padding -> 22.0000
-          ) => Number(subval))
+          ) => ({
+            label: Number(subval.label),
+            value: Number(subval.value),
+          }))
           break
         default:
-          result[key] = value
+          result[key] = value.map(subval => ({
+            label: subval.label,
+            value: subval.value,
+          }))
           break
       }
       return result

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -131,14 +131,14 @@ class Filter extends React.Component {
     let suggestions = []
     if (metacardDefinitions.enums[attribute]) {
       suggestions = metacardDefinitions.enums[attribute].map(suggestion => {
-        return { label: suggestion, value: suggestion }
+        return { label: suggestion.label, value: suggestion.value }
       })
     } else if (this.props.suggester) {
       suggestions = (await this.props.suggester(
         metacardDefinitions.metacardTypes[attribute]
       )).map(suggestion => ({
-        label: suggestion,
-        value: suggestion,
+        label: suggestion.label,
+        value: suggestion.value,
       }))
     }
 


### PR DESCRIPTION
…f label and value

#### What does this PR do?
This makes DDF to send k-v pairs of label and value for an attribute's suggested values so that UI can show corresponding label and value for each attribute.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@leo-sakh 
@bennuttle 
@lavoywj 
@bdeining 
@rymach 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/core-apis 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@rzwiefel
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Unit tests
You can run DDF and then do advanced search. Select an attribute type that has suggested values (i.e. location.country-code), and then see if the dropdown menu shows something like `USA (United States of America)`
When it's making query, the query string should be something like `ATTRIBUTE_NAME ILIKE %USA%`.

#### Any background context you want to provide?
Currently, the dropdown menu for attributes only show a single string value. This changes DDF to return K-V pair of `Value (Context)` So that users can see what the `Value` stands for. (For cases like country codes).

#### What are the relevant tickets?
Fixes: #6021 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
