### PR TITLE
[2.19.x] DDF-6074 Fixes query request filters not showing up in the security audit log

### DIFF
--- a/catalog/security/catalog-security-logging/src/main/java/org/codice/ddf/catalog/security/logging/SecurityLoggingPlugin.java
+++ b/catalog/security/catalog-security-logging/src/main/java/org/codice/ddf/catalog/security/logging/SecurityLoggingPlugin.java
@@ -38,7 +38,6 @@ import ddf.catalog.operation.Response;
 import ddf.catalog.operation.Update;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.UpdateResponse;
-import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.plugin.PluginExecutionException;
 import ddf.catalog.plugin.PostFederatedQueryPlugin;
 import ddf.catalog.plugin.PostIngestPlugin;
@@ -110,11 +109,8 @@ public class SecurityLoggingPlugin
   @Override
   public QueryRequest process(QueryRequest input)
       throws PluginExecutionException, StopProcessingException {
-    String additional = "";
     Query query = input.getQuery();
-    if (query instanceof QueryImpl) {
-      additional = ((QueryImpl) query).getFilter().toString();
-    }
+    String additional = query.toString();
     logOperation(CatalogOperationType.QUERY_REQUEST, input, additional);
     return input;
   }
@@ -193,11 +189,8 @@ public class SecurityLoggingPlugin
   @Override
   public QueryRequest process(Source source, QueryRequest input)
       throws PluginExecutionException, StopProcessingException {
-    String additional = "";
     Query query = input.getQuery();
-    if (query instanceof QueryImpl) {
-      additional = ((QueryImpl) query).getFilter().toString() + " for source " + source.getId();
-    }
+    String additional = query.toString() + " for source " + source.getId();
     logOperation(CatalogOperationType.QUERY_REQUEST, input, additional);
     return input;
   }


### PR DESCRIPTION
#### What does this PR do?
Fixes query request filters not showing up in the security audit log

#### Who is reviewing it? 
@bakejeyner
@garrettfreibott  
@SmithJosh 
@stustison 

#### Select relevant component teams: 
@codice/security 

#### How should this be tested?
Query Intrigue using different filters and verify that those filters are logged in the security log.
This branch does not need ddf-ui

#### What are the relevant tickets?
Fixes: #6074

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
