### PR TITLE
[2.19.x] G-9315 Prevent Save/Search of empty Location Keyword

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/list-editor/list-editor.view.js
@@ -196,9 +196,7 @@ module.exports = Marionette.LayoutView.extend({
     } else if (shouldLimit === true) {
       filters = this.listFilters.currentView.model.getValue()
     }
-    if (filters) {
-      this.model.set('list.filters', filters)
-    }
+    this.model.set('list.filters', filters ? filters : undefined)
   },
   save() {
     this.saveTitle()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/list/result-filter.list.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/list/result-filter.list.view.js
@@ -26,7 +26,10 @@ module.exports = ResultFilter.extend({
     this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
   },
   saveFilter() {
-    this.model.set('value', this.getFilter())
-    this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
+    const filter = this.getFilter()
+    if (this.isValidFilter(filter)) {
+      this.model.set('value', filter)
+      this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
+    }
   },
 })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/result-filter.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/result-filter/result-filter.view.js
@@ -80,26 +80,33 @@ module.exports = Marionette.LayoutView.extend({
       .savePreferences()
     this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
   },
-  saveFilter() {
-    const filter = this.getFilter()
+  isValidFilter(filter) {
+    let isValid = true
     if (filter.filters && filter.filters.length < 1) {
       this.removeFilter()
-      return
+      isValid = false
+    } else {
+      const errorMessages = getFilterErrors(filter.filters)
+      if (errorMessages.length !== 0) {
+        showErrorMessages(errorMessages)
+        isValid = false
+      }
     }
-    const errorMessages = getFilterErrors(filter.filters)
-    if (errorMessages.length !== 0) {
-      showErrorMessages(errorMessages)
-      return
+    return isValid
+  },
+  saveFilter() {
+    const filter = this.getFilter()
+    if (this.isValidFilter(filter)) {
+      user
+        .get('user')
+        .get('preferences')
+        .set('resultFilter', filter)
+      user
+        .get('user')
+        .get('preferences')
+        .savePreferences()
+      this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
     }
-    user
-      .get('user')
-      .get('preferences')
-      .set('resultFilter', filter)
-    user
-      .get('user')
-      .get('preferences')
-      .savePreferences()
-    this.$el.trigger('closeDropdown.' + CustomElements.getNamespace())
   },
   handleFilter() {
     const resultFilter = this.getResultFilter()

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -30,6 +30,7 @@ const wreqr = require('../../js/wreqr.js')
 const user = require('../singletons/user-instance.js')
 const cql = require('../../js/cql.js')
 const announcement = require('../announcement/index.jsx')
+import { showErrorMessages } from '../../react-component/utils/validation'
 
 const formTitle = properties.i18n['form.title']
   ? properties.i18n['form.title'].toLowerCase()
@@ -129,9 +130,14 @@ module.exports = Marionette.LayoutView.extend({
         isSearchFormEditor: true,
         onSave: () => {
           if (this.model.get('title').trim() !== '') {
-            this.updateQuerySettings(collection, id)
-            this.saveTemplateToBackend(collection, id)
-            this.navigateToForms()
+            const errorMessages = this.editor.currentView.getErrorMessages()
+            if (errorMessages.length !== 0) {
+              showErrorMessages(errorMessages)
+            } else {
+              this.updateQuerySettings(collection, id)
+              this.saveTemplateToBackend(collection, id)
+              this.navigateToForms()
+            }
           } else {
             announcement.announce(
               {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/group/index.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/group/index.js
@@ -15,7 +15,10 @@
 const React = require('react')
 
 const Group = props => (
-  <div className="input-group" {...props}>
+  <div
+    className={`input-group ${props.readOnly ? 'read-only-group' : ''}`}
+    {...props}
+  >
     {props.children}
   </div>
 )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/base.line.js
@@ -100,6 +100,7 @@ const BaseLine = props => {
     widthKey,
     mode,
     polyType,
+    readOnly,
   } = props
   const [currentValue, setCurrentValue] = useState(
     JSON.stringify(props[geometryKey])
@@ -128,6 +129,7 @@ const BaseLine = props => {
         <TextField
           label={label}
           value={currentValue}
+          readOnly={readOnly}
           onChange={value => {
             value = convertWktString(value.trim())
             if (geometryKey.includes('poly')) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/keyword.js
@@ -130,6 +130,7 @@ class Keyword extends React.Component {
             polygonBufferUnits={polygonBufferUnits}
             setBufferState={setBufferState}
             polyType={polyType}
+            readOnly={true}
           />
         ) : null}
         {!loading && polygon !== undefined && polyType === 'multipolygon' ? (
@@ -140,6 +141,7 @@ class Keyword extends React.Component {
             polygonBufferUnits={polygonBufferUnits}
             setBufferState={setBufferState}
             polyType={polyType}
+            readOnly={true}
           />
         ) : null}
       </div>

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.less
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.less
@@ -35,6 +35,15 @@
         opacity: @minimumOpacity;
       }
 
+      > .read-only {
+        background: transparent;
+        cursor: default;
+      }
+
+      > input.read-only {
+        border-bottom: 2px solid;
+      }
+
       > span {
         min-width: 9.375rem;
         font-size: @minimumFontSize;
@@ -48,6 +57,17 @@
       > label {
         font-size: @minimumFontSize;
       }
+    }
+
+    .read-only-group,
+    .read-only {
+      border: none;
+      outline: none;
+      box-shadow: none;
+    }
+
+    .read-only-group {
+      margin-bottom: @minimumSpacing;
     }
 
     min-height: 1px;

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/text-field/text-field.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/text-field/text-field.js
@@ -48,16 +48,27 @@ const Input = styled.input`
 `
 
 const TextField = props => {
-  const { label, addon, value, type = 'text', onChange, ...rest } = props
+  const {
+    label,
+    addon,
+    readOnly,
+    value,
+    type = 'text',
+    onChange,
+    ...rest
+  } = props
+  const isReadOnly = readOnly != undefined ? readOnly : false
   return (
-    <Group>
+    <Group readOnly={isReadOnly}>
       {label !== undefined ? (
-        <span className="input-group-addon">
+        <span className={`input-group-addon ${isReadOnly ? 'read-only' : ''}`}>
           {label}
           &nbsp;
         </span>
       ) : null}
       <Input
+        className={`${isReadOnly ? 'read-only' : ''}`}
+        readOnly={isReadOnly}
         value={value !== undefined ? value : ''}
         type={type}
         onChange={e => {
@@ -66,7 +77,9 @@ const TextField = props => {
         {...rest}
       />
       {addon !== undefined ? (
-        <label className="input-group-addon">{addon}</label>
+        <label className={`input-group-addon ${isReadOnly ? 'read-only' : ''}`}>
+          {addon}
+        </label>
       ) : null}
     </Group>
   )


### PR DESCRIPTION
ddf-ui PRs:
3.4.x codice/ddf-ui#451

---------------------
#### What does this PR do?

- Prevents the user from saving and/or executing any location (e.g. 'anyGeo', 'location', 'center point' ) that is empty ('no keyword is selected').
- Also made keyword shape read only (can still copy and paste the geometry)
- Fix issue when a buffer is inputed for multiPolygon Keyword, error occurs


#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@hayleynorton
@cassandrabailey293 
@zta6 
@Lambeaux 
@mojogitoverhere 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
• build / run / profile install / upload sample data
• Ingest gazetteer data keywords
    https://github.com/codice/ddf/blob/master/distribution/ddf-common/src/main/resources/data/countries.geo.json
    `>gazetteer:update /..<path of file>../countries.geo.json`
    https://download.geonames.org/export/dump/
    `>gazetteer:update /..<path of file>../VA.zip`

**Workspace**
1. Create advanced search (Advanced Search)
2. Select one of these filter field types (anyGeo, location, center) , then select 'Keyword' option. DO NOT type/select any keywords (e.g. China, United State etc.). 
3. Try to search/save and verify that you are prevented to search/save, by a dialogue error message.
4. Go back and enter a keyword.
5. Verify you are not able to modify the geometry input, but can copy the data and paste it somewhere else.
6. Verify you are still able to modify the buffer, and buffer units.
7. Click Search, and verify you can now search. 
8. Try editing the filter after it has been create and ensure Keyword behave same as above.
9. Do steps 1 to 8 for (Result Filter and Lists)
10. Ensure no regression for Advanced Search, Result Filter and Lists

**Search Form**
1. Create new Search Form
2. Follow steps 2 to 8 from Workspace steps.
3. Ensure no regression for Search Form
4. Can bring created Search form in workspace and ensure no regressions


**Issue 2 - Unable to add buffer to MultiPolygon Keyword filters**
1. For Result Filter and List Filter, try to add buffer for MultiPolygon Keyword
2. Ensure no error occurs and able to use buffer to search/save.
3. Make sure no regression for Polygon Keywords as well.

-Can change theme (Dark, Sea etc.) to ensure read-only Keyword shape is being displayed properly no matter the theme

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

##### Before
###### Workspace - Advance Search
![Before-Keyword_i1_advance](https://user-images.githubusercontent.com/65194214/98415730-1147a780-203b-11eb-9b7e-44136fc2adcd.gif)

###### Workspace - List
![Before-Keyword_i1_Lists](https://user-images.githubusercontent.com/65194214/98415734-13aa0180-203b-11eb-8782-615c2f5eaf65.gif)

###### Workspace - Result Filter
![Before-Keyword_i1_Result-Filter](https://user-images.githubusercontent.com/65194214/98415737-16a4f200-203b-11eb-99e1-01bbe7cbb800.gif)

###### Search Form
![Before-Keyword_i1_SearchForm](https://user-images.githubusercontent.com/65194214/98415753-1a387900-203b-11eb-9f57-a323835c74d4.gif)

###### MultiPolygon Buffer Issue
![Before-Keyword_i2_Buffer_List](https://user-images.githubusercontent.com/65194214/98415778-23294a80-203b-11eb-90ee-e6dd0d8cefc1.gif)
![Before-Keyword_i2_Buffer_ResultFilter](https://user-images.githubusercontent.com/65194214/98415781-258ba480-203b-11eb-9746-e73d44e3d013.gif)

##### After
###### Workspace - Advance Search
![After-Keyword_i1_advance](https://user-images.githubusercontent.com/65194214/98415790-2a505880-203b-11eb-8ecb-e940607b37b5.gif)

###### Workspace - List
![After-Keyword_i1_Lists](https://user-images.githubusercontent.com/65194214/98415799-2fada300-203b-11eb-9ca3-99075acae309.gif)

###### Workspace - Result Filter
![After-Keyword_i1_Result Filter](https://user-images.githubusercontent.com/65194214/98415806-32a89380-203b-11eb-8b9e-aec0eac200e4.gif)

###### Search Form
![After-Keyword_i1_SearchForm](https://user-images.githubusercontent.com/65194214/98415821-389e7480-203b-11eb-8e13-9bc3fd042f0c.gif)

###### MultiPolygon Buffer Issue
![After-Keyword_i2_Buffer_List](https://user-images.githubusercontent.com/65194214/98415857-481dbd80-203b-11eb-8b32-7baf518ccdcd.gif)
![After-Keyword_i2_Buffer_ResultFilter](https://user-images.githubusercontent.com/65194214/98415863-4b18ae00-203b-11eb-989b-d9fb587977ba.gif)



#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
