### PR TITLE
DDF-6146 - Change null sort to match solr

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedQueryMonitor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedQueryMonitor.java
@@ -131,7 +131,7 @@ class SortedQueryMonitor implements Runnable {
               Comparator.comparing(
                   r -> getAttributeValue((Result) r, sortType),
                   ((sortOrder == SortOrder.ASCENDING)
-                      ? Comparator.nullsFirst(Comparator.<Comparable>naturalOrder())
+                      ? Comparator.nullsLast(Comparator.<Comparable>naturalOrder())
                       : Comparator.nullsLast(Comparator.<Comparable>reverseOrder())));
         }
         resultComparator.addComparator(comparator);

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/federation/impl/SortedQueryMonitorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/federation/impl/SortedQueryMonitorTest.java
@@ -293,12 +293,12 @@ public class SortedQueryMonitorTest {
 
   @Test
   public void testSortAscendingNullFirst() throws Exception {
-    testSorting(new String[] {null, "a"}, new String[] {null, "a"}, SortOrder.ASCENDING);
+    testSorting(new String[] {null, "a"}, new String[] {"a", null}, SortOrder.ASCENDING);
   }
 
   @Test
   public void testSortAscendingNullLast() throws Exception {
-    testSorting(new String[] {"a", null}, new String[] {null, "a"}, SortOrder.ASCENDING);
+    testSorting(new String[] {"a", null}, new String[] {"a", null}, SortOrder.ASCENDING);
   }
 
   @Test
@@ -325,7 +325,7 @@ public class SortedQueryMonitorTest {
   public void testSortDateAscendingWithNull() throws Exception {
     testSorting(
         new Serializable[] {TEST_DATE_2, null},
-        new Serializable[] {null, TEST_DATE_2},
+        new Serializable[] {TEST_DATE_2, null},
         SortOrder.ASCENDING);
   }
 
@@ -358,7 +358,7 @@ public class SortedQueryMonitorTest {
     Serializable o = new TestSerial();
     testSorting(
         new Serializable[] {TEST_DATE_1, o},
-        new Serializable[] {o, TEST_DATE_1},
+        new Serializable[] {TEST_DATE_1, o},
         SortOrder.ASCENDING);
   }
 


### PR DESCRIPTION
#### What does this PR do?
When sorting on an attribute where some of the results do not have that attribute it can cause issues with paging.  The reason is because the sorting mechanism in DDF for ascending sort order sorts nulls first.  Solr, on the other hand, always sorts nulls last regardless of the sort order.  Therefore, when paging through results if a result with a null attribute that is being sorted on shows up in a later page it will get sorted to the beginning of the list inside DDF and skipped in the returned result list.  This also has the effect of a result page containing a duplicate entry from the previous page.  This PR changes the DDF sort to match Solr where nulls are always last.
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@pklinef 
@bdeining 

#### Select relevant component teams: 

@codice/core-apis 
@codice/data  
@codice/solr 
@codice/ui 


#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@jlcsmith


#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Add a second source to DDF
2. Ingest some data for the local source as well as the second source
  - For example: 
      Local source - apple, apricot, banana, blackberry, blueberry, cherry
      Second source - bentley, bugatti, mclaren, mercedes, nissan, opel
3. Send a query via postman with both sources in the same query with page size = 4, sort by title, and sort ascending
4. Verify that there are 3 pages to go through and that each of them are sorted appropriately and all 12 results are returned across the 3 pages
5. Remove the title attribute from the apple record
6. Repeat steps 3 & 4
7. Verify that the original apple entry is returned as the last result in the third page and that no duplicates are returned in any of the pages of results

Prior to this change, steps 5 through 7 would have had the effect where the blackberry record would have been returned twice (once on two different pages) and the apple entry would not be returned at all.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6146 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
