### PR TITLE
DDF-6223 Added Logout Redirect

### DIFF
--- a/platform/security/servlet/security-servlet-logout/pom.xml
+++ b/platform/security/servlet/security-servlet-logout/pom.xml
@@ -146,12 +146,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.92</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.58</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/platform/security/servlet/security-servlet-logout/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/servlet/security-servlet-logout/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,6 +36,7 @@
     <service ref="logoutService" interface="org.codice.ddf.security.logout.service.LogoutService"/>
 
     <reference id="securityManager" interface="ddf.security.service.SecurityManager"/>
+    
 
     <service interface="javax.servlet.Servlet">
         <service-properties>
@@ -46,10 +47,10 @@
             <argument>
                 <reference interface="org.codice.ddf.security.token.storage.api.TokenStorage"/>
             </argument>
-            <argument value="/logout/logout-response.html"/>
             <argument>
                 <reference interface="ddf.security.audit.SecurityLogger"/>
             </argument>
+            <property name="redirectUrl" value="/logout/logout-response.html"/>
         </bean>
     </service>
 


### PR DESCRIPTION
#### What does this PR do?
Enables downstream projects to add a custom logout redirect url that users will be directed to upon logging out.

#### Who is reviewing it? 
@mojogitoverhere 
@brhumphe 
@Lambeaux 
@kentmorrissey 

#### Ask 2 committers to review/merge the PR and tag them here.
@lambeaux
@mojogitoverhere

#### How should this be tested?
Since there is no way to configure the redirectUrl in DDF, we just want to make sure nothing has changed regarding logout from a DDF perspective. Install DDF and logout to ensure logout directs users to the same logout page as before these changes were implemented.

#### What are the relevant tickets?
Fixes: #6223 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
