### PR TITLE
[2.19.x] DDF-UI-396 Result Form shows 'Make Default Form' even though already default

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-add/query-add.view.js
@@ -67,10 +67,15 @@ module.exports = Marionette.LayoutView.extend({
     ) {
       return
     }
-    const searchForm = new SearchForm(currentQuerySettings.get('template'))
+    const currentTemplate = currentQuerySettings.get('template')
+    const searchForm = new SearchForm(currentTemplate)
     const sharedAttributes = searchForm.transformToQueryStructure()
+    if (currentTemplate === undefined) {
+      sharedAttributes['detail-level'] = null
+    }
     this.model.set({
       type: currentQuerySettings.get('type'),
+      searchFormId: searchForm.id,
       ...sharedAttributes,
     })
   },
@@ -146,6 +151,7 @@ module.exports = Marionette.LayoutView.extend({
         (userDefaultTemplate['querySettings'] &&
           userDefaultTemplate['querySettings']['detail-level']) ||
         'allFields',
+      searchFormId: userDefaultTemplate['id'],
     }
   },
   showTitle() {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-settings/query-settings.view.js
@@ -64,7 +64,11 @@ module.exports = plugin(
         Common.safeCallback(this.onBeforeShow)
       )
       this.resultForms = ResultFormCollection.getCollection()
-      this.listenTo(this.resultForms, 'change', this.renderResultForms)
+      this.listenTo(
+        this.resultForms,
+        'change add remove',
+        this.renderResultForms
+      )
       this.listenTo(user.getQuerySettings(), 'change:defaultResultFormId', () =>
         this.renderResultForms()
       )
@@ -97,12 +101,19 @@ module.exports = plugin(
       })
       resultFormsForDropdown = _.uniq(resultFormsForDropdown, 'id')
       let lastIndex = resultFormsForDropdown.length - 1
-      let defaultResultForm = resultFormsForDropdown.find(
-        form => form.id === user.getQuerySettings().get('defaultResultFormId')
-      )
+      let detailLevel = this.model.get('detail-level')
+      if (detailLevel === null) {
+        const defaultResultForm = resultFormsForDropdown.find(
+          form => form.id === user.getQuerySettings().get('defaultResultFormId')
+        )
+        detailLevel = defaultResultForm && defaultResultForm.value
+      }
+      const isValidDetailLevel =
+        resultFormsForDropdown.find(
+          dropdownItem => dropdownItem.value === detailLevel
+        ) !== undefined
       const propertyValue =
-        this.model.get('detail-level') ||
-        (defaultResultForm && defaultResultForm.value) ||
+        (isValidDetailLevel && detailLevel) ||
         (resultFormsForDropdown &&
           resultFormsForDropdown[lastIndex] &&
           resultFormsForDropdown[lastIndex].value)
@@ -250,7 +261,7 @@ module.exports = plugin(
       let federation = this._srcDropdownModel.get('federation')
       const spellcheck = this.model.get('spellcheck')
       const phonetics = this.model.get('phonetics')
-      let src
+      let src = this.model.get('src')
       if (federation === 'selected') {
         src = this._srcDropdownModel.get('value')
         if (src === undefined || src.length === 0) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-interactions/search-form-interactions.view.js
@@ -113,18 +113,24 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
   },
   ui: {},
   initialize() {
-    this.listenTo(user.getQuerySettings(), 'change', function() {
-      this.$el.toggleClass(
-        'is-current-template',
-        user.getQuerySettings().isDefaultTemplate(this.model)
-      )
-    })
+    this.listenTo(
+      user.getQuerySettings(),
+      'change:defaultResultFormId change:template',
+      function() {
+        this.$el.toggleClass(
+          'is-current-template',
+          user.getQuerySettings().isDefaultResultForm(this.model) ||
+            user.getQuerySettings().isDefaultTemplate(this.model)
+        )
+      }
+    )
   },
   onRender() {
     this.$el.toggleClass('is-subscribed', Boolean(this.model.get('subscribed')))
     this.$el.toggleClass(
       'is-current-template',
-      user.getQuerySettings().isDefaultTemplate(this.model)
+      user.getQuerySettings().isDefaultResultForm(this.model) ||
+        user.getQuerySettings().isDefaultTemplate(this.model)
     )
     this.$el.toggleClass(
       'is-system-template',
@@ -213,6 +219,15 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
             },
           })
           loadingview.remove()
