### PR TITLE
[2.26.x] DDF-4729 adds WFS 1.1.0 sorting

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
@@ -764,9 +764,7 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
   }
 
   private boolean isValidInputParameters(String propertyName, Object literal) {
-    return !(literal == null
-        || StringUtils.isEmpty(propertyName)
-        || StringUtils.isEmpty(literal.toString()));
+    return !(literal == null || StringUtils.isEmpty(propertyName));
   }
 
   private boolean isValidInputParameters(String propertyName, String literal, double distance) {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -775,26 +775,24 @@ public class WfsSource extends AbstractWfsSource {
           if (areAnyFiltersSet(filter)) {
             wfsQuery.setFilter(filter);
           }
-          if (!this.disableSorting) {
-            if (query.getSortBy() != null) {
-              SortByType sortByType = buildSortBy(filterDelegateEntry.getKey(), query.getSortBy());
-              if (sortByType != null
-                  && sortByType.getSortProperty() != null
-                  && sortByType.getSortProperty().size() > 0) {
-                LOGGER.debug(
-                    "Sorting using sort property [{}] and sort order [{}].",
-                    sortByType.getSortProperty().get(0).getPropertyName(),
-                    sortByType.getSortProperty().get(0).getSortOrder());
-                wfsQuery.setSortBy(sortByType);
-              } else {
-                throw new UnsupportedQueryException(
-                    "Source "
-                        + this.getId()
-                        + " does not support specified sort property "
-                        + query.getSortBy().getPropertyName().getPropertyName()
-                        + " with sort order "
-                        + query.getSortBy().getSortOrder());
-              }
+          if (!this.disableSorting && query.getSortBy() != null) {
+            SortByType sortByType = buildSortBy(filterDelegateEntry.getKey(), query.getSortBy());
+            if (sortByType != null
+                && sortByType.getSortProperty() != null
+                && sortByType.getSortProperty().size() > 0) {
+              LOGGER.debug(
+                  "Sorting using sort property [{}] and sort order [{}].",
+                  sortByType.getSortProperty().get(0).getPropertyName(),
+                  sortByType.getSortProperty().get(0).getSortOrder());
+              wfsQuery.setSortBy(sortByType);
+            } else {
+              throw new UnsupportedQueryException(
+                  "Source "
+                      + this.getId()
+                      + " does not support specified sort property "
+                      + query.getSortBy().getPropertyName().getPropertyName()
+                      + " with sort order "
+                      + query.getSortBy().getSortOrder());
             }
           } else {
             LOGGER.debug("Sorting is disabled.");
@@ -1114,18 +1112,18 @@ public class WfsSource extends AbstractWfsSource {
 
   private void logMessage(GetFeatureType getFeature) {
     if (LOGGER.isDebugEnabled()) {
-    try {
-      StringWriter writer = new StringWriter();
-      JAXBContext contextObj = JAXBContext.newInstance(GetFeatureType.class);
+      try {
+        StringWriter writer = new StringWriter();
+        JAXBContext contextObj = JAXBContext.newInstance(GetFeatureType.class);
 
-      Marshaller marshallerObj = contextObj.createMarshaller();
-      marshallerObj.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        Marshaller marshallerObj = contextObj.createMarshaller();
+        marshallerObj.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
-      marshallerObj.marshal(new ObjectFactory().createGetFeature(getFeature), writer);
-      LOGGER.debug("WfsSource {}: {}", getId(), writer);
-    } catch (JAXBException e) {
-      LOGGER.debug("An error occurred debugging the GetFeature request", e);
-    }
+        marshallerObj.marshal(new ObjectFactory().createGetFeature(getFeature), writer);
+        LOGGER.debug("WfsSource {}: {}", getId(), writer);
+      } catch (JAXBException e) {
+        LOGGER.debug("An error occurred debugging the GetFeature request", e);
+      }
     }
   }
 

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -79,6 +79,7 @@
             <property name="metacardTypeEnhancers" ref="metacardTypeEnhancers"/>
             <property name="metacardMappers" ref="metacardMappers"/>
             <property name="srsName" value="EPSG:4326"/>
+            <property name="disableSorting" value="true"/>
 
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -67,7 +67,7 @@
             <Option label="Crosses" value="Crosses"/>
             <Option label="Disjoint" value="Disjoint"/>
             <Option label="DWithin" value="DWithin"/>
-            <Option label="Intersect" value="Intersect"/>
+            <Option label="Intersects" value="Intersects"/>
             <Option label="Equals" value="Equals"/>
             <Option label="Overlaps" value="Overlaps"/>
             <Option label="Touches" value="Touches"/>
@@ -88,6 +88,9 @@
           name="Single-Character Wildcard Character" id="singleChar" required="false" type="Char" default="?"/>
         <AD description="Escape character to use in PropertyIsLike filters."
           name="Escape Character" id="escapeChar" required="false" type="Char" default="\\"/>
+        <AD description="When selected, the system will not specify sort criteria with the query.  This should only be used if the remote source is unable to handle sorting."
+            name="Disable Sorting" id="disableSorting" required="true"
+            type="Boolean" default="true"/>
     </OCD>
 
     <Designate pid="Wfs_v110_Federated_Source" factoryPid="Wfs_v110_Federated_Source">

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -319,6 +319,15 @@ public class WfsFilterDelegateTest {
           + "</PropertyIsLike>"
           + "</Filter>";
 
+  private final String propertyIsLikeXmlEmpty =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+          + "<Filter xmlns:ns2=\"http://www.opengis.net/gml\" xmlns=\"http://www.opengis.net/ogc\" xmlns:ns3=\"http://www.w3.org/1999/xlink\">"
+          + "<PropertyIsLike matchCase=\"true\" escapeChar=\"!\" singleChar=\"?\" wildCard=\"*\">"
+          + "<PropertyName>mockProperty</PropertyName>"
+          + "<Literal></Literal>"
+          + "</PropertyIsLike>"
+          + "</Filter>";
+
   private final String propertyIsLikeXmlLiteralMatchCaseFalse =
       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
           + "<Filter xmlns:ns2=\"http://www.opengis.net/gml\" xmlns=\"http://www.opengis.net/ogc\" xmlns:ns3=\"http://www.w3.org/1999/xlink\">"
@@ -1838,6 +1847,13 @@ public class WfsFilterDelegateTest {
     final LineStringType lineStringType =
         (LineStringType) binarySpatialOpType.getGeometry().getValue();
     assertThat(lineStringType.getCoordinates().getValue(), is("30.0,10.0 10.0,30.0 50.0,40.0"));
+  }
+
+  @Test
+  public void testStringPropertyIsLikeEmpty() throws JAXBException, SAXException, IOException {
+    WfsFilterDelegate delegate = createTextualDelegate();
+    FilterType filter = delegate.propertyIsLike(Metacard.ANY_TEXT, "", true);
+    assertXMLEqual(propertyIsLikeXmlEmpty, marshal(filter));
   }
 
   private JAXBElement<FilterType> getFilterTypeJaxbElement(FilterType filterType) {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -239,9 +239,9 @@ public class WfsSourceTest {
 
   private static final String LITERAL = "literal";
 
-  private static final String MOCK_TEMPORAL_SORT_PROEPRTY = "myTemporalSortProperty";
-  private static final String MOCK_RELEVANCE_SORT_PROEPRTY = "myRelevanceSortProperty";
-  private static final String MOCK_DISTANCE_SORT_PROEPRTY = "myDistanceSortProperty";
+  private static final String MOCK_TEMPORAL_SORT_PROPERTY = "myTemporalSortProperty";
+  private static final String MOCK_RELEVANCE_SORT_PROPERTY = "myRelevanceSortProperty";
+  private static final String MOCK_DISTANCE_SORT_PROPERTY = "myDistanceSortProperty";
 
   private static final String WFS_ID = "WFS_ID";
 
@@ -1427,7 +1427,7 @@ public class WfsSourceTest {
     final QueryImpl propertyIsLikeQuery =
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     setupMapper(
-        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.ASCENDING));
 
@@ -1436,7 +1436,7 @@ public class WfsSourceTest {
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
     for (final GetFeatureType getFeatureType : captor.getAllValues()) {
-      assertFeature(getFeatureType, true, MOCK_TEMPORAL_SORT_PROEPRTY, "ASC");
+      assertFeature(getFeatureType, true, MOCK_TEMPORAL_SORT_PROPERTY, "ASC");
     }
   }
 
@@ -1447,7 +1447,7 @@ public class WfsSourceTest {
     final QueryImpl propertyIsLikeQuery =
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     setupMapper(
-        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.DESCENDING));
 
@@ -1456,7 +1456,7 @@ public class WfsSourceTest {
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
     for (final GetFeatureType getFeatureType : captor.getAllValues()) {
-      assertFeature(getFeatureType, true, MOCK_TEMPORAL_SORT_PROEPRTY, "DESC");
+      assertFeature(getFeatureType, true, MOCK_TEMPORAL_SORT_PROPERTY, "DESC");
     }
   }
 
@@ -1467,7 +1467,7 @@ public class WfsSourceTest {
     final QueryImpl propertyIsLikeQuery =
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     setupMapper(
-        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
     source.setMetacardMappers(metacardMappers);
     source.setDisableSorting(true);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.ASCENDING));
@@ -1477,7 +1477,7 @@ public class WfsSourceTest {
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
     for (final GetFeatureType getFeatureType : captor.getAllValues()) {
-      assertFeature(getFeatureType, false, MOCK_TEMPORAL_SORT_PROEPRTY, "ASC");
+      assertFeature(getFeatureType, false, MOCK_TEMPORAL_SORT_PROPERTY, "ASC");
     }
   }
 
@@ -1496,7 +1496,6 @@ public class WfsSourceTest {
     source.setDisableSorting(false);
     propertyIsLikeQuery.setSortBy(new SortByImpl("title", SortOrder.ASCENDING));
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
   }
 
@@ -1512,11 +1511,10 @@ public class WfsSourceTest {
     final QueryImpl propertyIsLikeQuery =
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     setupMapper(
-        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, (String) null));
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
   }
 
@@ -1532,11 +1530,10 @@ public class WfsSourceTest {
     final QueryImpl propertyIsLikeQuery =
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     setupMapper(
-        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(null, "ASC"));
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
   }
 
@@ -1552,11 +1549,10 @@ public class WfsSourceTest {
     final QueryImpl propertyIsLikeQuery =
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     setupMapper(
-        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
   }
 

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -39,6 +39,7 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.filter.impl.SortByImpl;
 import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.Query;
@@ -109,10 +110,13 @@ import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.GetCapabilitiesRequest
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs11Constants;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.opengis.filter.Filter;
+import org.opengis.filter.sort.SortOrder;
 import org.osgi.framework.BundleContext;
 
 public class WfsSourceTest {
@@ -235,6 +239,12 @@ public class WfsSourceTest {
 
   private static final String LITERAL = "literal";
 
+  private static final String MOCK_TEMPORAL_SORT_PROEPRTY = "myTemporalSortProperty";
+  private static final String MOCK_RELEVANCE_SORT_PROEPRTY = "myRelevanceSortProperty";
+  private static final String MOCK_DISTANCE_SORT_PROEPRTY = "myDistanceSortProperty";
+
+  private static final String WFS_ID = "WFS_ID";
+
   private static final Comparator<QueryType> QUERY_TYPE_COMPARATOR =
       (queryType1, queryType2) -> {
         String typeName1 = queryType1.getTypeName().get(0).getLocalPart();
@@ -267,6 +277,8 @@ public class WfsSourceTest {
   private ClientBuilderFactory clientBuilderFactory = mock(ClientBuilderFactory.class);
 
   private List<MetacardMapper> metacardMappers = new ArrayList<>();
+
+  @Rule public ExpectedException expectedEx = ExpectedException.none();
 
   @BeforeClass
   public static void setupClass() {
@@ -360,6 +372,7 @@ public class WfsSourceTest {
         .scheduleWithFixedDelay(any(), anyInt(), anyInt(), any());
 
     source = new WfsSource(clientBuilderFactory, encryptionService, mockScheduler);
+    source.setId(WFS_ID);
     source.setFilterAdapter(new GeotoolsFilterAdapterImpl());
     source.setContext(mockContext);
     source.setWfsMetacardTypeRegistry(mockWfsMetacardTypeRegistry);
@@ -1190,6 +1203,7 @@ public class WfsSourceTest {
             .put("connectionTimeout", connectionTimeout)
             .put("receiveTimeout", receiveTimeout)
             .put("pollInterval", 1)
+            .put("disableSorting", false)
             .build();
     source.refresh(configuration);
 
@@ -1224,6 +1238,7 @@ public class WfsSourceTest {
             .put("connectionTimeout", connectionTimeout)
             .put("receiveTimeout", receiveTimeout)
             .put("pollInterval", 1)
+            .put("disableSorting", false)
             .build();
     source.refresh(configuration);
 
@@ -1251,6 +1266,7 @@ public class WfsSourceTest {
             .put("connectionTimeout", connectionTimeout)
             .put("receiveTimeout", receiveTimeout)
             .put("pollInterval", 1)
+            .put("disableSorting", false)
             .build();
     source.refresh(configuration);
 
@@ -1272,6 +1288,7 @@ public class WfsSourceTest {
             .put("allowRedirects", false)
             .put("disableCnCheck", false)
             .put("pollInterval", 1)
+            .put("disableSorting", false)
             .build();
     source.refresh(configuration);
 
@@ -1313,6 +1330,7 @@ public class WfsSourceTest {
             .put("allowRedirects", false)
             .put("disableCnCheck", false)
             .put("pollInterval", 1)
+            .put("disableSorting", false)
             .build();
     source.refresh(configuration);
 
@@ -1369,6 +1387,210 @@ public class WfsSourceTest {
           query.getFilter().getComparisonOps().getValue(),
           is(instanceOf(PropertyIsLikeType.class)));
     }
+  }
+
+  @Test
+  public void testSortingNoSortBy() throws Exception {
+    // Setup
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    propertyIsLikeQuery.setPageSize(1);
+
+    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    verify(mockWfs, times(2)).getFeature(captor.capture());
+
+    final GetFeatureType getResults = captor.getAllValues().get(1);
+    assertThat(getResults.getResultType(), is(ResultTypeType.RESULTS));
+    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+      assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
+      final QueryType queryType = getFeatureType.getQuery().get(0);
+      assertThat(queryType.isSetSortBy(), is(false));
+    }
+  }
+
+  /**
+   * WFS 1.1.0 Sorting uses the following format: Valid sort orders are "ASC" and "DESC". Ref:
+   * http://schemas.opengis.net/filter/1.1.0/sort.xsd <wfs:Query typeName="QName QName">
+   * <wfs:PropertyName>QName</wfs:PropertyName> <ogc:Filter> <ogc:Equals> <ogc:PropertyName/>
+   * <gml:Point>... </gml:Point> </ogc:Equals> </ogc:Filter> <ogc:SortBy> <ogc:SortProperty>
+   * <ogc:PropertyName>property</ogc:PropertyName> <ogc:SortOrder>ASC</ogc:SortOrder>
+   * </ogc:SortProperty> </ogc:SortBy> </wfs:Query>
+   */
+  @Test
+  public void testSortingSortOrderAscending() throws Exception {
+    // Setup
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.ASCENDING));
+
+    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    verify(mockWfs, times(2)).getFeature(captor.capture());
+
+    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+      assertFeature(getFeatureType, true, MOCK_TEMPORAL_SORT_PROEPRTY, "ASC");
+    }
+  }
+
+  @Test
+  public void testSortingSortOrderDescending() throws Exception {
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.DESCENDING));
+
+    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    verify(mockWfs, times(2)).getFeature(captor.capture());
+
+    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+      assertFeature(getFeatureType, true, MOCK_TEMPORAL_SORT_PROEPRTY, "DESC");
+    }
+  }
+
+  @Test
+  public void testSortingDisabled() throws Exception {
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+    source.setMetacardMappers(metacardMappers);
+    source.setDisableSorting(true);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.ASCENDING));
+
+    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    verify(mockWfs, times(2)).getFeature(captor.capture());
+
+    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+      assertFeature(getFeatureType, false, MOCK_TEMPORAL_SORT_PROEPRTY, "ASC");
+    }
+  }
+
+  @Test
+  public void testSortingNoSortMapping() throws Exception {
+    // if sorting is enabled but there is no sort mapping, throw an UnsupportedQueryException
+    expectedEx.expect(UnsupportedQueryException.class);
+    expectedEx.expectMessage("Source WFS_ID does not support specified sort property title");
+
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(null, null, null);
+    source.setMetacardMappers(metacardMappers);
+    source.setDisableSorting(false);
+    propertyIsLikeQuery.setSortBy(new SortByImpl("title", SortOrder.ASCENDING));
+
+    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  @Test
+  public void testSortingNoSortOrder() throws Exception {
+    // if sort order is missing, throw UnsupportedQueryException
+    expectedEx.expect(UnsupportedQueryException.class);
+    expectedEx.expectMessage(
+        "Source WFS_ID does not support specified sort property TEMPORAL with sort order null");
+
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, (String) null));
+
+    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  @Test
+  public void testSortingNoSortProperty() throws Exception {
+    // if sort property is missing, throw UnsupportedQueryException
+    expectedEx.expect(UnsupportedQueryException.class);
+    expectedEx.expectMessage(
+        "Source WFS_ID does not support specified sort property null with sort order SortOrder[ASCENDING]");
+
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(null, "ASC"));
+
+    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  @Test
+  public void testSortingBadSortOrder() throws Exception {
+    // if sort order is invalid throw UnsupportedQueryException
+    expectedEx.expect(UnsupportedQueryException.class);
+    expectedEx.expectMessage(
+        "Source WFS_ID does not support specified sort property TEMPORAL with sort order SortOrder[foo]");
+
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROEPRTY, MOCK_RELEVANCE_SORT_PROEPRTY, MOCK_DISTANCE_SORT_PROEPRTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
+
+    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  private void assertFeature(
+      GetFeatureType getFeatureType,
+      boolean sortingEnabled,
+      String sortProperty,
+      String sortOrder) {
+    assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
+    final QueryType queryType = getFeatureType.getQuery().get(0);
+    if (sortingEnabled) {
+      assertThat(queryType.isSetSortBy(), is(true));
+      assertThat(queryType.getSortBy().getSortProperty().size(), is(1));
+      assertThat(
+          queryType.getSortBy().getSortProperty().get(0).getPropertyName().getContent().size(),
+          is(1));
+      assertThat(
+          queryType.getSortBy().getSortProperty().get(0).getPropertyName().getContent().get(0),
+          is(sortProperty));
+      assertThat(
+          queryType.getSortBy().getSortProperty().get(0).getSortOrder().value(), is(sortOrder));
+    } else {
+      assertThat(queryType.isSetSortBy(), is(false));
+    }
+  }
+
+  private void setupMapper(
+      String temporalSortProperty, String relevanceSortProperty, String distanceSortProperty) {
+    final MetacardMapperImpl metacardMapper = new MetacardMapperImpl();
+    metacardMapper.setSortByTemporalFeatureProperty(temporalSortProperty);
+    metacardMapper.setSortByDistanceFeatureProperty(relevanceSortProperty);
+    metacardMapper.setSortByRelevanceFeatureProperty(distanceSortProperty);
+    metacardMapper.setFeatureType("SampleFeature0");
+    metacardMappers.add(metacardMapper);
   }
 
   private SourceResponse executeQuery(int startIndex, int pageSize)

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsFilterDelegate.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsFilterDelegate.java
@@ -1172,9 +1172,7 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
   }
 
   private boolean isValidInputParameters(String propertyName, Object literal) {
-    if (literal == null
-        || StringUtils.isEmpty(propertyName)
-        || StringUtils.isEmpty(literal.toString())) {
+    if (literal == null || StringUtils.isEmpty(propertyName)) {
       return false;
     }
     return true;

--- a/catalog/spatial/wfs/spatial-wfs-common/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-common/pom.xml
@@ -41,7 +41,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.62</minimum>
+                                            <minimum>0.64</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
@@ -51,7 +51,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.46</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSource.java
+++ b/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSource.java
@@ -22,6 +22,7 @@ import ddf.catalog.util.impl.MaskableImpl;
 import java.util.List;
 import java.util.function.Predicate;
 import javax.xml.namespace.QName;
+import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.spatial.ogc.wfs.catalog.mapper.MetacardMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,52 +79,47 @@ public abstract class AbstractWfsSource extends MaskableImpl
     if (featureType == null || incomingPropertyName == null || metacardMapperList == null) {
       return null;
     }
-    metacardMapperList.forEach(
-        m -> {
-          LOGGER.debug(
-              "Sorting: Mapper: featureType {}, mapped property for {} : {}",
-              m.getFeatureType(),
-              incomingPropertyName,
-              m.getFeatureProperty(incomingPropertyName));
-        });
-    LOGGER.debug(
-        "Mapping sort proeprty: featureType {}, incomingPropertyName {}",
-        featureType,
-        incomingPropertyName);
+    if (LOGGER.isDebugEnabled()) {
+      metacardMapperList.forEach(
+          m -> {
+            LOGGER.debug(
+                "Sorting: Mapper: featureType {}, mapped property for {} : {}",
+                m.getFeatureType(),
+                incomingPropertyName,
+                m.getFeatureProperty(incomingPropertyName));
+          });
+      LOGGER.debug(
+          "Mapping sort property: featureType {}, incomingPropertyName {}",
+          featureType,
+          incomingPropertyName);
+    }
     MetacardMapper metacardToFeaturePropertyMapper =
         lookupMetacardAttributeToFeaturePropertyMapper(featureType, metacardMapperList);
     String mappedPropertyName = null;
 
     if (metacardToFeaturePropertyMapper != null) {
 
-      if (org.apache.commons.lang.StringUtils.equals(Result.TEMPORAL, incomingPropertyName)
-          || org.apache.commons.lang.StringUtils.equals(Metacard.EFFECTIVE, incomingPropertyName)) {
+      if (StringUtils.equals(Result.TEMPORAL, incomingPropertyName)
+          || StringUtils.equals(Metacard.EFFECTIVE, incomingPropertyName)) {
         mappedPropertyName =
-            org.apache.commons.lang.StringUtils.isNotBlank(
-                    metacardToFeaturePropertyMapper.getSortByTemporalFeatureProperty())
-                ? metacardToFeaturePropertyMapper.getSortByTemporalFeatureProperty()
-                : null;
-      } else if (org.apache.commons.lang.StringUtils.equals(
-          Result.RELEVANCE, incomingPropertyName)) {
+            StringUtils.defaultIfBlank(
+                metacardToFeaturePropertyMapper.getSortByTemporalFeatureProperty(), null);
+      } else if (StringUtils.equals(Result.RELEVANCE, incomingPropertyName)) {
         mappedPropertyName =
-            org.apache.commons.lang.StringUtils.isNotBlank(
-                    metacardToFeaturePropertyMapper.getSortByRelevanceFeatureProperty())
-                ? metacardToFeaturePropertyMapper.getSortByRelevanceFeatureProperty()
-                : null;
+            StringUtils.defaultIfBlank(
+                metacardToFeaturePropertyMapper.getSortByRelevanceFeatureProperty(), null);
       } else if (org.apache.commons.lang.StringUtils.equals(
           Result.DISTANCE, incomingPropertyName)) {
         mappedPropertyName =
-            org.apache.commons.lang.StringUtils.isNotBlank(
-                    metacardToFeaturePropertyMapper.getSortByDistanceFeatureProperty())
-                ? metacardToFeaturePropertyMapper.getSortByDistanceFeatureProperty()
-                : null;
+            StringUtils.defaultIfBlank(
+                metacardToFeaturePropertyMapper.getSortByDistanceFeatureProperty(), null);
       } else {
         mappedPropertyName =
             metacardToFeaturePropertyMapper.getFeatureProperty(incomingPropertyName);
       }
     }
 
-    LOGGER.debug("mapped sort proeprty from {} to {}", incomingPropertyName, mappedPropertyName);
+    LOGGER.debug("mapped sort property from {} to {}", incomingPropertyName, mappedPropertyName);
     return mappedPropertyName;
   }
 

--- a/catalog/spatial/wfs/spatial-wfs-common/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSourceTest.java
+++ b/catalog/spatial/wfs/spatial-wfs-common/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSourceTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.catalog.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import ddf.catalog.data.ContentType;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.resource.ResourceNotFoundException;
+import ddf.catalog.resource.ResourceNotSupportedException;
+import ddf.catalog.source.SourceMonitor;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.namespace.QName;
+import org.codice.ddf.spatial.ogc.wfs.catalog.mapper.MetacardMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractWfsSourceTest {
+  private AbstractWfsSource wfsSource;
+  private static final String FEATURE_NAME = "SampleFeature";
+  private static final String TEMPORAL_SORT_PROEPRTY = "myTemporalSortProperty";
+  private static final String RELEVANCE_SORT_PROEPRTY = "myRelevanceSortProperty";
+  private static final String DISTANCE_SORT_PROEPRTY = "myDistanceSortProperty";
+  private List<MetacardMapper> mappers;
+
+  @Before
+  public void setup() {
+    wfsSource = new TestWfsSource();
+    mappers = new ArrayList<>();
+    MetacardMapper mockMapper = mock(MetacardMapper.class);
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+
+    doReturn(featureName.toString()).when(mockMapper).getFeatureType();
+    doReturn(DISTANCE_SORT_PROEPRTY).when(mockMapper).getSortByDistanceFeatureProperty();
+    doReturn(TEMPORAL_SORT_PROEPRTY).when(mockMapper).getSortByTemporalFeatureProperty();
+    doReturn(RELEVANCE_SORT_PROEPRTY).when(mockMapper).getSortByRelevanceFeatureProperty();
+    mappers.add(mockMapper);
+  }
+
+  @Test
+  public void testSortMapping() throws Exception {
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+    String mappedTemporalProperty =
+        wfsSource.mapSortByPropertyName(featureName, Result.TEMPORAL, mappers);
+    String mappedRelevanceProperty =
+        wfsSource.mapSortByPropertyName(featureName, Result.RELEVANCE, mappers);
+    String mappedDistanceProperty =
+        wfsSource.mapSortByPropertyName(featureName, Result.DISTANCE, mappers);
+    assertThat(mappedTemporalProperty, is(TEMPORAL_SORT_PROEPRTY));
+    assertThat(mappedRelevanceProperty, is(RELEVANCE_SORT_PROEPRTY));
+    assertThat(mappedDistanceProperty, is(DISTANCE_SORT_PROEPRTY));
+  }
+
+  @Test
+  public void testNullFeatureType() throws Exception {
+    String mappedTemporalProperty = wfsSource.mapSortByPropertyName(null, Result.TEMPORAL, mappers);
+    assertThat(mappedTemporalProperty, nullValue());
+  }
+
+  @Test
+  public void testNullProperty() throws Exception {
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+    String mappedTemporalProperty = wfsSource.mapSortByPropertyName(featureName, null, mappers);
+    assertThat(mappedTemporalProperty, nullValue());
+  }
+
+  @Test
+  public void testNullMapper() throws Exception {
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+    String mappedTemporalProperty =
+        wfsSource.mapSortByPropertyName(featureName, Result.TEMPORAL, null);
+    assertThat(mappedTemporalProperty, nullValue());
+  }
+
+  @Test
+  public void testSortMappingEffective() throws Exception {
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+    String mappedTemporalProperty =
+        wfsSource.mapSortByPropertyName(featureName, Metacard.EFFECTIVE, mappers);
+    assertThat(mappedTemporalProperty, is(TEMPORAL_SORT_PROEPRTY));
+  }
+
+  private class TestWfsSource extends AbstractWfsSource {
+    @Override
+    public ResourceResponse retrieveResource(URI uri, Map<String, Serializable> map)
+        throws IOException, ResourceNotFoundException, ResourceNotSupportedException {
+      return null;
+    }
+
+    @Override
+    public Set<String> getSupportedSchemes() {
+      return null;
+    }
+
+    @Override
+    public Set<String> getOptions(Metacard metacard) {
+      return null;
+    }
+
+    @Override
+    public String getConfigurationPid() {
+      return null;
+    }
+
+    @Override
+    public void setConfigurationPid(String s) {}
+
+    @Override
+    public boolean isAvailable() {
+      return false;
+    }
+
+    @Override
+    public boolean isAvailable(SourceMonitor sourceMonitor) {
+      return false;
+    }
+
+    @Override
+    public SourceResponse query(QueryRequest queryRequest) throws UnsupportedQueryException {
+      return null;
+    }
+
+    @Override
+    public Set<ContentType> getContentTypes() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Ports & refactors the WFS 2.0 sorting functionality into the WFS 1.1.0 source. Adds flag to enable/disable sorting (default to disable).  Adds mapping of DDF sort attributes to WFS attributes.


#### Who is reviewing it? 
@millerw8 
@jrnorth 
@glenhein 
@derekwilhelm 

#### Select relevant component teams: 
@codice/data 

#### Ask 2 committers to review/merge the PR and tag them here.
@jrnorth 
@emmberk 

#### How should this be tested?
1) build / install DDF
2) build DDF UI master (update ddf.version to 2.26.1-SNAPSHOT)
3) install DDF UI features into DDF per the README https://github.com/codice/ddf-ui/blob/master/README.md
4) Verify Intrigue UI is accessible
5) start up GeoServer
6) configure a Metacard to WFS Feature Map 
```
Feature type = {http://www.openplans.org/topp}states
Metacard title to feature property mapping = STATE_NAME
```
Save the config
7) configure a new WFS v1.1.0 Federated Source
```
WFS URL = http://<host>:<port>/geoserver/ows
Forced Feature Type = states
disable sorting true (should be default)
```
Save the config
8) From Intrigue, execute an anyText contains * search with sorting by “title” A-Z, source = WFS.  Verify the WFS results are returned.  Note, the results will not be sorted (as expected)
9) Update the WFS 1.1.0 Federated Source configuration and ENABLE sorting
10) repeat the same query.  The results should now be sorted by state name (Alabama, Arizona, etc).
11) verify paging works as expected and the results are still sorted
12) change the query to sort by “created” timestamp
13) Verify no results are returned (expected) and the heartbeat indicates a warning.  Tooltip will say “Something went wrong searching this source”.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #4729 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
