### PR TITLE
DDF-6245 Remove catalog-ui features from etc/application-definitions/search-ui.json and update the default search redirect to /search/simple

### DIFF
--- a/catalog/ui/search-ui/search-redirect/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/ui/search-ui/search-redirect/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,7 +28,7 @@
 
     <bean id="redirectServlet" class="org.codice.ddf.ui.searchui.filter.RedirectServlet"
           init-method="init">
-        <argument value="${org.codice.ddf.external.context}/search/catalog/"/>
+        <argument value="${org.codice.ddf.external.context}/search/simple/"/>
         <cm:managed-properties persistent-id="org.codice.ddf.ui.searchui.filter.RedirectServlet"
                                update-strategy="container-managed"/>
     </bean>

--- a/catalog/ui/search-ui/search-redirect/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/ui/search-ui/search-redirect/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
     <OCD name="Search UI Redirect" id="org.codice.ddf.ui.searchui.filter.RedirectServlet">
         <AD description="Specifies the redirect URI to use when accessing the /search URI."
             name="Redirect URI" id="defaultUri" type="String"
-            default="${org.codice.ddf.external.context}/search/catalog/"/>
+            default="${org.codice.ddf.external.context}/search/simple/"/>
     </OCD>
 
     <Designate pid="org.codice.ddf.ui.searchui.filter.RedirectServlet">

--- a/catalog/ui/search-ui/search-redirect/src/test/groovy/org/codice/ddf/ui/searchui/filter/RedirectServletSpec.groovy
+++ b/catalog/ui/search-ui/search-redirect/src/test/groovy/org/codice/ddf/ui/searchui/filter/RedirectServletSpec.groovy
@@ -21,7 +21,7 @@ import javax.servlet.http.HttpServletResponse
 class RedirectServletSpec extends Specification {
 
     // the default property value for defaultUri
-    private static final String DEFAULT_DEFAULTURI = '/search/catalog/'
+    private static final String DEFAULT_DEFAULTURI = '/search/simple/'
 
     def 'test default defaultUri'() {
         given:

--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/search-ui.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/search-ui.json
@@ -1,10 +1,8 @@
 {
   "name": "search-ui-app",
-  "description": "The Search UI is an application that not only provides results in a html format but also provides a convenient, simple querying user interface.\nThe left pane of the SearchUI contains basic fields to query the Catalog and other Sources. The right pane consists of a map.\nIt includes both standard (3d globe) and simple (text page) versions.::Search UI",
+  "description": "The Search UI is an application that not only provides results in a html format but also provides a convenient, simple querying user interface.::Search UI",
   "bundleLocations": [
-    "mvn:ddf.ui.search/search-endpoint/${project.version}",
     "mvn:ddf.ui.search/search-redirect/${project.version}",
-    "mvn:ddf.ui.search/standard/${project.version}",
-    "mvn:ddf.ui/catalog-ui-search/${project.version}"
+    "mvn:ddf.ui.search/simple/${project.version}"
   ]
 }

--- a/distribution/docs/src/main/resources/content/_reference/_tables/RedirectServlet.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/RedirectServlet.adoc
@@ -20,7 +20,7 @@
 |defaultUri
 |String
 |Specifies the redirect URI to use when accessing the /search URI.
-|`${org.codice.ddf.external.context}/search/catalog/`
+|`${org.codice.ddf.external.context}/search/simple/`
 |true
 
 |===


### PR DESCRIPTION
#### What does this PR do?
- Removes catalog-ui features from `etc/application-definitions/search-ui.json`
- Updates the default search redirect to `/search/simple`

2.25.x PR: https://github.com/codice/ddf/pull/6246

#### Who is reviewing it? 
@garrettfreibott @blen-desta @bakejeyner @stustison 

#### How should this be tested?
- [x] Confirm that `/search` redirects to `/search/simple`.
- [x] Confirm that the `Search UI `app still appears in the old and new Admin Console, and that the redirect is configurable.

#### Any background context you want to provide?
catalog-ui was moved to it's own repo and is not included in DDF anymore. The only search ui that exists in DDF now is the Simple Search UI.

#### What are the relevant tickets?
Fixes: #6245

#### Screenshots
![image](https://user-images.githubusercontent.com/8041246/90179240-ffb77200-dd61-11ea-8db3-a97a33e86b1d.png)
![image](https://user-images.githubusercontent.com/8041246/90179306-19f15000-dd62-11ea-828f-affb9dacfc23.png)
![image](https://user-images.githubusercontent.com/8041246/90179283-0f36bb00-dd62-11ea-8df0-25f8bb1d5ad3.png)
![image](https://user-images.githubusercontent.com/8041246/90179358-31c8d400-dd62-11ea-91e6-e2052e7a80f7.png)
![image](https://user-images.githubusercontent.com/8041246/90179406-3f7e5980-dd62-11ea-957e-55d97b33e7a6.png)
![image](https://user-images.githubusercontent.com/8041246/90179498-62a90900-dd62-11ea-8b32-d5ba362428c7.png)
![image](https://user-images.githubusercontent.com/8041246/90179433-4dcc7580-dd62-11ea-8e59-5c398a1a3d19.png)
![image](https://user-images.githubusercontent.com/8041246/90179668-a865d180-dd62-11ea-9203-69fa3507fa36.png)

#### Checklist:
- [x] Documentation Updated
- [n/a] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [n/a] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.