### PR TITLE
Skip DDF distribution module on sonar stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,10 @@ pipeline {
                 }
             }
         }
-
+         /*
+          SonarCloud requires JDK 11 for sonar analysis. ACDebugger required Java 8 currently and so we need to skip the distribution/ddf module
+          to prevent the build failure when running the sonar analysis. This is fine since Sonar analysis primarily looks at Java code.
+        */
         stage ('SonarCloud') {
             when {
                 // Sonar Cloud only supports a single branch in the free/OSS tier
@@ -181,7 +184,7 @@ pipeline {
                     // -DskipITs is temporary to skip all the tests that were failing at the time. See https://github.com/codice/ddf/issues/5777
                     withMaven(maven: 'maven-latest', jdk: 'jdk11', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
                         script {
-                            sh 'mvn -q -B -DskipITs -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=ddf -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn -q -B -DskipITs -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=ddf -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !distribution/alliance,!$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
                     // -DskipITs is temporary to skip all the tests that were failing at the time. See https://github.com/codice/ddf/issues/5777
                     withMaven(maven: 'maven-latest', jdk: 'jdk11', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
                         script {
-                            sh 'mvn -q -B -DskipITs -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=ddf -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !distribution/alliance,!$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn -q -B -DskipITs -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=ddf -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !distribution/ddf,!$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                         }
                     }
                 }


### PR DESCRIPTION
#### What does this PR do?
Skips the distribution/ddf module when running the Sonar analysis. There is still a dependency on ACDebugger, which requires JDK8 (specifically tools.jar which has been removed in Java 9). Even running the sonar command on this module will cause a build failure as tools.jar will not be resolved. The workaround here is to skip the module on this stage since sonar primarily does Java analysis which the distribution/ddf module does not include.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@TonyMorrison
@codice/build
@codice/continuous-integration
@stustison
@LinkMJB

#### Ask 2 committers to review/merge the PR and tag them here.
@Lambeaux
@mojogitoverhere

#### How should this be tested?
Build passes Sonar stage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/ddf/6491)
<!-- Reviewable:end -->
