### PR TITLE
DDF-6169 fixes support for multiple wfs 1.1.0 sources

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -293,7 +293,7 @@ public class WfsSource extends AbstractWfsSource {
     "unused"
   })
   public void destroy(int code) {
-    wfsMetacardTypeRegistry.clear();
+    wfsMetacardTypeRegistry.clear(getId());
     availabilityPollFuture.cancel(true);
     scheduler.shutdownNow();
   }
@@ -608,7 +608,7 @@ public class WfsSource extends AbstractWfsSource {
     // registering the MetacardTypes - the concern is that if this registration is too lengthy
     // a query could come in that is handled while the MetacardType registrations are
     // in a state of flux.
-    wfsMetacardTypeRegistry.clear();
+    wfsMetacardTypeRegistry.clear(getId());
 
     List<String> featureNames = new ArrayList<>();
     if (!mcTypeRegs.isEmpty()) {

--- a/catalog/spatial/wfs/spatial-wfs-metacardtype-registry-api/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/WfsMetacardTypeRegistry.java
+++ b/catalog/spatial/wfs/spatial-wfs-metacardtype-registry-api/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/WfsMetacardTypeRegistry.java
@@ -44,6 +44,9 @@ public interface WfsMetacardTypeRegistry {
    */
   void registerMetacardType(MetacardType metacardType, String sourceId, String featureSimpleName);
 
+  /** Used to clear all entries of the registry for a specific source */
+  void clear(String sourceId);
+
   /** Used to clear all entries of the registry */
-  void clear();
+  void clearAll();
 }

--- a/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/impl/WfsMetacardTypeRegistryImpl.java
+++ b/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/impl/WfsMetacardTypeRegistryImpl.java
@@ -17,6 +17,7 @@ import com.google.common.base.Verify;
 import ddf.catalog.data.MetacardType;
 import java.util.ArrayList;
 import java.util.Dictionary;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import org.codice.ddf.configuration.DictionaryMap;
@@ -81,7 +82,24 @@ public final class WfsMetacardTypeRegistryImpl implements WfsMetacardTypeRegistr
   }
 
   /** {@inheritDoc} */
-  public void clear() {
+  @Override
+  public void clear(String sourceId) {
+    Verify.verifyNotNull(sourceId, "argument 'sourceId' may not be null.");
+    for (Iterator<ServiceRegistration<MetacardType>> iter = serviceRegistrations.iterator();
+        iter.hasNext(); ) {
+      ServiceRegistration registration = iter.next();
+      if (registration.getReference() != null
+          && registration.getReference().getProperty((SOURCE_ID)) != null
+          && registration.getReference().getProperty(SOURCE_ID).equals(sourceId)) {
+        registration.unregister();
+        iter.remove();
+      }
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void clearAll() {
     serviceRegistrations.stream().forEach(ServiceRegistration::unregister);
     serviceRegistrations.clear();
   }

--- a/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/impl/WfsMetacardTypeRegistryImpl.java
+++ b/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/impl/WfsMetacardTypeRegistryImpl.java
@@ -20,6 +20,8 @@ import java.util.Dictionary;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.codice.ddf.configuration.DictionaryMap;
 import org.codice.ddf.spatial.ogc.wfs.catalog.metacardtype.registry.WfsMetacardTypeRegistry;
 import org.osgi.framework.BundleContext;
@@ -35,6 +37,8 @@ public final class WfsMetacardTypeRegistryImpl implements WfsMetacardTypeRegistr
 
   private List<ServiceRegistration<MetacardType>> serviceRegistrations;
 
+  private final Lock registryLock = new ReentrantLock();
+
   public WfsMetacardTypeRegistryImpl(BundleContext bundleContext) {
     this.bundleContext = bundleContext;
     this.serviceRegistrations = new ArrayList<>();
@@ -47,19 +51,25 @@ public final class WfsMetacardTypeRegistryImpl implements WfsMetacardTypeRegistr
       return Optional.empty();
     }
 
-    Optional<ServiceRegistration<MetacardType>> serviceRegistrationOptional =
-        serviceRegistrations
-            .stream()
-            .filter(s -> s.getReference().getProperty(SOURCE_ID) != null)
-            .filter(s -> s.getReference().getProperty(SOURCE_ID).equals(sourceId))
-            .filter(s -> s.getReference().getProperty(FEATURE_NAME) != null)
-            .filter(s -> s.getReference().getProperty(FEATURE_NAME).equals(simpleName))
-            .findFirst();
+    try {
+      // acquire a lock to protect read access on serviceRegistrations
+      registryLock.lock();
+      Optional<ServiceRegistration<MetacardType>> serviceRegistrationOptional =
+          serviceRegistrations
+              .stream()
+              .filter(s -> s.getReference().getProperty(SOURCE_ID) != null)
+              .filter(s -> s.getReference().getProperty(SOURCE_ID).equals(sourceId))
+              .filter(s -> s.getReference().getProperty(FEATURE_NAME) != null)
+              .filter(s -> s.getReference().getProperty(FEATURE_NAME).equals(simpleName))
+              .findFirst();
 
-    if (serviceRegistrationOptional.isPresent()) {
-      MetacardType featureMetacardType =
-          bundleContext.getService(serviceRegistrationOptional.get().getReference());
-      return Optional.of(featureMetacardType);
+      if (serviceRegistrationOptional.isPresent()) {
+        MetacardType featureMetacardType =
+            bundleContext.getService(serviceRegistrationOptional.get().getReference());
+        return Optional.of(featureMetacardType);
+      }
+    } finally {
+      registryLock.unlock();
     }
 
     return Optional.empty();
@@ -78,29 +88,43 @@ public final class WfsMetacardTypeRegistryImpl implements WfsMetacardTypeRegistr
     properties.put(FEATURE_NAME, featureSimpleName);
     ServiceRegistration<MetacardType> serviceRegistration =
         bundleContext.registerService(MetacardType.class, metacardType, properties);
-    serviceRegistrations.add(serviceRegistration);
+    try {
+      registryLock.lock();
+      serviceRegistrations.add(serviceRegistration);
+    } finally {
+      registryLock.unlock();
+    }
   }
 
   /** {@inheritDoc} */
   @Override
   public void clear(String sourceId) {
     Verify.verifyNotNull(sourceId, "argument 'sourceId' may not be null.");
-    for (Iterator<ServiceRegistration<MetacardType>> iter = serviceRegistrations.iterator();
-        iter.hasNext(); ) {
-      ServiceRegistration registration = iter.next();
-      if (registration.getReference() != null
-          && registration.getReference().getProperty((SOURCE_ID)) != null
-          && registration.getReference().getProperty(SOURCE_ID).equals(sourceId)) {
-        registration.unregister();
-        iter.remove();
+    try {
+      registryLock.lock();
+      for (Iterator<ServiceRegistration<MetacardType>> iter = serviceRegistrations.iterator();
+          iter.hasNext(); ) {
+        ServiceRegistration registration = iter.next();
+        if (registration.getReference() != null
+            && registration.getReference().getProperty(SOURCE_ID).equals(sourceId)) {
+          registration.unregister();
+          iter.remove();
+        }
       }
+    } finally {
+      registryLock.unlock();
     }
   }
 
   /** {@inheritDoc} */
   @Override
   public void clearAll() {
-    serviceRegistrations.stream().forEach(ServiceRegistration::unregister);
-    serviceRegistrations.clear();
+    try {
+      registryLock.lock();
+      serviceRegistrations.stream().forEach(ServiceRegistration::unregister);
+      serviceRegistrations.clear();
+    } finally {
+      registryLock.unlock();
+    }
   }
 }

--- a/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/impl/WfsMetacardTypeRegistryTest.java
+++ b/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/impl/WfsMetacardTypeRegistryTest.java
@@ -53,7 +53,6 @@ public class WfsMetacardTypeRegistryTest {
     mockBundleContext = mock(BundleContext.class);
     mockServiceRegistration = mock(ServiceRegistration.class);
     ServiceReference mockServiceReference = mock(ServiceReference.class);
-    //    ServiceReference mockServiceReference = mock(ServiceReference.class);
     mockMetacardType = mock(MetacardType.class);
 
     when(mockServiceRegistration.getReference()).thenReturn(mockServiceReference);
@@ -106,7 +105,6 @@ public class WfsMetacardTypeRegistryTest {
 
   @Test
   public void testClear() {
-    // setup
     ServiceRegistration mockServiceRegistration1 = mock(ServiceRegistration.class);
     ServiceRegistration mockServiceRegistration2 = mock(ServiceRegistration.class);
     ServiceReference mockServiceReference1 = mock(ServiceReference.class);

--- a/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/impl/WfsMetacardTypeRegistryTest.java
+++ b/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/metacardtype/registry/impl/WfsMetacardTypeRegistryTest.java
@@ -118,10 +118,6 @@ public class WfsMetacardTypeRegistryTest {
         .thenReturn(TEST_SOURCE_ID);
     when(mockServiceReference2.getProperty(WfsMetacardTypeRegistryImpl.SOURCE_ID))
         .thenReturn(TEST_SOURCE_ID_2);
-    when(mockServiceReference1.getProperty(WfsMetacardTypeRegistryImpl.FEATURE_NAME))
-        .thenReturn("feature_a");
-    when(mockServiceReference2.getProperty(WfsMetacardTypeRegistryImpl.FEATURE_NAME))
-        .thenReturn("feature_b");
     when(mockBundleContext.registerService(
             same(MetacardType.class), any(MetacardType.class), any(Dictionary.class)))
         .thenReturn(mockServiceRegistration1)


### PR DESCRIPTION
#### What does this PR do?
Fixes the WFS 1.1.0 Source and Wfs Metacard Feature Type Registry to support multiple active sources.

Note - this does include an API change, but the API is marked experimental.

#### Who is reviewing it? 
@jrnorth 
@bdeining 
@rzwiefel 

#### Select relevant component teams: 
@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.
@jrnorth 
@bdeining 
@rzwiefel 

#### How should this be tested?
1. Configure 2 WFS 1.1.0 Federated Sources
2. Optional: disable the cache to eliminate this from the test (Catalog Federated Strategy -> Query Result Cache Strategy=None
3. Query both and verify results come back from each
4. Disable and then re-enable each source
5. Re-verify that a query against both sources work

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6169 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
