### PR TITLE
[2.19.x] G-7920 Improve Result Form UX

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-form/result-form.view.js
@@ -68,7 +68,7 @@ module.exports = Marionette.LayoutView.extend({
         model: new Property({
           readOnly: this.model.get('readOnly'),
           enumFiltering: true,
-          showValidationIssues: true,
+          showValidationIssues: false,
           enumMulti: true,
           enum: allowedValues,
           values: this.model.get('descriptors'),
@@ -138,7 +138,7 @@ module.exports = Marionette.LayoutView.extend({
         }
         this.showWarningSymbol(
           $titleValidationElement,
-          'Name field cannot be blank'
+          'Title field cannot be blank'
         )
       }
       if (attributesEmpty) {


### PR DESCRIPTION
#### What does this PR do?
Improves result form UX by only showing input validation errors when the user tries to click Save

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@kentmorrissey @brhumphe @brianfelix


#### Ask 2 committers to review/merge the PR and tag them here.
@lambeaux
@millerw8

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Open the `Result Form` page in Intrigue
2. Click `+ New Result Form`
3. Verify no validation errors are shown
4. Click `Save` without entering any values
5. Verify validation errors for Title and Attributes are now shown
6. Play around with modifying existing result forms to test for regressions

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
