### PR TITLE
[2.26.x] Fix printErrorMessage when executeWithSubject fails in SubjectCommands

### DIFF
--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -202,17 +202,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.32</minimum>
+                                            <minimum>0.46</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.33</minimum>
+                                            <minimum>0.45</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RangeCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/RangeCommand.java
@@ -29,6 +29,8 @@ import java.util.List;
 import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.support.table.Row;
+import org.apache.karaf.shell.support.table.ShellTable;
 import org.joda.time.DateTime;
 import org.opengis.filter.Filter;
 import org.opengis.filter.sort.SortOrder;
@@ -90,11 +92,6 @@ public class RangeCommand extends CatalogCommands {
 
   @Override
   protected Object executeWithSubject() throws Exception {
-    String formatString = "%1$-7s %2$-33s %3$-26s %4$-" + MAX_LENGTH + "s%n";
-
-    console.printf(formatString, "", "", "", "");
-    printHeaderMessage(String.format(formatString, NUMBER, ID, attributeName, TITLE));
-
     Filter filter;
 
     Date wayInTheFuture = new DateTime().plusYears(5000).toDate();
@@ -140,6 +137,13 @@ public class RangeCommand extends CatalogCommands {
 
     List<Result> results = response.getResults();
 
+    final ShellTable table = new ShellTable();
+    table.column(NUMBER);
+    table.column(ID);
+    table.column(attributeName);
+    table.column(TITLE).maxSize(MAX_LENGTH);
+    table.emptyTableText("No results");
+
     int i = 1;
     for (Result result : results) {
       Attribute attribute = result.getMetacard().getAttribute(attributeName);
@@ -147,16 +151,14 @@ public class RangeCommand extends CatalogCommands {
         String returnedDate = new DateTime(attribute.getValue()).toString(DATETIME_FORMATTER);
         String title = result.getMetacard().getTitle();
 
-        console.printf(
-            formatString,
-            i,
-            result.getMetacard().getId(),
-            returnedDate,
-            title.substring(0, Math.min(title.length(), MAX_LENGTH)));
+        final Row row = table.addRow();
+        row.addContent(i, result.getMetacard().getId(), returnedDate, title);
       }
 
       i++;
     }
+
+    table.print(console, true);
 
     return null;
   }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SubjectCommands.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/SubjectCommands.java
@@ -19,6 +19,7 @@ import ddf.security.service.SecurityServiceException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import javax.annotation.Nullable;
 import org.apache.karaf.shell.api.action.Option;
@@ -103,8 +104,10 @@ public abstract class SubjectCommands extends CommandSupport {
   }
 
   /**
-   * {@link InvocationTargetException} wraps the {@link java.security.PrivilegedActionException}
-   * that wraps the checked {@link Exception} thrown by {@link PrivilegedExceptionAction#run()}
+   * The {@link InvocationTargetException} wraps the {@link java.security.PrivilegedActionException}
+   * that wraps the checked {@link Exception} thrown by {@link PrivilegedExceptionAction#run()}. The
+   * {@link InvocationTargetException} wraps any unchecked {@link Exception} thrown by {@link
+   * PrivilegedExceptionAction#run()}.
    */
   @Nullable
   private Object runWithoutUsername() {
@@ -116,7 +119,12 @@ public abstract class SubjectCommands extends CommandSupport {
     } catch (SecurityServiceException e) {
       printErrorMessage(e.getMessage());
     } catch (InvocationTargetException e) {
-      printErrorMessage(e.getCause().getCause().getMessage());
+      final Throwable cause = e.getCause();
+      if (cause instanceof PrivilegedActionException) {
+        printErrorMessage(cause.getCause().getMessage());
+      } else {
+        printErrorMessage(cause.getMessage());
+      }
     }
 
     return null;


### PR DESCRIPTION
#### What does this PR do?
- Fixes the error message printed out to the Karaf console when `executeWithSubject` throws an `Exception` in any class that implements `SubjectCommands`
- Update `catalog:range` command to only print table header row when there are no errors

Before:
```
admin@root()> catalog:range name ___ ___

#       ID                                name                       Title

null
```

After:
```
admin@root()> catalog:range name ___ ___
Could not parse date parameters.
```

#### How should this be tested?

Verify that both checked and unchecked exceptions are handled (log and karaf console output) correctly for comands that extend `SubjectCommands`. I tested with `catalog:range`. Here are the commands that I used:

|                        | run with username                                           | run without username                           |
|----------------------|-------------------------------------------------------------|------------------------------------------------|
| successful execution  | `catalog:range --user admin modified 01-23-2009 01-24-2009` | `catalog:range modified 01-23-2009 01-24-2009` |
| unchecked `Exception`  | `catalog:range --user admin modified 01-23-2009 01-23-2009` | `catalog:range modified 01-23-2009 01-23-2009` |
| checked `Exception`    | `catalog:range --user admin modified _ 01-23-2009`          | `catalog:range modified _ 01-23-2009`          |

Additionally, make sure that the table update in `RangeCommand` doesn't cause any regressions. Verify that output is still outputted correctly in the table and that the max title length is enforced.

#### Checklist:
- [n/a] Documentation Updated
- [n/a] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.