### PR TITLE
Removes a initial capacity default that is too high

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/ResultIterable.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/ResultIterable.java
@@ -155,7 +155,7 @@ public class ResultIterable implements Iterable<Result> {
   private static class ResultIterator implements Iterator<Result> {
 
     private final QueryFunction queryFunction;
-    private final Set<String> foundIds = new HashSet<>(2048);
+    private final Set<String> foundIds = new HashSet<>();
     private int currentIndex;
     private QueryImpl queryCopy;
     private QueryRequestImpl queryRequestCopy;


### PR DESCRIPTION
#### What does this PR do?
Removes the default initial capacity (2048) of the hashset used to store duplicate ids seen while using the ResultIterable. Without having metrics or evidence to support being kept at its previous value-- it is being set to the default constructor. I could maybe see it being set to something around the default page size for the ui, but even that can differ across environment,  and we would (again) be purely guessing. If anyone has some solid reasoning for keeping it at 2048 (or for any number) please do share.

#### Who is reviewing it? 
anyone

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
ResultIterable is used widely enough that itests for common services should catch if an issue was introduced (However, being this was just a change to initial capacity there should be no direct effects to the logic/correctness)


#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
