### PR TITLE
Enable Java garbage collection logging

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -80,7 +80,7 @@ export DDF_ON_ERROR="bin/ddf_on_error.sh script "
 JAVA_ERROR_OPTS="-XX:OnOutOfMemoryError=\${DDF_ON_ERROR}%p -XX:OnError=\${DDF_ON_ERROR}%p"
 
 # Defines java garbage collection logging options
-GC_OPTS="-Xlog:gc=debug:file=${DDF_HOME}/data/log/gc.log:time,uptime,level,tags:filecount=5,filesize=100m"
+GC_OPTS="-Xlog:gc=info:file=${DDF_HOME}/data/log/gc.log:time,uptime,level,tags:filecount=5,filesize=100m"
 
 export KARAF_OPTS="-Dfile.encoding=UTF8"
 

--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -80,7 +80,7 @@ export DDF_ON_ERROR="bin/ddf_on_error.sh script "
 JAVA_ERROR_OPTS="-XX:OnOutOfMemoryError=\${DDF_ON_ERROR}%p -XX:OnError=\${DDF_ON_ERROR}%p"
 
 # Defines java garbage collection logging options
-GC_OPTS="-Xlog:gc=info:file=${DDF_HOME}/data/log/gc.log:time,uptime,level,tags:filecount=5,filesize=100m"
+GC_OPTS="-Xlog:gc=info:file=${DDF_HOME}/data/log/gc.log:time,uptime,level,tags:filecount=5,filesize=50m"
 
 export KARAF_OPTS="-Dfile.encoding=UTF8"
 

--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -80,7 +80,7 @@ export DDF_ON_ERROR="bin/ddf_on_error.sh script "
 JAVA_ERROR_OPTS="-XX:OnOutOfMemoryError=\${DDF_ON_ERROR}%p -XX:OnError=\${DDF_ON_ERROR}%p"
 
 # Defines java garbage collection logging options
-GC_OPTS="-Xlog:gc=info:file=${DDF_HOME}/data/log/gc.log:time,uptime,level,tags:filecount=5,filesize=50m"
+GC_OPTS="-Xlog:gc*=info:file=${DDF_HOME}/data/log/gc.log:time,uptime,level,tags:filecount=9,filesize=20m"
 
 export KARAF_OPTS="-Dfile.encoding=UTF8"
 

--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -79,6 +79,9 @@ export DDF_ON_ERROR="bin/ddf_on_error.sh script "
 # Defines the special on-error Java options
 JAVA_ERROR_OPTS="-XX:OnOutOfMemoryError=\${DDF_ON_ERROR}%p -XX:OnError=\${DDF_ON_ERROR}%p"
 
+# Defines java garbage collection logging options
+GC_OPTS="-Xlog:gc=debug:file=${DDF_HOME}/data/log/gc.log:time,uptime,level,tags:filecount=5,filesize=100m"
+
 export KARAF_OPTS="-Dfile.encoding=UTF8"
 
-export JAVA_OPTS="-Xms2g -Xmx6g -XX:+UnlockDiagnosticVMOptions -Dddf.home=${DDF_HOME} -Dddf.home.perm=${DDF_HOME}/ -XX:+DisableAttachMechanism $JAVA_ERROR_OPTS"
+export JAVA_OPTS="-Xms2g -Xmx6g -XX:+UnlockDiagnosticVMOptions -Dddf.home=${DDF_HOME} -Dddf.home.perm=${DDF_HOME}/ -XX:+DisableAttachMechanism $JAVA_ERROR_OPTS $GC_OPTS"

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -83,4 +83,4 @@ rem Defines the special on-error Java options
 rem set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR%%%p -XX:OnError=%DDF_ON_ERROR%%%p
 set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR% -XX:OnError=%DDF_ON_ERROR%
 set KARAF_OPTS=-Dfile.encoding=UTF8
-set JAVA_OPTS=-Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS%
+set JAVA_OPTS=-Xlog:gc=debug:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=5,filesize=100m -Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS%

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -84,5 +84,5 @@ rem set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR%%%p -XX:OnError=%DD
 set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR% -XX:OnError=%DDF_ON_ERROR%
 set KARAF_OPTS=-Dfile.encoding=UTF8
 rem Java garbage collection logging options
-set GC_OPTS=-Xlog:gc=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=5,filesize=100m 
+set GC_OPTS=-Xlog:gc=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=5,filesize=50m 
 set JAVA_OPTS=-Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS% %GC_OPTS%

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -83,4 +83,4 @@ rem Defines the special on-error Java options
 rem set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR%%%p -XX:OnError=%DDF_ON_ERROR%%%p
 set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR% -XX:OnError=%DDF_ON_ERROR%
 set KARAF_OPTS=-Dfile.encoding=UTF8
