### PR TITLE
DDF-6043 Allow DDF to register external attribute validators

### DIFF
--- a/catalog/core/catalog-core-definitionparser/src/main/java/ddf/catalog/definition/impl/DefinitionParser.java
+++ b/catalog/core/catalog-core-definitionparser/src/main/java/ddf/catalog/definition/impl/DefinitionParser.java
@@ -73,6 +73,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -103,6 +104,8 @@ import org.codice.gsonsupport.GsonTypeAdapters.LongDoubleTypeAdapter;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -156,6 +159,8 @@ public class DefinitionParser {
 
   private final List<MetacardType> metacardTypes;
 
+  private final List<AttributeValidator> attributeValidators;
+
   private final List<MetacardType> coreTypes =
       ImmutableList.of(
           new AssociationsAttributes(),
@@ -175,12 +180,14 @@ public class DefinitionParser {
       AttributeRegistry attributeRegistry,
       AttributeValidatorRegistry attributeValidatorRegistry,
       DefaultAttributeValueRegistry defaultAttributeValueRegistry,
-      List<MetacardType> metacardTypes) {
+      List<MetacardType> metacardTypes,
+      List<AttributeValidator> attributeValidators) {
     this(
         attributeRegistry,
         attributeValidatorRegistry,
         defaultAttributeValueRegistry,
         metacardTypes,
+        attributeValidators,
         FrameworkUtil::getBundle);
 
     FileAlterationObserver fileAlterationObserver =
@@ -217,11 +224,13 @@ public class DefinitionParser {
       AttributeValidatorRegistry attributeValidatorRegistry,
       DefaultAttributeValueRegistry defaultAttributeValueRegistry,
       List<MetacardType> metacardTypes,
+      List<AttributeValidator> attributeValidators,
       Function<Class, Bundle> bundleLookup) {
     this.attributeRegistry = attributeRegistry;
     this.attributeValidatorRegistry = attributeValidatorRegistry;
     this.defaultAttributeValueRegistry = defaultAttributeValueRegistry;
     this.metacardTypes = metacardTypes;
+    this.attributeValidators = attributeValidators;
     this.bundleLookup = bundleLookup;
   }
 
@@ -620,10 +629,48 @@ public class DefinitionParser {
           wrapper.reportingMetacardValidator(relationshipValidator);
           break;
         }
+      case "custom":
+        {
+          List<Outer.Validator> collection = ((Outer.ValidatorCollection) validator).validators;
+          collection.forEach(
+              item -> {
+                AttributeValidator av =
+                    (AttributeValidator)
+                        this.getService(
+                            AttributeValidator.class.getName(),
+                            String.format("(id=%s)", item.validator));
+                if (av != null) {
+                  wrapper.attributeValidator(av);
+                }
+              });
+          break;
+        }
       default:
         throw new IllegalStateException("Validator does not exist. (" + validator.validator + ")");
     }
     return wrapper;
+  }
+
+  private Object getService(String clazz, String filter) {
+    BundleContext bundleContext = getBundleContext();
+    ServiceReference<?>[] refs;
+    try {
+      refs = bundleContext.getServiceReferences(clazz, filter);
+      if (refs != null) {
+        if (refs.length > 1) {
+          LOGGER.warn(
+              "More than one service references are found with class: {}, and filter: {}\n"
+                  + "Ignoring rest of service references except for the first of the below list:",
+              clazz,
+              filter);
+          Arrays.stream(refs).forEachOrdered(ref -> LOGGER.warn(ref.toString()));
+        }
+        return bundleContext.getService(refs[0]);
+      }
+    } catch (InvalidSyntaxException e) {
+      LOGGER.warn("Invalid filter: {}", filter);
+    }
+    return null;
   }
 
   /** TODO DDF-3578 once MetacardValidator is eliminated, this pattern can be cleaned up */

--- a/catalog/core/catalog-core-definitionparser/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-definitionparser/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,6 +27,9 @@
         <argument>
             <reference-list interface="ddf.catalog.data.MetacardType" />
         </argument>
+        <argument>
+            <reference-list interface="ddf.catalog.validation.AttributeValidator" />
+        </argument>
     </bean>
 
 </blueprint>


### PR DESCRIPTION
Master Port of #6399 

#### What does this PR do?
Adds DDF to register external attribute validators via Definition Parser

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@leo-sakh 
@bennuttle 
@lavoywj 
@jMoneee 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@adimka
@ahoffer
@andrewkfiedler
@AzGoalie
@bdeining
@bdthomson
@blen-desta
@brendan-hofmann
@brjeter
@clockard
@coyotesqrl
@djblue
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@jlcsmith
@jrnorth
@lambeaux
@lessarderic
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rzwiefel
@shaundmorris
@stustison
@tbatie
@troymohl
@vinamartin
-->
@rzwiefel
@jrnorth

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Create a new AttributeValidator service from a downstream project
2. Update the json file read by DDF. Update an attribute to include a custom validator like below:
```
"anAttribute": [
    {
        "validator": "custom",
        "validators": [
            {
                "validator": "service_id_for_your_new_validator_service_from_step_1"
            }
        ]
    }
]
```
3. Check and see if `DefinitionParser` correctly registers the validator for attribute (An easier way would be to attach a debugger)

#### Any background context you want to provide?
This allows downstream projects to define custom validator mapping to the json file, and allows to use downstream-specific validator.

#### What are the relevant tickets?
Fixes: #6043 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
