### PR TITLE
[2.19.x] G-9476 kml not exporting InnerBoundary

### DIFF
--- a/catalog/spatial/kml/spatial-kml-util/pom.xml
+++ b/catalog/spatial/kml/spatial-kml-util/pom.xml
@@ -90,17 +90,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.81</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.76</minimum>
+                                            <minimum>0.82</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.72</minimum>
+                                            <minimum>0.78</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/kml/spatial-kml-util/src/main/java/org/codice/ddf/spatial/kml/converter/MetacardToKml.java
+++ b/catalog/spatial/kml/spatial-kml-util/src/main/java/org/codice/ddf/spatial/kml/converter/MetacardToKml.java
@@ -97,8 +97,19 @@ public class MetacardToKml {
     de.micromata.opengis.kml.v_2_2_0.Polygon kmlPoly = KmlFactory.createPolygon();
     List<Coordinate> kmlCoords =
         kmlPoly.createAndSetOuterBoundaryIs().createAndSetLinearRing().createAndSetCoordinates();
-    for (com.vividsolutions.jts.geom.Coordinate coord : jtsPoly.getCoordinates()) {
+
+    for (com.vividsolutions.jts.geom.Coordinate coord :
+        jtsPoly.getExteriorRing().getCoordinates()) {
       kmlCoords.add(new Coordinate(coord.x, coord.y));
+    }
+    for (int n = 0; n < jtsPoly.getNumInteriorRing(); n++) {
+      kmlCoords =
+          kmlPoly.createAndAddInnerBoundaryIs().createAndSetLinearRing().createAndSetCoordinates();
+      com.vividsolutions.jts.geom.Coordinate[] childCoordinates =
+          jtsPoly.getInteriorRingN(n).getCoordinates();
+      for (com.vividsolutions.jts.geom.Coordinate coord : childCoordinates) {
+        kmlCoords.add(new Coordinate(coord.x, coord.y));
+      }
     }
     return kmlPoly;
   }


### PR DESCRIPTION
ddf PRs:
2.23.x codice/ddf#6459
master codice/ddf#6458

---------------------
#### What does this PR do?
kml not exporting InnerBoundary, witch causes issue of being unable to import Multipolygon with holes, and causes issues upstream.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer
@hayleynorton
@zta6
@mojogitoverhere

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
• build / run / profile install / upload sample data
1. Go to Workspace and Create/Update new workspace
2. Upload some content (Click on Navigation icon on upper left corner)
3. Search for uploaded items
4. Add or update "locations" attributes to a Shape with hole(s). Added shape should be displayed on 2D map.
	a. Items can be added via the Inspector Visual. Example locations bellow (for other example look at bottom):
	MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20), (15 5, 40 10, 10 20, 15 5)))
5. Click on ellipses to the bottom right of updated result and click "Export as"
6. Select KML export and click "Download" 
7. Open exported kml file. Ensure there exist an "innerBoundaryIs" for the hole items and "outerBoundaryIs" exist for primary shape.
8. Click on 'Lists' tab
9. Click on "new list"
10. Fill out form and Click "Create New List"
11. Click on icon left to the ellipse menu button (when hover over icon says "Add items to the list.")
12. Import the exported kml file and ensure no regression

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->
##### Before
<img width="1752" alt="G-9476_Before UnitedStates" src="https://user-images.githubusercontent.com/65194214/102260227-6b0a7f80-3ecd-11eb-9c8c-a1e0448d3197.png">

<img width="1132" alt="G-9476_Before SampleMultiPolygon" src="https://user-images.githubusercontent.com/65194214/102260243-7067ca00-3ecd-11eb-9b16-abdd05ffa6fb.png">

##### After
<img width="1696" alt="G-9476_After UnitedStates" src="https://user-images.githubusercontent.com/65194214/102260264-765dab00-3ecd-11eb-8748-0dbaaa1c5b74.png">

<img width="880" alt="G-9476_After SampleMultiPolygon" src="https://user-images.githubusercontent.com/65194214/102260277-79589b80-3ecd-11eb-903d-d8d5363e8621.png">

