### PR TITLE
[2.19.x] G-9826 Fix saving search forms by relaxing overly strict attribute name validation

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizer.java
@@ -45,7 +45,7 @@ class AttributeValueNormalizer {
   // Primary purpose is to protect persistence layer from bad symbols leaking into valid prop names
   // https://codice.atlassian.net/wiki/spaces/CODICE/pages/77627393/Taxonomy+Guidelines
   private static final Pattern EXPECTED_ATTRIBUTE_NAME_PATTERN =
-      Pattern.compile("(ext\\.)?(\\p{Alpha}+\\.)?\\p{Alpha}+(-\\p{Alpha}+)*");
+      Pattern.compile("(\\p{Alpha}+([-.]\\p{Alpha}+)*)+");
 
   private static final Pattern EXPECTED_RELATIVE_FUNCTION_PATTERN =
       Pattern.compile("RELATIVE\\(\\p{Alnum}+\\)");

--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizer.java
@@ -45,7 +45,7 @@ class AttributeValueNormalizer {
   // Primary purpose is to protect persistence layer from bad symbols leaking into valid prop names
   // https://codice.atlassian.net/wiki/spaces/CODICE/pages/77627393/Taxonomy+Guidelines
   private static final Pattern EXPECTED_ATTRIBUTE_NAME_PATTERN =
-      Pattern.compile("(\\p{Alpha}+([-.]\\p{Alpha}+)*)+");
+      Pattern.compile("\\p{Alpha}+([-.]\\p{Alpha}+)*");
 
   private static final Pattern EXPECTED_RELATIVE_FUNCTION_PATTERN =
       Pattern.compile("RELATIVE\\(\\p{Alnum}+\\)");

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizerTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizerTest.java
@@ -168,8 +168,89 @@ public class AttributeValueNormalizerTest {
   }
 
   @Test(expected = FilterProcessingException.class)
-  public void testBadPropertyNameToXml() {
+  public void testBadPropertyNameQuotesToXml() {
     normalizer.normalizeForXml(PROPERTY_NAME_WITH_QUOTES, VALID_ISO_8601_DATE_STRING);
+  }
+
+  @Test(expected = FilterProcessingException.class)
+  public void testBadPropertyNameNumbersToXml() {
+    normalizer.normalizeForXml("anyText2", VALID_ISO_8601_DATE_STRING);
+  }
+
+  @Test
+  public void testBadPropertyNameSymbolsToXml() {
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText!", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText@", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText#", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText$", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText%", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText^", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText&", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText*", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText>", VALID_ISO_8601_DATE_STRING));
+    assertThrows(
+        FilterProcessingException.class,
+        () -> normalizer.normalizeForXml("anyText<", VALID_ISO_8601_DATE_STRING));
+  }
+
+  @Test
+  public void testGoodPropertyNameBasicToXml() {
+    assertThat(
+        normalizer.normalizeForXml("anyText", VALID_ISO_8601_DATE_STRING),
+        is(equalTo(VALID_ISO_8601_DATE_STRING)));
+  }
+
+  @Test
+  public void testGoodPropertyNameCompoundDotOnceToXml() {
+    assertThat(
+        normalizer.normalizeForXml("metacard.version", VALID_ISO_8601_DATE_STRING),
+        is(equalTo(VALID_ISO_8601_DATE_STRING)));
+  }
+
+  @Test
+  public void testGoodPropertyNameCompoundDotTwiceToXml() {
+    assertThat(
+        normalizer.normalizeForXml("metacard.version.action", VALID_ISO_8601_DATE_STRING),
+        is(equalTo(VALID_ISO_8601_DATE_STRING)));
+  }
+
+  @Test
+  public void testGoodPropertyNameCompoundDashOnceToXml() {
+    assertThat(
+        normalizer.normalizeForXml("versioned-on", VALID_ISO_8601_DATE_STRING),
+        is(equalTo(VALID_ISO_8601_DATE_STRING)));
+  }
+
+  @Test
+  public void testGoodPropertyNameCompoundDashTwiceToXml() {
+    assertThat(
+        normalizer.normalizeForXml("versioned-not-after", VALID_ISO_8601_DATE_STRING),
+        is(equalTo(VALID_ISO_8601_DATE_STRING)));
+  }
+
+  @Test
+  public void testGoodPropertyNameCompoundBothToXml() {
+    assertThat(
+        normalizer.normalizeForXml("metacard.version.versioned-on", VALID_ISO_8601_DATE_STRING),
+        is(equalTo(VALID_ISO_8601_DATE_STRING)));
   }
 
   @Test(expected = FilterProcessingException.class)
@@ -210,5 +291,18 @@ public class AttributeValueNormalizerTest {
 
   private static AttributeDescriptor createDateDescriptor() {
     return new AttributeDescriptorImpl("created", true, true, true, false, BasicTypes.DATE_TYPE);
+  }
+
+  private static <T> void assertThrows(Class<T> clazz, Runnable op) {
+    boolean wasThrown = false;
+    try {
+      op.run();
+    } catch (Exception e) {
+      wasThrown = true;
+      assertThat(
+          "Thrown exception " + e.getClass() + " did not satisfy provided class " + clazz,
+          clazz.isAssignableFrom(e.getClass()));
+    }
+    assertThat("Runnable finished with no exception thrown", wasThrown);
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Relaxes attribute validation on search forms so that valid attributes do not keep a search form from getting saved. 

#### Background context
Forms XML structures in Solr have never had comprehensive validation to inform the UI when it's sending incompatible data. This means changes to the UI data structures were able to impact the persistence layer and potentially break the system when old data is read that no longer conformant to what the UI wants. 

Essentially, we had no systems to detect when we were putting ourselves in a migration situation (or near one), in particular for nested data (like forms XML) which get translated directly from UI data structures. 

In response, uni-directional validation was added to search forms which aggressively rejects bad data when persisting it, but provides a best effort attempt to read data without throwing errors. This validation coverage included but was not limited to: 
- Standardize the date format string for dates (UI used to use epoch but then swapped to ISO).
- Ensure attribute names are not malformed (a bug in the UI at one point led to attribute names getting persisted in double quotes).

Part of attribute validation involved writing a regex using the taxonomy guidelines as a basis:
https://codice.atlassian.net/wiki/spaces/CODICE/pages/77627393/Taxonomy+Guidelines

But in practice there are always exceptions to the rules: 
https://github.com/codice/ddf/blob/ddf-2.19.18/distribution/docs/src/main/resources/content/_metadataReference/history-attributes-table.adoc

Tweaking the regex ensures we're still validating but are now open to more variability in the attribute names. 

#### Who is reviewing it? 
#### Ask 2 committers to review/merge the PR and tag them here.
@brianfelix
@cassandrabailey293
@millerw8
@mojogitoverhere

#### How should this be tested?
Using the **DDF distribution** itself so the problematic attributes are not hidden, create search forms and ensure they save and get reloaded correctly, using attributes like the ones from this list:
https://github.com/codice/ddf/blob/ddf-2.19.18/distribution/docs/src/main/resources/content/_metadataReference/history-attributes-table.adoc

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
