### PR TITLE
[2.26.x] Require userPrincipal for DefaultSecurityAssertion

### DIFF
--- a/platform/security/core/security-core-impl/pom.xml
+++ b/platform/security/core/security-core-impl/pom.xml
@@ -282,7 +282,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.56</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
@@ -292,7 +292,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/assertion/impl/DefaultSecurityAssertionBuilder.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/assertion/impl/DefaultSecurityAssertionBuilder.java
@@ -18,6 +18,7 @@ import ddf.security.assertion.AuthenticationStatement;
 import ddf.security.assertion.SecurityAssertion;
 import java.security.Principal;
 import java.util.Date;
+import java.util.Objects;
 
 public class DefaultSecurityAssertionBuilder {
 
@@ -85,6 +86,7 @@ public class DefaultSecurityAssertionBuilder {
   }
 
   public SecurityAssertion build() {
+    Objects.requireNonNull(securityAssertion.userPrincipal, "userPrincipal cannot be null");
     return securityAssertion;
   }
 }

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/assertion/impl/DefaultSecurityAssertionBuilderTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/assertion/impl/DefaultSecurityAssertionBuilderTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.security.assertion.impl;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import ddf.security.assertion.AttributeStatement;
+import ddf.security.assertion.AuthenticationStatement;
+import ddf.security.assertion.SecurityAssertion;
+import java.security.Principal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import org.junit.Test;
+
+public class DefaultSecurityAssertionBuilderTest {
+
+  @Test
+  public void testDefaultSecurityAssertionBuilder() {
+    Principal principal = mock(Principal.class);
+    AttributeStatement attributeStatement = mock(AttributeStatement.class);
+    AuthenticationStatement authenticationStatement = mock(AuthenticationStatement.class);
+    Object token = new Object();
+    Date notBefore = Date.from(Instant.now());
+    Date notOnOrAfter = Date.from(Instant.now().plus(Duration.ofMinutes(1)));
+
+    DefaultSecurityAssertionBuilder builder = new DefaultSecurityAssertionBuilder();
+    SecurityAssertion assertion =
+        builder
+            .userPrincipal(principal)
+            .addPrincipal(principal)
+            .issuer("test")
+            .addAttributeStatement(attributeStatement)
+            .addAuthnStatement(authenticationStatement)
+            .addSubjectConfirmation("subjectConfirmation")
+            .tokenType("testToken")
+            .token(token)
+            .notBefore(notBefore)
+            .notOnOrAfter(notOnOrAfter)
+            .weight(7)
+            .build();
+
+    assertThat(assertion.getPrincipal(), is(principal));
+    assertThat(assertion.getPrincipals(), hasItem(principal));
+    assertThat(assertion.getIssuer(), is("test"));
+    assertThat(assertion.getAttributeStatements(), hasItem(attributeStatement));
+    assertThat(assertion.getSubjectConfirmations(), hasItem("subjectConfirmation"));
+    assertThat(assertion.getTokenType(), is("testToken"));
+    assertThat(assertion.getToken(), is(token));
+    assertThat(assertion.getNotBefore(), is(notBefore));
+    assertThat(assertion.getNotOnOrAfter(), is(notOnOrAfter));
+    assertThat(assertion.getWeight(), is(7));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testDefaultSecurityAssertionBuilderNoUserPrincipal() {
+    DefaultSecurityAssertionBuilder builder = new DefaultSecurityAssertionBuilder();
+    builder
+        .addPrincipal(mock(Principal.class))
+        .issuer("test")
+        .addAttributeStatement(mock(AttributeStatementDefault.class))
+        .notBefore(Date.from(Instant.now()))
+        .notOnOrAfter(Date.from(Instant.now().plus(Duration.ofMinutes(1))))
+        .build();
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Requires a user principal to be provided when building a SecurityAssertionDefault. The builder as-is allows assertions to be created without one, even though DDF assumes that a principal will be present.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@vinamartin @jlcsmith @andrewkfiedler @jordanwilking 
 
#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/security 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
CI 

#### Any background context you want to provide?
We found a case where invalid security assertions were being created with the default security assertion builder. This should prevent that in the future.

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
