### PR TITLE
[2.19.x] G-9824 Greatly speeds up search form GET requests by not creating a JAXBContext for each form being processed

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/TemplateTransformer.java
@@ -56,6 +56,8 @@ import org.slf4j.LoggerFactory;
 public class TemplateTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(TemplateTransformer.class);
 
+  private final FilterReader reader;
+
   private final FilterWriter writer;
 
   private final AttributeRegistry registry;
@@ -63,6 +65,12 @@ public class TemplateTransformer {
   public TemplateTransformer(FilterWriter writer, AttributeRegistry registry) {
     this.writer = writer;
     this.registry = registry;
+
+    try {
+      this.reader = new FilterReader();
+    } catch (JAXBException e) {
+      throw new FilterProcessingException("Could not initialize the filter reader", e);
+    }
   }
 
   public boolean invalidFormTemplate(Metacard metacard) {
@@ -133,7 +141,6 @@ public class TemplateTransformer {
     Map<String, List<Serializable>> securityAttributes = retrieveSecurityIfPresent(metacard);
 
     try {
-      FilterReader reader = new FilterReader();
       String formsFilter = wrapped.getFormsFilter();
       if (formsFilter == null) {
         LOGGER.debug(

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/filter/FilterReader.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/filter/FilterReader.java
@@ -35,12 +35,8 @@ import org.xml.sax.XMLReader;
 public class FilterReader {
   private final JAXBContext context;
 
-  private final SAXParserFactory factory;
-
   public FilterReader() throws JAXBException {
     this.context = JAXBContext.newInstance(FilterType.class);
-    this.factory = XMLUtils.getInstance().getSecureSAXParserFactory();
-    this.factory.setNamespaceAware(true);
   }
 
   public JAXBElement<FilterType> unmarshalFilter(InputStream inputStream) throws JAXBException {
@@ -50,6 +46,9 @@ public class FilterReader {
   @SuppressWarnings("unchecked")
   private <T> JAXBElement<T> unmarshal(InputStream inputStream, Class<T> tClass)
       throws JAXBException {
+    SAXParserFactory factory = XMLUtils.getInstance().getSecureSAXParserFactory();
+    factory.setNamespaceAware(true);
+
     SAXParser parser;
     try {
       parser = factory.newSAXParser();


### PR DESCRIPTION
#### What does this PR do?
Search form read operations for a single form take noticeably longer than other ops. There's a noticeable delay while debugging GET ops over lines that create `FilterReader` in `TemplateTransformer`. When this compounds for many search forms, the user will be left waiting. 

This PR fixes the issue, which is the creation of a `JAXBContext`, not per request, but **per form** being processed. This is causing redundant JAXB initialization processing of XML metadata that isn't necessary and now it only gets created once when the application starts: 
https://stackoverflow.com/a/7400735

This was missed the first time through because the javadocs made no mention of thread safety. 
https://docs.oracle.com/javase/8/docs/api/javax/xml/bind/JAXBContext.html

#### Who is reviewing it? 
#### Ask 2 committers to review/merge the PR and tag them here.
@brianfelix
@cassandrabailey293
@millerw8
@mojogitoverhere

#### How should this be tested?
Create a bunch of search forms of various shapes and sizes, then refresh the page several times, repeatedly. Best case scenario would be multiple users requesting their forms at the same time. 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
