### PR TITLE
DDF-6342 Remove unused Kernel features

### DIFF
--- a/distribution/ddf-catalog/pom.xml
+++ b/distribution/ddf-catalog/pom.xml
@@ -156,8 +156,8 @@
                         <configuration>
                             <rules>
                                 <requireFilesSize>
-                                    <maxsize>330000000</maxsize>
-                                    <minsize>290000000</minsize>
+                                    <maxsize>300000000</maxsize>
+                                    <minsize>260000000</minsize>
                                     <files>
                                         <file>${project.build.directory}/${distribution.file.name}.zip</file>
                                     </files>

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -107,7 +107,7 @@ grant codeBase "file:/registry-federation-admin-impl/registry-publication-action
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}-", "read";
 }
 
-grant codeBase "file:/spatial-csw-source/spatial-csw-endpoint/org.apache.camel.camel-core/com.google.guava/ddf-pubsub/registry-source-configuration-handler/registry-api-impl/org.apache.camel.camel-blueprint/fabric8-karaf-checks/registry-publication-update-handler/org.eclipse.jetty.websocket.server" {
+grant codeBase "file:/spatial-csw-source/spatial-csw-endpoint/org.apache.camel.camel-core/com.google.guava/ddf-pubsub/registry-source-configuration-handler/registry-api-impl/org.apache.camel.camel-blueprint/registry-publication-update-handler/org.eclipse.jetty.websocket.server" {
     permission java.lang.RuntimePermission "createClassLoader";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}-", "read";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}ws-security${/}server${/}-", "read";

--- a/features/kernel/src/main/feature/feature.xml
+++ b/features/kernel/src/main/feature/feature.xml
@@ -17,8 +17,6 @@
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
     <repository>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</repository>
-    <repository>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</repository>
-    <repository>mvn:io.fabric8/fabric8-karaf-features/${fabric8.version}/xml/features</repository>
 
     <feature name="kernel" version="${project.version}"
              description="Minimual set of features and dependencies commonly used.">

--- a/features/utilities/src/main/feature/feature.xml
+++ b/features/utilities/src/main/feature/feature.xml
@@ -17,6 +17,7 @@
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
     <repository>mvn:ddf.features/kernel/${project.version}/xml/features</repository>
+    <repository>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</repository>
 
     <feature name="platform-util" version="${project.version}"
              description="Platform Utilities">

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -56,8 +56,6 @@
                 <value>/favicon.ico</value>
                 <value>/error</value>
                 <value>/webjars</value>
-                <value>/health-check</value>
-                <value>/readiness-check</value>
             </array>
         </property>
         <property name="traversalDepth">

--- a/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/policy/security-policy-context/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -50,7 +50,7 @@
         <AD description="List of contexts that will not use security. Note that sub-contexts to ones listed here will also skip security, unless authentication types are provided for it. For example: if /foo is listed here, then /foo/bar will also not require any sort of authentication. However, if /foo is listed and /foo/bar has authentication types provided in the 'Authentication Types' field, then that more specific policy will be used."
             name="White Listed Contexts" id="whiteListContexts" cardinality="100"
             type="String"
-            default="${org.codice.ddf.system.rootContext}/SecurityTokenService,${org.codice.ddf.system.rootContext}/internal/metrics,/proxy,${org.codice.ddf.system.rootContext}/saml,${org.codice.ddf.system.rootContext}/idp,/idp,${org.codice.ddf.system.rootContext}/platform/config/ui,${org.codice.ddf.system.rootContext}/logout,/logout,${org.codice.ddf.system.rootContext}/internal/session,${org.codice.ddf.system.rootContext}/admin/fonts,/favicon.ico,/error,/webjars,/health-check,/readiness-check"/>
+            default="${org.codice.ddf.system.rootContext}/SecurityTokenService,${org.codice.ddf.system.rootContext}/internal/metrics,/proxy,${org.codice.ddf.system.rootContext}/saml,${org.codice.ddf.system.rootContext}/idp,/idp,${org.codice.ddf.system.rootContext}/platform/config/ui,${org.codice.ddf.system.rootContext}/logout,/logout,${org.codice.ddf.system.rootContext}/internal/session,${org.codice.ddf.system.rootContext}/admin/fonts,/favicon.ico,/error,/webjars"/>
 
     </OCD>
 

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,6 @@
         <decanter.version>1.3.0</decanter.version>
         <dropwizard.version>3.2.6</dropwizard.version>
         <equinox.version>3.13.0</equinox.version>
-        <fabric8.version>3.0.12</fabric8.version>
         <felix.configadmin.version>1.9.16</felix.configadmin.version>
         <felix.coordinator.version>1.0.2</felix.coordinator.version>
         <felix.fileinstall.version>3.6.6</felix.fileinstall.version>


### PR DESCRIPTION
#### What does this PR do?
Removes unused features from the kernel. This shrinks the kernel from 120MB to 89MB.
This also resolves some CVEs as the features were pulling in some old dependencies with known vulnerabilities. 

#### Who is reviewing it? 
@blen-desta @emmberk @garrettfreibott @stustison 

#### Select relevant component teams: 
@codice/security 

#### How should this be tested?
CI

#### Any background context you want to provide?
The fabric8 features repo was originally added to provide health and readiness endpoints for DDF: https://github.com/codice/ddf/pull/3155
But later the features were turned off by default. Apparently there were issues with system startup when they were turned on: https://github.com/codice/ddf/pull/3302

#### What are the relevant tickets?
Fixes: #6342

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
