### PR TITLE
[2.19.x] G-9033 fix Saved search form fails to display Geometry

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -104,7 +104,7 @@ class LocationInput extends React.Component {
     switch (filter.type) {
       // these cases are for when the model matches the filter model
       case 'DWITHIN':
-        const value = filter.value.value ? filter.value : filter
+        const value = filter.value && filter.value.value ? filter.value : filter
         if (CQLUtils.isPointRadiusFilter(value)) {
           wreqr.vent.trigger('search:circledisplay', this.locationModel)
         } else if (CQLUtils.isPolygonFilter(value)) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -79,6 +79,11 @@ class LocationInput extends React.Component {
     this.props.listenTo(this.locationModel, 'change:mode', () => {
       this.clearLocation()
     })
+    this.props.listenTo(this.locationModel, 'change:polygon', () => {
+      if (this.locationModel.get('mode') !== 'poly') {
+        wreqr.vent.trigger('search:polydisplay', this.locationModel)
+      }
+    })
   }
   componentWillUnmount() {
     this.locationModel.off('change', this.setModelState)

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -104,9 +104,10 @@ class LocationInput extends React.Component {
     switch (filter.type) {
       // these cases are for when the model matches the filter model
       case 'DWITHIN':
-        if (CQLUtils.isPointRadiusFilter(filter.value)) {
+        const value = filter.value.value ? filter.value : filter
+        if (CQLUtils.isPointRadiusFilter(value)) {
           wreqr.vent.trigger('search:circledisplay', this.locationModel)
-        } else if (CQLUtils.isPolygonFilter(filter.value)) {
+        } else if (CQLUtils.isPolygonFilter(value)) {
           wreqr.vent.trigger('search:polydisplay', this.locationModel)
         } else {
           wreqr.vent.trigger('search:linedisplay', this.locationModel)
@@ -116,7 +117,14 @@ class LocationInput extends React.Component {
         if (CQLUtils.isLineFilter(filter)) {
           wreqr.vent.trigger('search:linedisplay', this.locationModel)
         } else {
-          wreqr.vent.trigger('search:polydisplay', this.locationModel)
+          if (
+            filter.geojson &&
+            filter.geojson.properties.type === 'BoundingBox'
+          ) {
+            wreqr.vent.trigger('search:bboxdisplay', this.locationModel)
+          } else {
+            wreqr.vent.trigger('search:polydisplay', this.locationModel)
+          }
         }
         break
       // these cases are for when the model matches the location model


### PR DESCRIPTION
#### What does this PR do?
non polygon geometries were failing to show up in search form editor after creation. Only an issue if the user creates the search form then opens it without refreshing

#### Who is reviewing it? 
@cassandrabailey293 @hayleynorton @zta6 @abel-connexta 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining
@mojogitoverhere

#### How should this be tested?
- build / install
- navigate to search forms page and create a new form with a bbox geo 
- without refreshing open the newly created search form and verify the geo is displayed
- repeat for point radius
- test with other shapes and verify they are displayed correctly

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
