### PR TITLE
[2.26.x] DDF-6421 - Enable configuration of solr highlight parameters

### DIFF
--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/PropertyExistsDelegate.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/PropertyExistsDelegate.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.source.solr;
+
+import ddf.catalog.filter.impl.SimpleFilterDelegate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PropertyExistsDelegate extends SimpleFilterDelegate<Boolean> {
+
+  private List<String> propertyNames;
+
+  public PropertyExistsDelegate(String... propertyName) {
+    propertyNames = Arrays.asList(propertyName);
+  }
+
+  public PropertyExistsDelegate(List<String> propertyNames) {
+    this.propertyNames = new ArrayList<>(propertyNames);
+  }
+
+  @Override
+  public <S> Boolean defaultOperation(
+      Object property, S literal, Class<S> literalClass, Enum operation) {
+    return false;
+  }
+
+  @Override
+  public Boolean and(List<Boolean> operands) {
+    return operands.stream().anyMatch(op -> op);
+  }
+
+  @Override
+  public Boolean or(List<Boolean> operands) {
+    return operands.stream().anyMatch(op -> op);
+  }
+
+  @Override
+  public Boolean not(Boolean operand) {
+    return operand;
+  }
+
+  @Override
+  public <S> Boolean comparisonOperation(
+      String propertyName,
+      S literal,
+      Class<S> literalClass,
+      ComparisonPropertyOperation comparisonPropertyOperation) {
+    return propertyNames.contains(propertyName);
+  }
+}

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -167,7 +167,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     filterDelegateFactory = solrFilterDelegateFactory;
     filterAdapter = catalogFilterAdapter;
     resolver = dynamicSchemaResolver;
-    highlighter = new ResultHighlighter(resolver);
+    highlighter = new ResultHighlighter(resolver, filterAdapter);
   }
 
   public SolrClient getClient() {

--- a/distribution/ddf-common/src/main/resources-filtered/etc/custom.system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/custom.system.properties
@@ -95,6 +95,8 @@ solr.commit.nrt.metacardTypes=workspace,metacard.query,metacard.list,query-templ
 # Comma-separated list of metacard fields that should never show up as search result highlights
 solr.highlight.blacklist=metacard-tags
 solr.highlight.enabled=false
+# solr.highlight.anytext.expand=false
+# solr.highlight.config.file=etc/solr-highlighter.properties
 
 # Whether or not case-insensitive sorting is enabled
 solr.query.sort.caseInsensitive=true

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -143,6 +143,10 @@ grant codeBase "file:/solr-factory-impl/solr-dependencies" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}serverKeystore.jks", "read";
 }
 
+grant codeBase "file:/catalog-solr-provider/catalog-solr-cache" {
+    permission java.io.FilePermission "${ddf.home.perm}etc${/}solr-highlighter.properties", "read";
+}
+
 grant codeBase "file:/security-handler-oidc" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}keystores${/}serverTruststore.jks", "read";
 }


### PR DESCRIPTION
#### What does this PR do?
Allows solr highlighter parameters to be configurable in the system.

#### Who is reviewing it? 
@pklinef 
@jlcsmith 

#### Select relevant component teams: 
@codice/solr 


#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@vinamartin

#### How should this be tested?
1. Perform a full build
2. Unzip/install DDF
3. Create the file `<ddf_home>/etc/solr-highlighter.properties`
4. Add various highlighter settings to this file
 - Some examples: `hl.fl=title_txt`, `hl.requireFieldMatch=false`
5. Enable solr highlighting via the `custom.system.properties` file: set `solr.highlight.enabled=true`
6. Start DDF
7. Perform a search
8. Verify (via debugging DDF or via Solr logs) that the highlight parameters as specified in the config file are applied to the query

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6421 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
