### PR TITLE
[2.26.x] Prevents potential NPE during security auditing

### DIFF
--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/assertion/impl/SecurityAssertionDefault.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/assertion/impl/SecurityAssertionDefault.java
@@ -133,6 +133,9 @@ public class SecurityAssertionDefault implements SecurityAssertion {
 
   @Override
   public String toString() {
+    if (userPrincipal == null) {
+      return "UNKNOWN";
+    }
     return userPrincipal.getName();
   }
 }


### PR DESCRIPTION
#### What does this PR do?
This toString() method can result in an NPE if the user principal is null/empty.
I'm not entirely sure this is the correct solution so I'm looking for feedback on better ideas here.
This issue was introduced in: https://github.com/codice/ddf/pull/6455

#### Who is reviewing it? 
@SmithJosh 
@jlcsmith 
@derekwilhelm 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
