### PR TITLE
Update PreFederatedQueryPlugin logic to maintain context and post query plugins

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedFederationStrategy.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedFederationStrategy.java
@@ -29,6 +29,7 @@ import ddf.catalog.plugin.PreFederatedQueryPlugin;
 import ddf.catalog.plugin.StopProcessingException;
 import ddf.catalog.source.Source;
 import ddf.catalog.util.impl.RelevanceResultComparator;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -152,7 +153,8 @@ public class SortedFederationStrategy implements FederationStrategy {
       offset = this.maxStartIndex;
     }
 
-    final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, null);
+    final Map<String, Serializable> properties = Collections.synchronizedMap(new HashMap<>());
+    final QueryResponseImpl queryResponseQueue = new QueryResponseImpl(queryRequest, properties);
 
     Map<Future<SourceResponse>, QueryRequest> futures = new HashMap<>();
 
@@ -203,7 +205,7 @@ public class SortedFederationStrategy implements FederationStrategy {
     // transfer them into a different Queue. That is what the
     // OffsetResultHandler does.
     if (offset > 1 && sources.size() > 1) {
-      offsetResults = new QueryResponseImpl(queryRequest, null);
+      offsetResults = new QueryResponseImpl(queryRequest, properties);
       queryExecutorService.submit(
           new OffsetResultHandler(queryResponseQueue, offsetResults, pageSize, offset));
     }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -835,7 +835,7 @@ public class QueryOperations extends DescribableImpl {
               if (!canAccessSource) {
                 notPermittedSources.add(source.getId());
               }
-              if (source.isAvailable() && canAccessSource) {
+              if (canAccessSource) {
                 sourcesToQuery.add(source);
               } else {
                 exceptions.add(queryOps.createUnavailableProcessingDetails(source));

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/federation/impl/SortedQueryMonitorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/federation/impl/SortedQueryMonitorTest.java
@@ -138,7 +138,7 @@ public class SortedQueryMonitorTest {
     assertThat(queryResponse.getResults().size()).isEqualTo(4);
     HashMap<String, Long> hitsPerSource =
         (HashMap<String, Long>) queryResponse.getProperties().get("hitsPerSource");
-    assertThat(hitsPerSource.size()).isEqualTo(3);
+    assertThat(hitsPerSource.size()).isEqualTo(4);
     for (int[] idAndCount : new int[][] {{1, 3}, {2, 1}, {3, 0}}) {
       assertThat(hitsPerSource.get("Source-" + idAndCount[0])).isEqualTo(idAndCount[1]);
     }
@@ -179,7 +179,7 @@ public class SortedQueryMonitorTest {
     assertThat(queryResponse.getHits()).isEqualTo(3);
     HashMap<String, Long> hitsPerSource =
         (HashMap<String, Long>) queryResponse.getProperties().get("hitsPerSource");
-    assertThat(hitsPerSource.size()).isEqualTo(1);
+    assertThat(hitsPerSource.size()).isEqualTo(2);
     assertThat(hitsPerSource.get("Source-1")).isEqualTo(3);
     assertThat(queryResponse.getProcessingDetails())
         .extracting(byName("exception"))
@@ -222,7 +222,7 @@ public class SortedQueryMonitorTest {
     assertThat(queryResponse.getResults().size()).isEqualTo(3);
     HashMap<String, Long> hitsPerSource =
         (HashMap<String, Long>) queryResponse.getProperties().get("hitsPerSource");
-    assertThat(hitsPerSource.size()).isEqualTo(1);
+    assertThat(hitsPerSource.size()).isEqualTo(2);
     assertThat(hitsPerSource.get("Source-1")).isEqualTo(3);
     assertThat(queryResponse.getProcessingDetails())
         .extracting(byName("exception"))
@@ -244,7 +244,7 @@ public class SortedQueryMonitorTest {
     Set<ProcessingDetails> processingDetailsOfMockedSourceResponse = new HashSet<>();
     doReturn(processingDetailsOfMockedSourceResponse)
         .when(mockedSourceResponseWithProcessingDetails)
-        .getProcessingDetails();
+        .getProcessingErrors();
 
     QueryRequest mockedQueryRequest = mock(QueryRequest.class);
 


### PR DESCRIPTION
#### What does this PR do?
Forward port of updates in 2.20.x (parts of https://github.com/codice/ddf/pull/6096 and parts of https://github.com/codice/ddf/pull/6103):

- Calculate startindex from statusBySource
- Allow PostFederatedQueryPlugins to return query responses
- Allow PostFederatedQueryPlugins to be ran on sources that are "unavailable"
- Fixes other issues with post federated

#### How should this be tested?

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
