### PR TITLE
CDM fix for binding system subject to thread

### DIFF
--- a/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
+++ b/catalog/core/catalog-core-directorymonitor/src/test/java/org/codice/ddf/catalog/content/monitor/ContentDirectoryMonitorTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 
 import ddf.catalog.data.AttributeRegistry;
+import ddf.security.audit.SecurityLogger;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -403,11 +404,12 @@ public class ContentDirectoryMonitorTest extends ExchangeTestSupport {
   }
 
   private ContentDirectoryMonitor createContentDirectoryMonitor() {
+    Security security = new Security();
+    security.setSecurityLogger(mock(SecurityLogger.class));
     ContentDirectoryMonitor monitor =
         new ContentDirectoryMonitor(
-            camelContext, mock(AttributeRegistry.class), 1, 1, Runnable::run, new Security());
+            camelContext, mock(AttributeRegistry.class), 1, 1, Runnable::run, security);
 
-    monitor.systemSubjectBinder = exchange -> {};
     monitor.setNumThreads(1);
     monitor.setReadLockIntervalMilliseconds(1000);
     return monitor;


### PR DESCRIPTION
#### What does this PR do?
Attache the system subject to the camel thread for CDM in a way that ensures it works regardless of the camel thread used to run the route.

#### Who is reviewing it? 
@jrnorth 
@kcover 


#### Ask 2 committers to review/merge the PR and tag them here.

@shaundmorris


#### How should this be tested?
Verify CDM still works

#### Any background context you want to provide?
In downstream projects using the cdm it was found that the system subject wasn't being attached to the camel thread running the cdm route when the thread wasn't the one that had initialized the route. 
