### PR TITLE
[2.19.x] DDF-6223 Added Logout Redirect

### DIFF
--- a/platform/security/servlet/security-servlet-logout/pom.xml
+++ b/platform/security/servlet/security-servlet-logout/pom.xml
@@ -139,7 +139,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.71</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LocalLogoutServlet.java
+++ b/platform/security/servlet/security-servlet-logout/src/main/java/org/codice/ddf/security/servlet/logout/LocalLogoutServlet.java
@@ -17,6 +17,7 @@ import ddf.security.SecurityConstants;
 import ddf.security.common.SecurityTokenHolder;
 import ddf.security.common.audit.SecurityLogger;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -26,6 +27,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.logging.log4j.util.Strings;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.slf4j.Logger;
@@ -33,6 +36,8 @@ import org.slf4j.LoggerFactory;
 
 public class LocalLogoutServlet extends HttpServlet {
   private static final Logger LOGGER = LoggerFactory.getLogger(LocalLogoutServlet.class);
+
+  private String redirectUrl = "";
 
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -44,11 +49,15 @@ public class LocalLogoutServlet extends HttpServlet {
     invalidateSession(request, response);
 
     boolean mustCloseBrowser = (checkForBasic(request) || checkForPki(request));
-    String message = String.format("{ \"mustCloseBrowser\": %b }", mustCloseBrowser);
 
+    String message =
+        String.format(
+            "{ \"mustCloseBrowser\": %b, \"redirectUrl\": \"%s\" }",
+            mustCloseBrowser, getRedirectUrlMessage());
+
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType("application/json");
     try {
-      response.setStatus(HttpServletResponse.SC_OK);
-      response.setContentType("application/json");
       response.getWriter().write(message);
       response.flushBuffer();
     } catch (IOException e) {
@@ -101,5 +110,27 @@ public class LocalLogoutServlet extends HttpServlet {
     cookie.setPath("/");
     cookie.setComment("EXPIRING COOKIE at " + System.currentTimeMillis());
     response.addCookie(cookie);
+  }
+
+  private String getRedirectUrlMessage() {
+    String redirectUrlMessage = "";
+    if (Strings.isNotBlank(redirectUrl)) {
+      try {
+        URIBuilder redirectUrlBuilder = new URIBuilder(redirectUrl);
+        redirectUrlMessage =
+            redirectUrlBuilder == null ? "" : redirectUrlBuilder.build().toString();
+      } catch (URISyntaxException e) {
+        LOGGER.debug(
+            "Invalid URL of {} set for logout redirect URL. Users will not be redirected to {} upon logout.",
+            redirectUrl,
+            redirectUrl,
+            e);
+      }
+    }
+    return redirectUrlMessage;
+  }
+
+  public void setRedirectUrl(String redirectUrl) {
+    this.redirectUrl = redirectUrl;
   }
 }

--- a/platform/security/servlet/security-servlet-logout/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/servlet/security-servlet-logout/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,7 +34,9 @@
 
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
 
-    <bean id="logoutServlet" class="org.codice.ddf.security.servlet.logout.LocalLogoutServlet"/>
+    <bean id="logoutServlet" class="org.codice.ddf.security.servlet.logout.LocalLogoutServlet">
+        <property name="redirectUrl" value=""/>
+    </bean>
 
     <service ref="logoutServlet" interface="javax.servlet.Servlet">
         <service-properties>

--- a/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/LogoutServletTest.java
+++ b/platform/security/servlet/security-servlet-logout/src/test/java/org/codice/ddf/security/servlet/logout/LogoutServletTest.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -68,6 +69,11 @@ public class LogoutServletTest {
     System.setProperty("security.audit.roles", "none");
   }
 
+  @After
+  public void testCleanup() {
+    localLogoutServlet.setRedirectUrl("");
+  }
+
   @Test
   public void testLocalLogoutBasicAuth() {
     // Used for detecting basic auth
@@ -85,7 +91,7 @@ public class LogoutServletTest {
       fail(e.getMessage());
     }
     verify(httpSession).invalidate();
-    verify(printWriter).write("{ \"mustCloseBrowser\": true }");
+    verify(printWriter).write("{ \"mustCloseBrowser\": true, \"redirectUrl\": \"\" }");
   }
 
   @Test
@@ -107,7 +113,7 @@ public class LogoutServletTest {
       fail(e.getMessage());
     }
     verify(httpSession).invalidate();
-    verify(printWriter).write("{ \"mustCloseBrowser\": true }");
+    verify(printWriter).write("{ \"mustCloseBrowser\": true, \"redirectUrl\": \"\" }");
   }
 
   @Test
@@ -128,7 +134,52 @@ public class LogoutServletTest {
       fail(e.getMessage());
     }
     verify(httpSession).invalidate();
-    verify(printWriter).write("{ \"mustCloseBrowser\": false }");
+    verify(printWriter).write("{ \"mustCloseBrowser\": false, \"redirectUrl\": \"\" }");
+  }
+
+  @Test
+  public void testLocalLogoutredirectUrlNotBasicOrPki() {
+    // Used for detecting basic auth
+    localLogoutServlet.setRedirectUrl("redirectUrlAddress.com");
+    when(request.getHeaders(anyString()))
+        .thenReturn(Collections.enumeration(Collections.emptyList()));
+
+    // used for detecting pki
+    when(request.getAttribute("javax.servlet.request.X509Certificate")).thenReturn(null);
+
+    SecurityTokenHolder securityTokenHolder = mock(SecurityTokenHolder.class);
+    when(httpSession.getAttribute(SecurityConstants.SECURITY_TOKEN_KEY))
+        .thenReturn(securityTokenHolder);
+    try {
+      localLogoutServlet.doGet(request, response);
+    } catch (ServletException e) {
+      fail(e.getMessage());
+    }
+    verify(httpSession).invalidate();
+    verify(printWriter)
+        .write("{ \"mustCloseBrowser\": false, \"redirectUrl\": \"redirectUrlAddress.com\" }");
+  }
+
+  @Test
+  public void testLocalLogoutInvalidredirectUrl() {
+    // Used for detecting basic auth
+    localLogoutServlet.setRedirectUrl("/redirect    UrlAddress");
+    when(request.getHeaders(anyString()))
+        .thenReturn(Collections.enumeration(Collections.emptyList()));
+
+    // used for detecting pki
+    when(request.getAttribute("javax.servlet.request.X509Certificate")).thenReturn(null);
+
+    SecurityTokenHolder securityTokenHolder = mock(SecurityTokenHolder.class);
+    when(httpSession.getAttribute(SecurityConstants.SECURITY_TOKEN_KEY))
+        .thenReturn(securityTokenHolder);
+    try {
+      localLogoutServlet.doGet(request, response);
+    } catch (ServletException e) {
+      fail(e.getMessage());
+    }
+    verify(httpSession).invalidate();
+    verify(printWriter).write("{ \"mustCloseBrowser\": false, \"redirectUrl\": \"\" }");
   }
 
   @Test()

--- a/ui/packages/security-logout/src/main/webapp/js/main.js
+++ b/ui/packages/security-logout/src/main/webapp/js/main.js
@@ -63,6 +63,9 @@ async function logout(actions) {
 
   if (localLogoutAction) {
     const response = await $.ajax(localLogoutAction.url)
+    if (response.redirectUrl && response.redirectUrl != '') {
+      window.location.href = response.redirectUrl
+    }
     if (response.mustCloseBrowser === true) {
       $('#close-browser-msg').show()
       return


### PR DESCRIPTION
#### What does this PR do?
Enables downstream projects to add a custom logout redirect url that users will be directed to upon logging out.

#### Who is reviewing it? 
@mojogitoverhere 
@brhumphe 
@Lambeaux 
@kentmorrissey 

#### Ask 2 committers to review/merge the PR and tag them here.
@lambeaux
@mojogitoverhere

#### How should this be tested?
Since there is no way to configure the redirectUri in DDF, we just want to make sure nothing has changed regarding logout from a DDF perspective. Install DDF and logout to ensure logout directs users to the same logout page as before these changes were implemented.

#### What are the relevant tickets?
Fixes: #6223 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests