### PR TITLE
[2.25.x] DDF-6239 Wrap XmlParser marshall and unmarshall in doPrivileged blocks

### DIFF
--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -409,10 +409,6 @@ grant codeBase "file:/security-certificate-generator" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read,write";
 }
 
-grant codeBase "file:/platform-parser-xml" {
-    permission java.lang.RuntimePermission "setContextClassLoader";
-}
-
 grant codeBase "file:/catalog-core-localstorageprovider/token-storage-impl" {
     permission java.io.FilePermission "${ddf.home.perm}content", "write";
     permission java.io.FilePermission "${ddf.home.perm}content${/}-", "read, write";


### PR DESCRIPTION
#### What does this PR do?
Addresses an `AccessControlException` in `XmlParser`, and cleans up the related permission

Note: might be easier to review if you ignore whitespace

#### Who is reviewing it? 
@blen-desta @bakejeyner @stustison

#### How should this be tested?
Confirm that the `AccessControlException` no longer occurs in the downstream project itest. Ping me for testing instructions.

The XML input transformer is tested in itests, so there's no need to manually test that.

#### Any background context you want to provide?
I don't know why this doesn't fail in DDF itests because there are itests that use the XML input transformer. I don't know how to reproduce this issue in DDF. 🤷

#### What are the relevant tickets?
Fixes: https://github.com/codice/ddf/issues/6239

#### Screenshots
This is the `context` that was failing the permission check
![image](https://user-images.githubusercontent.com/8041246/90046897-f2c55080-dc85-11ea-829f-d5bcb67e212d.png)

#### Checklist:
- [n/a] Documentation Updated
- [n/a] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests - Unable to add unit tests for this
- [x] Update / Add Integration Tests - I don't know why itests weren't failing before, so there are no itests to update.

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.