-set JAVA_OPTS=-Xlog:gc=debug:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=5,filesize=100m -Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS%
+set JAVA_OPTS=-Xlog:gc=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=5,filesize=100m -Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS%

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -83,4 +83,6 @@ rem Defines the special on-error Java options
 rem set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR%%%p -XX:OnError=%DDF_ON_ERROR%%%p
 set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR% -XX:OnError=%DDF_ON_ERROR%
 set KARAF_OPTS=-Dfile.encoding=UTF8
-set JAVA_OPTS=-Xlog:gc=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=5,filesize=100m -Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS%
+rem Java garbage collection logging options
+set GC_OPTS=-Xlog:gc=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=5,filesize=100m 
+set JAVA_OPTS=-Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS% %GC_OPTS%

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -84,5 +84,5 @@ rem set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR%%%p -XX:OnError=%DD
 set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR% -XX:OnError=%DDF_ON_ERROR%
 set KARAF_OPTS=-Dfile.encoding=UTF8
 rem Java garbage collection logging options
-set GC_OPTS=-Xlog:gc=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=5,filesize=50m 
+set GC_OPTS=-Xlog:gc*=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=9,filesize=20m 
 set JAVA_OPTS=-Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS% %GC_OPTS%


### PR DESCRIPTION
#### What does this PR do?
Enables java garbage collection logging to data/log/

### Things to consider:

**What log level should we set by default?** 
Available levels are the typical 'trace, debug, info, warning, error'
Currently set on *info*. 

Debug offers course grained info related to setup and a vague description of what garbage collection has occurred:
`[2021-02-25T16:16:25.549-0700][0.013s][debug][gc] Initialize mark stack with 4096 chunks, maximum 16384`
`[2021-02-25T16:17:49.941-0700][84.405s][debug][gc] GC(51) Reclaimed 601 empty regions`

Info offers some information as to what type of garbage collection is occurring: 
`[2021-02-25T16:17:50.089-0700][84.553s][info ][gc] GC(51) Concurrent Cycle 402.641ms`
`[2021-02-25T16:17:50.387-0700][84.850s][info ][gc] GC(52) Pause Young (Normal) (G1 Evacuation Pause) 510M->212M(2732M) 10.561ms`

Trace lists the memory addresses/regions reclaimed:
`[2021-02-25T16:17:49.941-0700][84.405s][trace][gc] GC(51) Reclaimed empty region 681 (F) bot 0x0000000695200000`
`[2021-02-25T16:17:49.941-0700][84.405s][trace][gc] GC(51) Reclaimed empty region 682 (F) bot 0x0000000695400000`

I have not seen any warning/error messages, they're probably quite rare. 

**What do we want the log messages to print?** 
There's a list of 'decorations' to include/exclude from the log messages. The `decorations` section of this page gives a quick + simple explanation of them: https://openjdk.java.net/jeps/158
Right now I have: `time,uptime,level,tags:filecount=5,filesize=100m`
Notably I don't current had Thread ID or Process ID turned on, do we see value in those?
Also, it would take quite some time to accumulate 100mb of logs, perhaps we should rollover at a smaller file size so that if you do have to search through these log files they're a bit more managably sized?

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@jMoneee 
@abel-connexta 
@lavoywj 
@shaundmorris 
@kentmorrissey 
@frnkshin 
@hayleynorton 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
 *after some changes the log messages now look like: 
 ```
 [2021-03-22T18:52:42.931-0600][189.175s][info][gc,heap       ] GC(50) Humongous regions: 0->0
[2021-03-22T18:52:42.931-0600][189.175s][info][gc,metaspace  ] GC(50) Metaspace: 174832K->174832K(1220608K)
[2021-03-22T18:52:42.931-0600][189.175s][info][gc            ] GC(50) Pause Young (Normal) (G1 Evacuation Pause) 1271M->690M(2868M) 61.755ms
[2021-03-22T18:52:42.931-0600][189.175s][info][gc,cpu        ] GC(50) User=0.31s Sys=0.11s Real=0.06s
```


Build + start ddf on both windows and *nix systems (I've verified on Windows)
Verify `gc` file appears in `ddf-2.27.0-SNAPSHOT/data/log` directory and has log messages in it
Verify log messages appear similar to the examples listed above. 

**ALTERNATIVELY** 
you could copy the setenv (for *nix) or setenv.bat (windows) from this PR to the `/bin` of a working, recent ddf build, replacing the old `setenv` with this one. Then you can start your ddf as normal and verify the other parts listed above. 