### PR TITLE
[2.26.x] DDF-6437 - Correctly translate NOT query operator

### DIFF
--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -204,7 +204,7 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
 
   @Override
   public SolrQuery not(SolrQuery operand) {
-    return new SolrQuery(" NOT " + operand.getQuery());
+    return new SolrQuery("(*:* NOT " + operand.getQuery() + ")");
   }
 
   @Override

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
@@ -602,6 +602,28 @@ public class SolrProviderQuery {
   }
 
   @Test
+  public void contextualLogicalNotWithNonMatchingOrPositiveCase()
+      throws UnsupportedQueryException, IngestException {
+    createContextualMetacards();
+
+    SolrFilterBuilder builder = getFilterBuilder();
+    Filter filter =
+        builder.anyOf(
+            builder.not(
+                builder
+                    .attribute(Metacard.METADATA)
+                    .is()
+                    .like()
+                    .text(Library.FLAGSTAFF_QUERY_PHRASE)),
+            builder.attribute(Metacard.METADATA).is().like().text("Pennsylvania"));
+
+    SourceResponse sourceResponse = provider.query(new QueryRequestImpl(new QueryImpl(filter)));
+
+    assertEquals(
+        "Did not find NOT Flagstaff OR Pennsylvania", ONE_HIT, sourceResponse.getResults().size());
+  }
+
+  @Test
   public void contextualLogicalNestedOrAndPositiveCase()
       throws UnsupportedQueryException, IngestException {
     createContextualMetacards();


### PR DESCRIPTION
#### What does this PR do?
The NOT operator in queries are translating to invalid solr queries.  This PR changes the translation to be `(*:* NOT <query>)` instead of `NOT <query>` so that the solr query is generated properly.

#### Who is reviewing it? 
@pklinef 
@andrewkfiedler 

#### Select relevant component teams: 

@codice/solr 


#### Ask 2 committers to review/merge the PR and tag them here.

@jlcsmith
@vinamartin


#### How should this be tested?
1. Ingest a document with title `test.txt`
2. Perform a cql search: `((NOT (("title" ILIKE 'something'))) OR ("title" ILIKE 'test'))`
3. Verify that the `test.txt` document is returned in the results

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6437 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
