### PR TITLE
[2.19.x] DDF-UI-276 fix error when deleting a default search form

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -222,7 +222,9 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
             }
           } else if (id === template.id) {
             this.handleClearDefault()
-            this.options.queryModel.resetToDefaults()
+            if (this.options.queryModel) {
+              this.options.queryModel.resetToDefaults()
+            }
           } else {
             const defaults = {
               type: 'custom',


### PR DESCRIPTION
#### What does this PR do?
fixes error that occurs when deleting a default search form

#### Who is reviewing it? 
@zta6 @hayleynorton @cassandrabailey293 @abel-connexta 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere


#### How should this be tested?
- build / run
- create new search from, set as default
- delete the form and verify no error is seen in the console
- create another search form and use it in a search
- delete the form and verify no error is seen in the console

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: codice/ddf-ui#276

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
