### PR TITLE
[2.26.x] Updates SortedQueryMonitor to include a case insensitive sort

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/CaseInsensitiveIfStringComparator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/CaseInsensitiveIfStringComparator.java
@@ -40,19 +40,10 @@ public class CaseInsensitiveIfStringComparator implements Comparator<Result> {
     Attribute b = contentB.getMetacard().getAttribute(sortType);
 
     if (!sortType.isEmpty()) {
-      if (a == null && b == null) {
-        return 0;
-      }
-      if (a == null && b.getValue() instanceof String) {
-        // push null values to the end regardless of sort order
-        return -1;
-      } else if (b == null && a.getValue() instanceof String) {
-        // push null values to the end regardless of sort order
-        return 1;
-      } else if (a != null
-          && b != null
-          && a.getValue() instanceof String
-          && b.getValue() instanceof String) {
+      if (a == null || b == null) {
+        // preserve null ordering
+        return fallback.compare(contentA, contentB);
+      } else if (a.getValue() instanceof String && b.getValue() instanceof String) {
         return (sortOrder == SortOrder.ASCENDING)
             ? String.CASE_INSENSITIVE_ORDER.compare(
                 a.getValue().toString(), b.getValue().toString())

--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/CaseInsensitiveIfStringComparator.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/util/impl/CaseInsensitiveIfStringComparator.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.util.impl;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Result;
+import java.util.Comparator;
+import org.opengis.filter.sort.SortOrder;
+
+/** Comparator that ignores case for string attributes or falls back to the passed in comparator */
+public class CaseInsensitiveIfStringComparator implements Comparator<Result> {
+
+  private SortOrder sortOrder = SortOrder.DESCENDING;
+  private String sortType = "";
+  private final Comparator<Result> fallback;
+
+  public CaseInsensitiveIfStringComparator(
+      SortOrder sortOrder, String sortType, Comparator<Result> fallback) {
+    if (sortOrder != null) {
+      this.sortOrder = sortOrder;
+    }
+    this.sortType = sortType;
+    this.fallback = fallback;
+  }
+
+  @Override
+  public int compare(Result contentA, Result contentB) {
+    Attribute a = contentA.getMetacard().getAttribute(sortType);
+    Attribute b = contentB.getMetacard().getAttribute(sortType);
+
+    if (!sortType.isEmpty()) {
+      if (a == null && b == null) {
+        return 0;
+      }
+      if (a == null && b.getValue() instanceof String) {
+        // push null values to the end regardless of sort order
+        return -1;
+      } else if (b == null && a.getValue() instanceof String) {
+        // push null values to the end regardless of sort order
+        return 1;
+      } else if (a != null
+          && b != null
+          && a.getValue() instanceof String
+          && b.getValue() instanceof String) {
+        return (sortOrder == SortOrder.ASCENDING)
+            ? String.CASE_INSENSITIVE_ORDER.compare(
+                a.getValue().toString(), b.getValue().toString())
+            : String.CASE_INSENSITIVE_ORDER
+                .reversed()
+                .compare(a.getValue().toString(), b.getValue().toString());
+      }
+    }
+
+    return fallback.compare(contentA, contentB);
+  }
+}

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedQueryMonitor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedQueryMonitor.java
@@ -31,6 +31,7 @@ import ddf.catalog.operation.impl.SourceResponseImpl;
 import ddf.catalog.plugin.PluginExecutionException;
 import ddf.catalog.plugin.PostFederatedQueryPlugin;
 import ddf.catalog.plugin.StopProcessingException;
+import ddf.catalog.util.impl.CaseInsensitiveIfStringComparator;
 import ddf.catalog.util.impl.CollectionResultComparator;
 import ddf.catalog.util.impl.DistanceResultComparator;
 import ddf.catalog.util.impl.RelevanceResultComparator;
@@ -127,12 +128,13 @@ class SortedQueryMonitor implements Runnable {
         } else if (Result.RELEVANCE.equals(sortType)) {
           comparator = new RelevanceResultComparator(sortOrder);
         } else {
-          comparator =
+          Comparator<Result> fallback =
               Comparator.comparing(
                   r -> getAttributeValue((Result) r, sortType),
                   ((sortOrder == SortOrder.ASCENDING)
                       ? Comparator.nullsLast(Comparator.<Comparable>naturalOrder())
                       : Comparator.nullsLast(Comparator.<Comparable>reverseOrder())));
+          comparator = new CaseInsensitiveIfStringComparator(sortOrder, sortType, fallback);
         }
         resultComparator.addComparator(comparator);
       }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/federation/impl/SortedQueryMonitorTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/federation/impl/SortedQueryMonitorTest.java
@@ -292,6 +292,32 @@ public class SortedQueryMonitorTest {
   }
 
   @Test
+  public void testCaseInsensitiveAscendingSortNoNulls() throws Exception {
+    testSorting(new String[] {"C", "b", "a"}, new String[] {"a", "b", "C"}, SortOrder.ASCENDING);
+  }
+
+  @Test
+  public void testCaseInsensitiveDescendingSortNoNulls() throws Exception {
+    testSorting(new String[] {"a", "b", "C"}, new String[] {"C", "b", "a"}, SortOrder.DESCENDING);
+  }
+
+  @Test
+  public void testCaseInsensitiveAscendingSortWithNulls() throws Exception {
+    testSorting(
+        new String[] {null, "C", "b", "a", null},
+        new String[] {"a", "b", "C", null, null},
+        SortOrder.ASCENDING);
+  }
+
+  @Test
+  public void testCaseInsensitiveDescendingSortWithNulls() throws Exception {
+    testSorting(
+        new String[] {null, "a", "b", "C"},
+        new String[] {"C", "b", "a", null},
+        SortOrder.DESCENDING);
+  }
+
+  @Test
   public void testSortAscendingNullFirst() throws Exception {
     testSorting(new String[] {null, "a"}, new String[] {"a", null}, SortOrder.ASCENDING);
   }


### PR DESCRIPTION
#### What does this PR do?
Adds a new comparator for doing case insensitive sort on string attributes.
Even though solr was returning the results with case insensitive sorting (https://github.com/codice/ddf/pull/6320), they were getting resorted in the incorrect order. 

#### Who is reviewing it? 
@pklinef 
@jordanwilking 
@stevenmalmgren 

#### Ask 2 committers to review/merge the PR and tag them here.
@derekwilhelm 
@jlcsmith 

#### How should this be tested?
1. Perform a full build
2. Install DDF and DDF-UI
3. Upload/ingest several documents with sortable names
4. For example: apple.txt, apricot.txt, banana.txt, blackberry.txt, blueberry.txt, broccoli.txt, carrot.txt, cherry.txt, tangerine.txt
5. Edit some of the titles in the metacards to contain uppercase letters 
6. Hit the cql endpoint or any other endpoint that allows for query and sort by title ascending
7. Verify the results are correctly sorted
8. Verify asc/desc order is correct then try with a few other attributes like thumbnail (verify this doesn't result in an NPE), description, etc.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
