### PR TITLE
[2.19.x] DDF-6183  G-2068 Allow search forms to fully leverage boolean logic

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -55,8 +55,6 @@ module.exports = Marionette.LayoutView.extend({
       if (isFormBuilder !== true) {
         this.turnOffFieldAdditions()
       }
-      this.turnOffNesting()
-      this.turnOffRootOperator()
     }
   },
   onBeforeShow() {
@@ -184,12 +182,6 @@ module.exports = Marionette.LayoutView.extend({
     this.$el.removeClass('is-editing')
     this.filterOperator.currentView.turnOffEditing()
     this.filterContents.currentView.turnOffEditing()
-  },
-  turnOffNesting() {
-    this.$el.addClass('hide-nesting')
-  },
-  turnOffRootOperator() {
-    this.$el.addClass('hide-root-operator')
   },
   turnOffFieldAdditions() {
     this.$el.addClass('hide-field-button')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -124,8 +124,6 @@ module.exports = Marionette.LayoutView.extend({
     this.editor.show(
       new QueryAdvanced({
         model: this.model,
-        isForm: true,
-        isFormBuilder: true,
         isSearchFormEditor: true,
         onSave: () => {
           if (this.model.get('title').trim() !== '') {
@@ -201,6 +199,7 @@ module.exports = Marionette.LayoutView.extend({
       error: () => {
         this.errorMessage()
       },
+      wait: true,
     }
     this.model.set(json)
     json.id ? this.model.save({}, options) : collection.create(json, options)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -124,6 +124,7 @@ module.exports = Marionette.LayoutView.extend({
     this.editor.show(
       new QueryAdvanced({
         model: this.model,
+        isFormBuilder: true,
         isSearchFormEditor: true,
         onSave: () => {
           if (this.model.get('title').trim() !== '') {


### PR DESCRIPTION
#### What does this PR do?
Allows creation of search forms to include all Boolean logical filters as the advanced query builder does.
#### Who is reviewing it? 
@bennuttle 
@leo-sakh 
@jMoneee
 @frnkshin 

#### How should this be tested?
1. Build / run DDF and install 
2. Navigate to search forms, create a new form, verify you can use all Boolean logical operators as expected, and form saves / can be used as expected
3. Try to create another search for that has invalid boolean logic (i.e. 'OR' with only one field, etc), verify error is caught and form isn't created

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6183 

#### Screenshots
-See issue for before screenshot

-After: 
<img width="586" alt="after" src="https://user-images.githubusercontent.com/43187475/87797762-fe953280-c7ff-11ea-8c3f-2d26d9aefedc.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
