### PR TITLE
[2.26.x] Address AccessControlException in XStreamWfs11FeatureTransformer

### DIFF
--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/main/java/org/codice/ddf/spatial/ogc/wfs/transformer/xstream/XStreamWfs11FeatureTransformer.java
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/src/main/java/org/codice/ddf/spatial/ogc/wfs/transformer/xstream/XStreamWfs11FeatureTransformer.java
@@ -20,6 +20,8 @@ import com.thoughtworks.xstream.security.NoTypePermission;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import java.io.InputStream;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Optional;
 import javax.xml.namespace.QName;
@@ -50,7 +52,9 @@ public class XStreamWfs11FeatureTransformer implements FeatureTransformer<Featur
 
   @Override
   public Optional<Metacard> apply(InputStream document, WfsMetadata<FeatureTypeType> metadata) {
-    XStream xStream = new XStream(new WstxDriver());
+    final WstxDriver driver = new WstxDriver();
+    XStream xStream =
+        AccessController.doPrivileged((PrivilegedAction<XStream>) () -> new XStream(driver));
     xStream.addPermission(NoTypePermission.NONE);
     xStream.allowTypeHierarchy(Metacard.class);
     xStream.setClassLoader(this.getClass().getClassLoader());


### PR DESCRIPTION
#### What does this PR do?
Addresses this `AccessControlException` in `XStreamWfs11FeatureTransformer` that occurred in a downstream project:
```
2020-12-15T15:56:58,035 | ERROR | StrategyThread 6 | DefaultErrorHandler              | org.apache.camel.spi.CamelLogger  203 | 118 - org.apache.camel.camel-core-engine - 3.4.0 | Failed delivery for (MessageId: ... on ExchangeId: ...). Exhausted after delivery attempt: 1 caught: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "createClassLoader")

Message History (complete message history is disabled)
---------------------------------------------------------------------------------------------------------------------------------------
RouteId              ProcessorId          Processor                                                                        Elapsed (ms)
[TransformFeatureCo] [TransformFeatureCo] [from[direct://wfsTransformFeatureCollection]                                  ] [        46]
	...
[TransformFeatureMe] [bean14            ] [bean[ref:wfsTransformerProcessor method:apply(${body}, ${header.metadata})]   ] [         0]

Stacktrace
---------------------------------------------------------------------------------------------------------------------------------------

java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "createClassLoader")
	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472) ~[?:1.8.0_275]
	at java.security.AccessController.checkPermission(AccessController.java:886) ~[?:1.8.0_275]
	at java.lang.SecurityManager.checkPermission(SecurityManager.java:549) ~[?:1.8.0_275]
	at java.lang.SecurityManager.checkCreateClassLoader(SecurityManager.java:611) ~[?:1.8.0_275]
	at java.lang.ClassLoader.checkCreateClassLoader(ClassLoader.java:271) ~[?:1.8.0_275]
	at java.lang.ClassLoader.<init>(ClassLoader.java:329) ~[?:1.8.0_275]
	at com.thoughtworks.xstream.core.util.CompositeClassLoader.<init>(CompositeClassLoader.java:73) ~[?:?]
	at com.thoughtworks.xstream.XStream.<init>(XStream.java:411) ~[?:?]
	at com.thoughtworks.xstream.XStream.<init>(XStream.java:378) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.transformer.xstream.XStreamWfs11FeatureTransformer.apply(XStreamWfs11FeatureTransformer.java:53) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.featuretransformer.impl.WfsTransformerProcessor.apply(WfsTransformerProcessor.java:52) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_275]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_275]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_275]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_275]
	at org.apache.camel.support.ObjectHelper.invokeMethodSafe(ObjectHelper.java:209) ~[?:?]
	at org.apache.camel.component.bean.MethodInfo.invoke(MethodInfo.java:421) ~[?:?]
	at org.apache.camel.component.bean.MethodInfo$1.doProceed(MethodInfo.java:242) ~[?:?]
	at org.apache.camel.component.bean.MethodInfo$1.proceed(MethodInfo.java:213) ~[?:?]
	at org.apache.camel.component.bean.AbstractBeanProcessor.process(AbstractBeanProcessor.java:154) ~[?:?]
	at org.apache.camel.component.bean.BeanProcessor.process(BeanProcessor.java:56) ~[?:?]
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler$SimpleTask.run(RedeliveryErrorHandler.java:395) ~[?:?]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:148) ~[?:?]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor.scheduleMain(DefaultReactiveExecutor.java:60) ~[?:?]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:147) ~[?:?]
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:286) ~[?:?]
	at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:83) ~[?:?]
	at org.apache.camel.support.AsyncProcessorSupport.process(AsyncProcessorSupport.java:40) ~[?:?]
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:49) ~[?:?]
	at org.apache.camel.component.bean.AbstractCamelInvocationHandler$1.call(AbstractCamelInvocationHandler.java:188) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_275]
	at org.apache.camel.component.bean.AbstractCamelInvocationHandler.doInvoke(AbstractCamelInvocationHandler.java:206) ~[?:?]
	at org.apache.camel.component.bean.AbstractCamelInvocationHandler.invokeProxy(AbstractCamelInvocationHandler.java:168) ~[?:?]
	at org.apache.camel.component.bean.CamelInvocationHandler.doInvokeProxy(CamelInvocationHandler.java:44) ~[?:?]
	at org.apache.camel.component.bean.AbstractCamelInvocationHandler.invoke(AbstractCamelInvocationHandler.java:81) ~[?:?]
	at com.sun.proxy.$Proxy137.apply(Unknown Source) ~[?:?]
	at Proxy552e797a_d317_4986_82d3_2ce5a0f39524.apply(Unknown Source) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.v110.catalog.source.WfsMessageBodyReader.readFrom(WfsMessageBodyReader.java:63) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.v110.catalog.source.WfsMessageBodyReader.readFrom(WfsMessageBodyReader.java:30) ~[?:?]
	at org.apache.cxf.jaxrs.utils.JAXRSUtils.readFromMessageBodyReader(JAXRSUtils.java:1428) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.impl.ResponseImpl.doReadEntity(ResponseImpl.java:402) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.client.AbstractClient.readBody(AbstractClient.java:552) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.handleResponse(ClientProxyImpl.java:1017) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.doChainedInvocation(ClientProxyImpl.java:905) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.invoke(ClientProxyImpl.java:345) ~[bundleFile:3.4.0]
	at com.sun.proxy.$Proxy141.getFeature(Unknown Source) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.v110.catalog.source.WfsSource.query(WfsSource.java:700) ~[?:?]
	at Proxycd0c2b4a_eb74_4688_884c_78b1029fddce.query(Unknown Source) ~[?:?]
	at ddf.catalog.federation.impl.TimedSource.query(TimedSource.java:56) ~[?:?]
	at ddf.catalog.federation.impl.SortedFederationStrategy.lambda$federate$0(SortedFederationStrategy.java:199) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_275]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_275]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_275]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_275]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_275]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_275]
2020-12-15T15:56:58,080 | ERROR | StrategyThread 6 | DefaultErrorHandler              | org.apache.camel.spi.CamelLogger  203 | 118 - org.apache.camel.camel-core-engine - 3.4.0 | Failed delivery for (MessageId: ... on ExchangeId: ...). Exhausted after delivery attempt: 1 caught: java.lang.NullPointerException

Message History (complete message history is disabled)
---------------------------------------------------------------------------------------------------------------------------------------
RouteId              ProcessorId          Processor                                                                        Elapsed (ms)
[TransformFeatureCo] [TransformFeatureCo] [from[direct://wfsTransformFeatureCollection]                                  ] [        91]
	...
[TransformFeatureCo] [split2            ] [split[org.apache.camel.support.builder.TokenXMLExpressionIterator@5b8374c8]   ] [         0]

Stacktrace
---------------------------------------------------------------------------------------------------------------------------------------

java.lang.NullPointerException: null
	at org.codice.ddf.spatial.ogc.wfs.featuretransformer.impl.WfsRouteBuilder$MetacardAggregationStrategy.getValue(WfsRouteBuilder.java:86) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.featuretransformer.impl.WfsRouteBuilder$MetacardAggregationStrategy.getValue(WfsRouteBuilder.java:82) ~[?:?]
	at org.apache.camel.processor.aggregate.AbstractListAggregationStrategy.aggregate(AbstractListAggregationStrategy.java:93) ~[?:?]
	at org.apache.camel.AggregationStrategy.aggregate(AggregationStrategy.java:84) ~[?:?]
	at org.apache.camel.processor.MulticastProcessor.doAggregateInternal(MulticastProcessor.java:618) ~[?:?]
	at org.apache.camel.processor.MulticastProcessor.doAggregateSync(MulticastProcessor.java:600) ~[?:?]
	at org.apache.camel.processor.MulticastProcessor.doAggregate(MulticastProcessor.java:586) ~[?:?]
	at org.apache.camel.processor.MulticastProcessor$MulticastTask.aggregate(MulticastProcessor.java:405) ~[?:?]
	at org.apache.camel.processor.MulticastProcessor$MulticastTask.lambda$null$0(MulticastProcessor.java:385) ~[?:?]
	at org.apache.camel.AsyncCallback.run(AsyncCallback.java:46) ~[?:?]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor$Worker.schedule(DefaultReactiveExecutor.java:148) ~[?:?]
	at org.apache.camel.impl.engine.DefaultReactiveExecutor.scheduleMain(DefaultReactiveExecutor.java:60) ~[?:?]
	at org.apache.camel.processor.Pipeline.process(Pipeline.java:147) ~[?:?]
	at org.apache.camel.processor.CamelInternalProcessor.process(CamelInternalProcessor.java:286) ~[?:?]
	at org.apache.camel.impl.engine.DefaultAsyncProcessorAwaitManager.process(DefaultAsyncProcessorAwaitManager.java:83) ~[?:?]
	at org.apache.camel.support.AsyncProcessorSupport.process(AsyncProcessorSupport.java:40) ~[?:?]
	at org.apache.camel.component.direct.DirectProducer.process(DirectProducer.java:49) ~[?:?]
	at org.apache.camel.component.bean.AbstractCamelInvocationHandler$1.call(AbstractCamelInvocationHandler.java:188) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_275]
	at org.apache.camel.component.bean.AbstractCamelInvocationHandler.doInvoke(AbstractCamelInvocationHandler.java:206) ~[?:?]
	at org.apache.camel.component.bean.AbstractCamelInvocationHandler.invokeProxy(AbstractCamelInvocationHandler.java:168) ~[?:?]
	at org.apache.camel.component.bean.CamelInvocationHandler.doInvokeProxy(CamelInvocationHandler.java:44) ~[?:?]
	at org.apache.camel.component.bean.AbstractCamelInvocationHandler.invoke(AbstractCamelInvocationHandler.java:81) ~[?:?]
	at com.sun.proxy.$Proxy137.apply(Unknown Source) ~[?:?]
	at Proxy552e797a_d317_4986_82d3_2ce5a0f39524.apply(Unknown Source) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.v110.catalog.source.WfsMessageBodyReader.readFrom(WfsMessageBodyReader.java:63) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.v110.catalog.source.WfsMessageBodyReader.readFrom(WfsMessageBodyReader.java:30) ~[?:?]
	at org.apache.cxf.jaxrs.utils.JAXRSUtils.readFromMessageBodyReader(JAXRSUtils.java:1428) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.impl.ResponseImpl.doReadEntity(ResponseImpl.java:402) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.client.AbstractClient.readBody(AbstractClient.java:552) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.handleResponse(ClientProxyImpl.java:1017) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.doChainedInvocation(ClientProxyImpl.java:905) ~[bundleFile:3.4.0]
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.invoke(ClientProxyImpl.java:345) ~[bundleFile:3.4.0]
	at com.sun.proxy.$Proxy141.getFeature(Unknown Source) ~[?:?]
	at org.codice.ddf.spatial.ogc.wfs.v110.catalog.source.WfsSource.query(WfsSource.java:700) ~[?:?]
	at Proxycd0c2b4a_eb74_4688_884c_78b1029fddce.query(Unknown Source) ~[?:?]
	at ddf.catalog.federation.impl.TimedSource.query(TimedSource.java:56) ~[?:?]
	at ddf.catalog.federation.impl.SortedFederationStrategy.lambda$federate$0(SortedFederationStrategy.java:199) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_275]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_275]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_275]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_275]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_275]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_275]
```
#### Who is reviewing it? 
@vinamartin @SmithJosh @jlcsmith 

#### Select relevant component teams: 
@codice/security 

#### How should this be tested?
Test querying a WFS 1.1 source in the downstream project, and confirm that the `AccessControlException` is no longer logged

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.