### PR TITLE
[2.19.x] DDF-UI-286 G-8697 Utilized attribute alias in read-only filters

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-attribute.js
@@ -17,6 +17,8 @@ import styled from 'styled-components'
 import { getFilteredAttributeList } from './filterHelper'
 import EnumInput from '../inputs/enum-input'
 
+const metacardDefinitions = require('../../component/singletons/metacard-definitions.js')
+
 const Root = styled.div`
   display: inline-block;
   vertical-align: middle;
@@ -40,7 +42,7 @@ const FilterAttributeDropdown = ({
           supportedAttributes={supportedAttributes}
         />
       ) : (
-        value
+        metacardDefinitions.getLabel(value)
       )}
     </Root>
   )


### PR DESCRIPTION
#### What does this PR do?
Uses attribute alias for the read-only filters when using a search form
#### Who is reviewing it? 
@abel-connexta @andrewzimmer @cassandrabailey293 @zta6 
#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@shaundmorris 
#### How should this be tested?
Create a search form and create a query using that search form
Verify that the attribute aliases are displayed instead of the raw attribute names
#### Any background context you want to provide?
#### What are the relevant tickets?
Fixes: codice/ddf-ui#286
G-8697
#### Screenshots
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
