### PR TITLE
[2.25.x] DDF-6259 Add setAllowGuest in SubjectRetrievalInterceptor

### DIFF
--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/client/interceptor/SubjectRetrievalInterceptor.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/client/interceptor/SubjectRetrievalInterceptor.java
@@ -32,6 +32,7 @@ import org.apache.cxf.transport.http.UntrustedURLConnectionIOException;
 import org.apache.cxf.transport.https.HttpsURLConnectionInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.codice.ddf.security.handler.AuthenticationTokenFactory;
+import org.codice.ddf.security.handler.BaseAuthenticationToken;
 
 /**
  * SubjectRetrievalInterceptor provides a implementation of {@link AbstractPhaseInterceptor} that
@@ -116,6 +117,7 @@ public class SubjectRetrievalInterceptor extends AbstractPhaseInterceptor<Messag
         AuthenticationToken token =
             tokenFactory.fromCertificates(certs, urlConnectionInfo.getURI().getHost());
 
+        ((BaseAuthenticationToken) token).setAllowGuest(true);
         Subject receiverSubject = securityManager.getSubject(token);
         message.put(Subject.class, receiverSubject);
 


### PR DESCRIPTION
#### What does this PR do?
See https://github.com/codice/ddf/issues/6259

#### Who is reviewing it? 
@stustison @blen-desta @bakejeyner @garrettfreibott

#### Select relevant component teams: 
@codice/security


#### How should this be tested?
Confirm downstream itest is fixed. See me for testing instructions.

#### What are the relevant tickets?
https://github.com/codice/ddf/issues/6259

#### Checklist:
- [n/a] Documentation Updated
- [n/a] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests - there aren't any existing unit tests for this class
- [x] Update / Add Integration Tests - no itest updates needed

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.