### PR TITLE
[2.23.x] DDF-6076 G-2260 Moved Map Layers to Search UI app

### DIFF
--- a/catalog/admin/module/catalog-admin-module-maplayers/src/main/java/org/codice/ddf/catalog/admin/plugin/MaplayersPlugin.java
+++ b/catalog/admin/module/catalog-admin-module-maplayers/src/main/java/org/codice/ddf/catalog/admin/plugin/MaplayersPlugin.java
@@ -25,7 +25,7 @@ public class MaplayersPlugin extends AbstractApplicationPlugin {
     this.displayName = "Map Layers";
     this.iframeLocation = URI.create("./map-layers/index.html");
     List<String> apps = new ArrayList<>();
-    apps.add("catalog-app");
+    apps.add("search-ui-app");
     this.setAssociations(apps);
   }
 }


### PR DESCRIPTION
#### 2.19.x PR https://github.com/codice/ddf/pull/6077
#### master PR https://github.com/codice/ddf/pull/6078
__________
#### What does this PR do?
This PR moves the Map Layers tab from the Catalog app into the Search UI app
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@millerw8
@shaundmorris
#### How should this be tested?
Open the admin console and verify that the Map Layers tab is under the Search UI app and not the Catalog app
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: #6076
G-2260
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
