### PR TITLE
G-9585 fix export result (compressed)

### DIFF
--- a/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvMetacardTransformer.java
+++ b/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvMetacardTransformer.java
@@ -48,11 +48,8 @@ public class CsvMetacardTransformer implements MetacardTransformer {
 
     Map<String, String> aliases =
         (Map<String, String>) arguments.getOrDefault("aliases", new HashMap<>());
-    String attributeString =
-        arguments.get(CsvQueryResponseTransformer.COLUMN_ORDER_KEY) != null
-            ? (String) arguments.get(CsvQueryResponseTransformer.COLUMN_ORDER_KEY)
-            : "";
-    List<String> attributes = Arrays.asList((attributeString).split(","));
+    List<String> attributes = getColumnOrder(arguments);
+
     List<AttributeDescriptor> allAttributes =
         new ArrayList<AttributeDescriptor>(metacard.getMetacardType().getAttributeDescriptors());
     List<AttributeDescriptor> descriptors =
@@ -64,5 +61,16 @@ public class CsvMetacardTransformer implements MetacardTransformer {
     Appendable appendable =
         writeMetacardsToCsv(Collections.singletonList(metacard), descriptors, aliases);
     return createResponse(appendable);
+  }
+
+  private List<String> getColumnOrder(Map<String, Serializable> arguments) {
+    if (arguments.get("columnOrder") instanceof String) {
+      String attributeString =
+          arguments.get("columnOrder") != null ? (String) arguments.get("columnOrder") : "";
+      return Arrays.asList((attributeString).split(","));
+    } else if (arguments.get("columnOrder") instanceof List) {
+      return (List<String>) arguments.get("columnOrder");
+    }
+    return new ArrayList<>();
   }
 }

--- a/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvMetacardTransformer.java
+++ b/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvMetacardTransformer.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
@@ -65,12 +66,13 @@ public class CsvMetacardTransformer implements MetacardTransformer {
 
   private List<String> getColumnOrder(Map<String, Serializable> arguments) {
     if (arguments.get("columnOrder") instanceof String) {
-      String attributeString =
-          arguments.get("columnOrder") != null ? (String) arguments.get("columnOrder") : "";
-      return Arrays.asList((attributeString).split(","));
-    } else if (arguments.get("columnOrder") instanceof List) {
-      return (List<String>) arguments.get("columnOrder");
+      String[] attributes =
+          Optional.of(arguments.get("columnOrder")).map(String.class::cast).orElse("").split(",");
+      return Arrays.asList(attributes);
     }
-    return new ArrayList<>();
+    return Optional.of(arguments.get("columnOrder"))
+        .filter(value -> value instanceof List)
+        .map(value -> (List<String>) value)
+        .orElse(new ArrayList<>());
   }
 }

--- a/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
+++ b/catalog/transformer/catalog-transformer-zip/src/main/java/org/codice/ddf/catalog/transformer/zip/ZipCompression.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
@@ -99,12 +98,13 @@ public class ZipCompression implements QueryResponseTransformer {
       throw new CatalogTransformerException("A valid transformer ID must be provided.");
     }
 
-    InputStream inputStream = createZip(sourceResponse, transformerId);
+    InputStream inputStream = createZip(sourceResponse, transformerId, arguments);
 
     return new BinaryContentImpl(inputStream, mimeType);
   }
 
