### PR TITLE
[2.20.x-perf] DDF-6097 Update PreFederatedQueryPlugin logic to maintain context

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -42,6 +42,12 @@ import ddf.catalog.source.Source;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.util.impl.RelevanceResultComparator;
 import ddf.catalog.util.impl.Requests;
+import org.apache.commons.lang3.Validate;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -56,10 +62,6 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.Validate;
-import org.opengis.filter.sort.SortOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting {@link
@@ -73,9 +75,9 @@ import org.slf4j.LoggerFactory;
  *   <li>{@link ddf.catalog.data.Result#RELEVANCE}
  * </ul>
  *
- * The supported ordering includes {@link org.opengis.filter.sort.SortOrder#DESCENDING} and {@link
- * org.opengis.filter.sort.SortOrder#ASCENDING}. For this class to function properly a sort value
- * and sort order must be provided.
+ * <p>The supported ordering includes {@link org.opengis.filter.sort.SortOrder#DESCENDING} and
+ * {@link org.opengis.filter.sort.SortOrder#ASCENDING}. For this class to function properly a sort
+ * value and sort order must be provided.
  *
  * @see ddf.catalog.data.Metacard
  * @see ddf.catalog.operation.Query
@@ -236,7 +238,8 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
       offset = this.maxStartIndex;
     }
 
-    final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, null);
+    final Map<String, Serializable> properties = Collections.synchronizedMap(new HashMap<>());
+    final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, properties);
 
     Map<Future<SourceResponse>, QueryRequest> futures = new HashMap<>();
 
@@ -287,7 +290,7 @@ public class CachingFederationStrategy implements FederationStrategy, PostIngest
     // transfer them into a different Queue. That is what the
     // OffsetResultHandler does.
     if (offset > 1 && sources.size() > 1) {
-      offsetResults = new QueryResponseImpl(queryRequest, null);
+      offsetResults = new QueryResponseImpl(queryRequest, properties);
       queryExecutorService.submit(
           new OffsetResultHandler(queryResponseQueue, offsetResults, pageSize, offset));
     }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/cache/solr/impl/CachingFederationStrategy.java
@@ -42,11 +42,6 @@ import ddf.catalog.source.Source;
 import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.util.impl.RelevanceResultComparator;
 import ddf.catalog.util.impl.Requests;
-import org.apache.commons.lang3.Validate;
-import org.opengis.filter.sort.SortOrder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,6 +57,10 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.Validate;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class represents a {@link ddf.catalog.federation.FederationStrategy} based on sorting {@link

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -828,7 +828,7 @@ public class QueryOperations extends DescribableImpl {
               if (!canAccessSource) {
                 notPermittedSources.add(source.getId());
               }
-              if (source.isAvailable() && canAccessSource) {
+              if (canAccessSource) {
                 sourcesToQuery.add(source);
               } else {
                 exceptions.add(queryOps.createUnavailableProcessingDetails(source));

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CachingFederationStrategyTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CachingFederationStrategyTest.java
@@ -582,7 +582,7 @@ public class CachingFederationStrategyTest {
     Set<ProcessingDetails> processingDetails = new HashSet<>();
     processingDetails.add(processingDetailsForNullPointer);
     processingDetails.add(processingDetailsForUnsupportedQuery);
-    doReturn(processingDetails).when(mockResponseWithProcessingDetails).getProcessingErrors();
+    doReturn(processingDetails).when(mockResponseWithProcessingDetails).getProcessingDetails();
 
     QueryRequest fedQueryRequest = new QueryRequestImpl(mockQuery, properties);
     when(mockSource.query(any(QueryRequest.class))).thenReturn(mockResponseWithProcessingDetails);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CachingFederationStrategyTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/CachingFederationStrategyTest.java
@@ -582,7 +582,7 @@ public class CachingFederationStrategyTest {
     Set<ProcessingDetails> processingDetails = new HashSet<>();
     processingDetails.add(processingDetailsForNullPointer);
     processingDetails.add(processingDetailsForUnsupportedQuery);
-    doReturn(processingDetails).when(mockResponseWithProcessingDetails).getProcessingDetails();
+    doReturn(processingDetails).when(mockResponseWithProcessingDetails).getProcessingErrors();
 
     QueryRequest fedQueryRequest = new QueryRequestImpl(mockQuery, properties);
     when(mockSource.query(any(QueryRequest.class))).thenReturn(mockResponseWithProcessingDetails);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SortedQueryMonitorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/cache/solr/impl/SortedQueryMonitorTest.java
@@ -146,7 +146,7 @@ public class SortedQueryMonitorTest {
     assertThat(queryResponse.getResults().size()).isEqualTo(4);
     HashMap<String, Long> hitsPerSource =
         (HashMap<String, Long>) queryResponse.getProperties().get("hitsPerSource");
-    assertThat(hitsPerSource.size()).isEqualTo(3);
+    assertThat(hitsPerSource.size()).isEqualTo(4);
     for (int[] idAndCount : new int[][] {{1, 3}, {2, 1}, {3, 0}}) {
       assertThat(hitsPerSource.get("Source-" + idAndCount[0])).isEqualTo(idAndCount[1]);
     }
@@ -192,7 +192,7 @@ public class SortedQueryMonitorTest {
     assertThat(queryResponse.getHits()).isEqualTo(3);
     HashMap<String, Long> hitsPerSource =
         (HashMap<String, Long>) queryResponse.getProperties().get("hitsPerSource");
-    assertThat(hitsPerSource.size()).isEqualTo(1);
+    assertThat(hitsPerSource.size()).isEqualTo(2);
     assertThat(hitsPerSource.get("Source-1")).isEqualTo(3);
     assertThat(queryResponse.getProcessingDetails())
         .extracting(byName("exception"))
@@ -240,7 +240,7 @@ public class SortedQueryMonitorTest {
     assertThat(queryResponse.getResults().size()).isEqualTo(3);
     HashMap<String, Long> hitsPerSource =
         (HashMap<String, Long>) queryResponse.getProperties().get("hitsPerSource");
-    assertThat(hitsPerSource.size()).isEqualTo(1);
+    assertThat(hitsPerSource.size()).isEqualTo(2);
     assertThat(hitsPerSource.get("Source-1")).isEqualTo(3);
     assertThat(queryResponse.getProcessingDetails())
         .extracting(byName("exception"))
@@ -262,7 +262,7 @@ public class SortedQueryMonitorTest {
     Set<ProcessingDetails> processingDetailsOfMockedSourceResponse = new HashSet<>();
     doReturn(processingDetailsOfMockedSourceResponse)
         .when(mockedSourceResponseWithProcessingDetails)
-        .getProcessingDetails();
+        .getProcessingErrors();
 
     QueryRequest mockedQueryRequest = mock(QueryRequest.class);
 

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/Status.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/query/cql/Status.java
@@ -15,7 +15,10 @@ package org.codice.ddf.catalog.ui.query.cql;
 
 import ddf.catalog.operation.ProcessingDetails;
 import ddf.catalog.operation.QueryResponse;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Status {
 
@@ -29,6 +32,8 @@ public class Status {
 
   private final boolean successful;
 
+  private List<String> warnings = new ArrayList<>();
+
   public Status(QueryResponse response, String source, long elapsedTime) {
     elapsed = elapsedTime;
     id = source;
@@ -36,6 +41,7 @@ public class Status {
     count = response.getResults().size();
     hits = response.getHits();
     successful = isSuccessful(response.getProcessingDetails());
+    warnings = getWarnings(response.getProcessingDetails());
   }
 
   public Status(
@@ -45,6 +51,7 @@ public class Status {
     this.hits = hits;
     this.elapsed = elapsedTime;
     this.successful = isSuccessful(details);
+    this.warnings = getWarnings(details);
   }
 
   private boolean isSuccessful(final Set<ProcessingDetails> details) {
@@ -54,6 +61,15 @@ public class Status {
       }
     }
     return true;
+  }
+
+  private List<String> getWarnings(final Set<ProcessingDetails> details) {
+    return details
+        .stream()
+        .filter(detail -> !detail.hasException())
+        .map(detail -> detail.getWarnings())
+        .flatMap(procesingWarnings -> procesingWarnings.stream())
+        .collect(Collectors.toList());
   }
 
   public long getHits() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/dropdown/query-src/dropdown.query-src.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/dropdown/query-src/dropdown.query-src.view.js
@@ -37,7 +37,7 @@ const renderSourceAvailable = source => (
         <i className="fa fa-exclamation-triangle src-availability" />
       ) : null}
       {renderSourceLocal(source)}
-      <span className="src-title">{source.id}</span>
+      <span className="src-title" style={{marginLeft: "5px"}}>{source.id}</span>
     </span>
   </React.Fragment>
 )

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.hbs
@@ -14,18 +14,25 @@
 <td>
     {{id}}
     {{#if hasReturned}}
-        {{#unless successful}}
-            <span class="fa fa-warning" title="{{messages}}"></span>
-        {{/unless}}
+        {{#if warnings}}
+            <span class="fa fa-warning warning" title="{{warnings}}"></span>
+        {{else}}
+            {{#unless successful}}
+                <span class="fa fa-warning error" title="{{messages}}"></span>
+            {{/unless}}
+        {{/if}}
     {{/if}}
 </td>
 <td>
     {{#if anyHasReturned}}
         {{top}}
+        {{#if warnings}}
+            <span class="fa fa-warning warning" title="{{warnings}}"></span>
+        {{/if}}
     {{/if}}
     {{#if hasReturned}}
         {{#unless successful}}
-            <span class="fa fa-warning" title="{{messages}}"></span>
+            <span class="fa fa-warning error" title="{{messages}}"></span>
         {{/unless}}
     {{/if}}
     {{#if anyHasNotReturned}}
@@ -36,8 +43,11 @@
     {{#if hasReturned}}
         {{#if successful}}
             {{hits}}
+            {{#if warnings}}
+                <span class="fa fa-warning warning" title="{{warnings}}"></span>
+            {{/if}}
         {{else}}
-            <span class="fa fa-warning" title="{{messages}}"></span>
+            <span class="fa fa-warning error" title="{{messages}}"></span>
         {{/if}}
     {{else}}
         <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>
@@ -47,8 +57,11 @@
     {{#if hasReturned}}
         {{#if successful}}
             {{elapsed}}
+            {{#if warnings}}
+                <span class="fa fa-warning warning" title="{{warnings}}"></span>
+            {{/if}}
         {{else}}
-            <span class="fa fa-warning" title="{{messages}}"></span>
+            <span class="fa fa-warning error" title="{{messages}}"></span>
         {{/if}}
     {{else}}
         <span class="fa fa-circle-o-notch fa-spin" title="Waiting for source to return"></span>

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-status/query-status-row.less
@@ -1,6 +1,10 @@
 @{customElementNamespace}query-status-row {
-  .fa-warning {
+  .error {
     color: @negative-color !important;
+  }
+
+  .warning {
+    color: @warning-color !important;
   }
 
   .status-filter {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -239,7 +239,10 @@ Query.Model = PartialAssociatedModel.extend({
       const totalHits = this.get('result')
         .get('status')
         .reduce((total, status) => {
-          return total + status.get('hits')
+          if (status.get('id') !== 'cache') {
+            return total + status.get('hits')
+          }
+          return total
         }, 0)
 
       this.set('totalHits', totalHits)

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -89,7 +89,6 @@ const reducer = (state = [{}], action) => {
     case 'PREVIOUS_PAGE':
       return state.slice(0, -1)
     case 'UPDATE_RESULTS':
-      console.log('UPDATE_RESULTS:: ', action.payload)
       const srcs = action.payload.status
         .filter(status => status.id !== 'cache')
         .map(({ id, count }) => ({ id, count }))

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -89,13 +89,15 @@ const reducer = (state = [{}], action) => {
     case 'PREVIOUS_PAGE':
       return state.slice(0, -1)
     case 'UPDATE_RESULTS':
-      const srcs = action.payload.results
-        .map(({ src }) => src)
-        .reduce((counts, src) => {
-          if (counts[src] === undefined) {
-            counts[src] = 0
+      console.log('UPDATE_RESULTS:: ', action.payload)
+      const srcs = action.payload.status
+        .filter(status => status.id !== 'cache')
+        .map(({ id, count }) => ({ id, count }))
+        .reduce((counts, status) => {
+          const { id, count } = status
+          if (count !== 0) {
+            counts[id] = count
           }
-          counts[src] += 1
           return counts
         }, {})
 
@@ -425,7 +427,6 @@ Query.Model = PartialAssociatedModel.extend({
       ...data,
       cql: cqlString,
       srcs: selectedSources.filter(isHarvested),
-      // TODO: Blake - This needs to change to `getStartIndexForSourceGroup`, of which there are 3 source groups (Cache, Harvested, Federated)
       start: this.currentIndexForSourceGroup.local,
     }
 
@@ -435,7 +436,6 @@ Query.Model = PartialAssociatedModel.extend({
         ...data,
         cql: cqlString,
         srcs: [source],
-        // TODO: Blake - This needs to change to `getStartIndexForSourceGroup`, of which there are 3 source groups (Cache, Harvested, Federated)
         start: this.currentIndexForSourceGroup[source],
       }))
 
@@ -450,16 +450,12 @@ Query.Model = PartialAssociatedModel.extend({
         // limit the cached results to only those from a selected source. This adds metacard_source to the cql string.
         cql: CacheSourceSelector.trimCacheSources(cqlString, sources),
         srcs: ['cache'],
-        // TODO: Blake - This needs to change to `getStartIndexForSourceGroup`, of which there are 3 source groups (Cache, Harvested, Federated)
-        start: 1,
+        start: query.getStartIndexForSource('cache'),
       })
     }
 
-    console.log('Executing Searches: ', searchesToRun)
-
     const currentSearches = this.preQueryPlugin(searchesToRun)
 
-    console.log('About to run queries, state: ', this.state)
     currentSearches.then(currentSearches => {
       if (currentSearches.length === 0) {
         announcement.announce({
@@ -514,6 +510,7 @@ Query.Model = PartialAssociatedModel.extend({
               })
             }
 
+            // TODO: Need to do something here?
             const srcStatus = result.get('status').get(search.src)
             if (srcStatus) {
               srcStatus.set({

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponseSourceStatus.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QueryResponseSourceStatus.js
@@ -31,6 +31,7 @@ module.exports = Backbone.AssociatedModel.extend({
       cacheMessages: [],
       hasReturned: false,
       messages: [],
+      warnings: [],
     }
   },
   initialize() {


### PR DESCRIPTION
#### What does this PR do?

**Backend**
- Pass a synchronized hashmap for properties to the QueryResponse that accumulates results in the `OffsetResultHandler` so that they are not thrown away.
- Allow `PostFederatedQueryPlugin`s that were ran after a Source Error occured to still return an updated QueryResponse.
- Move the calculation/aggregation of hits per source, properties, and processing details to after any `PostFederatedQueryPlugin`s are ran so that even those ran after a Source Error are included.
- Pass `ProcessingDetails` from the `SourceResponse` to each invocation of a `PreFederatedQueryPlugin`.
- Remove where the ProcessingDetails from the `SourceResponse` were being copied into the final QueryResponse. This is done so that if you have a `PostFederatedQueryPlugin` that wants to mutate/remove any of these errors, they are not still copied into the final set of `ProcessingDetails`.
- Remove the `source.isAvailable()` check in `QueryOperations` so that you can still end up in a `PostFederatedQueryPlugin` even if the source was unavailable.
- Added a new `warning` field on `Status.java` that adds all non-exception `ProcessingDetails`. (Unsure if this is safe).

**Frontend**
- Added correct calculations for start indexes by summing the startIndexes of each source before making a multi-source query.
- Fixed pagination in that the total hits count wasn't being calculated correctly and it looked like you had more pages to go through when you actually were at the last page.
- Added a new warning triangle in yellow to indicate if the `Status` for a query had any warnings.
<img src="https://user-images.githubusercontent.com/7236299/82709953-9a5a5600-9c36-11ea-936b-34cad6c3fb1c.png" width="600px" />

- Improved spacing on the selected sources list (the source names were too close to the icons)
<img src="https://user-images.githubusercontent.com/7236299/82709753-2a4bd000-9c36-11ea-9992-14c7243135ce.png" width="400px" />

**Changed Bundles**
`catalog/ui/catalog-ui-search`
`catalog/core/catalog-core-standardframework`

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@rzwiefel 
@derekwilhelm 


#### Select relevant component teams: 
@codice/core-apis 
@codice/security 
@codice/solr 
@codice/ui 


#### Ask 2 committers to review/merge the PR and tag them here.
@pklinef 
@jlcsmith 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6097 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
