### PR TITLE
DDF-4729 adds WFS 1.1.0 sorting

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
@@ -764,9 +764,7 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
   }
 
   private boolean isValidInputParameters(String propertyName, Object literal) {
-    return !(literal == null
-        || StringUtils.isEmpty(propertyName)
-        || StringUtils.isEmpty(literal.toString()));
+    return !(literal == null || StringUtils.isEmpty(propertyName));
   }
 
   private boolean isValidInputParameters(String propertyName, String literal, double distance) {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -70,6 +70,10 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.namespace.QName;
 import net.opengis.filter.v_1_1_0.FilterType;
+import net.opengis.filter.v_1_1_0.PropertyNameType;
+import net.opengis.filter.v_1_1_0.SortByType;
+import net.opengis.filter.v_1_1_0.SortOrderType;
+import net.opengis.filter.v_1_1_0.SortPropertyType;
 import net.opengis.filter.v_1_1_0.SpatialOperatorType;
 import net.opengis.wfs.v_1_1_0.FeatureTypeType;
 import net.opengis.wfs.v_1_1_0.GetFeatureType;
@@ -106,6 +110,8 @@ import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.GetCapabilitiesRequest
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs11Constants;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.source.reader.XmlSchemaMessageBodyReaderWfs11;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -248,6 +254,9 @@ public class WfsSource extends AbstractWfsSource {
 
   private static final String FEATURE_MEMBER_ELEMENT = "featureMember";
 
+  private static final String DISABLE_SORTING = "disableSorting";
+  private boolean disableSorting;
+
   static {
     try (InputStream properties =
         WfsSource.class.getResourceAsStream(DESCRIBABLE_PROPERTIES_FILE)) {
@@ -327,6 +336,7 @@ public class WfsSource extends AbstractWfsSource {
     setWildcardChar((Character) configuration.get(WILDCARD_CHAR_KEY));
     setSingleChar((Character) configuration.get(SINGLE_CHAR_KEY));
     setEscapeChar((Character) configuration.get(ESCAPE_CHAR_KEY));
+    setDisableSorting((Boolean) configuration.get(DISABLE_SORTING));
 
     createClientFactory();
     configureWfsFeatures();
@@ -666,7 +676,9 @@ public class WfsSource extends AbstractWfsSource {
     if (origPageSize <= 0 || origPageSize > WFS_MAX_FEATURES_RETURNED) {
       origPageSize = WFS_MAX_FEATURES_RETURNED;
     }
-    QueryImpl modifiedQuery = new QueryImpl(query);
+
+    QueryImpl modifiedQuery =
+        new QueryImpl(query, 1, Constants.DEFAULT_PAGE_SIZE, query.getSortBy(), false, 300000L);
 
     int pageNumber = query.getStartIndex() / origPageSize + 1;
 
@@ -763,6 +775,28 @@ public class WfsSource extends AbstractWfsSource {
           if (areAnyFiltersSet(filter)) {
             wfsQuery.setFilter(filter);
           }
+          if (!this.disableSorting && query.getSortBy() != null) {
+            SortByType sortByType = buildSortBy(filterDelegateEntry.getKey(), query.getSortBy());
+            if (sortByType != null
+                && sortByType.getSortProperty() != null
+                && sortByType.getSortProperty().size() > 0) {
+              LOGGER.debug(
+                  "Sorting using sort property [{}] and sort order [{}].",
+                  sortByType.getSortProperty().get(0).getPropertyName(),
+                  sortByType.getSortProperty().get(0).getSortOrder());
+              wfsQuery.setSortBy(sortByType);
+            } else {
+              throw new UnsupportedQueryException(
+                  "Source "
+                      + this.getId()
+                      + " does not support specified sort property "
+                      + query.getSortBy().getPropertyName().getPropertyName()
+                      + " with sort order "
+                      + query.getSortBy().getSortOrder());
+            }
+          } else {
+            LOGGER.debug("Sorting is disabled.");
+          }
           queries.add(wfsQuery);
         } else {
           LOGGER.debug(
@@ -783,6 +817,43 @@ public class WfsSource extends AbstractWfsSource {
       throw new UnsupportedQueryException(
           "Unable to build query. No filters could be created from query criteria.");
     }
+  }
+
+  private SortByType buildSortBy(QName featureType, SortBy incomingSortBy) {
+    net.opengis.filter.v_1_1_0.ObjectFactory filterObjectFactory =
+        new net.opengis.filter.v_1_1_0.ObjectFactory();
+
+    String propertyName =
+        mapSortByPropertyName(
+            featureType, incomingSortBy.getPropertyName().getPropertyName(), metacardMappers);
+
+    if (propertyName != null) {
+
+      SortOrder sortOrder = incomingSortBy.getSortOrder();
+
+      SortPropertyType sortPropertyType = filterObjectFactory.createSortPropertyType();
+      PropertyNameType propertyNameType = filterObjectFactory.createPropertyNameType();
+      List<Serializable> props = Arrays.asList(propertyName);
+      propertyNameType.setContent(props);
+      sortPropertyType.setPropertyName(propertyNameType);
+
+      if (SortOrder.ASCENDING.equals(sortOrder)) {
+        sortPropertyType.setSortOrder(SortOrderType.ASC);
+      } else if (SortOrder.DESCENDING.equals(sortOrder)) {
+        sortPropertyType.setSortOrder(SortOrderType.DESC);
+      } else {
+        LOGGER.debug(
+            "Unable to build query. Unknown sort order of [{}].",
+            sortOrder == null ? null : sortOrder.identifier());
+        return null;
+      }
+
+      SortByType sortByType = filterObjectFactory.createSortByType();
+      sortByType.getSortProperty().add(sortPropertyType);
+
+      return sortByType;
+    }
+    return null;
   }
 
   private boolean areAnyFiltersSet(FilterType filter) {
@@ -1103,6 +1174,10 @@ public class WfsSource extends AbstractWfsSource {
 
   public void setEscapeChar(final Character escapeChar) {
     this.escapeChar = escapeChar;
+  }
+
+  public void setDisableSorting(final Boolean disableSorting) {
+    this.disableSorting = disableSorting;
   }
 
   @Override

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -79,6 +79,7 @@
             <property name="metacardTypeEnhancers" ref="metacardTypeEnhancers"/>
             <property name="metacardMappers" ref="metacardMappers"/>
             <property name="srsName" value="EPSG:4326"/>
+            <property name="disableSorting" value="true"/>
 
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -67,7 +67,7 @@
             <Option label="Crosses" value="Crosses"/>
             <Option label="Disjoint" value="Disjoint"/>
             <Option label="DWithin" value="DWithin"/>
-            <Option label="Intersect" value="Intersect"/>
+            <Option label="Intersects" value="Intersects"/>
             <Option label="Equals" value="Equals"/>
             <Option label="Overlaps" value="Overlaps"/>
             <Option label="Touches" value="Touches"/>
@@ -88,6 +88,9 @@
           name="Single-Character Wildcard Character" id="singleChar" required="false" type="Char" default="?"/>
         <AD description="Escape character to use in PropertyIsLike filters."
           name="Escape Character" id="escapeChar" required="false" type="Char" default="\\"/>
+        <AD description="When selected, the system will not specify sort criteria with the query.  This should only be used if the remote source is unable to handle sorting."
+            name="Disable Sorting" id="disableSorting" required="true"
+            type="Boolean" default="true"/>
     </OCD>
 
     <Designate pid="Wfs_v110_Federated_Source" factoryPid="Wfs_v110_Federated_Source">

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -319,6 +319,15 @@ public class WfsFilterDelegateTest {
           + "</PropertyIsLike>"
           + "</Filter>";
 
+  private final String propertyIsLikeXmlEmpty =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+          + "<Filter xmlns:ns2=\"http://www.opengis.net/gml\" xmlns=\"http://www.opengis.net/ogc\" xmlns:ns3=\"http://www.w3.org/1999/xlink\">"
+          + "<PropertyIsLike matchCase=\"true\" escapeChar=\"!\" singleChar=\"?\" wildCard=\"*\">"
+          + "<PropertyName>mockProperty</PropertyName>"
+          + "<Literal></Literal>"
+          + "</PropertyIsLike>"
+          + "</Filter>";
+
   private final String propertyIsLikeXmlLiteralMatchCaseFalse =
       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
           + "<Filter xmlns:ns2=\"http://www.opengis.net/gml\" xmlns=\"http://www.opengis.net/ogc\" xmlns:ns3=\"http://www.w3.org/1999/xlink\">"
@@ -1838,6 +1847,13 @@ public class WfsFilterDelegateTest {
     final LineStringType lineStringType =
         (LineStringType) binarySpatialOpType.getGeometry().getValue();
     assertThat(lineStringType.getCoordinates().getValue(), is("30.0,10.0 10.0,30.0 50.0,40.0"));
+  }
+
+  @Test
+  public void testStringPropertyIsLikeEmpty() throws JAXBException, SAXException, IOException {
+    WfsFilterDelegate delegate = createTextualDelegate();
+    FilterType filter = delegate.propertyIsLike(Metacard.ANY_TEXT, "", true);
+    assertXMLEqual(propertyIsLikeXmlEmpty, marshal(filter));
   }
 
   private JAXBElement<FilterType> getFilterTypeJaxbElement(FilterType filterType) {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -1583,8 +1583,8 @@ public class WfsSourceTest {
       String temporalSortProperty, String relevanceSortProperty, String distanceSortProperty) {
     final MetacardMapperImpl metacardMapper = new MetacardMapperImpl();
     metacardMapper.setSortByTemporalFeatureProperty(temporalSortProperty);
-    metacardMapper.setSortByDistanceFeatureProperty(relevanceSortProperty);
-    metacardMapper.setSortByRelevanceFeatureProperty(distanceSortProperty);
+    metacardMapper.setSortByDistanceFeatureProperty(distanceSortProperty);
+    metacardMapper.setSortByRelevanceFeatureProperty(relevanceSortProperty);
     metacardMapper.setFeatureType("SampleFeature0");
     metacardMappers.add(metacardMapper);
   }

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsFilterDelegate.java
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v2_0_0/catalog/source/WfsFilterDelegate.java
@@ -1172,9 +1172,7 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
   }
 
   private boolean isValidInputParameters(String propertyName, Object literal) {
-    if (literal == null
-        || StringUtils.isEmpty(propertyName)
-        || StringUtils.isEmpty(literal.toString())) {
+    if (literal == null || StringUtils.isEmpty(propertyName)) {
       return false;
     }
     return true;

--- a/catalog/spatial/wfs/spatial-wfs-common/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-common/pom.xml
@@ -41,17 +41,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.57</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.42</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSource.java
+++ b/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSource.java
@@ -13,13 +13,24 @@
  */
 package org.codice.ddf.spatial.ogc.wfs.catalog.common;
 
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
 import ddf.catalog.service.ConfiguredService;
 import ddf.catalog.source.ConnectedSource;
 import ddf.catalog.source.FederatedSource;
 import ddf.catalog.util.impl.MaskableImpl;
+import java.util.List;
+import java.util.function.Predicate;
+import javax.xml.namespace.QName;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.spatial.ogc.wfs.catalog.mapper.MetacardMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractWfsSource extends MaskableImpl
     implements FederatedSource, ConnectedSource, ConfiguredService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractWfsSource.class);
 
   protected static final String CERT_ALIAS_KEY = "certAlias";
 
@@ -57,5 +68,73 @@ public abstract class AbstractWfsSource extends MaskableImpl
 
   public void setSslProtocol(String sslProtocol) {
     this.sslProtocol = sslProtocol;
+  }
+
+  /**
+   * If a MetacardMapper cannot be found or there is no mapping for the incomingPropertyName, return
+   * null. This will cause a query to be constructed without an AbstractSortingClause.
+   */
+  protected String mapSortByPropertyName(
+      QName featureType, String incomingPropertyName, List<MetacardMapper> metacardMapperList) {
+    if (featureType == null || incomingPropertyName == null || metacardMapperList == null) {
+      return null;
+    }
+    if (LOGGER.isDebugEnabled()) {
+      metacardMapperList.forEach(
+          m -> {
+            LOGGER.debug(
+                "Sorting: Mapper: featureType {}, mapped property for {} : {}",
+                m.getFeatureType(),
+                incomingPropertyName,
+                m.getFeatureProperty(incomingPropertyName));
+          });
+      LOGGER.debug(
+          "Mapping sort property: featureType {}, incomingPropertyName {}",
+          featureType,
+          incomingPropertyName);
+    }
+    MetacardMapper metacardToFeaturePropertyMapper =
+        lookupMetacardAttributeToFeaturePropertyMapper(featureType, metacardMapperList);
+    String mappedPropertyName = null;
+
+    if (metacardToFeaturePropertyMapper != null) {
+
+      if (StringUtils.equals(Result.TEMPORAL, incomingPropertyName)
+          || StringUtils.equals(Metacard.EFFECTIVE, incomingPropertyName)) {
+        mappedPropertyName =
+            StringUtils.defaultIfBlank(
+                metacardToFeaturePropertyMapper.getSortByTemporalFeatureProperty(), null);
+      } else if (StringUtils.equals(Result.RELEVANCE, incomingPropertyName)) {
+        mappedPropertyName =
+            StringUtils.defaultIfBlank(
+                metacardToFeaturePropertyMapper.getSortByRelevanceFeatureProperty(), null);
+      } else if (org.apache.commons.lang.StringUtils.equals(
+          Result.DISTANCE, incomingPropertyName)) {
+        mappedPropertyName =
+            StringUtils.defaultIfBlank(
+                metacardToFeaturePropertyMapper.getSortByDistanceFeatureProperty(), null);
+      } else {
+        mappedPropertyName =
+            metacardToFeaturePropertyMapper.getFeatureProperty(incomingPropertyName);
+      }
+    }
+
+    LOGGER.debug("mapped sort property from {} to {}", incomingPropertyName, mappedPropertyName);
+    return mappedPropertyName;
+  }
+
+  protected MetacardMapper lookupMetacardAttributeToFeaturePropertyMapper(
+      QName featureType, List<MetacardMapper> metacardMapperList) {
+
+    final Predicate<MetacardMapper> matchesFeatureType =
+        mapper -> mapper.getFeatureType().equals(featureType.toString());
+    return metacardMapperList.stream()
+        .filter(matchesFeatureType)
+        .findAny()
+        .orElseGet(
+            () -> {
+              LOGGER.debug("Could not find a MetacardMapper for featureType {}.", featureType);
+              return null;
+            });
   }
 }

--- a/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSource.java
+++ b/catalog/spatial/wfs/spatial-wfs-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSource.java
@@ -108,8 +108,7 @@ public abstract class AbstractWfsSource extends MaskableImpl
         mappedPropertyName =
             StringUtils.defaultIfBlank(
                 metacardToFeaturePropertyMapper.getSortByRelevanceFeatureProperty(), null);
-      } else if (org.apache.commons.lang.StringUtils.equals(
-          Result.DISTANCE, incomingPropertyName)) {
+      } else if (StringUtils.equals(Result.DISTANCE, incomingPropertyName)) {
         mappedPropertyName =
             StringUtils.defaultIfBlank(
                 metacardToFeaturePropertyMapper.getSortByDistanceFeatureProperty(), null);

--- a/catalog/spatial/wfs/spatial-wfs-common/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSourceTest.java
+++ b/catalog/spatial/wfs/spatial-wfs-common/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSourceTest.java
@@ -44,9 +44,9 @@ import org.junit.Test;
 public class AbstractWfsSourceTest {
   private AbstractWfsSource wfsSource;
   private static final String FEATURE_NAME = "SampleFeature";
-  private static final String TEMPORAL_SORT_PROEPRTY = "myTemporalSortProperty";
-  private static final String RELEVANCE_SORT_PROEPRTY = "myRelevanceSortProperty";
-  private static final String DISTANCE_SORT_PROEPRTY = "myDistanceSortProperty";
+  private static final String TEMPORAL_SORT_PROPERTY = "myTemporalSortProperty";
+  private static final String RELEVANCE_SORT_PROPERTY = "myRelevanceSortProperty";
+  private static final String DISTANCE_SORT_PROPERTY = "myDistanceSortProperty";
   private List<MetacardMapper> mappers;
 
   @Before
@@ -57,9 +57,9 @@ public class AbstractWfsSourceTest {
     QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
 
     doReturn(featureName.toString()).when(mockMapper).getFeatureType();
-    doReturn(DISTANCE_SORT_PROEPRTY).when(mockMapper).getSortByDistanceFeatureProperty();
-    doReturn(TEMPORAL_SORT_PROEPRTY).when(mockMapper).getSortByTemporalFeatureProperty();
-    doReturn(RELEVANCE_SORT_PROEPRTY).when(mockMapper).getSortByRelevanceFeatureProperty();
+    doReturn(DISTANCE_SORT_PROPERTY).when(mockMapper).getSortByDistanceFeatureProperty();
+    doReturn(TEMPORAL_SORT_PROPERTY).when(mockMapper).getSortByTemporalFeatureProperty();
+    doReturn(RELEVANCE_SORT_PROPERTY).when(mockMapper).getSortByRelevanceFeatureProperty();
     mappers.add(mockMapper);
   }
 
@@ -72,9 +72,9 @@ public class AbstractWfsSourceTest {
         wfsSource.mapSortByPropertyName(featureName, Result.RELEVANCE, mappers);
     String mappedDistanceProperty =
         wfsSource.mapSortByPropertyName(featureName, Result.DISTANCE, mappers);
-    assertThat(mappedTemporalProperty, is(TEMPORAL_SORT_PROEPRTY));
-    assertThat(mappedRelevanceProperty, is(RELEVANCE_SORT_PROEPRTY));
-    assertThat(mappedDistanceProperty, is(DISTANCE_SORT_PROEPRTY));
+    assertThat(mappedTemporalProperty, is(TEMPORAL_SORT_PROPERTY));
+    assertThat(mappedRelevanceProperty, is(RELEVANCE_SORT_PROPERTY));
+    assertThat(mappedDistanceProperty, is(DISTANCE_SORT_PROPERTY));
   }
 
   @Test
@@ -103,7 +103,7 @@ public class AbstractWfsSourceTest {
     QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
     String mappedTemporalProperty =
         wfsSource.mapSortByPropertyName(featureName, Metacard.EFFECTIVE, mappers);
-    assertThat(mappedTemporalProperty, is(TEMPORAL_SORT_PROEPRTY));
+    assertThat(mappedTemporalProperty, is(TEMPORAL_SORT_PROPERTY));
   }
 
   private class TestWfsSource extends AbstractWfsSource {

--- a/catalog/spatial/wfs/spatial-wfs-common/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSourceTest.java
+++ b/catalog/spatial/wfs/spatial-wfs-common/src/test/java/org/codice/ddf/spatial/ogc/wfs/catalog/common/AbstractWfsSourceTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.catalog.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import ddf.catalog.data.ContentType;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.SourceResponse;
+import ddf.catalog.resource.ResourceNotFoundException;
+import ddf.catalog.resource.ResourceNotSupportedException;
+import ddf.catalog.source.SourceMonitor;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.namespace.QName;
+import org.codice.ddf.spatial.ogc.wfs.catalog.mapper.MetacardMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractWfsSourceTest {
+  private AbstractWfsSource wfsSource;
+  private static final String FEATURE_NAME = "SampleFeature";
+  private static final String TEMPORAL_SORT_PROEPRTY = "myTemporalSortProperty";
+  private static final String RELEVANCE_SORT_PROEPRTY = "myRelevanceSortProperty";
+  private static final String DISTANCE_SORT_PROEPRTY = "myDistanceSortProperty";
+  private List<MetacardMapper> mappers;
+
+  @Before
+  public void setup() {
+    wfsSource = new TestWfsSource();
+    mappers = new ArrayList<>();
+    MetacardMapper mockMapper = mock(MetacardMapper.class);
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+
+    doReturn(featureName.toString()).when(mockMapper).getFeatureType();
+    doReturn(DISTANCE_SORT_PROEPRTY).when(mockMapper).getSortByDistanceFeatureProperty();
+    doReturn(TEMPORAL_SORT_PROEPRTY).when(mockMapper).getSortByTemporalFeatureProperty();
+    doReturn(RELEVANCE_SORT_PROEPRTY).when(mockMapper).getSortByRelevanceFeatureProperty();
+    mappers.add(mockMapper);
+  }
+
+  @Test
+  public void testSortMapping() throws Exception {
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+    String mappedTemporalProperty =
+        wfsSource.mapSortByPropertyName(featureName, Result.TEMPORAL, mappers);
+    String mappedRelevanceProperty =
+        wfsSource.mapSortByPropertyName(featureName, Result.RELEVANCE, mappers);
+    String mappedDistanceProperty =
+        wfsSource.mapSortByPropertyName(featureName, Result.DISTANCE, mappers);
+    assertThat(mappedTemporalProperty, is(TEMPORAL_SORT_PROEPRTY));
+    assertThat(mappedRelevanceProperty, is(RELEVANCE_SORT_PROEPRTY));
+    assertThat(mappedDistanceProperty, is(DISTANCE_SORT_PROEPRTY));
+  }
+
+  @Test
+  public void testNullFeatureType() throws Exception {
+    String mappedTemporalProperty = wfsSource.mapSortByPropertyName(null, Result.TEMPORAL, mappers);
+    assertThat(mappedTemporalProperty, nullValue());
+  }
+
+  @Test
+  public void testNullProperty() throws Exception {
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+    String mappedTemporalProperty = wfsSource.mapSortByPropertyName(featureName, null, mappers);
+    assertThat(mappedTemporalProperty, nullValue());
+  }
+
+  @Test
+  public void testNullMapper() throws Exception {
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+    String mappedTemporalProperty =
+        wfsSource.mapSortByPropertyName(featureName, Result.TEMPORAL, null);
+    assertThat(mappedTemporalProperty, nullValue());
+  }
+
+  @Test
+  public void testSortMappingEffective() throws Exception {
+    QName featureName = new QName("http://example.com", FEATURE_NAME, "Prefix");
+    String mappedTemporalProperty =
+        wfsSource.mapSortByPropertyName(featureName, Metacard.EFFECTIVE, mappers);
+    assertThat(mappedTemporalProperty, is(TEMPORAL_SORT_PROEPRTY));
+  }
+
+  private class TestWfsSource extends AbstractWfsSource {
+    @Override
+    public ResourceResponse retrieveResource(URI uri, Map<String, Serializable> map)
+        throws IOException, ResourceNotFoundException, ResourceNotSupportedException {
+      return null;
+    }
+
+    @Override
+    public Set<String> getSupportedSchemes() {
+      return null;
+    }
+
+    @Override
+    public Set<String> getOptions(Metacard metacard) {
+      return null;
+    }
+
+    @Override
+    public String getConfigurationPid() {
+      return null;
+    }
+
+    @Override
+    public void setConfigurationPid(String s) {}
+
+    @Override
+    public boolean isAvailable() {
+      return false;
+    }
+
+    @Override
+    public boolean isAvailable(SourceMonitor sourceMonitor) {
+      return false;
+    }
+
+    @Override
+    public SourceResponse query(QueryRequest queryRequest) throws UnsupportedQueryException {
+      return null;
+    }
+
+    @Override
+    public Set<ContentType> getContentTypes() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Forward port of #6419  
* DDF-4729 adds WFS 1.1.0 sorting

- adds flag to enable/disable sorting
- adds mapping of DDF sort attributes to WFS attributes

#### Who is reviewing it? 
@millerw8
@jrnorth
@glenhein
@derekwilhelm

#### Select relevant component teams: 
@codice/data

#### Ask 2 committers to review/merge the PR and tag them here.
@jrnorth 
@millerw8 

#### How should this be tested?
See test instructions in #4729 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
