### PR TITLE
[2.19.x] DDF-6221 Make MatchAnyValidator to not get registered to AttributeValidatorRegistry if MatchAnyValidator with same content exists for an attribute

### DIFF
--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
@@ -25,15 +25,21 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MatchAnyValidator implements AttributeValidator {
   private final List<AttributeValidator> validators;
 
   public MatchAnyValidator(List<AttributeValidator> validators) {
-    this.validators = validators;
+    this.validators =
+        validators
+            .stream()
+            .sorted(Comparator.comparingInt(Object::hashCode))
+            .collect(Collectors.toList());
   }
 
   @Override

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
@@ -19,10 +19,6 @@ import ddf.catalog.validation.AttributeValidator;
 import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
 import ddf.catalog.validation.report.AttributeValidationReport;
 import ddf.catalog.validation.violation.ValidationViolation;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -30,6 +26,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 
 public class MatchAnyValidator implements AttributeValidator {
   private final List<AttributeValidator> validators;

--- a/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
+++ b/catalog/core/catalog-core-validator/src/main/java/ddf/catalog/validation/impl/validator/MatchAnyValidator.java
@@ -19,12 +19,15 @@ import ddf.catalog.validation.AttributeValidator;
 import ddf.catalog.validation.impl.report.AttributeValidationReportImpl;
 import ddf.catalog.validation.report.AttributeValidationReport;
 import ddf.catalog.validation.violation.ValidationViolation;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.collections.CollectionUtils;
 
 public class MatchAnyValidator implements AttributeValidator {
   private final List<AttributeValidator> validators;
@@ -93,5 +96,25 @@ public class MatchAnyValidator implements AttributeValidator {
       }
     }
     return Optional.of(result);
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(23, 37).append(validators).toHashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    MatchAnyValidator that = (MatchAnyValidator) obj;
+
+    return new EqualsBuilder().append(validators, that.validators).isEquals();
   }
 }

--- a/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/MatchAnyValidatorTest.java
+++ b/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/MatchAnyValidatorTest.java
@@ -13,6 +13,11 @@
  */
 package ddf.catalog.validation.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
 import com.google.common.collect.ImmutableSet;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.types.Core;
@@ -22,18 +27,12 @@ import ddf.catalog.validation.impl.validator.MatchAnyValidator;
 import ddf.catalog.validation.impl.validator.PatternValidator;
 import ddf.catalog.validation.impl.validator.SizeValidator;
 import ddf.catalog.validation.report.AttributeValidationReport;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MatchAnyValidatorTest {
 

--- a/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/MatchAnyValidatorTest.java
+++ b/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/MatchAnyValidatorTest.java
@@ -62,6 +62,8 @@ public class MatchAnyValidatorTest {
 
   private MatchAnyValidator matchAnyValidator;
 
+  private MatchAnyValidator matchAnyValidator2;
+
   private PatternValidator patternValidator;
 
   private EnumerationValidator enumerationValidator;
@@ -164,5 +166,23 @@ public class MatchAnyValidatorTest {
 
     attributeValidationReportOptional = matchAnyValidator.validate(VALID_ATTRIBUTE_3);
     assertThat(attributeValidationReportOptional.isPresent(), is(false));
+  }
+
+  @Test
+  public void testNotEquals() {
+    matchAnyValidator =
+        new MatchAnyValidator(Arrays.asList(enumerationValidator, patternValidator));
+    matchAnyValidator2 =
+        new MatchAnyValidator(Arrays.asList(enumerationValidator2, patternValidator));
+    assertThat(matchAnyValidator.equals(matchAnyValidator2), is(false));
+  }
+
+  @Test
+  public void testEquals() {
+    matchAnyValidator =
+        new MatchAnyValidator(Arrays.asList(enumerationValidator, patternValidator));
+    matchAnyValidator2 =
+        new MatchAnyValidator(Arrays.asList(enumerationValidator, patternValidator));
+    assertThat(matchAnyValidator.equals(matchAnyValidator2), is(true));
   }
 }

--- a/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/MatchAnyValidatorTest.java
+++ b/catalog/core/catalog-core-validator/src/test/java/ddf/catalog/validation/impl/MatchAnyValidatorTest.java
@@ -13,11 +13,6 @@
  */
 package ddf.catalog.validation.impl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-
 import com.google.common.collect.ImmutableSet;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.types.Core;
@@ -27,12 +22,18 @@ import ddf.catalog.validation.impl.validator.MatchAnyValidator;
 import ddf.catalog.validation.impl.validator.PatternValidator;
 import ddf.catalog.validation.impl.validator.SizeValidator;
 import ddf.catalog.validation.report.AttributeValidationReport;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class MatchAnyValidatorTest {
 
@@ -182,7 +183,7 @@ public class MatchAnyValidatorTest {
     matchAnyValidator =
         new MatchAnyValidator(Arrays.asList(enumerationValidator, patternValidator));
     matchAnyValidator2 =
-        new MatchAnyValidator(Arrays.asList(enumerationValidator, patternValidator));
+        new MatchAnyValidator(Arrays.asList(patternValidator, enumerationValidator));
     assertThat(matchAnyValidator.equals(matchAnyValidator2), is(true));
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Adds `equals()` and `hashCode()` methods to `MatchAnyValidator` to not allow adding in multiple of the same `MatchAnyValidator`s if one already exists for an `attribute`.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@leo-sakh 
@bennuttle 
@jMoneee 

#### Select relevant component teams: 
@codice/core-apis 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@millerw8
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Build and install
2. Edit `/etc/definition/core-attributes-validator.json` file with the following contents
```
{
  "validators": {
    "datatype":
    [
      {
        "validator": "enumerationignorecase",
        "arguments": [
          "Collection",
          "Dataset",
          "Event",
          "Image",
          "Interactive Resource",
          "Moving Image",
          "Physical Object",
          "Service",
          "Software",
          "Sound",
          "Still Image",
          "Text"
        ]
      }
    ],
    "location.country-code":
    [
        {
            "validator": "match_any",
            "validators": [
                {
                    "validator": "iso3_countryignorecase"
                }
            ]
        }
    ]
  }
}
```
3. Run DDF
4. Check that the dropdown populates countrycodes for `location.country-code` attribute (On the UI dropdown possibly).
5. In Karaf console, run `$ bundle:restart 432` (Or try to find the bundle ID by running `$ bundle:list | grep Definition`) to restart `Definition Parser`.
6. Repeat step 4
7. Observe that the dropdown still populates country codes. (Current behavior is that it doesn't show country codes in the dropdown)

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6221 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
