### PR TITLE
[2.25.x] Added pax-logging-api dependency to fix unit test failure

### DIFF
--- a/libs/test-common/pom.xml
+++ b/libs/test-common/pom.xml
@@ -184,6 +184,12 @@
             <artifactId>platform-util</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+            <version>1.10.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
#### What does this PR do?
Added pax-logging-api dependency to fix unit test failure

```
[ERROR] Failures:
[ERROR]   PaxExamRuleIT.validBeforeAndAfter:177
Expecting:
 <["Problem starting test container."]>
to contain:
 <["test failed"]>
but could not find:
 <["test failed"]>
[INFO]
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 1
```

#### Who is reviewing it? 
@emmberk
@garrettfreibott
@SmithJosh 
@stustison 

#### How should this be tested?
CI build

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
