### PR TITLE
[2.19.x] G-9340 Search Form Location Keyword and BBox option not retained after refresh

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/data/QueryTemplateMetacard.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/data/QueryTemplateMetacard.java
@@ -46,9 +46,9 @@ import org.codice.ddf.catalog.ui.security.accesscontrol.AccessControlUtil;
  *       templates it should be present and it should be unique
  *   <li>{@link Core#DESCRIPTION} - additional information about a template, should be present but
  *       not necessarily unique
- *   <li>{@link QueryTemplateType#QUERY_TEMPLATE_FILTER} - contains validated Filter XML 2.0 that
- *       represents the query structure to execute, with filter functions denoting information that
- *       is needed before execution can occur.
+ *   <li>{@link QueryTemplateType#QUERY_TEMPLATE_FILTER} - contains validated Filter GSON string or
+ *       XML 2.0 that represents the query structure to execute, with filter functions denoting
+ *       information that is needed before execution can occur.
  * </ul>
  *
  * <p><i>This code is experimental. While it is functional and tested, it may change or be removed
@@ -89,8 +89,8 @@ public class QueryTemplateMetacard extends MetacardImpl {
     return null;
   }
 
-  public void setFormsFilter(String filterXml) {
-    setAttribute(QUERY_TEMPLATE_FILTER, filterXml);
+  public void setFormsFilter(String filter) {
+    setAttribute(QUERY_TEMPLATE_FILTER, filter);
   }
 
   public Map<String, Object> getQuerySettings() {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/data/QueryTemplateType.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/data/QueryTemplateType.java
@@ -52,7 +52,7 @@ public class QueryTemplateType extends MetacardTypeImpl {
               true /* stored */,
               false /* tokenized */,
               false /* multivalued */,
-              BasicTypes.XML_TYPE));
+              BasicTypes.STRING_TYPE));
   // @formatter:on
 
   public QueryTemplateType() {

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FormTemplate.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/model/pojo/FormTemplate.java
@@ -30,9 +30,9 @@ import org.codice.ddf.catalog.ui.forms.api.FilterNode;
  * <p><i>This code is experimental. While it is functional and tested, it may change or be removed
  * in a future version of the library.</i>
  */
-public class FormTemplate extends CommonTemplate {
+public class FormTemplate<T> extends CommonTemplate {
   @SerializedName("filterTemplate")
-  private FilterNode root;
+  private T root;
 
   private String creator;
 
@@ -40,7 +40,7 @@ public class FormTemplate extends CommonTemplate {
 
   public FormTemplate(
       Metacard metacard,
-      FilterNode root,
+      T root,
       Map<String, List<Serializable>> securityAttributes,
       String creator,
       Map<String, Object> querySettings) {
@@ -50,7 +50,7 @@ public class FormTemplate extends CommonTemplate {
     this.querySettings = querySettings;
   }
 
-  public FilterNode getRoot() {
+  public T getRoot() {
     return root;
   }
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -210,10 +210,13 @@ module.exports = Marionette.LayoutView.extend({
   setDefaultTitle() {
     this.model.set('title', this.model.get('cql'))
   },
+  getFilters() {
+    return this.queryAdvanced.currentView.getFilters()
+  },
   serializeTemplateParameters() {
     this.queryAdvanced.currentView.sortCollection()
     return {
-      filterTree: this.queryAdvanced.currentView.getFilters(),
+      filterTree: this.getFilters(),
       filterSettings: this.querySettings.currentView.toJSON(),
     }
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -134,9 +134,22 @@ module.exports = Marionette.LayoutView.extend({
             if (errorMessages.length !== 0) {
               showErrorMessages(errorMessages)
             } else {
-              this.updateQuerySettings(collection, id)
-              this.saveTemplateToBackend(collection, id)
-              this.navigateToForms()
+              const filterTree = this.editor.currentView.getFilters()
+              if (filterTree.filters && filterTree.filters.length > 0) {
+                console.log(this.editor.currentView.getFilters())
+                this.updateQuerySettings(collection, id)
+                this.saveTemplateToBackend(collection, id)
+                this.navigateToForms()
+              } else {
+                announcement.announce(
+                  {
+                    title: 'Some fields need your attention',
+                    message: `Search ${formTitle} filter(s) cannot be empty.`,
+                    type: 'error',
+                  },
+                  2500
+                )
+              }
             }
           } else {
             announcement.announce(


### PR DESCRIPTION
ddf-ui PRs:
3.4.x codice/ddf-ui#

----------------
#### What does this PR do?
Solve following issues:
Issue 1 - Search Form Location Keyword and Bounding Box option not retained after refresh
Issue 2 - When remove all filter’s field, error occurs when try to save
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@andrewzimmer 
@hayleynorton
@zta6 
@Lambeaux 
@mojogitoverhere
@millerw8  

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
• build / run / profile install / ingest sample data
• Ingest gazetteer data keywords
	https://github.com/codice/ddf/blob/master/distribution/ddf-common/src/main/resources/data/countries.geo.json
	>gazetteer:update /..<path of file>../countries.geo.json 
Issue 1:
1. Navigate to "Search Forms"
2. Click on '+ Search Forms' to create 
3. Fill out all required field (e.g. 'Title')
4. Add Keyword and Bounding Box for 'anyGeo' or 'location' or 'media.frame-center'
5. Can add other type of locations and/or none-location fields
6. Click on 'Save'
7. Refresh the page and open previously created search form
8. Ensure Keyword and Bounding Box are represented correctly, should look same as when you first created it.

Issue 2:
Follow steps 1 to 3 from Issue 1
4. Remove all field(s) from filter (e.g. anyText, anyGeo etc.)
5. Click on Save
6. Ensure you are stopped to save, by an error banner, stating filter cannot be empty.
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->
##### Before - Issue 1
![G-9340_Before-i1](https://user-images.githubusercontent.com/65194214/103231041-18c95580-48f4-11eb-872f-6c607034d23c.gif)

##### After - Issue 1
![G-9340_After-i1](https://user-images.githubusercontent.com/65194214/103231052-21219080-48f4-11eb-8311-5a7402dbc4ae.gif)

##### Before - Issue 2
![G-9340_Before-i2](https://user-images.githubusercontent.com/65194214/103231045-1c5cdc80-48f4-11eb-91cc-1233a1f692c7.gif)

##### After - Issue 2
![G-9340_After-i2](https://user-images.githubusercontent.com/65194214/103231058-24b51780-48f4-11eb-906d-f9ce363670c6.gif)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
