### PR TITLE
[2.19.x] G-8885; Use window.event instead of event

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/inputs/masked-text-field.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/location-new/inputs/masked-text-field.js
@@ -26,13 +26,16 @@ class MaskedTextField extends React.Component {
     // Sometimes the event variable is defined, other times it's undefined.
     // We must capture the event in a variable when it's defined
     // in order to leverage it in checks below even when it's undefined.
-    if (event) {
-      this.prevEvent = event
+    if (window.event) {
+      this.prevEvent = window.event
+    } else if (this.prevEvent === undefined) {
+      return value
     }
     if (
       value === undefined ||
       !value.includes('.') ||
-      (((event && event.type === 'input') || this.prevEvent.type === 'input') &&
+      (((window.event && window.event.type === 'input') ||
+        this.prevEvent.type === 'input') &&
         this.prevEvent.target.id === this.props.label)
     ) {
       return value


### PR DESCRIPTION


#### What does this PR do?
This PR fixes an issue where the anyGeo component was jumping off the search form in a specific version of Firefox. The problem was the usage of `event` in the `padEndWithZeros` method, which was being called many times by the pipe function. I removed the pipe function since we only want to call `padEndWIthZeros` when switching to the DMS tab from other tabs.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@hayleynorton @andrewzimmer @zta6 @abel-connexta 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
0. build, profile/install
1. Verify no regression with DMS coordinate entry/switching tabs
2. Download Firefox 60 ESR: https://ftp.mozilla.org/pub/firefox/releases/60.0esr/mac/en-US/
3. Go to the UI and Advanced Search -> anyGeo
4. Select Bounding Box
5. Switch to the DMS tab
6. Verify that there is no `event is not defined` error in the console and that the component works as expected
7. Repeat for Point Radius

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
