### PR TITLE
Add admin-configurable default table columns

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/config/ConfigurationApplication.java
@@ -237,7 +237,8 @@ public class ConfigurationApplication implements SparkApplication {
 
   private String basicSearchMatchType;
 
-  private List<String> defaultSources = Collections.emptyList();;
+  private List<String> defaultSources = Collections.emptyList();
+  private List<String> defaultTableColumns = Collections.emptyList();
 
   private Set<String> editorAttributes = Collections.emptySet();
   private Set<String> requiredAttributes = Collections.emptySet();
@@ -593,6 +594,7 @@ public class ConfigurationApplication implements SparkApplication {
     config.put("i18n", i18n);
     config.put("attributeSuggestionList", attributeSuggestionList);
     config.put("defaultSources", defaultSources);
+    config.put("defaultTableColumns", defaultTableColumns);
     return config;
   }
 
@@ -1310,6 +1312,23 @@ public class ConfigurationApplication implements SparkApplication {
     } else {
       this.defaultSources =
           defaultSources
+              .stream()
+              .filter(StringUtils::isNotBlank)
+              .map(String::trim)
+              .collect(Collectors.toList());
+    }
+  }
+
+  public List<String> setDefaultTableColumns() {
+    return defaultTableColumns;
+  }
+
+  public void setDefaultTableColumns(List<String> defaultTableColumns) {
+    if (defaultTableColumns == null || defaultTableColumns.isEmpty()) {
+      this.defaultTableColumns = Collections.emptyList();
+    } else {
+      this.defaultTableColumns =
+          defaultTableColumns
               .stream()
               .filter(StringUtils::isNotBlank)
               .map(String::trim)

--- a/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
+++ b/catalog/ui/catalog-ui-search/src/main/resources/OSGI-INF/metatype/org.codice.ddf.catalog.ui.xml
@@ -330,8 +330,16 @@
         </AD>
 
         <AD id="defaultSources"
-            name="Default Sources Selection"
+            name="Default Sources"
             description="List of default sources for use in queries"
+            type="String"
+            cardinality="1000"
+            required="false">
+        </AD>
+
+        <AD id="defaultTableColumns"
+            name="Default Table Columns"
+            description="List of default columns for the table visualization"
             type="String"
             cardinality="1000"
             required="false">

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/table-visibility.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/table/table-visibility.view.js
@@ -113,6 +113,7 @@ module.exports = Marionette.ItemView.extend({
         element.getAttribute('data-propertyid')
       )
     )
+    prefs.set('hasSelectedColumns', true)
     prefs.savePreferences()
     this.psuedoDestroy()
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -137,6 +137,7 @@ User.Preferences = Backbone.AssociatedModel.extend({
       visualization: '3dmap',
       columnHide: [],
       columnOrder: ['title', 'created', 'modified', 'thumbnail'],
+      hasSelectedColumns: false,
       uploads: [],
       fontSize: ThemeUtils.getFontSize(_get(properties, 'zoomPercentage', 100)),
       resultCount: properties.resultCount,


### PR DESCRIPTION
This is the ddf part of the table column default.

Notes:

- Decided to make a new config, so there's no conflict with the results config.
- Had to add a way to determine whether the user had chosen to hide an attributes. An empty columnHide could mean that the user wants to see all attributes.
- Couldn't add the defaults directly to the user prefs, because we need to know what attributes are available before before we can negate them.