### PR TITLE
[2.19.x] G-9247 Loosing Result Selector Menu

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/result-filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/result-filter.view.js
@@ -82,6 +82,10 @@ module.exports = Marionette.LayoutView.extend({
   },
   saveFilter() {
     const filter = this.getFilter()
+    if (filter.filters && filter.filters.length < 1) {
+      this.removeFilter()
+      return
+    }
     const errorMessages = getFilterErrors(filter.filters)
     if (errorMessages.length !== 0) {
       showErrorMessages(errorMessages)

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/visualization/maps/map.view.js
@@ -461,10 +461,10 @@ const View = Marionette.LayoutView.extend({
       .get('preferences')
       .get('resultFilter')
     if (resultFilter && this.showResultFilter) {
+      //Ensure no alteration occurs to 'resultFilter'
+      const filter = { ...resultFilter }
       this.handleFilter(
-        CQLUtils.transformCQLToFilter(
-          CQLUtils.transformFilterToCQL(resultFilter)
-        ),
+        CQLUtils.transformCQLToFilter(CQLUtils.transformFilterToCQL(filter)),
         '#c89600'
       )
     }

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -33,6 +33,7 @@ const moment = require('moment-timezone')
 const Theme = require('./Theme.js')
 const ThemeUtils = require('../ThemeUtils.js')
 const QuerySettings = require('./QuerySettings.js')
+const cql = require('../../js/cql.js')
 require('backbone-associations')
 
 import plugin from 'plugins/user'
@@ -204,6 +205,13 @@ User.Preferences = Backbone.AssociatedModel.extend({
     this.listenTo(this, 'change:goldenLayoutMetacard', this.savePreferences)
     this.listenTo(this, 'change:goldenLayoutAlert', this.savePreferences)
     this.listenTo(this, 'change:mapHome', this.savePreferences)
+  },
+  get(attr) {
+    const value = Backbone.AssociatedModel.prototype.get.call(this, attr)
+    if (attr === 'resultFilter' && value && value.type === 'NOT') {
+      return cql.simplify(value)
+    }
+    return value
   },
   handleRemove() {
     this.savePreferences()


### PR DESCRIPTION
ddf-ui PRs:
3.4.x codice/ddf-ui#428

---------------------
#### What does this PR do?
Resolved following List issues:
Issue 1 - Error when saving "NOT AND" or "NOT OR" filters.
Issue 2 - Error when remove all fields in filter and saving.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@hayleynorton
@cassandrabailey293 
@zta6 
@Lambeaux 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
**Issue 1 - Error when saving "NOT AND" or "NOT OR" filters.**
1. Go to Workspaces, open or click create a New Workspace
2. Perform any type of Search that returns results
3. Click on "Filter" Result menu icon 
4.  Select "NOT AND" or "NOT OR"
5.  Open console log
6. Add some fields and click "Save Filter"
7. Ensure no error occurs
8. Ensure the Result menu icons are still there and able to edit filter created
9. Refresh page and ensure no error occurs and Result menu icons are still there and able to edit filter created  
10. Ensure no regression with Filters

**Issue 2 - Error when saving remove all fields in filter and saving.**
Follow steps 1 to 3 from Issue 1.

4.  Click minus icon to remove  filter field(s)
5.  Open console log
6. Click "Save Filter"
7. Ensure no error occurs, and Ensure when re-open "Filter" it is reset to default.
8. Add some field(s) to the filter, then Save Filter.
9. Refresh page and follow steps 1 to 7.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->
##### Issue 1 - Before
![Before-GSR-9247_i1](https://user-images.githubusercontent.com/65194214/97052524-61ecda00-153e-11eb-987b-8e9dbbf4e765.gif)

##### Issue 1 - After
![After-GSR-9247_i1](https://user-images.githubusercontent.com/65194214/97052531-6618f780-153e-11eb-91f3-bed16028ce97.gif)

##### Issue 2 - Before
![Before-GSR-9247_i2](https://user-images.githubusercontent.com/65194214/97052539-69ac7e80-153e-11eb-87ec-31e8cb9287ee.gif)

##### Issue 2 - After
![After-GSR-9247_i2](https://user-images.githubusercontent.com/65194214/97052547-6d400580-153e-11eb-8fee-c64fd3715add.gif)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