##### Example of "United State of America" shape
`MULTIPOLYGON(((-94.8176 49.3891,-94.64 48.84,-94.3291 48.6707,-92.61 48.45,-91.64 48.14,-90.83 48.27,-89.2729 48.0198,-88.3781 48.3029,-84.8761 46.9001,-84.7792 46.6371,-84.5437 46.5387,-84.6049 46.4396,-84.1421 46.5122,-83.8908 46.1169,-83.4696 45.9947,-83.5929 45.8169,-82.5509 45.3475,-82.1376 43.5711,-83.12 42.08,-83.0298 41.8328,-82.6901 41.6751,-78.9394 42.8636,-79.1717 43.4663,-78.7203 43.6251,-76.82 43.6288,-76.5 44.0185,-74.867 45.0005,-71.5051 45.0082,-71.405 45.255,-70.66 45.46,-70 46.6931,-69.2372 47.4478,-68.905 47.185,-68.2344 47.3549,-67.7905 47.0664,-67.7913 45.7028,-66.9647 44.8097,-70.1162 43.6841,-70.8149 42.8653,-70.825 42.335,-70.495 41.805,-70.08 41.78,-70.185 42.145,-69.885 41.9228,-69.965 41.6372,-72.8764 41.2207,-73.71 40.9311,-72.2413 41.1195,-71.945 40.93,-73.345 40.63,-73.982 40.628,-73.9523 40.7507,-74.2567 40.4735,-73.9624 40.4276,-74.1784 39.7093,-74.906 38.9395,-74.9804 39.1964,-75.528 39.4985,-75.32 38.96,-75.0718 38.782,-75.0567 38.4041,-75.9402 37.2169,-75.722 37.9371,-76.2329 38.3192,-76.35 39.15,-76.5427 38.7176,-76.3293 38.0833,-76.99 38.24,-76.3016 37.9179,-76.2587 36.9664,-75.9718 36.8973,-75.7275 35.5507,-76.3632 34.8085,-77.3976 34.512,-78.055 33.9255,-78.5543 33.8613,-79.0607 33.494,-79.2036 33.1584,-80.3013 32.5094,-81.3363 31.4405,-81.4904 30.73,-81.3137 30.0355,-80.5356 28.4721,-80.53 28.04,-80.0565 26.88,-80.1316 25.8168,-80.381 25.2062,-80.68 25.08,-81.1721 25.2013,-81.33 25.64,-81.71 25.87,-82.7051 27.495,-82.8553 27.8862,-82.65 28.55,-82.93 29.1,-83.7096 29.9366,-84.1 30.09,-85.1088 29.6362,-85.7731 30.1526,-86.4 30.4,-89.1805 30.316,-89.5938 30.16,-89.4137 29.8942,-89.43 29.4886,-89.2177 29.2911,-89.4082 29.1596,-89.7793 29.3071,-90.1546 29.1174,-90.8802 29.1485,-91.6268 29.677,-92.4991 29.5523,-93.2264 29.7838,-94.69 29.48,-95.6003 28.7386,-96.594 28.3075,-97.14 27.83,-97.37 27.38,-97.38 26.69,-97.14 25.87,-97.53 25.84,-99.02 26.37,-99.52 27.54,-100.11 28.11,-100.9576 29.3807,-101.6624 29.7793,-102.48 29.76,-103.11 28.97,-103.94 29.27,-104.457 29.572,-105.0374 30.644,-106.5076 31.7545,-108.24 31.7549,-108.2419 31.3422,-111.0236 31.3347,-114.815 32.5253,-114.7214 32.7208,-117.1278 32.5353,-117.2959 33.0462,-117.944 33.6212,-118.4106 33.7409,-118.5199 34.0278,-119.081 34.078,-119.4388 34.3485,-120.3678 34.4471,-120.6229 34.6086,-120.7443 35.1569,-121.7146 36.1615,-122.5475 37.5518,-122.512 37.7834,-123.7272 38.9517,-123.8652 39.767,-124.3981 40.3132,-124.1789 41.142,-124.2137 41.9996,-124.5328 42.766,-124.1421 43.7084,-123.8989 45.5234,-124.0796 46.8648,-124.6872 48.1844,-124.5661 48.3797,-123.12 48.04,-122.5874 47.096,-122.34 47.36,-122.84 49,-95.1591 49,-95.1561 49.3843,-94.8176 49.3891),(-155.0678 71.1478,-154.3442 70.6964,-153.9 70.89,-152.21 70.83,-152.27 70.6,-150.74 70.43,-149.72 70.53,-144.92 69.99,-143.5894 70.1525,-140.986 69.712,-140.9978 60.3064,-140.013 60.2768,-139.039 60,-137.4525 58.905,-136.4797 59.4639,-135.4758 59.7878,-134.945 59.2706,-133.3555 58.4103,-131.7078 56.5521,-130.0078 55.9158,-129.98 55.285,-130.5361 54.8028,-131.9672 55.4978,-132.25 56.37,-133.5392 57.1789,-134.0781 58.1231,-136.6281 58.2122,-137.8 58.5,-139.8678 59.5378,-142.5744 60.0844,-143.9589 59.9992,-147.1144 60.8847,-148.2243 60.673,-148.0181 59.9783,-149.7279 59.7057,-151.7164 59.1558,-151.8594 59.745,-151.4097 60.7258,-150.3469 61.0336,-150.6211 61.2844,-151.8958 60.7272,-152.5783 60.0617,-154.0192 59.3503,-153.2875 58.8647,-154.2325 58.1464,-156.3083 57.4228,-156.5561 56.98,-158.1172 56.4636,-158.4333 55.9942,-159.6033 55.5667,-160.2897 55.6436,-163.0694 54.6897,-164.7856 54.4042,-164.9422 54.5722,-161.8042 55.895,-160.5636 56.0081,-160.0706 56.4181,-157.7228 57.57,-157.5503 58.3283,-157.0417 58.9189,-158.1947 58.6158,-158.5172 58.7878,-159.0586 58.4242,-159.7117 58.9314,-159.9813 58.5725,-160.3553 59.0711,-161.355 58.6708,-161.9689 58.6717,-162.055 59.2669,-161.8742 59.6336,-162.5181 59.9897,-163.8183 59.7981,-165.3464 60.5075,-165.3508 61.0739,-166.1214 61.5,-165.7345 62.075,-164.9192 62.6331,-164.5625 63.1464,-163.7533 63.2194,-163.0672 63.0595,-162.2606 63.5419,-161.5344 63.4558,-160.7725 63.7661,-160.9583 64.2228,-161.5181 64.4028,-160.7778 64.7886,-162.453 64.5594,-162.7578 64.3386,-163.5464 64.5592,-164.9608 64.4469,-166.4253 64.6867,-166.845 65.0889,-168.1106 65.67,-164.4747 66.5767,-163.6525 66.5767,-163.7886 66.0772,-161.6778 66.1161,-162.4897 66.7356,-163.7197 67.1164,-165.3903 68.0428,-166.7644 68.3589,-166.2047 68.883,-164.4308 68.9155,-163.1686 69.3711,-162.9306 69.8581,-161.9089 70.3333,-159.0392 70.8916,-158.1197 70.8247,-156.5808 71.3578,-155.0678 71.1478),(-153.0063 57.1158,-154.0051 56.7347,-154.5164 56.9927,-154.671 57.4612,-153.2287 57.969,-152.5648 57.9014,-152.1411 57.5911,-153.0063 57.1158),(-155.5421 19.0835,-155.6882 18.9162,-155.9366 19.0594,-156.0735 19.7029,-155.8501 19.9773,-155.8611 20.2672,-155.2245 19.993,-154.8074 19.5087,-155.5421 19.0835),(-156.0793 20.644,-156.4144 20.5724,-156.7106 20.9268,-156.2571 20.9175,-155.9957 20.764,-156.0793 20.644),(-156.7582 21.1768,-156.7893 21.0687,-157.3252 21.0978,-157.2503 21.2196,-156.7582 21.1768),(-157.6528 21.3222,-158.1267 21.3124,-158.2926 21.5791,-158.0252 21.717,-157.6528 21.3222),(-159.3451 21.982,-159.4637 21.883,-159.8005 22.0653,-159.3657 22.2149,-159.3451 21.982),(-165.5792 59.91,-166.1928 59.7544,-167.4553 60.2131,-166.4678 60.3842,-165.6744 60.2936,-165.5792 59.91),(-171.7317 63.7825,-171.1144 63.5922,-170.4911 63.695,-168.6894 63.2975,-169.5294 62.9769,-170.6714 63.3758,-171.5531 63.3178,-171.7911 63.4058,-171.7317 63.7825)))`
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
