### PR TITLE
[2.19.x] DDF-6199 Update workspace's modified attribute prior to manual saving

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -136,14 +136,17 @@ module.exports = PartialAssociatedModel.extend({
         .length === 0
     ) {
       this.set('saved', false)
+      this.set('metacard.modified', Date.now())
     }
   },
   handleQueryChange() {
     this.set('saved', false)
+    this.set('metacard.modified', Date.now())
   },
   handleChange(model) {
     if (workspaceShouldBeResaved(model)) {
       this.set('saved', false)
+      this.set('metacard.modified', Date.now())
     }
   },
   saveLocal(options) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Workspace.js
@@ -136,22 +136,22 @@ module.exports = PartialAssociatedModel.extend({
         .length === 0
     ) {
       this.set('saved', false)
-      this.set('metacard.modified', Date.now())
+      this.updateMetacardModifiedTimestamp()
     }
   },
   handleQueryChange() {
     this.set('saved', false)
-    this.set('metacard.modified', Date.now())
+    this.updateMetacardModifiedTimestamp()
   },
   handleChange(model) {
     if (workspaceShouldBeResaved(model)) {
       this.set('saved', false)
-      this.set('metacard.modified', Date.now())
+      this.updateMetacardModifiedTimestamp()
     }
   },
   saveLocal(options) {
     this.set('id', this.get('id') || Common.generateUUID())
-    this.set('metacard.modified', Date.now())
+    this.updateMetacardModifiedTimestamp()
     const localWorkspaces = this.collection.getLocalWorkspaces()
     localWorkspaces[this.get('id')] = this.toJSON()
     window.localStorage.setItem('workspaces', JSON.stringify(localWorkspaces))
@@ -185,6 +185,9 @@ module.exports = PartialAssociatedModel.extend({
         Backbone.AssociatedModel.prototype.save.apply(this, arguments)
       }
     }
+  },
+  updateMetacardModifiedTimestamp() {
+    this.set('metacard.modified', Date.now())
   },
   handleError() {
     this.set('saved', false)


### PR DESCRIPTION
#### What does this PR do?
Addresses #6199 by adding a few calls to update the workspace's modified attribute when the workspace is modified.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@leo-sakh 
@frnkshin 
@lavoywj 
@jMoneee 
@bdeining 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.

#### How should this be tested?
See steps to reproduce in #6199 and verify the behavior is working as listed as expected there

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6199 



#### Screenshots
See the before and after. Workspace 1 is edited but not saved in each image.
<!--(if appropriate)-->
Before:
![image](https://user-images.githubusercontent.com/2730407/88593432-8ca5c000-d02d-11ea-8893-7f4b70f90dcb.png)

After:
<img width="1675" alt="Screen Shot 2020-07-27 at 5 17 58 PM" src="https://user-images.githubusercontent.com/2730407/88593306-56684080-d02d-11ea-8539-aafe4d146a12.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
