### PR TITLE
DDF-6408 Improve Logging for CDM  [2.21.x]

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/ddf/catalog/Constants.java
+++ b/catalog/core/catalog-core-api/src/main/java/ddf/catalog/Constants.java
@@ -125,6 +125,8 @@ public final class Constants {
 
   public static final String INGEST_LOGGER_NAME = "ingestLogger";
 
+  public static final String CDM_LOGGER_NAME = "cdmLogger";
+
   public static final String REMOTE_DESTINATION_KEY = "remote-destination";
 
   public static final String LOCAL_DESTINATION_KEY = "local-destination";

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/AbstractDurableFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/AbstractDurableFileConsumer.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -32,7 +34,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class AbstractDurableFileConsumer extends GenericFileConsumer<File> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDurableFileConsumer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   //  Implement these to serialize the observers states.
   protected FileSystemPersistenceProvider fileSystemPersistenceProvider;

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitor.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import ddf.catalog.Constants;
 import ddf.catalog.data.AttributeRegistry;
 import java.io.Serializable;
@@ -56,6 +58,8 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
   public static final String IN_PLACE = "in_place";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ContentDirectoryMonitor.class);
+
+  private static final Logger CDM_LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private static final int MAX_THREAD_SIZE = 8;
 
@@ -169,6 +173,7 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
    * called whenever an existing route is updated.
    */
   public void init() {
+    CDM_LOGGER.debug("Initializing monitor for {}", monitoredDirectory);
     SECURITY.runAsAdmin(
         () -> {
           CompletableFuture.runAsync(this::configure, configurationExecutor);
@@ -177,6 +182,7 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
   }
 
   private Object configure() {
+    CDM_LOGGER.debug("Configuring monitor for {}", monitoredDirectory);
     if (StringUtils.isEmpty(monitoredDirectory)) {
       LOGGER.warn("Cannot setup camel route - must specify a directory to be monitored");
       return null;
@@ -262,7 +268,7 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
       String[] keyValue = s.split("=", 2);
 
       if (keyValue.length < 2) {
-        LOGGER.error("Invalid attribute override configured for monitored directory");
+        CDM_LOGGER.error("Invalid attribute override configured for monitored directory");
         throw new IllegalStateException(
             "Invalid attribute override configured for monitored directory");
       }
@@ -382,7 +388,7 @@ public class ContentDirectoryMonitor implements DirectoryMonitor {
             break;
         }
 
-        LOGGER.debug("ContentDirectoryMonitor inbox = {}", stringBuilder);
+        CDM_LOGGER.debug("ContentDirectoryMonitor inbox = {}", stringBuilder);
 
         RouteDefinition routeDefinition = from(stringBuilder.toString());
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileAlterationListener.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileAlterationListener.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import ddf.catalog.data.types.Core;
 import java.io.File;
 import java.util.Collections;
@@ -37,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class DurableFileAlterationListener
     implements AsyncFileAlterationListener, FileAlterationListener {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DurableFileAlterationListener.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private static final String FILE_EXTENSION_HEADER = "org.codice.ddf.camel.FileExtension";
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileEndpoint.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileEndpoint.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -44,7 +46,7 @@ import org.slf4j.LoggerFactory;
 )
 public class DurableFileEndpoint extends GenericFileEndpoint<File> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DurableFileEndpoint.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private final Boolean isDav;
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileSystemFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableFileSystemFileConsumer.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import java.io.File;
 import org.apache.camel.Processor;
 import org.apache.camel.component.file.GenericFileEndpoint;
@@ -25,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public class DurableFileSystemFileConsumer extends AbstractDurableFileConsumer {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DurableFileSystemFileConsumer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private DurableFileAlterationListener listener;
 
@@ -71,6 +73,7 @@ public class DurableFileSystemFileConsumer extends AbstractDurableFileConsumer {
         observer = backwardsCompatibility(fileName);
       } else if (observer == null) {
         observer = new AsyncFileAlterationObserver(new File(fileName), jsonSerializer);
+        observer.initializePeriodicLogging();
       }
     }
   }
@@ -90,6 +93,7 @@ public class DurableFileSystemFileConsumer extends AbstractDurableFileConsumer {
 
     try {
       newObserver.initialize();
+      newObserver.initializePeriodicLogging();
     } catch (IllegalStateException e) {
       //  There was an IO error setting up the initial state of the observer
       LOGGER.info("Error initializing the new state of the CDM. retrying on next poll");
@@ -106,5 +110,9 @@ public class DurableFileSystemFileConsumer extends AbstractDurableFileConsumer {
   public void shutdown() throws Exception {
     super.shutdown();
     listener.destroy();
+
+    if (observer != null) {
+      observer.destroy();
+    }
   }
 }

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableWebDavFileConsumer.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/DurableWebDavFileConsumer.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import com.github.sardine.Sardine;
 import com.github.sardine.SardineFactory;
 import ddf.catalog.data.types.Core;
@@ -36,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public class DurableWebDavFileConsumer extends AbstractDurableFileConsumer {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DurableWebDavFileConsumer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private static final String FILE_EXTENSION_HEADER = "org.codice.ddf.camel.FileExtension";
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/FileSystemPersistenceProvider.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/FileSystemPersistenceProvider.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import com.hazelcast.core.MapLoader;
 import com.hazelcast.core.MapStore;
 import java.io.BufferedInputStream;
@@ -48,7 +50,7 @@ import org.slf4j.LoggerFactory;
 public class FileSystemPersistenceProvider
     implements MapLoader<String, Object>, MapStore<String, Object> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemPersistenceProvider.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private static final String PERSISTED_FILE_SUFFIX = ".ser";
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/JsonPersistantStore.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/JsonPersistantStore.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonIOException;
@@ -35,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public class JsonPersistantStore implements ObjectPersistentStore {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(JsonPersistantStore.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private static final String PERSISTED_FILE_SUFFIX = ".json";
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/CompletionSynchronization.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/CompletionSynchronization.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor.synchronizations;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.function.BiConsumer;
@@ -24,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 public class CompletionSynchronization implements Synchronization {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(CompletionSynchronization.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private final AsyncFileEntry asyncFileEntry;
 
@@ -49,6 +51,11 @@ public class CompletionSynchronization implements Synchronization {
     if (!connected) {
       LOGGER.debug(
           "a network error occurred, The file [{}] failed to process", asyncFileEntry.getName());
+    } else if (exchange != null && exchange.getException() != null) {
+      LOGGER.debug(
+          "Exchange {} failed synchronization on exception: {}",
+          exchange.getExchangeId(),
+          exchange.getException());
     }
 
     callback.accept(asyncFileEntry, false);

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/DeletionSynchronization.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/DeletionSynchronization.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor.synchronizations;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.Synchronization;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -22,8 +24,7 @@ import org.slf4j.LoggerFactory;
 
 public class DeletionSynchronization implements Synchronization {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DeletionSynchronization.class);
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
   private final String reference;
 
   private final FileSystemPersistenceProvider productToMetacardIdMap;

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/FileDeletionSynchronization.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/FileDeletionSynchronization.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor.synchronizations;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import java.io.File;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.Synchronization;
@@ -22,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 public class FileDeletionSynchronization implements Synchronization {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FileDeletionSynchronization.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private final File file;
 

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/LoggingSynchronization.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/synchronizations/LoggingSynchronization.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor.synchronizations;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import java.io.File;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.Synchronization;
@@ -23,7 +25,7 @@ public class LoggingSynchronization implements Synchronization {
 
   private final File file;
   private final String task;
-  private static final Logger LOGGER = LoggerFactory.getLogger(LoggingSynchronization.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   public LoggingSynchronization(File file, String task) {
     this.file = file;

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/watcher/FileWatcher.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/watcher/FileWatcher.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor.watcher;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import java.io.File;
 import java.util.function.Consumer;
 import org.apache.commons.lang.Validate;
@@ -25,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FileWatcher {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FileWatcher.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private final File watchedFile;
 
@@ -67,7 +69,7 @@ public class FileWatcher {
   public boolean check() {
     long currentSize = watchedFile.length();
     if (currentSize == lastFileSize) {
-      LOGGER.debug("File [{}]'s size is stabilized.", watchedFile.getName());
+      LOGGER.trace("File [{}]'s size is stabilized.", watchedFile.getName());
       fileCallback.accept(watchedFile);
       return true;
     } else {

--- a/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/watcher/FilesWatcher.java
+++ b/catalog/core/catalog-core-directorymonitor/src/main/java/org/codice/ddf/catalog/content/monitor/watcher/FilesWatcher.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ddf.catalog.content.monitor.watcher;
 
+import static ddf.catalog.Constants.CDM_LOGGER_NAME;
+
 import java.io.File;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -27,7 +29,7 @@ import org.slf4j.LoggerFactory;
 /** Periodically calls {@link FileWatcher#check()} on all watched {@link FileWatcher}s. */
 public class FilesWatcher {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FilesWatcher.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CDM_LOGGER_NAME);
 
   private static final long DEFAULT_POLL_TIME_SEC = 5;
 

--- a/distribution/ddf-common/src/main/resources/etc/log4j2.xml
+++ b/distribution/ddf-common/src/main/resources/etc/log4j2.xml
@@ -53,6 +53,16 @@
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
 
+        <RollingFile name="cdm" append="true"
+                     fileName="${sys:karaf.log}/cdm.log"
+                     filePattern="${sys:karaf.log}/cdm.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="${log4j2.pattern}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="20 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
         <RollingFile name="securityMain" append="true" ignoreExceptions="false"
                      fileName="${sys:karaf.log}/security.log"
                      filePattern="${sys:karaf.log}/security.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
@@ -104,6 +114,12 @@
 
         <Logger name="ingestLogger" level="info" additivity="false">
             <AppenderRef ref="ingestError"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <Logger name="cdmLogger" level="info" additivity="false">
+            <AppenderRef ref="cdm"/>
             <AppenderRef ref="syslog"/>
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>

--- a/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/ddf-common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -60,6 +60,14 @@ log4j2.logger.ingestLogger.appenderRef.ingestError.ref = ingestError
 log4j2.logger.ingestLogger.appenderRef.syslog.ref = syslog
 log4j2.logger.ingestLogger.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
 
+# cdmLogger
+log4j2.logger.cdmLogger.name = cdmLogger
+log4j2.logger.cdmLogger.level = INFO
+log4j2.logger.cdmLogger.additivity = false
+log4j2.logger.cdmLogger.appenderRef.cdm.ref = cdm
+log4j2.logger.cdmLogger.appenderRef.syslog.ref = syslog
+log4j2.logger.cdmLogger.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
+
 # org.apache.solr
 log4j2.logger.org_apache_solr.name = org.apache.solr
 log4j2.logger.org_apache_solr.level = INFO
@@ -165,6 +173,21 @@ log4j2.appender.ingestError.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.ingestError.policies.size.size = 20MB
 log4j2.appender.ingestError.strategy.type = DefaultRolloverStrategy
 log4j2.appender.ingestError.strategy.max = 10
+
+# Content Directory Monitor
+log4j2.appender.contentDirectoryMonitor.type = RollingFile
+log4j2.appender.contentDirectoryMonitor.name = cdm
+log4j2.appender.contentDirectoryMonitor.fileName = ${karaf.log}/cdm.log
+log4j2.appender.contentDirectoryMonitor.filePattern = ${karaf.log}/cdm.log-%d{yyyy-MM-dd-HH}-%i.log.gz
+log4j2.appender.contentDirectoryMonitor.append = true
+log4j2.appender.contentDirectoryMonitor.ignoreExceptions = false
+log4j2.appender.contentDirectoryMonitor.layout.type = PatternLayout
+log4j2.appender.contentDirectoryMonitor.layout.pattern = [%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n
+log4j2.appender.contentDirectoryMonitor.policies.type = Policies
+log4j2.appender.contentDirectoryMonitor.policies.size.type = SizeBasedTriggeringPolicy
+log4j2.appender.contentDirectoryMonitor.policies.size.size = 20MB
+log4j2.appender.contentDirectoryMonitor.strategy.type = DefaultRolloverStrategy
+log4j2.appender.contentDirectoryMonitor.strategy.max = 10
 
 # securityMain
 log4j2.appender.securityMain.type = RollingFile

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/content-directory-monitor.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/content-directory-monitor.adoc
@@ -147,8 +147,19 @@ an operating system automatically generates files that should not be ingested.  
 This file type and any temporary files are included in the blacklist.
 
 .Errors
-If the CDM fails to read the file, an error will be logged in the ingest log. If the directory monitor is
+If the CDM fails to read the file, an error will be logged in the CDM log. If the directory monitor is
 configured to *Delete* or *Move*, the original file is also moved to the `\.errors` directory.
+
+.Logging
+CDM will send logs detailing the processing of files in the directory to `cdm.log`.
+
+[TIP]
+====
+The log level for CDM can be set with the following console command. At the DEBUG level, CDM will periodically log the list of files still currently processing.
+----
+log:set DEBUG cdmLogger
+----
+====
 
 .Other
 * Multiple directories can be monitored. Each directory has an independent configuration.


### PR DESCRIPTION
#### What does this PR do?
Improves logging in the **catalog-core-directorymonitor** bundle:
  - CDM now has its own log in **data/logs**
  - Concurrent set keeps track of files still being processed in **AsyncFileAlterationObserver**
  - Additional Logging information in cdm classes

#### Who is reviewing it? 
@mdang8  
@cjlange 

#### Select relevant component teams: 
@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.
@clockard 


#### How should this be tested?
1. Pull and build this branch
2. Set up DDF with a normal profile and set cdmLogging to TRACE
3. Create a directory of files to use for the cdm. There should be 20 or more files in this directory. Duplicate all of the files to a subdirectory within the first directory.
    3a. Add permissions for the directory in **security/configurations.policy**. Message me for details 
4. Set up a "Monitor in place" CDM in the admin console by going to **Catalog -> Configuration -> Catalog Content Directory Monitor**, be sure to specify the path of the directory created in step 3
5. Open cdm.log in **data/log**. Verify that the CDM was successfully set up. Verify that CDM shows "files processing", the number of files that need to be committed to the monitor. Also make sure that the logs occasionally display a list of files still needing to be processed.

#### What are the relevant tickets?
Fixes: #6408

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
