### PR TITLE
Make Solr query time allowed configurable

### DIFF
--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/SolrMetacardClientImplTest.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/SolrMetacardClientImplTest.java
@@ -69,6 +69,7 @@ import org.apache.solr.client.solrj.response.SpellCheckResponse.Collation;
 import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.util.NamedList;
 import org.codice.solr.client.solrj.SolrClient;
 import org.junit.Before;
 import org.junit.Test;
@@ -272,6 +273,25 @@ public class SolrMetacardClientImplTest {
     List<Result> results = clientImpl.query(request).getResults();
     assertThat(results.size(), is(1));
     verify(queryResponse, times(2)).getResults();
+  }
+
+  @Test
+  public void testPartialResults() throws Exception {
+    QueryRequest request = createQuery(builder.attribute("anyText").is().like().text("normal"));
+
+    List<String> names = Collections.emptyList();
+    List<String> values = Collections.emptyList();
+
+    Map<String, String> attributes = createAttributes(names, values);
+
+    when(queryResponse.getResults()).thenReturn(createSolrDocumentList(attributes));
+    NamedList responseHeader = mock(NamedList.class);
+    when(queryResponse.getResponseHeader()).thenReturn(responseHeader);
+    when(responseHeader.get("partialResults")).thenReturn(Boolean.TRUE);
+    mockDynamicSchemsolverCalls(createAttributeDescriptor(names), attributes);
+
+    SourceResponse response = clientImpl.query(request);
+    assertThat(response.getPropertyValue("partial-results"), is(Boolean.TRUE));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
- Allows the `solr.query.timeAllowed` system property to set a time
  allowed to do a Solr query.  This is not a hard limit.
- Time allowed is not enabled by default.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

- Install standard profile and ingest data
- `log:set DEBUG ddf.catalog.source.solr`
- Find (`list | grep -i provider`) and restart Solr provider bundle
- `search test` or other search terms for your data that have not been queried and cached yet
- Verify logs contain details about partial results being returned
```
15:28:44,012 | DEBUG | StrategyThread 1 | talog.source.solr.SolrMetacardClientImpl  334 | atalog-solr-provider | Found 0 partial results for query [ ( (point-of-contact_txt_tokenized:"test" ... location.crs-code_txt_tokenized:"test") AND metacard-tags_txt_tokenized:"resource" ) ] that took 8ms.
```
- `system:property solr.query.timeAllowed 1000`
- `search test` again and verify no log about partial results and that all results are returned.


#### Any background context you want to provide?
https://lucene.apache.org/solr/guide/8_6/common-query-parameters.html#timeallowed-parameter

https://youtu.be/SVt5MBw8Li8?t=1639
https://www.slideshare.net/lucidworks/making-reddit-search-relevant-and-scalable-anupama-joshi-jerry-bao-reddit#74

#### What are the relevant tickets?
Fixes: n/a

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
