### PR TITLE
DDF-2749 removed references to intrigue from docs

### DIFF
--- a/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/high-availability-supported-capabilities.adoc
+++ b/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/high-availability-supported-capabilities.adoc
@@ -10,9 +10,8 @@
 Only these capabilities are supported in a Highly Available Cluster.
 For a detailed list of features, look at the `ha.json` file located in `${home_directory}/etc/profiles/`.
 
-* User Interfaces:
+* User Interface:
 ** Simple
-** Intrigue
 * Catalog:
 ** Validation
 ** Plug-ins: Expiration Date, JPEG2000, Metacard Validation, Schematron, Versioning

--- a/distribution/docs/src/main/resources/content/_managing/_datamanagement/attributes-added-by-input-transformers.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_datamanagement/attributes-added-by-input-transformers.adoc
@@ -21,6 +21,5 @@ If no transformer can successfully transform the resource, the ingest process fa
 
 [IMPORTANT]
 ====
-Each of the ingest methods have their own subtle differences when resolving the resource's mimetype/input transformer. +
-For example: a resource ingested through Intrigue may not produce the same metacard attributes as the same resource ingested through the Content Directory Monitor.
+Each of the ingest methods may have subtle differences when resolving the resource's mimetype/input transformer.
 ====

--- a/distribution/docs/src/main/resources/content/_reference/_appReferences/mg-spatial.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_appReferences/mg-spatial.adoc
@@ -40,7 +40,7 @@ The resource argument can be one of three types:
 The `-c` or `--create` flag can be used to clear out the existing gazetteer metacards before adding new entries.
 
 |`build-suggester-index`
-|Builds the Solr suggester index used for placename autocompletion in Intrigue when using the
+|Builds the Solr suggester index used for placename autocompletion when using the
 offline gazetteer. This index is built automatically whenever gazetteer metacards are created,
 updated, or deleted, but if those builds fail then this command can be used to attempt to build the
 index again.


### PR DESCRIPTION
#### What does this PR do?

removes unneeded references to Intrigue UI in the DDF documentation.

#### Select relevant component teams: 
@codice/docs 

#### Ask 2 committers to review/merge the PR and tag them here.

@ahoffer
@clockard
@mcalcote
@paouelle
@shaundmorris
@stustison


#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
