### PR TITLE
Fix jacoco EOFException in catalog-rest-endpoint module

### DIFF
--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -251,6 +251,20 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>jacoco.argline</propertyName>
+                            <!-- This is a work around. This module has unit tests and integration
+                                 tests. Without this change the build can fail with
+                                 "Error while checking code coverage: null: EOFException"
+                                 This change attempts to have integration tests write to a separate file -->
+                            <destFile>${project.build.directory}/jacoco-it.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>default-check</id>
                         <goals>
                             <goal>check</goal>


### PR DESCRIPTION
#### What does this PR do?
Attempts to fixes a jacoco build failure (EOFException) in the catalog-rest-endpoint. This attempt is done by using a different jacoco.exec file for integration tests. Not sure if this is the best workaround so looking for feedback.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@AdamBurstynski 
@TonyMorrison 
@LinkMJB 

#### Select relevant component teams: 

@codice/build 
@codice/continuous-integration 
@codice/test 

#### Ask 2 committers to review/merge the PR and tag them here.

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/ddf/6274)
<!-- Reviewable:end -->
