### PR TITLE
[2.25.x] DDF-6308 Fix handling of encoded urls in OIDC logout action provider

### DIFF
--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProvider.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProvider.java
@@ -168,7 +168,8 @@ public class OidcLogoutActionProvider implements ActionProvider {
       return null;
     }
     Map<String, String> queryParams =
-        URLEncodedUtils.parse(refererUri, StandardCharsets.UTF_8).stream()
+        URLEncodedUtils.parse(refererUri, StandardCharsets.UTF_8)
+            .stream()
             .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
 
     String previousUrl;

--- a/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProvider.java
+++ b/platform/security/handler/security-handler-oidc/src/main/java/org/codice/ddf/security/handler/oidc/OidcLogoutActionProvider.java
@@ -23,15 +23,19 @@ import ddf.security.assertion.SecurityAssertion;
 import ddf.security.assertion.jwt.impl.SecurityAssertionJwt;
 import ddf.security.common.PrincipalHolder;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import org.apache.cxf.common.util.StringUtils;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.security.handler.api.OidcHandlerConfiguration;
 import org.pac4j.core.context.JEEContext;
@@ -122,23 +126,9 @@ public class OidcLogoutActionProvider implements ActionProvider {
 
       URIBuilder urlBuilder =
           new URIBuilder(SystemBaseUrl.EXTERNAL.constructUrl("/oidc/logout", true));
-      String referer = request.getHeader("Referer");
-      if (!StringUtils.isEmpty(referer)) {
-        String[] parts;
-        if (referer.contains("prevurl")) {
-          parts = referer.split("\\?prevurl=");
-        } else {
-          parts = referer.split("\\?service=");
-        }
-
-        if (parts.length > 1) {
-          String previousUrl = parts[1];
-
-          if (previousUrl.startsWith("/")) {
-            previousUrl = SystemBaseUrl.EXTERNAL.constructUrl(previousUrl, false);
-          }
-          urlBuilder.addParameter("prevurl", previousUrl);
-        }
+      String prevUrl = getPreviousUrl(request);
+      if (prevUrl != null) {
+        urlBuilder.addParameter("prevurl", prevUrl);
       }
 
       RedirectionAction logoutAction =
@@ -162,6 +152,40 @@ public class OidcLogoutActionProvider implements ActionProvider {
   @Override
   public String getId() {
     return ID;
+  }
+
+  private String getPreviousUrl(HttpServletRequest request) {
+    String referer = request.getHeader("Referer");
+    if (referer == null) {
+      return null;
+    }
+
+    URI refererUri;
+    try {
+      refererUri = new URI(referer);
+    } catch (URISyntaxException e) {
+      // Shouldn't happen if the Referer header is set by the browser
+      return null;
+    }
+    Map<String, String> queryParams =
+        URLEncodedUtils.parse(refererUri, StandardCharsets.UTF_8).stream()
+            .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
+
+    String previousUrl;
+    if (queryParams.containsKey("prevurl")) {
+      previousUrl = queryParams.get("prevurl");
+    } else if (queryParams.containsKey("service")) {
+      previousUrl = queryParams.get("service");
+    } else {
+      return null;
+    }
+
+    if (previousUrl.startsWith("/")) {
+      // An absolute path won't include the external context. Need to add it ourselves
+      previousUrl = SystemBaseUrl.EXTERNAL.constructUrl(previousUrl, false);
+    }
+
+    return previousUrl;
   }
 
   private <T> boolean canHandle(T subjectMap) {


### PR DESCRIPTION
#### What does this PR do?
Fixes the OIDC logout action provider so it process the prevurl query parameter in the Referer header correctly.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@blen-desta @bakejeyner @emmberk @garrettfreibott @stustison 

Tagging @jlcsmith for visibility

#### Select relevant component teams: 
@codice/security 

#### How should this be tested?
The easy way:
1. Install DDF and configure OIDC authentication (https://octoconsulting.atlassian.net/wiki/spaces/DDF/pages/702939155/Connect+Keycloak+to+DDF+using+OIDC may help)
2. Sign in to an OIDC-protected web context
3. Browse to `https://localhost:8993/logout?service=https%3A%2F%2Flocalhost%3A8993%2Fsearch%2Fsimple`
4. Click the "sign in again" link on the logout landing page. Verify you can sign back in as you would expect (no 404 response)

The hard way:
1. Install DDF, and install [Intrigue](https://github.com/codice/ddf-ui/) on top of it.
2. Configure OIDC authentication (https://octoconsulting.atlassian.net/wiki/spaces/DDF/pages/702939155/Connect+Keycloak+to+DDF+using+OIDC may help)
3. Sign in to Intrigue
4. Wait for 15 minutes to be logged out due to inactivity. Verify that the "sign in again link" on the logout landing page works. (To make this quicker, reduce the inactivity timeout to 2 minutes. The config is in the admin UI under Platform > Configuration > Platform UI Configuration)

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6308

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.