-  private InputStream createZip(SourceResponse sourceResponse, String transformerId)
+  private InputStream createZip(
+      SourceResponse sourceResponse, String transformerId, Map<String, Serializable> arguments)
       throws CatalogTransformerException {
     ServiceReference<MetacardTransformer> serviceRef =
         getTransformerServiceReference(transformerId);
@@ -122,8 +122,7 @@ public class ZipCompression implements QueryResponseTransformer {
       for (Result result : sourceResponse.getResults()) {
         Metacard metacard = result.getMetacard();
 
-        BinaryContent binaryContent =
-            getTransformedMetacard(metacard, Collections.emptyMap(), transformer);
+        BinaryContent binaryContent = getTransformedMetacard(metacard, arguments, transformer);
 
         if (binaryContent != null) {
           ZipEntry entry = new ZipEntry(METACARD_PATH + metacard.getId() + extension);

--- a/distribution/ddf-common/src/main/resources/security/default.policy
+++ b/distribution/ddf-common/src/main/resources/security/default.policy
@@ -122,6 +122,10 @@ grant codeBase "file:/org.apache.servicemix.bundles.wsdl4j/spatial-commands/spat
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 }
 
+grant codeBase "file:/catalog-transformer-zip" {
+	permission java.lang.RuntimePermission "createClassLoader";
+}
+
 grant codeBase "file:/checksum/catalog-plugin-checksum/org.eclipse.jetty.http/security-realm-saml/security-core-services/org.apache.felix.configadmin/service-atom-transformer/spatial-commands/spatial-geocoding-feature/org.apache.karaf.shell.core/registry-federation-admin-service-impl/catalog-core-commands/spatial-geocoding-offline-catalog/spatial-geocoding-offline-index/spatial-geocoding-geocoder/spatial-geocoding-plugin/spatial-wfs-v2_0_0-source/spatial-wfs-v2_0_0-connectedsource/spatial-wfs-v1_1_0-source/spatial-wfs-featuretransformer/spatial-wfs-featuretransformer-xstream/resourcemanagement-usage-ui/catalog-rest-endpoint/catalog-core-camelcomponent/org.eclipse.jetty.websocket.server/catalog-rest-service/org.apache.camel.camel-support/org.apache.camel.camel-bean/org.apache.camel.camel-base/org.apache.camel.camel-direct/org.apache.camel.camel-api/catalog-core-directorymonitor" {
     permission java.lang.RuntimePermission "createClassLoader";
 }


### PR DESCRIPTION
backend portion of master port of https://github.com/codice/ddf/pull/6496

should be built with 3.4.x DDF-UI pr https://github.com/codice/ddf-ui/pull/506

___________________________________________________________________

#### What does this PR do?
This pr fixes issues with the request body for zipped export that was causing the backend to throw exceptions and not export the result(s). Namely, the request requires a sort to be passed as one of the arguments. Previously, this was causing ALL export selected (Compressed) to fail. Nothing would happen when users clicked download, no indication of failure, for all formats. Adding the sort, as well as the following changes, fixed MOST of the export formats. 

In addition, `columnOrder` can be passed as either a comma-delimited string, or as a list of strings. Changes were made to accommodate this. 

Also, I made changes to pass the arguments along to the metacard transformer for the zipped (compressed) export for similar reasons. 

Another issue was that we were passing a URI-encoded value for the `transformerId` in the case of zipped export. That argument shouldn't be encoded since it's part of the request body, not the url. 

With all of these changes, ALMOST all of the zipped export is working. There are some strange behaviors I have not addressed in this pr:

1. When exporting (compressed) and selecting the `csv` export format, the zipped file does not unzip with the default Mac Finder utility. I have to use [The Unarchiver](https://theunarchiver.com/) . Similarly, on Windows, it cannot be unzipped with Winrar, but 7zip unzips it with a warning.
2. Similar behavior was noticed on Mac (not verified on Windows) for the `Preview` export format.
3. ~~For `GMD Metadata` and `Overlay Thumbnail` , still nothing when the user clicks.~~  UPDATE: `Overlay Thumbnail` downloads a zip, but it fails to expand for me, even for records with a thumbnail/image associated. UPDATE TWO: With the latest commit, GMD Metadata now works after giving it the class loader permission.


#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

@frnkshin @leo-sakh @lavoywj @jMoneee 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

1.  Build with ddf-ui
2. ingest some records:
[Archive.zip](https://github.com/codice/ddf/files/5851210/Archive.zip)
**NOTE:** try with some other types of data as well, i.e., data without location information
3. execute a search and select one or more results 
4. click the three-dot menu on the search pane and select "Export Selected(Compressed)"
5. Go through each of the export formats, download and unzip them, and ensure you get the following behavior:

- [x] Binary Resource: works
- [x] CSV: doesn't work with default Mac Finder/winrar unzip, but works with Unarchiver (or 7zip for windows)
- [x] CSW Record XML: works
- [x] GMD Metadata: doesn't work with default Mac Finder/winrar unzip, but works with Unarchiver (or 7zip for windows)
- [x] GeoJSON: works
- [x] KML: works
- [x] KMZ: works
- [x] Metadata XML: works
- [x] OGC GML: works
- [x] Overlay Thumbnail: Nothing happens when click Download (or, zip is downloaded but cannot be opened)
- [x] Preview: doesn't work with default Mac Finder/winrar unzip, but works with Unarchiver (or 7zip for windows)
- [x] Preview HTML: works
- [x] PropertyJSON: works
- [x] RTF: works
- [x] Thumbnail: works

6. Verify no regression with regular (non-compressed) exporting


#### Any background context you want to provide?
As mentioned earlier, additional improvements for export are being addressed in addition to this pr. 

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
