### PR TITLE
[2.19.x] G-8304 Fix intermediate result form dropdown state

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-editor/query-editor.view.js
@@ -22,6 +22,7 @@ const QueryTitle = require('../query-title/query-title.view.js')
 const store = require('../../js/store.js')
 import ExtensionPoints from '../../extension-points'
 import { showErrorMessages } from '../../react-component/utils/validation'
+import ResultFormCollection from '../result-form/result-form-collection-instance'
 
 module.exports = Marionette.LayoutView.extend({
   template,
@@ -89,7 +90,10 @@ module.exports = Marionette.LayoutView.extend({
   },
   showForm(form) {
     const options = form.options || {}
-    if (this.model.get('detail-level') === undefined) {
+    if (
+      this.model.get('detail-level') === undefined ||
+      this.resultFormIsInvalid(this.model.get('detail-level'))
+    ) {
       this.model.set('detail-level', 'allFields')
     }
     this.queryContent.show(
@@ -97,6 +101,13 @@ module.exports = Marionette.LayoutView.extend({
         model: this.model,
         ...options,
       })
+    )
+  },
+  resultFormIsInvalid(resultFormTitle) {
+    return (
+      ResultFormCollection.getCollection().findWhere({
+        title: resultFormTitle,
+      }) === undefined
     )
   },
   showQueryForm(form) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -137,7 +137,7 @@ module.exports = plugin(
     handleChangeDetailLevel(model, values) {
       $.each(model.get('enum'), (index, value) => {
         if (values[0] === value.value) {
-          this.model.set('detail-level', value)
+          this.model.set('detail-level', value.value)
         }
       })
     },


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where users were able to get select an invalid result form and get into a bad state if they did not explicitly click "Search" or "Save" before running an Advanced search.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@Lambeaux 
@brhumphe 
@kentmorrissey 
@brianfelix 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8

#### How should this be tested?
**NOTE: To fully test the fix, you should build the latest 2.19.x branch and run the PR fix along side it with the dev server (see testing instructions)**

##### Reproduce the bug
1. Checkout the latest 2.19.x code WITHOUT THIS PR and build / start DDF
2. Open Intrigue
3. Create a new result form
4. Go to the workspaces page, create a new Advanced Search (all defaults are ok), and click "Search"
5. Re-open the query by clicking the Pencil icon and then click the Save icon to save the workspace
6. Refresh the page
7. Open the query one more time with the Pencil icon and verify the Result Form now looks like the BEFORE screenshot (i.e. a map representation of the result form)

##### Ensure invalid result forms default to the "All Fields" form instead
1. Now checkout this PR and start the yarn dev server
2. Open Intrigue served by the dev server (http://localhost:8080/search/catalog/)
3. Open the same workspace used in the last steps
4. Open the query from before and verify that the Result Form was changed to "All Fields"

##### Verify users can no longer get into that bad state
1. Repeat steps 2-6 on the dev server Intrigue
2. Open the query one more time with the Pencil icon and verify the Result Form dropdown correctly shows the title of selected form instead of the map representation

#### What are the relevant tickets?
Fixes: n/a

#### Screenshots
##### BEFORE
<img width="1527" alt="Screen Shot 2020-07-19 at 10 23 56 PM" src="https://user-images.githubusercontent.com/8922441/87902898-987efa00-ca0f-11ea-83c8-a67e99bb5ad9.png">

##### AFTER
<img width="404" alt="Screen Shot 2020-07-19 at 10 24 13 PM" src="https://user-images.githubusercontent.com/8922441/87902888-94eb7300-ca0f-11ea-9298-bac5fd3da93d.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
