### PR TITLE
[2.19.x] G-8998 Run all searches not working

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/container.tsx
@@ -106,7 +106,9 @@ class WorkspaceInteractions extends React.Component<Props, State> {
       }
     )
   }
-  runAllSearches = () => {
+  sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms))
+
+  runAllSearches = async () => {
     store.clearOtherWorkspaces(this.props.workspace.id)
     wreqr.vent.trigger('router:navigate', {
       fragment: 'workspaces/' + this.props.workspace.id,
@@ -114,7 +116,13 @@ class WorkspaceInteractions extends React.Component<Props, State> {
         trigger: true,
       },
     })
-    const queries = this.props.workspace.get('queries')
+    const workspace = this.props.workspace
+    if (workspace.isPartial()){
+      workspace.fetchPartial()
+      while(workspace.isPartial())
+        await this.sleep(100)
+    }
+    const queries = workspace.get('queries')
     store.setCurrentQuery(queries.at(0))
     queries.forEach(function(query: any) {
       query.startSearch()

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/container.tsx
@@ -117,10 +117,9 @@ class WorkspaceInteractions extends React.Component<Props, State> {
       },
     })
     const workspace = this.props.workspace
-    if (workspace.isPartial()){
+    if (workspace.isPartial()) {
       workspace.fetchPartial()
-      while(workspace.isPartial())
-        await this.sleep(100)
+      while (workspace.isPartial()) await this.sleep(100)
     }
     const queries = workspace.get('queries')
     store.setCurrentQuery(queries.at(0))

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/workspace-interactions/container.tsx
@@ -108,7 +108,15 @@ class WorkspaceInteractions extends React.Component<Props, State> {
   }
   runAllSearches = () => {
     store.clearOtherWorkspaces(this.props.workspace.id)
-    this.props.workspace.get('queries').forEach(function(query: any) {
+    wreqr.vent.trigger('router:navigate', {
+      fragment: 'workspaces/' + this.props.workspace.id,
+      options: {
+        trigger: true,
+      },
+    })
+    const queries = this.props.workspace.get('queries')
+    store.setCurrentQuery(queries.at(0))
+    queries.forEach(function(query: any) {
       query.startSearch()
     })
   }


### PR DESCRIPTION
#### What does this PR do?
Makes 'run all searches' interaction open the workspace when used from the 'workspaces' page
Makes 'run all searches' open the first query in the workspace and display it's results

#### Who is reviewing it? 
@codice/ui 
@andrewzimmer 
@hayleynorton 
@abel-connexta 
@cassandrabailey293 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@gordocanchola 

#### How should this be tested?
Ingest some data so that you will get search results
Create a workspace with multiple queries, a single query, and no queries. 
From the workspaces page click the ellipsis on the workspace with multiple queries
Click 'run all searches' in the dropdown
Verify: 
    The workspace opens
    The first query in the workspace is selected and its results are shown
    Upon selecting the other queries in the workspace their results are already loaded
Repeat for the workspace with a single query
Repeat for the workspace with no queries - verify no error occurs in the UI or in the dev console
From the workspaces page, open the workspace with multiple queries. 
Click the ellipsis in the top left, select 'run all searches'
Verify this behaves the same as above
Repeat for the other two workspaces. 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
