### PR TITLE
[2.19.x] DDF-UI-294 G-8763 G-8787 fix Unable to remove results filters

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -183,6 +183,9 @@ module.exports = Marionette.LayoutView.extend({
     this.filterOperator.currentView.turnOffEditing()
     this.filterContents.currentView.turnOffEditing()
   },
+  turnOffNesting: function() {
+    this.$el.addClass('hide-nesting')
+  },
   turnOffFieldAdditions() {
     this.$el.addClass('hide-field-button')
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-old/location-old.view.js
@@ -156,9 +156,9 @@ module.exports = Marionette.LayoutView.extend({
     switch (filter.type) {
       // these cases are for when the model matches the filter model
       case 'DWITHIN':
-        if (CQLUtils.isPointRadiusFilter(filter)) {
+        if (CQLUtils.isPointRadiusFilter(filter.value)) {
           wreqr.vent.trigger('search:circledisplay', this.model)
-        } else if (CQLUtils.isPolygonFilter(filter)) {
+        } else if (CQLUtils.isPolygonFilter(filter.value)) {
           wreqr.vent.trigger('search:polydisplay', this.model)
         } else {
           wreqr.vent.trigger('search:linedisplay', this.model)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/result-filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/result-filter.view.js
@@ -18,7 +18,6 @@ const template = require('./result-filter.hbs')
 const CustomElements = require('../../js/CustomElements.js')
 const user = require('../singletons/user-instance.js')
 const FilterBuilderView = require('../filter-builder/filter-builder.view.js')
-const cql = require('../../js/cql.js')
 
 module.exports = Marionette.LayoutView.extend({
   template,
@@ -44,14 +43,14 @@ module.exports = Marionette.LayoutView.extend({
   onRender() {
     const resultFilter = this.getResultFilter()
     let filter
-    if (resultFilter) {
-      filter = cql.simplify(cql.read(resultFilter))
-    } else {
+    if (!resultFilter) {
       filter = {
         property: 'anyText',
         value: '',
         type: 'ILIKE',
       }
+    } else {
+      filter = resultFilter
     }
     this.editorProperties.show(
       new FilterBuilderView({
@@ -64,7 +63,7 @@ module.exports = Marionette.LayoutView.extend({
     this.handleFilter()
   },
   getFilter() {
-    return this.editorProperties.currentView.transformToCql()
+    return this.editorProperties.currentView.getFilters()
   },
   removeFilter() {
     user

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/result-filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/result-filter.view.js
@@ -18,6 +18,10 @@ const template = require('./result-filter.hbs')
 const CustomElements = require('../../js/CustomElements.js')
 const user = require('../singletons/user-instance.js')
 const FilterBuilderView = require('../filter-builder/filter-builder.view.js')
+import {
+  getFilterErrors,
+  showErrorMessages,
+} from '../../react-component/utils/validation'
 
 module.exports = Marionette.LayoutView.extend({
   template,
@@ -77,10 +81,16 @@ module.exports = Marionette.LayoutView.extend({
     this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
   },
   saveFilter() {
+    const filter = this.getFilter()
+    const errorMessages = getFilterErrors(filter.filters)
+    if (errorMessages.length !== 0) {
+      showErrorMessages(errorMessages)
+      return
+    }
     user
       .get('user')
       .get('preferences')
-      .set('resultFilter', this.getFilter())
+      .set('resultFilter', filter)
     user
       .get('user')
       .get('preferences')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-selector/result-selector.view.js
@@ -21,7 +21,6 @@ const PagingView = require('../paging/paging.view.js')
 const DropdownView = require('../dropdown/result-display/dropdown.result-display.view.js')
 const ResultFilterDropdownView = require('../dropdown/result-filter/dropdown.result-filter.view.js')
 const DropdownModel = require('../dropdown/dropdown.js')
-const cql = require('../../js/cql.js')
 const ResultSortDropdownView = require('../dropdown/result-sort/dropdown.result-sort.view.js')
 const user = require('../singletons/user-instance.js')
 const ResultStatusView = require('../result-status/result-status.view.js')
@@ -60,9 +59,6 @@ const ResultSelector = Marionette.LayoutView.extend({
       .get('user')
       .get('preferences')
       .get('resultFilter')
-    if (resultFilter) {
-      resultFilter = cql.simplify(cql.read(resultFilter))
-    }
     resultFilter = mixinBlackListCQL(resultFilter)
     const filteredResults = this.model
       .get('result')

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -459,7 +459,12 @@ const View = Marionette.LayoutView.extend({
       .get('preferences')
       .get('resultFilter')
     if (resultFilter) {
-      this.handleFilter(CQLUtils.transformCQLToFilter(resultFilter), '#c89600')
+      this.handleFilter(
+        CQLUtils.transformCQLToFilter(
+          CQLUtils.transformFilterToCQL(resultFilter)
+        ),
+        '#c89600'
+      )
     }
   },
   handleFilter(filter, color) {
@@ -470,14 +475,15 @@ const View = Marionette.LayoutView.extend({
     } else {
       let pointText
       let locationModel
+      const value = filter.value
       switch (filter.type) {
         case 'DWITHIN':
-          if (CQLUtils.isPolygonFilter(filter.value)) {
-            this.handleFilterAsPolygon(filter.value, color, filter.distance)
+          if (CQLUtils.isPolygonFilter(value)) {
+            this.handleFilterAsPolygon(value, color, filter.distance)
             break
           }
-          if (CQLUtils.isPointRadiusFilter(filter.value)) {
-            pointText = filter.value.value.substring(6)
+          if (CQLUtils.isPointRadiusFilter(value)) {
+            pointText = value.value.substring(6)
             pointText = pointText.substring(0, pointText.length - 1)
             const latLon = pointText.split(' ')
             locationModel = new LocationModel({

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/filter.js
@@ -180,7 +180,7 @@ function intersects(terraformerObject, value) {
 }
 
 function matchesPOLYGON(value, filter) {
-  const polygonToCheck = TerraformerWKTParser.parse(filter.value.value)
+  const polygonToCheck = TerraformerWKTParser.parse(filter.value)
   if (intersects(polygonToCheck, value)) {
     return true
   }
@@ -189,7 +189,7 @@ function matchesPOLYGON(value, filter) {
 
 const matchesBufferedPOLYGON = (value, filter) => {
   const bufferedPolygon = createBufferedPolygon(
-    polygonStringToCoordinates(filter.value.value),
+    polygonStringToCoordinates(filter.value),
     filter.distance
   )
   const teraformedPolygon = new Terraformer.Polygon({
@@ -203,9 +203,7 @@ function matchesCIRCLE(value, filter) {
   if (filter.distance <= 0) {
     return false
   }
-  const points = filter.value.value
-    .substring(6, filter.value.value.length - 1)
-    .split(' ')
+  const points = filter.value.substring(6, filter.value.length - 1).split(' ')
   const circleToCheck = new Terraformer.Circle(points, filter.distance, 64)
   const polygonCircleToCheck = new Terraformer.Polygon(circleToCheck.geometry)
   if (intersects(polygonCircleToCheck, value)) {
@@ -215,7 +213,7 @@ function matchesCIRCLE(value, filter) {
 }
 
 function matchesLINESTRING(value, filter) {
-  let pointText = filter.value.value.substring(11)
+  let pointText = filter.value.substring(11)
   pointText = pointText.substring(0, pointText.length - 1)
   const lineWidth = filter.distance || 0
   if (lineWidth <= 0) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -104,9 +104,9 @@ class LocationInput extends React.Component {
     switch (filter.type) {
       // these cases are for when the model matches the filter model
       case 'DWITHIN':
-        if (CQLUtils.isPointRadiusFilter(filter)) {
+        if (CQLUtils.isPointRadiusFilter(filter.value)) {
           wreqr.vent.trigger('search:circledisplay', this.locationModel)
-        } else if (CQLUtils.isPolygonFilter(filter)) {
+        } else if (CQLUtils.isPolygonFilter(filter.value)) {
           wreqr.vent.trigger('search:polydisplay', this.locationModel)
         } else {
           wreqr.vent.trigger('search:linedisplay', this.locationModel)


### PR DESCRIPTION
#### What does this PR do?
Fixes bug where user is unable to access the result filter after saving an anygeo filter
fixes bug where keyword/bbox geos are converted to polygons when the user reopens the result filter
backport of https://github.com/codice/ddf/pull/5436

#### Who is reviewing it? 
@hayleynorton @cassandrabailey293 @zta6 @abel-connexta 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere 

#### How should this be tested?
- build / install
- ingest records with location data or edit records to include a location
- search for all records
- use filter button to add an anygeo filter
- verify the results are filtered correclty and the result filter and be reopened and edited
- refreshed and verify user can edit
- save a keyword or bbox geometry filter, reopen and verify the value are as you enter them
- attempt to save an invalid geo and verify that its prevented 

#### Any background context you want to provide?

#### What are the relevant tickets?
codice/ddf-ui#294
G-8763

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
