### PR TITLE
[2.19.x] DDF-6254 Hide filters in search forms with no support

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -59,29 +59,47 @@ module.exports = Marionette.LayoutView.extend({
   },
   onBeforeShow() {
     this.$el.toggleClass('is-sortable', this.options.isSortable || false)
-    this.filterOperator.show(
-      DropdownView.createSimpleDropdown({
-        list: [
-          {
-            label: 'AND',
-            value: 'AND',
-          },
-          {
-            label: 'OR',
-            value: 'OR',
-          },
-          {
-            label: 'NOT AND',
-            value: 'NOT AND',
-          },
-          {
-            label: 'NOT OR',
-            value: 'NOT OR',
-          },
-        ],
-        defaultSelection: [this.model.get('operator') || 'AND'],
-      })
-    )
+    if (this.options.isFormBuilder === true) {
+      this.filterOperator.show(
+        DropdownView.createSimpleDropdown({
+          list: [
+            {
+              label: 'AND',
+              value: 'AND',
+            },
+            {
+              label: 'OR',
+              value: 'OR',
+            },
+          ],
+          defaultSelection: [this.model.get('operator') || 'AND'],
+        })
+      )
+    } else {
+      this.filterOperator.show(
+        DropdownView.createSimpleDropdown({
+          list: [
+            {
+              label: 'AND',
+              value: 'AND',
+            },
+            {
+              label: 'OR',
+              value: 'OR',
+            },
+            {
+              label: 'NOT AND',
+              value: 'NOT AND',
+            },
+            {
+              label: 'NOT OR',
+              value: 'NOT OR',
+            },
+          ],
+          defaultSelection: [this.model.get('operator') || 'AND'],
+        })
+      )
+    }
     this.listenTo(
       this.filterOperator.currentView.model,
       'change:value',

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -80,8 +80,8 @@ module.exports = Marionette.LayoutView.extend({
           label: 'OR',
           value: 'OR',
         },
-        ...(showExtraLabels ? extraLabels : [])
-      ]
+        ...(showExtraLabels ? extraLabels : []),
+      ],
     }
     this.filterOperator.show(
       DropdownView.createSimpleDropdown({

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/filter-builder/filter-builder.view.js
@@ -59,47 +59,36 @@ module.exports = Marionette.LayoutView.extend({
   },
   onBeforeShow() {
     this.$el.toggleClass('is-sortable', this.options.isSortable || false)
-    if (this.options.isFormBuilder === true) {
-      this.filterOperator.show(
-        DropdownView.createSimpleDropdown({
-          list: [
-            {
-              label: 'AND',
-              value: 'AND',
-            },
-            {
-              label: 'OR',
-              value: 'OR',
-            },
-          ],
-          defaultSelection: [this.model.get('operator') || 'AND'],
-        })
-      )
-    } else {
-      this.filterOperator.show(
-        DropdownView.createSimpleDropdown({
-          list: [
-            {
-              label: 'AND',
-              value: 'AND',
-            },
-            {
-              label: 'OR',
-              value: 'OR',
-            },
-            {
-              label: 'NOT AND',
-              value: 'NOT AND',
-            },
-            {
-              label: 'NOT OR',
-              value: 'NOT OR',
-            },
-          ],
-          defaultSelection: [this.model.get('operator') || 'AND'],
-        })
-      )
+    const extraLabels = [
+      {
+        label: 'NOT AND',
+        value: 'NOT AND',
+      },
+      {
+        label: 'NOT OR',
+        value: 'NOT OR',
+      },
+    ]
+    const showExtraLabels = !this.options || this.options.isFormBuilder !== true
+    const labels = {
+      list: [
+        {
+          label: 'AND',
+          value: 'AND',
+        },
+        {
+          label: 'OR',
+          value: 'OR',
+        },
+        ...(showExtraLabels ? extraLabels : [])
+      ]
     }
+    this.filterOperator.show(
+      DropdownView.createSimpleDropdown({
+        ...labels,
+        defaultSelection: [this.model.get('operator') || 'AND'],
+      })
+    )
     this.listenTo(
       this.filterOperator.currentView.model,
       'change:value',


### PR DESCRIPTION
#### What does this PR do?
Currently for search forms, only the `AND` & `NOT` operators have support implemented for them but `NOT AND` & `NOT OR` still show up as options in the selection dropdown, causing errors when trying to save forms that include those operators. This PR hides the operators that have no support implemented for them so they can't be selected for use on a search form.
#### Who is reviewing it? 
@bennuttle @leo-sakh @jMoneee @frnkshin 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->

#### How should this be tested?
1. Build / run DDF, install profile, and navigate to Search Forms
2. Create a new search form, verify the filter options dropdown only includes `AND` & `OR` options
3. Navigate to Intrigue, create a new advanced query, verify the filter options dropdown includes `AND`, `OR`, `NOT AND`, &`NOT OR` options
#### Any background context you want to provide?
Support for `NOT AND` / `NOT OR` in search forms could be implemented later on, this just prevents the use of them being used incorrectly 
#### What are the relevant tickets?
Fixes: #6254 

#### Screenshots
Before: 
<img width="583" alt="Screen Shot 2020-08-19 at 6 54 53 AM" src="https://user-images.githubusercontent.com/43187475/90644036-23a70780-e1e9-11ea-8660-7d433ac0ec9b.png">


After:
<img width="578" alt="Screen Shot 2020-08-19 at 6 56 15 AM" src="https://user-images.githubusercontent.com/43187475/90644058-2ace1580-e1e9-11ea-9cd2-61b31336d3e8.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
