### PR TITLE
[2.25.x] DDF-6229 Remove clearCache in itests

### DIFF
--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/SystemStateManager.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/ddf/itests/common/SystemStateManager.java
@@ -178,7 +178,6 @@ public class SystemStateManager {
 
   private void clearCatalogAndWait() {
     clearCatalog();
-    clearCache();
     with()
         .pollInterval(1, SECONDS)
         .await()
@@ -192,14 +191,6 @@ public class SystemStateManager {
             AbstractIntegrationTest.REMOVE_ALL,
             AbstractIntegrationTest.GENERIC_TIMEOUT_MILLISECONDS);
     LOGGER.debug("{} output: {}", AbstractIntegrationTest.REMOVE_ALL, output);
-  }
-
-  private void clearCache() {
-    String output =
-        console.runCommand(
-            "catalog:removeall -f -p --cache",
-            AbstractIntegrationTest.GENERIC_TIMEOUT_MILLISECONDS);
-    LOGGER.debug("{} output: {}", "catalog:removeall -f -p --cache", output);
   }
 
   private boolean isCatalogEmpty() {


### PR DESCRIPTION
#### What does this PR do?
The `--cache` option was removed from the `catalog:removeall` command in https://github.com/codice/ddf/pull/6117, so the itests has been logging `Error resetting system` configuration errors. This PR removes that step in the itests.

#### Who is reviewing it? 
@stustison @bakejeyner @blen-desta 

#### How should this be tested?
CI. No hero is needed.

#### Any background context you want to provide?
The `solr:cache --clear -f` command could be used instead, but it looks like this step is unnecessary because the itests have been executing without it since https://github.com/codice/ddf/pull/6117 was merged.

#### What are the relevant tickets?
https://github.com/codice/ddf/issues/6229

#### Checklist:
- [n/a] Documentation Updated
- [n/a] Update / Add Threat Dragon models
- [n/a] Update / Add Unit Tests
- [n/a] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.