### PR TITLE
[2.19.x] DDF-UI-245 Search form duplication and Make Default star icon missing

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -187,6 +187,7 @@ module.exports = Marionette.LayoutView.extend({
       title: this.model.get('title'),
       description: formModel.get('description'),
       created: formModel.get('createdOn'),
+      default: formModel.get('default'),
       owner: formModel.get('owner'),
       querySettings: filterSettings,
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.collection.view.js
@@ -41,7 +41,7 @@ module.exports = Marionette.ItemView.extend({
         {this.getButtons()}
         {forms.map(child => {
           return (
-            <Item key={child.get('id')}>
+            <Item key={child.cid}>
               <MarionetteRegionContainer
                 view={SearchFormView}
                 viewOptions={{


### PR DESCRIPTION
#### What does this PR do?
1. When a user creates a search form, and there's already at least one search form in the list, the search form will show existing form twice, rather than the one you just provided in the editor. 
2. When a user makes a search form as default, it show a star icon on top right. When that form is edited and saved, the star icon is no longer displayed.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@hayleynorton
@cassandrabailey293 
@zta6 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Issue 1 (Search form duplication):
	1. Create a search form titled "test1" or other name
	2. Create another search form titled "test 1" or other name
	3. Save "test 1" and Ensure both "test1" and "test 1" are both displayed properly
	4.Try to edit search field and make as default etc. and ensure only the one working with is effected and not both
	
Issue 2 (Make Default star icon missing):
	1. Create a search form titled "test1" or other name
	2.Click three-dot menu for search form and select "Make Default Form"
	3.Notice the star icon is displayed on top right corner 
	4.Click three-dot menu for search form and select "Edit Form"
	5. Edit title or leave as is and click "Save"
	6.Ensure the star icon is still displayed on top right corner 

#### Any background context you want to provide?

#### What are the relevant tickets?
codice/ddf-ui#245

#### Screenshots
<!--(if appropriate)-->

#### Issue 1 - Before changes
<img width="1918" alt="BEFORE-1 (empty)" src="https://user-images.githubusercontent.com/65194214/84388998-ae003900-abb2-11ea-81c5-6b79e1ef3fef.png">
<img width="781" alt="BEFORE-2 (add 1st)" src="https://user-images.githubusercontent.com/65194214/84389006-b193c000-abb2-11ea-833d-95d093d086d4.png">
<img width="1917" alt="BEFORE-3 (add 1st)" src="https://user-images.githubusercontent.com/65194214/84389010-b35d8380-abb2-11ea-90ff-40b843a07229.png">
<img width="655" alt="BEFORE-4 (add 2nd)" src="https://user-images.githubusercontent.com/65194214/84389013-b3f61a00-abb2-11ea-951b-4f7ccc9c77fc.png">
<img width="1920" alt="BEFORE-5 (add 2nd)" src="https://user-images.githubusercontent.com/65194214/84389015-b48eb080-abb2-11ea-8cae-4a17d74f3f16.png">
<img width="1917" alt="BEFORE-6 (makeDefault)" src="https://user-images.githubusercontent.com/65194214/84389017-b48eb080-abb2-11ea-8154-7773ea285e27.png">
<img width="1917" alt="BEFORE-7 (makeDefault)" src="https://user-images.githubusercontent.com/65194214/84389018-b5274700-abb2-11ea-962c-b5812709703d.png">
<img width="961" alt="BEFORE-8 (edit)" src="https://user-images.githubusercontent.com/65194214/84389020-b5274700-abb2-11ea-8229-dde09e783e1b.png">
<img width="656" alt="BEFORE-9 (edit)" src="https://user-images.githubusercontent.com/65194214/84389021-b5bfdd80-abb2-11ea-9c04-3b08ffb3e0c4.png">
<img width="964" alt="BEFORE-10 (edit)" src="https://user-images.githubusercontent.com/65194214/84389022-b6587400-abb2-11ea-8f1b-2e9a9561ebb9.png">
<img width="961" alt="BEFORE-11 (delete)" src="https://user-images.githubusercontent.com/65194214/84389023-b6587400-abb2-11ea-8df3-eb76123523d9.png">
<img width="1918" alt="BEFORE-12 (delete)" src="https://user-images.githubusercontent.com/65194214/84389025-b6587400-abb2-11ea-941e-7a8beb94efab.png">

#### Issue 1 - After changes
<img width="1920" alt="AFTER-1 (empty)" src="https://user-images.githubusercontent.com/65194214/84389046-bfe1dc00-abb2-11ea-802e-e6ea49e460fe.png">
<img width="652" alt="AFTER-2 (add 1st)" src="https://user-images.githubusercontent.com/65194214/84389048-c1130900-abb2-11ea-8a54-2c138c5e7c1d.png">
<img width="1918" alt="AFTER-3 (add 1st)" src="https://user-images.githubusercontent.com/65194214/84389052-c1130900-abb2-11ea-96fc-0dac04bf86ff.png">
<img width="653" alt="AFTER-4 (add 2nd)" src="https://user-images.githubusercontent.com/65194214/84389053-c1ab9f80-abb2-11ea-927a-b42ec96e079f.png">
<img width="1919" alt="AFTER-5 (add 2nd)" src="https://user-images.githubusercontent.com/65194214/84389054-c1ab9f80-abb2-11ea-8757-55101a90dd2f.png">
<img width="1920" alt="AFTER-6 (makeDefault)" src="https://user-images.githubusercontent.com/65194214/84389056-c2443600-abb2-11ea-8674-45b948a37e0f.png">
<img width="1920" alt="AFTER-7 (makeDefault)" src="https://user-images.githubusercontent.com/65194214/84389057-c2443600-abb2-11ea-8a3b-80bf59914109.png">
<img width="1920" alt="AFTER-8 (edit)" src="https://user-images.githubusercontent.com/65194214/84389059-c2dccc80-abb2-11ea-86af-eff9708bb903.png">
<img width="657" alt="AFTER-9 (edit)" src="https://user-images.githubusercontent.com/65194214/84389061-c3756300-abb2-11ea-8cac-11680d9ff2ed.png">
<img width="1919" alt="AFTER-10 (edit)" src="https://user-images.githubusercontent.com/65194214/84389062-c40df980-abb2-11ea-8e96-6bcac1f1e277.png">
<img width="1920" alt="AFTER-11 (delete)" src="https://user-images.githubusercontent.com/65194214/84389067-c4a69000-abb2-11ea-9ddd-4422ee5b51a0.png">
<img width="1917" alt="AFTER-12 (delete)" src="https://user-images.githubusercontent.com/65194214/84389069-c53f2680-abb2-11ea-8e47-105fa89371dd.png">

#### Issue 2 - Before changes
<img width="1919" alt="BEFORE-1" src="https://user-images.githubusercontent.com/65194214/84389227-f9b2e280-abb2-11ea-9d28-e217fe333617.png">
<img width="1920" alt="BEFORE-2" src="https://user-images.githubusercontent.com/65194214/84389233-fae40f80-abb2-11ea-8c3f-71b71a5d5ac0.png">
<img width="961" alt="BEFORE-3" src="https://user-images.githubusercontent.com/65194214/84389235-fb7ca600-abb2-11ea-863b-8ae599a01c2b.png">
<img width="659" alt="BEFORE-4" src="https://user-images.githubusercontent.com/65194214/84389236-fb7ca600-abb2-11ea-91ad-fdb736800762.png">
<img width="1918" alt="BEFORE-5" src="https://user-images.githubusercontent.com/65194214/84389237-fc153c80-abb2-11ea-8c0e-1eadd080c720.png">

#### Issue 2 - After changes
<img width="1916" alt="AFTER-1" src="https://user-images.githubusercontent.com/65194214/84389255-033c4a80-abb3-11ea-9b0b-2516bd0f8a62.png">
<img width="1919" alt="AFTER-2" src="https://user-images.githubusercontent.com/65194214/84389260-046d7780-abb3-11ea-9435-8aa5f11bb77f.png">
<img width="1915" alt="AFTER-3" src="https://user-images.githubusercontent.com/65194214/84389263-05060e00-abb3-11ea-9f3e-d21f12724767.png">
<img width="654" alt="AFTER-4" src="https://user-images.githubusercontent.com/65194214/84389266-05060e00-abb3-11ea-8ddf-fd2dfb5e5faf.png">
<img width="1916" alt="AFTER-5" src="https://user-images.githubusercontent.com/65194214/84389268-059ea480-abb3-11ea-8ca2-682c41780b37.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