+          if (this.model.get('type') === 'result') {
+            if (user.getQuerySettings().isDefaultResultForm(this.model)) {
+              this.handleClearDefault()
+              if (this.options.queryModel) {
+                this.options.queryModel.resetToDefaults()
+              }
+            }
+            return
+          }
           const template = user.getQuerySettings().get('template')
           if (!template) {
             user.getQuerySettings().set('type', 'text')
@@ -240,7 +255,9 @@ Anyone who has access to this search ${formTitleLowerCase} will subsequently los
                   template.querySettings['detail-level']) ||
                 'allFields',
             }
-            this.options.queryModel.resetToDefaults(defaults)
+            if (this.options.queryModel) {
+              this.options.queryModel.resetToDefaults(defaults)
+            }
           }
         }
       }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form/search-form.view.js
@@ -139,8 +139,9 @@ const CustomSearchForm = props => {
 
 export default Marionette.LayoutView.extend({
   template(props) {
-    const isDefault = user.getQuerySettings().isDefaultTemplate(this.model)
+    let isDefault
     if (props.type === 'custom') {
+      isDefault = user.getQuerySettings().isDefaultTemplate(this.model)
       return (
         <CustomSearchForm
           {...props}
@@ -149,8 +150,7 @@ export default Marionette.LayoutView.extend({
         />
       )
     } else if (props.type == 'result') {
-      const isDefault =
-        user.getQuerySettings().get('defaultResultFormId') === props.id
+      isDefault = user.getQuerySettings().isDefaultResultForm(this.model)
       return (
         <RelativeWrapper>
           <FormTitle data-help={props.title}>{props.title}</FormTitle>

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/Query.js
@@ -186,7 +186,7 @@ Query.Model = PartialAssociatedModel.extend({
         type: 'text',
         isLocal: false,
         isOutdated: false,
-        'detail-level': undefined,
+        'detail-level': null,
         spellcheck: false,
         phonetics: false,
       },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/QuerySettings.js
@@ -33,9 +33,6 @@ module.exports = Backbone.Model.extend({
     }
   },
   isTemplate(template) {
-    if (this.get('defaultResultFormId') === template.id) {
-      return true
-    }
     if (this.get('template') !== undefined) {
       return this.get('template').id === template.id
     } else {
@@ -48,5 +45,15 @@ module.exports = Backbone.Model.extend({
       this.get('template') &&
       this.get('template').default
     )
+  },
+  isDefaultResultForm(model) {
+    if (
+      model.get('type') === 'result' &&
+      this.get('defaultResultFormId') !== undefined
+    ) {
+      return this.get('defaultResultFormId') === model.id
+    } else {
+      return false
+    }
   },
 })


### PR DESCRIPTION
ddf-ui PRs:
3.4.x codice/ddf-ui#398

---------------------
#### What does this PR do?
Issue 1 - Unable to clear default Result Form if tried to switch Workspace Search Forms (works after refresh) 
Issue 2 - Unable to clear default Result Form if tried to select User custom Search Forms (still issue even after refresh)
Issue 3 - Deleted Result Form is still selected when Updating a custom Search Forms if selected prior to its deletion
Issue 4 - Deleted Result Form still appears in dropdown in Workspace Search 
Issue 5 - Exception is thrown when deleting a non-default Search Form
Issue 6 - Updated Search form that saved “All Field” in Search Form for Result form, gets overridden to existing default Result Form
Issue 7 - “Use Another Search Form” in workspace do not show correct selected Search Form for dropdown
Issue 8 - When default is removed from Search form, and there exists a default Result Form, if try to open new search form in workspace, default Result Form is not selected, instead “All Field” is.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@hayleynorton
@cassandrabailey293 
@zta6 

#### Select relevant component teams: 

#### Ask 2 committers to review/merge the PR and tag them here.
@bdeining 
@mojogitoverhere 
#### How should this be tested?
<!--(List steps with links to updated documentation)-->

- build / install

Issue 1:
  1. Open 'Result Forms' via the main menu ('hamburger') button
  2. Create a Result Form and set as default via the 3 ellipse button . If you click on the ellipse, you'll see the 'Clear Default Form'
  3. Go to Workspaces, open or click create a New Workspace
  4. Click on 'Search DDF Intrigue' or 'Create a Search'
  5. Click ellipse menu to switch to advance or basic or text search, just switch to something else then what was opened
  6. Now Open 'Result Forms' via the main menu ('hamburger') button
  7. Go to default Result Form, and click the ellipse menu button
  8. Ensure able to see the 'Clear Default Form' and can click on it to clear default

Issue 2:
  1. Open 'Search Forms' via the main menu ('hamburger') button
  2. Create a Search Form
  3. Go to Workspaces, open or click create a New Workspace
  4. Click on 'Search DDF Intrigue' or 'Create a Search'
  5. Click ellipse menu and click on 'Use Another Search Form'
  6. Select a Search Form from drop down
  7. Open 'Result Forms' via the main menu ('hamburger') button
  8. Create a Result Form and set as default via the 3 ellipse button.
  9. Click the ellipse menu button again
  10. Ensure able to see the 'Clear Default Form' 
  11. Refresh page and Ensure and Ensure able to see the 'Clear Default Form' and can click on it to clear default

Issue 3:
  1. Open 'Result Forms' via the main menu ('hamburger') button
  2. Create couple Result Forms 
  3. Open 'Search Forms' via the main menu ('hamburger') button
  4. Create a Search Form and make sure under 'Result Form' to select one of the created Result Forms
  5. Now Open 'Result Forms' via the main menu ('hamburger') button
  6. Delete a Result Form via the ellipse menu button
  7. Go to 'Search Forms' 
  8. Open previously created search form
  9. Ensure under 'Result Form', the deleted Result Form is not selected and does not appear in drop down list
  This behavior should work same in Workspace for Advanced and Basic Search forms
  
Issue 4:
  1. Open 'Result Forms' via the main menu ('hamburger') button
  2. Create couple Result Forms 
  3. Go to Workspaces, open or click create a New Workspace
  4. Click on 'Search DDF Intrigue' or 'Create a Search'
  5. Click ellipse menu to switch to advance or basic search
  6. Under 'Result Form' click drop down, should see all existing Result forms
  7. Now Open 'Result Forms' via the main menu ('hamburger') button
  8. Delete a Result Form via the ellipse menu button
  9. Do steps 3 to 6
  10. Ensure the deleted Result Form is not displayed in drop down list
  This behavior should work same in create/update custom 'Search Forms'

Issue 5:
  1. Open 'Search Forms' via the main menu ('hamburger') button
  2. Create couple Search Forms
  3. Set one as default via the 3 ellipse button
  4. Pull up and clear console log
  5. Try to delete the non-default Search form
  6. Ensure no exception are thrown for each item deleted
  
Issue 6:
  1. Open 'Result Forms' via the main menu ('hamburger') button
  2. Create couple Result Form and set one as default via the 3 ellipse button
  3. Open 'Search Forms' via the main menu ('hamburger') button
  4. Create a Search Form (Note-Under 'Result Form' the existing default Result Form that was created should be selected)
  5. Save changes
  6. Open created Search Form and make sure under 'Result Form' to select "All Field"
  7. Save changes
  8. Open updated Search Form
  9. Ensure under 'Result Form' the "All Field" option is selected. Can also try with other Result Forms that's not default.
  
Issue 7:
  1. Open 'Search Forms' via the main menu ('hamburger') button
  2. Create couple Search Forms
  3. Go to Workspaces, open or click create a New Workspace
  4. Click on 'Search DDF Intrigue' or 'Create a Search'
  5. Click ellipse menu and click on 'Use Another Search Form'
  6. Select a Search Form from drop down
  7. Ensure when do steps 4 to 5 again, the previously selected Search Form has 'check mark' next to it in list
  8. Open 'Search Forms' via the main menu ('hamburger') button
  9. Make one of other Search Form that you have not selected in step 6, as default
  10. Do steps 3 to 5
  11. Ensure the Search Form presented is the default Search Form and the drop down for 'Use Another Search Form' has the default Search Form selected 
  

Issue 8:
  1. Open 'Result Forms' via the main menu ('hamburger') button
  2. Create a Result Form and set as default via the 3 ellipse button
  3. Go to Workspaces, open or click create a New Workspace
  4. Click on 'Search DDF Intrigue' or 'Create a Search'
  5. Click ellipse menu to switch to advance or basic search
  6. Ensure under 'Result Form', the default Result Form is selected
  7. Open 'Search Forms' via the main menu ('hamburger') button
  8. Create a Search Form
  9. Set created Search Form as default
  10. Clear default from created Search Form
  11. Do steps 3 to 6

#### Any background context you want to provide?

#### What are the relevant tickets?
codice/ddf-ui#396

#### Screenshots
<!--(if appropriate)-->

##### Issue 1 - Before
![Before-RF_i1](https://user-images.githubusercontent.com/65194214/94618699-c9c64280-0268-11eb-9d31-e2937e894f0e.gif)

##### Issue 1 - After
![After-RF_i1](https://user-images.githubusercontent.com/65194214/94618658-b9ae6300-0268-11eb-9142-b2ddcf42129f.gif)

##### Issue 2 - Before
![Before-RF_i2](https://user-images.githubusercontent.com/65194214/94618712-cf238d00-0268-11eb-80b6-4f3b8d5c5f47.gif)

##### Issue 2 - After
![After-RF_i2](https://user-images.githubusercontent.com/65194214/94618716-d21e7d80-0268-11eb-8ffc-905554a32964.gif)

##### Issue 3 - Before
![Before-RF_i3](https://user-images.githubusercontent.com/65194214/94618727-d5b20480-0268-11eb-9099-5ebf7b20c87a.gif)

##### Issue 3 - After
![After-RF_i3](https://user-images.githubusercontent.com/65194214/94618732-d9458b80-0268-11eb-9eda-4e6506fcf453.gif)

##### Issue 4 - Before
![Before-RF_i4](https://user-images.githubusercontent.com/65194214/94618748-df3b6c80-0268-11eb-888c-c6cceb7b9fba.gif)

##### Issue 4 - After
![After-RF_i4](https://user-images.githubusercontent.com/65194214/94689713-709ff280-02ec-11eb-9cff-8a3a7fafba2c.gif)

##### Issue 5 - Before
![Before-RF_i5](https://user-images.githubusercontent.com/65194214/94618776-eebab580-0268-11eb-9233-fa3d597b9f18.gif)

##### Issue 5 - After
![After-RF_i5](https://user-images.githubusercontent.com/65194214/94689685-6aaa1180-02ec-11eb-914c-3d93ae4ba3f9.gif)

##### Issue 6 - Before
![Before-RF_i6](https://user-images.githubusercontent.com/65194214/94618781-f24e3c80-0268-11eb-8606-16faa33e011a.gif)

##### Issue 6 - After
![After-RF_i6](https://user-images.githubusercontent.com/65194214/94689662-62ea6d00-02ec-11eb-9cce-9b3645f3bb47.gif)

##### Issue 7 - Before
![Before-RF_i7](https://user-images.githubusercontent.com/65194214/94618793-f67a5a00-0268-11eb-8073-0fb289788ab9.gif)

##### Issue 7 - After
![After-RF_i7](https://user-images.githubusercontent.com/65194214/94689643-5cf48c00-02ec-11eb-8abc-09153730f94f.gif)

##### Issue 8 - Before
![Before-RF_i8](https://user-images.githubusercontent.com/65194214/94618802-fa0de100-0268-11eb-8371-2ef3c6a8319b.gif)

##### Issue 8 - After
![After-RF_i8](https://user-images.githubusercontent.com/65194214/94689617-536b2400-02ec-11eb-9c60-d68ed0116425.gif)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
