### PR TITLE
DDF-6277 Moves the Guest Claims Configuration under the Security App

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/security-services.json
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/application-definitions/security-services.json
@@ -17,8 +17,8 @@
     "mvn:ddf.security.claims/security-claims-property/${project.version}",
     "mvn:ddf.security.realm/security-realm-saml/${project.version}",
     "mvn:ddf.security.handler/security-handler-oidc/${project.version}",
-    "mvn:ddf.platform.security/security-oidc-realm/${project.version}",
-    "mvn:ddf.platform.security/security-guest-realm/${project.version}",
+    "mvn:ddf.security.realm/security-realm-oidc/${project.version}",
+    "mvn:ddf.security.realm/security-realm-guest/${project.version}",
     "mvn:ddf.security.certificate/security-crl-generator/${project.version}",
     "mvn:ddf.security.certificate/security-ocsp-checker/${project.version}"
   ]


### PR DESCRIPTION
#### What does this PR do?
Moves the Guest Claims Configuration under the Security App

#### Who is reviewing it? 
@bakejeyner
@emmberk
@garrettfreibott
@stustison

#### How should this be tested?
Verify that the `Guest Claims Configuration` and `OIDC Configuration Settings` are under the Security App in the Admin UI

#### What are the relevant tickets?
Fixes: #6277 

#### Screenshots
![Screen Shot 2020-09-01 at 3 04 39 PM](https://user-images.githubusercontent.com/29550062/91910774-7c07eb80-ec64-11ea-9479-5bc39b799578.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
