### PR TITLE
[2.19.x] G-9036 pan to geos defined on search form

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -121,18 +121,20 @@ module.exports = Marionette.LayoutView.extend({
         showResultFilter: false,
         selectionInterface: new SelectionInterface(),
         onMapLoaded: olMap => {
+          const filterTemplate = this.model.get('filterTemplate')
           this.showQueryForm(collection, id)
-          if (this.model.get('filterTemplate')) {
-            const geoFilters = (
-              this.model.get('filterTemplate').filters || [
-                this.model.get('filterTemplate'),
-              ]
-            ).filter(filter => CQLUtils.isGeoFilter(filter.type))
-            const coords = this.wktToCoords(geoFilters)
-            Common.queueExecution(() => {
-              this.map.currentView.map.zoomToExtent(coords)
-            })
+          if (!filterTemplate) {
+            return
           }
+          const geoFilters = (
+            filterTemplate.filters || [
+              filterTemplate,
+            ]
+          ).filter(filter => CQLUtils.isGeoFilter(filter.type))
+          const coords = this.wktToCoords(geoFilters)
+          Common.queueExecution(() => {
+            this.map.currentView.map.zoomToExtent(coords)
+          })
         },
       })
     )

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -143,8 +143,12 @@ module.exports = Marionette.LayoutView.extend({
     const parsedGeoCoords = wktList.map(wkt => {
       if (wkt.value.startsWith('POINT') && parseFloat(wkt.distance) !== 0) {
         const center = terraformer.parse(wkt.value).coordinates
-        return new TurfCircle(center, parseFloat(wkt.distance), CIRCLE_PRECISION_STEPS, 'meters')
-          .geometry.coordinates[0]
+        return new TurfCircle(
+          center,
+          parseFloat(wkt.distance),
+          CIRCLE_PRECISION_STEPS,
+          'meters'
+        ).geometry.coordinates[0]
       }
       return terraformer.parse(wkt.value).coordinates
     })

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -36,6 +36,8 @@ const TurfCircle = require('@turf/circle')
 const announcement = require('../announcement/index.jsx')
 import { showErrorMessages } from '../../react-component/utils/validation'
 
+const CIRCLE_PRECISION_STEPS = 64
+
 const formTitle = properties.i18n['form.title']
   ? properties.i18n['form.title'].toLowerCase()
   : 'form'
@@ -141,7 +143,7 @@ module.exports = Marionette.LayoutView.extend({
     const parsedGeoCoords = wktList.map(wkt => {
       if (wkt.value.startsWith('POINT') && parseFloat(wkt.distance) !== 0) {
         const center = terraformer.parse(wkt.value).coordinates
-        return new TurfCircle(center, parseFloat(wkt.distance), 64, 'meters')
+        return new TurfCircle(center, parseFloat(wkt.distance), CIRCLE_PRECISION_STEPS, 'meters')
           .geometry.coordinates[0]
       }
       return terraformer.parse(wkt.value).coordinates

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -127,9 +127,7 @@ module.exports = Marionette.LayoutView.extend({
             return
           }
           const geoFilters = (
-            filterTemplate.filters || [
-              filterTemplate,
-            ]
+            filterTemplate.filters || [filterTemplate]
           ).filter(filter => CQLUtils.isGeoFilter(filter.type))
           const coords = this.wktToCoords(geoFilters)
           Common.queueExecution(() => {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -33,7 +33,6 @@ const cql = require('../../js/cql.js')
 const CQLUtils = require('../../js/CQLUtils.js')
 const terraformer = require('terraformer-wkt-parser')
 const TurfCircle = require('@turf/circle')
-const _ = require('underscore')
 const announcement = require('../announcement/index.jsx')
 import { showErrorMessages } from '../../react-component/utils/validation'
 
@@ -139,18 +138,15 @@ module.exports = Marionette.LayoutView.extend({
     )
   },
   wktToCoords(wktList) {
-    const parsedGeoCoords = _.flatten(
-      wktList.map(wkt => {
-        if (wkt.value.startsWith('POINT') && parseFloat(wkt.distance) !== 0) {
-          const center = terraformer.parse(wkt.value).coordinates
-          return new TurfCircle(center, parseFloat(wkt.distance), 64, 'meters')
-            .geometry.coordinates[0]
-        }
-        return terraformer.parse(wkt.value).coordinates
-      }),
-      true
-    )
-    return this.createCoordinatePairs(this.flatten(parsedGeoCoords))
+    const parsedGeoCoords = wktList.map(wkt => {
+      if (wkt.value.startsWith('POINT') && parseFloat(wkt.distance) !== 0) {
+        const center = terraformer.parse(wkt.value).coordinates
+        return new TurfCircle(center, parseFloat(wkt.distance), 64, 'meters')
+          .geometry.coordinates[0]
+      }
+      return terraformer.parse(wkt.value).coordinates
+    })
+    return this.createCoordinatePairs(this.flatten(parsedGeoCoords.flat()))
   },
   flatten(arr) {
     return arr.reduce((flat, toFlatten) => {
@@ -160,7 +156,7 @@ module.exports = Marionette.LayoutView.extend({
     }, [])
   },
   createCoordinatePairs(arr) {
-    return arr.reduce(function(result, value, index, array) {
+    return arr.reduce((result, value, index, array) => {
       if (index % 2 === 0) {
         result.push(array.slice(index, index + 2))
       }

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/search-form-editor/search-form-editor.view.js
@@ -17,6 +17,7 @@ import styled from 'styled-components'
 import { ChangeBackground } from '../../react-component/styles/mixins/change-background'
 
 const Marionette = require('marionette')
+const Common = require('../../js/Common.js')
 const MapView = require('../visualization/maps/openlayers/openlayers.view.js')
 const properties = require('../../js/properties.js')
 const Router = require('../router/router.js')
@@ -29,6 +30,10 @@ const QueryTitle = require('../query-title/query-title.view.js')
 const wreqr = require('../../js/wreqr.js')
 const user = require('../singletons/user-instance.js')
 const cql = require('../../js/cql.js')
+const CQLUtils = require('../../js/CQLUtils.js')
+const terraformer = require('terraformer-wkt-parser')
+const TurfCircle = require('@turf/circle')
+const _ = require('underscore')
 const announcement = require('../announcement/index.jsx')
 import { showErrorMessages } from '../../react-component/utils/validation'
 
@@ -118,9 +123,49 @@ module.exports = Marionette.LayoutView.extend({
         selectionInterface: new SelectionInterface(),
         onMapLoaded: olMap => {
           this.showQueryForm(collection, id)
+          if (this.model.get('filterTemplate')) {
+            const geoFilters = (
+              this.model.get('filterTemplate').filters || [
+                this.model.get('filterTemplate'),
+              ]
+            ).filter(filter => CQLUtils.isGeoFilter(filter.type))
+            const coords = this.wktToCoords(geoFilters)
+            Common.queueExecution(() => {
+              this.map.currentView.map.zoomToExtent(coords)
+            })
+          }
         },
       })
     )
+  },
+  wktToCoords(wktList) {
+    const parsedGeoCoords = _.flatten(
+      wktList.map(wkt => {
+        if (wkt.value.startsWith('POINT') && parseFloat(wkt.distance) !== 0) {
+          const center = terraformer.parse(wkt.value).coordinates
+          return new TurfCircle(center, parseFloat(wkt.distance), 64, 'meters')
+            .geometry.coordinates[0]
+        }
+        return terraformer.parse(wkt.value).coordinates
+      }),
+      true
+    )
+    return this.createCoordinatePairs(this.flatten(parsedGeoCoords))
+  },
+  flatten(arr) {
+    return arr.reduce((flat, toFlatten) => {
+      return flat.concat(
+        Array.isArray(toFlatten) ? this.flatten(toFlatten) : toFlatten
+      )
+    }, [])
+  },
+  createCoordinatePairs(arr) {
+    return arr.reduce(function(result, value, index, array) {
+      if (index % 2 === 0) {
+        result.push(array.slice(index, index + 2))
+      }
+      return result
+    }, [])
   },
   showQueryForm(collection, id) {
     this.editor.show(


### PR DESCRIPTION
#### What does this PR do?
Previously, when a user defined any geometries on their search form (i.e., anyGeo, location attribute searches), the search form editor was not panning to these geometries. This PR fixes this behavior by panning to the extent defined by the collection of coordinates of all of the geometries defined on the search form. In other words, it will now pan/zoom to show the geometries. 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/ui 
#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. build, profile:install
2. create a search form with an `anyGeo` attribute, draw the geo somewhere away from your Home view 
3. fill in other necessary fields and save the search form
4. open the search form back up and verify that the map shows the geometry you created in step 2
5. edit the search form by adding a `location` attribute and drawing a geo 
6. re-open the search form and verify that the map shows the geometries you created in step 2 and step 5
7. pan to a location on the map with no geometries on it and set it as your new Home
8. leave the form and come back, verify that it still pans to the geos

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
