### PR TITLE
[2.19.x] G-9570 Retain boolean value after reload

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-boolean-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-boolean-input.js
@@ -29,7 +29,9 @@ const Root = styled.button`
 `
 
 const BooleanInput = props => {
-  const [value, setValue] = useState(props.value === true)
+  const [value, setValue] = useState(
+    props.value === true || props.value === 'true'
+  )
 
   useEffect(
     () => {


### PR DESCRIPTION
#### What does this PR do?
This PR alters the validation of data received from the server such
that when a user saves a Search Form which contains a boolean value of
`true`, that value will remain as `true` even after the user reloads the
relevant data from the server.
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@mojogitoverhere 
@Lambeaux 
@brhumphe 
@brianfelix 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->
@mojogitoverhere 
@Lambeaux 
#### How should this be tested?
<!--(List steps with links to updated documentation)-->

1. Build this branch
2. `profile:install standard`
3. Open the UI
4. Create a Search Form with the attribute 'spellcheck' set to `true`
5. Save th**e**~is~ ~s~**S**earch ~f~**F**orm
6. Refresh the webpage
7. Verify that the Search Form still has the attribute 'spellcheck' set to `true`
8. Clear the browser's cache
9. Verify that the Search Form still has the attribute 'spellcheck' set to `true`
10. Create another Search Form with the attribute 'spellcheck' set to `false`
11. Save the Search Form
12. Refresh the webpage
13. Verify that the Search Form still has the attribute 'spellcheck' set to `false`
14. Clear the browser's cache
15. Verify that the Search Form still has the attribute 'spellcheck' set to `false`

#### Any background context you want to provide?
When the user saves a Search Form with a boolean attribute, the UI sends the value of that boolean attribute to the server as a string, which is why this PR's addition of a check for `'true'` to the Search Form's validation of the server's data changes the previous behavior: that a saved Search Form with a boolean attribute set to `true` would switch its value to `false` after a reload of the data from the server. This fix strikes me as a bit hacky, though. I'd rather make the UI no longer send the value of a boolean attribute to the server as a string, since that sounds like a better/more robust fix to me. I attempted that fix, but got stuck in my investigation by some syntax in Javascript which I don't understand. I've marked this PR as a work in progress so that we can decide whether I should keep the fix as is, or ask someone for help with the syntax which I don't understand so that I can further pursue the (in my opinion) better fix. Additionally, I want to add a test for this fix, regardless of the fix's ultimate form, but let's take this one step at a time.

**@vinamartin and I decided that the fix as written is fine, especially since we don't know the scope of the potential problem** **of the UI saving boolean values in queries as strings. That problem might be limited to this situation, in which case we've** **just fixed it. If, in the future, we see a similar problem pop up in a separate case, then we should fix how the UI represents** **booleans in queries in JSON, but for now this seems fine.**

_**tl;dr: the fix seems hacky, but it works, and the less hacky fix doesn't seem worth the effort until we know that the scope of** **the problem exceeds 'boolean in saved Search Form is always false if saved Search Form's data comes from back end** **regardless of what the user saved the boolean as', since this fix fixes that problem.**_
#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
