### PR TITLE
[2.19.x] G-9203 fix search form editor title changes after cancel

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -110,6 +110,7 @@ module.exports = Marionette.LayoutView.extend({
         return
       }
     }
+    this.originalTitle = this.model.get('title')
     this.map.show(
       new MapView({
         showResultFilter: false,
@@ -143,6 +144,7 @@ module.exports = Marionette.LayoutView.extend({
           }
         },
         onCancel: () => {
+          this.resetTitle()
           this.navigateToForms()
         },
       })
@@ -204,6 +206,9 @@ module.exports = Marionette.LayoutView.extend({
     }
     this.model.set(json)
     json.id ? this.model.save({}, options) : collection.create(json, options)
+  },
+  resetTitle() {
+    this.model.set({ title: this.originalTitle })
   },
   navigateToForms() {
     const fragment = `forms`


### PR DESCRIPTION
#### What does this PR do?
prevents search form editor title from retaining the changes after the user cancels the edit
#### Who is reviewing it? 
@abel-connexta @zta6 @cassandrabailey293 @hayleynorton 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
@lambeaux
@mojogitoverhere

#### How should this be tested?
- build / install / run
- open search form editor and save a new search form with title and some attributes
- open again to edit and make some changes
- cancel the edit and verify that none of the changes were persisted

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
