### PR TITLE
[2.26.x] DDF-6360 Remove reference to deleted libs-bundles-opensaml artifact

### DIFF
--- a/features/security/src/main/feature/feature.xml
+++ b/features/security/src/main/feature/feature.xml
@@ -291,7 +291,6 @@
         <feature>security-core-services</feature>
 
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.opensaml/${opensaml.osgi.version}</bundle>
-        <bundle>mvn:ddf.lib.bundles/libs-bundles-opensaml/${project.version}</bundle>
 
         <bundle>mvn:ddf.security/security-saml-util/${project.version}</bundle>
 


### PR DESCRIPTION
#### What does this PR do?
Deletes reference from the security features descriptor to the old wrapped opensaml bundle. It no longer exists

#### Who is reviewing it? 
@shaundmorris 

#### Select relevant component teams: 
@codice/build 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
CI without cached m2

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6360

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
