### PR TITLE
[2.26.x] Support startIndex in GetFeature requests on WFS 1.1.0

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -161,6 +161,11 @@
             <version>0.11.0</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
             <groupId>org.codice.ddf.spatial</groupId>
             <artifactId>spatial-wfs-metacardtype-registry-api</artifactId>
             <version>${project.version}</version>
@@ -226,7 +231,6 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            jaxb2-basics-runtime;version="0.11.0",
                             spatial-wfs-common,
                             spatial-wfs-v1_1_0-common,
                             spatial-wfs-source,
@@ -240,6 +244,7 @@
                         <Import-Package>
                             !org.bouncycastle.crypto.*,
                             net.opengis.filter.v_1_1_0;version="[${org.jvnet.ogc.wfs.1.1.0.version},${org.jvnet.ogc.wfs.1.1.0.version}]",
+                            org.jvnet.jaxb2_commons.*,
                             *
                         </Import-Package>
                         <Include-Resource>{maven-resources},target/classes/describable.properties</Include-Resource>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/ExtendedGetFeatureType.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/ExtendedGetFeatureType.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
+
+import java.math.BigInteger;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+import net.opengis.wfs.v_1_1_0.GetFeatureType;
+import org.jvnet.jaxb2_commons.lang.CopyStrategy2;
+import org.jvnet.jaxb2_commons.lang.CopyTo2;
+import org.jvnet.jaxb2_commons.lang.Equals2;
+import org.jvnet.jaxb2_commons.lang.EqualsStrategy2;
+import org.jvnet.jaxb2_commons.lang.HashCode2;
+import org.jvnet.jaxb2_commons.lang.HashCodeStrategy2;
+import org.jvnet.jaxb2_commons.lang.MergeFrom2;
+import org.jvnet.jaxb2_commons.lang.MergeStrategy2;
+import org.jvnet.jaxb2_commons.lang.ToString2;
+import org.jvnet.jaxb2_commons.lang.ToStringStrategy2;
+import org.jvnet.jaxb2_commons.locator.ObjectLocator;
+import org.jvnet.jaxb2_commons.locator.util.LocatorUtils;
+
+@XmlRootElement(namespace = "http://www.opengis.net/wfs", name = "GetFeature")
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "GetFeatureType")
+public class ExtendedGetFeatureType extends GetFeatureType
+    implements Cloneable, CopyTo2, Equals2, HashCode2, MergeFrom2, ToString2 {
+
+  @XmlAttribute(name = "startIndex")
+  @XmlSchemaType(name = "positiveInteger")
+  protected BigInteger startIndex;
+
+  /**
+   * Gets the value of the startIndex property.
+   *
+   * @return possible object is {@link BigInteger }
+   */
+  public BigInteger getStartIndex() {
+    return startIndex;
+  }
+
+  /**
+   * Sets the value of the startIndex property.
+   *
+   * @param value allowed object is {@link BigInteger }
+   */
+  public void setStartIndex(BigInteger value) {
+    this.startIndex = value;
+  }
+
+  public boolean isSetStartIndex() {
+    return (this.startIndex != null);
+  }
+
+  public StringBuilder appendFields(
+      ObjectLocator locator, StringBuilder buffer, ToStringStrategy2 strategy) {
+    super.appendFields(locator, buffer, strategy);
+    {
+      BigInteger theStartIndex;
+      theStartIndex = this.getStartIndex();
+      strategy.appendField(
+          locator, this, "startIndex", buffer, theStartIndex, this.isSetStartIndex());
+    }
+    return buffer;
+  }
+
+  public boolean equals(
+      ObjectLocator thisLocator,
+      ObjectLocator thatLocator,
+      Object object,
+      EqualsStrategy2 strategy) {
+    if ((object == null) || (this.getClass() != object.getClass())) {
+      return false;
+    }
+    if (this == object) {
+      return true;
+    }
+    if (!super.equals(thisLocator, thatLocator, object, strategy)) {
+      return false;
+    }
+    final ExtendedGetFeatureType that = ((ExtendedGetFeatureType) object);
+    {
+      BigInteger lhsStartIndex;
+      lhsStartIndex = this.getStartIndex();
+      BigInteger rhsStartIndex;
+      rhsStartIndex = that.getStartIndex();
+      if (!strategy.equals(
+          LocatorUtils.property(thisLocator, "startIndex", lhsStartIndex),
+          LocatorUtils.property(thatLocator, "startIndex", rhsStartIndex),
+          lhsStartIndex,
+          rhsStartIndex,
+          this.isSetStartIndex(),
+          that.isSetStartIndex())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public int hashCode(ObjectLocator locator, HashCodeStrategy2 strategy) {
+    int currentHashCode = super.hashCode(locator, strategy);
+    {
+      BigInteger theStartIndex;
+      theStartIndex = this.getStartIndex();
+      currentHashCode =
+          strategy.hashCode(
+              LocatorUtils.property(locator, "startIndex", theStartIndex),
+              currentHashCode,
+              theStartIndex,
+              this.isSetStartIndex());
+    }
+    return currentHashCode;
+  }
+
+  public Object copyTo(ObjectLocator locator, Object target, CopyStrategy2 strategy) {
+    final Object draftCopy = ((target == null) ? createNewInstance() : target);
+    super.copyTo(locator, draftCopy, strategy);
+    if (draftCopy instanceof ExtendedGetFeatureType) {
+      final ExtendedGetFeatureType copy = ((ExtendedGetFeatureType) draftCopy);
+      {
+        Boolean startIndexShouldBeCopiedAndSet =
+            strategy.shouldBeCopiedAndSet(locator, this.isSetStartIndex());
+        if (startIndexShouldBeCopiedAndSet == Boolean.TRUE) {
+          BigInteger sourceStartIndex;
+          sourceStartIndex = this.getStartIndex();
+          BigInteger copyStartIndex =
+              ((BigInteger)
+                  strategy.copy(
+                      LocatorUtils.property(locator, "startIndex", sourceStartIndex),
+                      sourceStartIndex,
+                      this.isSetStartIndex()));
+          copy.setStartIndex(copyStartIndex);
+        } else {
+          if (startIndexShouldBeCopiedAndSet == Boolean.FALSE) {
+            copy.startIndex = null;
+          }
+        }
+      }
+    }
+    return draftCopy;
+  }
+
+  public void mergeFrom(
+      ObjectLocator leftLocator,
+      ObjectLocator rightLocator,
+      Object left,
+      Object right,
+      MergeStrategy2 strategy) {
+    super.mergeFrom(leftLocator, rightLocator, left, right, strategy);
+    if (right instanceof ExtendedGetFeatureType) {
+      final ExtendedGetFeatureType target = this;
+      final ExtendedGetFeatureType leftObject = ((ExtendedGetFeatureType) left);
+      final ExtendedGetFeatureType rightObject = ((ExtendedGetFeatureType) right);
+      {
+        Boolean startIndexShouldBeMergedAndSet =
+            strategy.shouldBeMergedAndSet(
+                leftLocator,
+                rightLocator,
+                leftObject.isSetStartIndex(),
+                rightObject.isSetStartIndex());
+        if (startIndexShouldBeMergedAndSet == Boolean.TRUE) {
+          BigInteger lhsStartIndex;
+          lhsStartIndex = leftObject.getStartIndex();
+          BigInteger rhsStartIndex;
+          rhsStartIndex = rightObject.getStartIndex();
+          BigInteger mergedStartIndex =
+              ((BigInteger)
+                  strategy.merge(
+                      LocatorUtils.property(leftLocator, "startIndex", lhsStartIndex),
+                      LocatorUtils.property(rightLocator, "startIndex", rhsStartIndex),
+                      lhsStartIndex,
+                      rhsStartIndex,
+                      leftObject.isSetStartIndex(),
+                      rightObject.isSetStartIndex()));
+          target.setStartIndex(mergedStartIndex);
+        } else {
+          if (startIndexShouldBeMergedAndSet == Boolean.FALSE) {
+            target.startIndex = null;
+          }
+        }
+      }
+    }
+  }
+
+  public GetFeatureType withStartIndex(BigInteger value) {
+    setStartIndex(value);
+    return this;
+  }
+}

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/ExtendedWfs.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/ExtendedWfs.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.v110.catalog.source;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import net.opengis.wfs.v_1_1_0.DescribeFeatureTypeType;
+import net.opengis.wfs.v_1_1_0.GetCapabilitiesType;
+import net.opengis.wfs.v_1_1_0.WFSCapabilitiesType;
+import org.apache.ws.commons.schema.XmlSchema;
+import org.codice.ddf.spatial.ogc.wfs.catalog.WfsFeatureCollection;
+import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsException;
+import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.DescribeFeatureTypeRequest;
+import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.GetCapabilitiesRequest;
+
+/** JAX-RS Interface to define a WFS server. Supports startIndex for GetFeature. */
+@Path("/")
+public interface ExtendedWfs {
+
+  /** GetCapabilites - HTTP GET */
+  @GET
+  @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+  WFSCapabilitiesType getCapabilities(@QueryParam("") GetCapabilitiesRequest request)
+      throws WfsException;
+
+  /** GetCapabilites - HTTP POST */
+  @POST
+  @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+  @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+  WFSCapabilitiesType getCapabilities(GetCapabilitiesType getCapabilitesRequest)
+      throws WfsException;
+
+  /** DescribeFeatureType - HTTP GET */
+  @GET
+  @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+  XmlSchema describeFeatureType(@QueryParam("") DescribeFeatureTypeRequest request)
+      throws WfsException;
+
+  /** DescribeFeatureType - HTTP POST */
+  @POST
+  @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+  @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+  XmlSchema describeFeatureType(DescribeFeatureTypeType describeFeatureRequest) throws WfsException;
+
+  /** GetFeature */
+  @POST
+  @Consumes({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+  @Produces({MediaType.TEXT_XML, MediaType.APPLICATION_XML})
+  WfsFeatureCollection getFeature(ExtendedGetFeatureType getFeature) throws WfsException;
+}

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -107,7 +107,6 @@ import org.codice.ddf.spatial.ogc.wfs.featuretransformer.FeatureTransformationSe
 import org.codice.ddf.spatial.ogc.wfs.featuretransformer.WfsMetadata;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.DescribeFeatureTypeRequest;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.GetCapabilitiesRequest;
-import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs11Constants;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.source.reader.XmlSchemaMessageBodyReaderWfs11;
 import org.opengis.filter.sort.SortBy;
@@ -226,7 +225,7 @@ public class WfsSource extends AbstractWfsSource {
 
   private Set<SourceMonitor> sourceMonitors = new HashSet<>();
 
-  private SecureCxfClientFactory<Wfs> factory;
+  private SecureCxfClientFactory<ExtendedWfs> factory;
 
   private String configurationPid;
 
@@ -256,6 +255,9 @@ public class WfsSource extends AbstractWfsSource {
 
   private static final String DISABLE_SORTING = "disableSorting";
   private boolean disableSorting;
+
+  private static final String SUPPORTS_START_INDEX = "supportsStartIndex";
+  private boolean supportsStartIndex = Boolean.FALSE;
 
   static {
     try (InputStream properties =
@@ -337,6 +339,7 @@ public class WfsSource extends AbstractWfsSource {
     setSingleChar((Character) configuration.get(SINGLE_CHAR_KEY));
     setEscapeChar((Character) configuration.get(ESCAPE_CHAR_KEY));
     setDisableSorting((Boolean) configuration.get(DISABLE_SORTING));
+    setSupportsStartIndex((Boolean) configuration.get(SUPPORTS_START_INDEX));
 
     createClientFactory();
     configureWfsFeatures();
@@ -357,14 +360,14 @@ public class WfsSource extends AbstractWfsSource {
 
   /** This method should only be called after all properties have been set. */
   private void createClientFactory() {
-    ClientBuilder<Wfs> clientBuilder = clientBuilderFactory.getClientBuilder();
+    ClientBuilder<ExtendedWfs> clientBuilder = clientBuilderFactory.getClientBuilder();
     if (BASIC.equals(authenticationType)
         && StringUtils.isNotBlank(username)
         && StringUtils.isNotBlank(password)) {
       factory =
           clientBuilder
               .endpoint(wfsUrl)
-              .interfaceClass(Wfs.class)
+              .interfaceClass(ExtendedWfs.class)
               .entityProviders(initProviders())
               .interceptor(new MarkableStreamInterceptor())
               .disableCnCheck(disableCnCheck)
@@ -380,7 +383,7 @@ public class WfsSource extends AbstractWfsSource {
       factory =
           clientBuilder
               .endpoint(wfsUrl)
-              .interfaceClass(Wfs.class)
+              .interfaceClass(ExtendedWfs.class)
               .entityProviders(initProviders())
               .interceptor(new MarkableStreamInterceptor())
               .disableCnCheck(disableCnCheck)
@@ -395,7 +398,7 @@ public class WfsSource extends AbstractWfsSource {
       factory =
           clientBuilder
               .endpoint(wfsUrl)
-              .interfaceClass(Wfs.class)
+              .interfaceClass(ExtendedWfs.class)
               .entityProviders(initProviders())
               .interceptor(new MarkableStreamInterceptor())
               .disableCnCheck(disableCnCheck)
@@ -410,13 +413,13 @@ public class WfsSource extends AbstractWfsSource {
   private List<?> initProviders() {
     // We need to tell the JAXBElementProvider to marshal the GetFeatureType
     // class as an element because it is missing the @XmlRootElement Annotation
-    JAXBElementProvider<GetFeatureType> provider = new JAXBElementProvider<>();
+    JAXBElementProvider<ExtendedGetFeatureType> provider = new JAXBElementProvider<>();
     Map<String, String> jaxbClassMap = new HashMap<>();
 
     // Ensure a namespace is used when the GetFeature request is generated
     String expandedName =
         new QName(Wfs11Constants.WFS_NAMESPACE, Wfs11Constants.GET_FEATURE).toString();
-    jaxbClassMap.put(GetFeatureType.class.getName(), expandedName);
+    jaxbClassMap.put(ExtendedGetFeatureType.class.getName(), expandedName);
     provider.setJaxbElementClassMap(jaxbClassMap);
     provider.setMarshallAsJaxbElement(true);
 
@@ -456,7 +459,7 @@ public class WfsSource extends AbstractWfsSource {
 
   private WFSCapabilitiesType getCapabilities() {
     WFSCapabilitiesType capabilities = null;
-    Wfs wfs = factory.getClient();
+    ExtendedWfs wfs = factory.getClient();
     try {
       capabilities = wfs.getCapabilities(new GetCapabilitiesRequest());
     } catch (WfsException wfse) {
@@ -514,7 +517,7 @@ public class WfsSource extends AbstractWfsSource {
   }
 
   private void buildFeatureFilters(List<FeatureTypeType> featureTypes, List<String> supportedGeo) {
-    Wfs wfs = factory.getClient();
+    ExtendedWfs wfs = factory.getClient();
 
     // Use local Map for metacardtype registrations and once they are populated with latest
     // MetacardTypes, then do actual registration
@@ -660,7 +663,7 @@ public class WfsSource extends AbstractWfsSource {
 
   @Override
   public SourceResponse query(QueryRequest request) throws UnsupportedQueryException {
-    Wfs wfs = factory.getClient();
+    ExtendedWfs wfs = factory.getClient();
 
     Query query = request.getQuery();
     LOGGER.debug("WFS Source {}: Received query: \n{}", getId(), query);
@@ -672,22 +675,25 @@ public class WfsSource extends AbstractWfsSource {
               + "]");
     }
 
+    Query modifiedQuery;
     int origPageSize = query.getPageSize();
     if (origPageSize <= 0 || origPageSize > WFS_MAX_FEATURES_RETURNED) {
       origPageSize = WFS_MAX_FEATURES_RETURNED;
     }
-
-    QueryImpl modifiedQuery =
-        new QueryImpl(query, 1, Constants.DEFAULT_PAGE_SIZE, query.getSortBy(), false, 300000L);
-
     int pageNumber = query.getStartIndex() / origPageSize + 1;
+    if (!supportsStartIndex) {
+      modifiedQuery =
+          new QueryImpl(query, 1, Constants.DEFAULT_PAGE_SIZE, query.getSortBy(), false, 300000L);
 
-    int modifiedPageSize = Math.min(pageNumber * origPageSize, WFS_MAX_FEATURES_RETURNED);
-    LOGGER.debug("WFS Source {}: modified page size = {}", getId(), modifiedPageSize);
-    modifiedQuery.setPageSize(modifiedPageSize);
+      int modifiedPageSize = Math.min(pageNumber * origPageSize, WFS_MAX_FEATURES_RETURNED);
+      LOGGER.debug("WFS Source {}: modified page size = {}", getId(), modifiedPageSize);
+      ((QueryImpl) modifiedQuery).setPageSize(modifiedPageSize);
+    } else {
+      modifiedQuery = query;
+    }
 
-    final GetFeatureType getHits = buildGetFeatureRequestHits(modifiedQuery);
-    final GetFeatureType getResults = buildGetFeatureRequestResults(modifiedQuery);
+    final ExtendedGetFeatureType getHits = buildGetFeatureRequestHits(modifiedQuery);
+    final ExtendedGetFeatureType getResults = buildGetFeatureRequestResults(modifiedQuery);
 
     try {
       LOGGER.debug("WFS Source {}: Getting hits.", getId());
@@ -708,33 +714,39 @@ public class WfsSource extends AbstractWfsSource {
           getId(),
           featureCollection.getFeatureMembers().size());
 
-      // Only return the number of results originally asked for in the
-      // query, or the entire list of results if it is smaller than the
-      // original page size.
-      int numberOfResultsToReturn =
-          Math.min(origPageSize, featureCollection.getFeatureMembers().size());
-      List<Result> results = new ArrayList<>(numberOfResultsToReturn);
-
-      int stopIndex =
-          Math.min(
-              origPageSize + query.getStartIndex(),
-              featureCollection.getFeatureMembers().size() + 1);
-
       LOGGER.debug(
-          "WFS Source {}: startIndex = {}, stopIndex = {}, origPageSize = {}, pageNumber = {}",
+          "WFS Source {}: startIndex = {}, origPageSize = {}, pageNumber = {}",
           getId(),
           query.getStartIndex(),
-          stopIndex,
           origPageSize,
           pageNumber);
 
-      for (int i = query.getStartIndex(); i < stopIndex; i++) {
-        Metacard mc = featureCollection.getFeatureMembers().get(i - 1);
-        mc = transform(mc, DEFAULT_WFS_TRANSFORMER_ID);
-        Result result = new ResultImpl(mc);
-        results.add(result);
-        debugResult(result);
+      List<Result> results;
+      if (supportsStartIndex) {
+        results = new ArrayList<>(featureCollection.getFeatureMembers().size());
+        for (Metacard mc : featureCollection.getFeatureMembers()) {
+          addTransformedResult(mc, results);
+        }
+      } else {
+        // Only return the number of results originally asked for in the
+        // query, or the entire list of results if it is smaller than the
+        // original page size.
+        int numberOfResultsToReturn =
+            Math.min(origPageSize, featureCollection.getFeatureMembers().size());
+        results = new ArrayList<>(numberOfResultsToReturn);
+
+        int stopIndex =
+            Math.min(
+                origPageSize + query.getStartIndex(),
+                featureCollection.getFeatureMembers().size() + 1);
+        LOGGER.debug("WFS Source {}: stopIndex = {}", getId(), stopIndex);
+
+        for (int i = query.getStartIndex(); i < stopIndex; i++) {
+          Metacard mc = featureCollection.getFeatureMembers().get(i - 1);
+          addTransformedResult(mc, results);
+        }
       }
+
       return new SourceResponseImpl(request, results, totalHits);
     } catch (WfsException wfse) {
       LOGGER.debug(WFS_ERROR_MESSAGE, wfse);
@@ -745,18 +757,25 @@ public class WfsSource extends AbstractWfsSource {
     }
   }
 
-  private GetFeatureType buildGetFeatureRequestHits(final Query query)
+  private void addTransformedResult(Metacard mc, List<Result> results) {
+    mc = transform(mc, DEFAULT_WFS_TRANSFORMER_ID);
+    Result result = new ResultImpl(mc);
+    results.add(result);
+    debugResult(result);
+  }
+
+  private ExtendedGetFeatureType buildGetFeatureRequestHits(final Query query)
       throws UnsupportedQueryException {
     return buildGetFeatureRequest(query, ResultTypeType.HITS, null);
   }
 
-  private GetFeatureType buildGetFeatureRequestResults(final Query query)
+  private ExtendedGetFeatureType buildGetFeatureRequestResults(final Query query)
       throws UnsupportedQueryException {
     return buildGetFeatureRequest(
         query, ResultTypeType.RESULTS, BigInteger.valueOf(query.getPageSize()));
   }
 
-  private GetFeatureType buildGetFeatureRequest(
+  private ExtendedGetFeatureType buildGetFeatureRequest(
       Query query, ResultTypeType resultType, BigInteger maxFeatures)
       throws UnsupportedQueryException {
     List<ContentType> contentTypes = getContentTypesFromQuery(query);
@@ -805,12 +824,15 @@ public class WfsSource extends AbstractWfsSource {
       }
     }
     if (!queries.isEmpty()) {
-      GetFeatureType getFeatureType = new GetFeatureType();
+      ExtendedGetFeatureType getFeatureType = new ExtendedGetFeatureType();
       getFeatureType.setMaxFeatures(maxFeatures);
       getFeatureType.getQuery().addAll(queries);
       getFeatureType.setService(Wfs11Constants.WFS);
       getFeatureType.setVersion(Wfs11Constants.VERSION_1_1_0);
       getFeatureType.setResultType(resultType);
+      if (supportsStartIndex && resultType.equals(ResultTypeType.RESULTS)) {
+        getFeatureType.setStartIndex(BigInteger.valueOf(query.getStartIndex()));
+      }
       logMessage(getFeatureType);
       return getFeatureType;
     } else {
@@ -1178,6 +1200,10 @@ public class WfsSource extends AbstractWfsSource {
 
   public void setDisableSorting(final Boolean disableSorting) {
     this.disableSorting = disableSorting;
+  }
+
+  public void setSupportsStartIndex(final Boolean supportsStartIndex) {
+    this.supportsStartIndex = supportsStartIndex;
   }
 
   @Override

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -80,6 +80,7 @@
             <property name="metacardMappers" ref="metacardMappers"/>
             <property name="srsName" value="EPSG:4326"/>
             <property name="disableSorting" value="true"/>
+            <property name="supportsStartIndex" value="false"/>
 
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -91,6 +91,9 @@
         <AD description="When selected, the system will not specify sort criteria with the query.  This should only be used if the remote source is unable to handle sorting."
             name="Disable Sorting" id="disableSorting" required="true"
             type="Boolean" default="true"/>
+        <AD description="Some WFS 1.1.0 servers like Geoserver support startIndex in queries. This enables efficient deep paging."
+            name="Supports startIndex" id="supportsStartIndex" required="false"
+            type="Boolean" default="false"/>
     </OCD>
 
     <Designate pid="Wfs_v110_Federated_Source" factoryPid="Wfs_v110_Federated_Source">

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -86,7 +86,6 @@ import net.opengis.filter.v_1_1_0.SpatialOpsType;
 import net.opengis.gml.v_3_1_1.PointType;
 import net.opengis.wfs.v_1_1_0.FeatureTypeListType;
 import net.opengis.wfs.v_1_1_0.FeatureTypeType;
-import net.opengis.wfs.v_1_1_0.GetFeatureType;
 import net.opengis.wfs.v_1_1_0.QueryType;
 import net.opengis.wfs.v_1_1_0.ResultTypeType;
 import net.opengis.wfs.v_1_1_0.WFSCapabilitiesType;
@@ -107,7 +106,6 @@ import org.codice.ddf.spatial.ogc.wfs.catalog.metacardtype.registry.WfsMetacardT
 import org.codice.ddf.spatial.ogc.wfs.catalog.source.WfsUriResolver;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.DescribeFeatureTypeRequest;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.GetCapabilitiesRequest;
-import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs;
 import org.codice.ddf.spatial.ogc.wfs.v110.catalog.common.Wfs11Constants;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -256,7 +254,7 @@ public class WfsSourceTest {
 
   private final GeotoolsFilterBuilder builder = new GeotoolsFilterBuilder();
 
-  private Wfs mockWfs = mock(Wfs.class);
+  private ExtendedWfs mockWfs = mock(ExtendedWfs.class);
 
   private WFSCapabilitiesType mockCapabilities = new WFSCapabilitiesType();
 
@@ -293,23 +291,23 @@ public class WfsSourceTest {
       final List<String> supportedGeos, final String srsName, final int results, final int hits)
       throws WfsException {
 
-    SecureCxfClientFactory<Wfs> mockFactory = mock(SecureCxfClientFactory.class);
+    SecureCxfClientFactory<ExtendedWfs> mockFactory = mock(SecureCxfClientFactory.class);
     when(mockFactory.getClient()).thenReturn(mockWfs);
 
     clientBuilderFactory = mock(ClientBuilderFactory.class);
-    ClientBuilder<Wfs> clientBuilder =
-        new ClientBuilderImpl<Wfs>(
+    ClientBuilder<ExtendedWfs> clientBuilder =
+        new ClientBuilderImpl<ExtendedWfs>(
             mock(OAuthSecurity.class),
             mock(SamlSecurity.class),
             mock(SecurityLogger.class),
             mock(SecurityManager.class)) {
           @Override
-          public SecureCxfClientFactory<Wfs> build() {
+          public SecureCxfClientFactory<ExtendedWfs> build() {
             return mockFactory;
           }
         };
 
-    when(clientBuilderFactory.<Wfs>getClientBuilder()).thenReturn(clientBuilder);
+    when(clientBuilderFactory.<ExtendedWfs>getClientBuilder()).thenReturn(clientBuilder);
 
     // GetCapabilities Response
     when(mockWfs.getCapabilities(any(GetCapabilitiesRequest.class))).thenReturn(mockCapabilities);
@@ -380,6 +378,7 @@ public class WfsSourceTest {
     source.setMetacardMappers(metacardMappers);
     source.setPollInterval(10);
     source.setWfsUrl(SAMPLE_WFS_URL);
+    source.setSupportsStartIndex(false);
     source.init();
   }
 
@@ -408,12 +407,13 @@ public class WfsSourceTest {
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     propertyIsLikeQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
 
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, propertyIsLikeQuery);
     assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
     QueryType query = getFeatureType.getQuery().get(0);
@@ -431,11 +431,12 @@ public class WfsSourceTest {
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text(LITERAL));
     propertyIsLikeQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, propertyIsLikeQuery);
     assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
     QueryType query = getFeatureType.getQuery().get(0);
@@ -460,11 +461,12 @@ public class WfsSourceTest {
         new QueryImpl(builder.allOf(propertyIsLikeFilter, contentTypeFilter));
     propertyIsLikeQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, propertyIsLikeQuery);
     assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
     QueryType query = getFeatureType.getQuery().get(0);
@@ -489,11 +491,12 @@ public class WfsSourceTest {
 
     propertyIsLikeQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, propertyIsLikeQuery);
     assertThat(ONE_FEATURE, is(getFeatureType.getQuery().size()));
     assertThat(sampleFeatures.get(0), is(getFeatureType.getQuery().get(0).getTypeName().get(0)));
@@ -521,11 +524,12 @@ public class WfsSourceTest {
 
     twoContentTypeQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(twoContentTypeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, twoContentTypeQuery);
     getFeatureType.getQuery().sort(QUERY_TYPE_COMPARATOR);
     assertThat(TWO_FEATURES, is(getFeatureType.getQuery().size()));
@@ -543,11 +547,12 @@ public class WfsSourceTest {
         new QueryImpl(builder.allOf(propertyIsLikeFilter, contentTypeFilter));
     propertyIsLikeQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, propertyIsLikeQuery);
     assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
     QueryType query = getFeatureType.getQuery().get(0);
@@ -565,11 +570,12 @@ public class WfsSourceTest {
     QueryImpl intersectQuery = new QueryImpl(intersectFilter);
     intersectQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(intersectQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, intersectQuery);
     assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
     QueryType query = getFeatureType.getQuery().get(0);
@@ -587,11 +593,12 @@ public class WfsSourceTest {
     QueryImpl intersectQuery = new QueryImpl(intersectFilter);
     intersectQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(intersectQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, intersectQuery);
     assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
     QueryType query = getFeatureType.getQuery().get(0);
@@ -611,11 +618,12 @@ public class WfsSourceTest {
     QueryImpl intersectQuery = new QueryImpl(intersectFilter);
     intersectQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(intersectQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, intersectQuery);
     assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
     QueryType query = getFeatureType.getQuery().get(0);
@@ -633,11 +641,12 @@ public class WfsSourceTest {
     QueryImpl intersectQuery = new QueryImpl(intersectFilter);
     intersectQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(intersectQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, intersectQuery);
     assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
     QueryType query = getFeatureType.getQuery().get(0);
@@ -666,11 +675,12 @@ public class WfsSourceTest {
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text(LITERAL));
     propertyIsLikeQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, propertyIsLikeQuery);
     assertThat(getFeatureType.getQuery().size(), is(TWO_FEATURES));
     Collections.sort(getFeatureType.getQuery(), QUERY_TYPE_COMPARATOR);
@@ -919,6 +929,37 @@ public class WfsSourceTest {
   }
 
   @Test
+  public void testPagingToSecondPageWithStartIndex() throws Exception {
+    int pageSize = 4;
+    int startIndex = 5;
+
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, MAX_FEATURES);
+    setUpMocks(null, null, pageSize, MAX_FEATURES);
+
+    List<Metacard> metacards = new ArrayList<>(pageSize);
+    for (int i = startIndex; i < startIndex + pageSize; i++) {
+      MetacardImpl mc = new MetacardImpl();
+      mc.setId("ID_" + i);
+      metacards.add(mc);
+    }
+
+    when(mockWfs.getFeature(withResultType(ResultTypeType.HITS)))
+        .thenReturn(new WfsFeatureCollectionImpl(MAX_FEATURES));
+    when(mockWfs.getFeature(hasStartIndex()))
+        .thenReturn(new WfsFeatureCollectionImpl(pageSize, metacards));
+
+    source.setSupportsStartIndex(true);
+
+    SourceResponse response = executeQuery(startIndex, pageSize);
+    List<Result> results = response.getResults();
+
+    assertThat(response.getHits(), equalTo((long) MAX_FEATURES));
+
+    // Verify that metacards 5 thru 8 were returned
+    assertCorrectMetacardsReturned(results, startIndex, pageSize);
+  }
+
+  @Test
   public void testGetContentTypes() throws Exception {
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, TWO_FEATURES);
     setUpMocks(null, null, TWO_FEATURES, TWO_FEATURES);
@@ -959,11 +1000,12 @@ public class WfsSourceTest {
     QueryImpl inQuery = new QueryImpl(totalFilter);
     inQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(inQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, inQuery);
 
     List<QueryType> filterQueries =
@@ -1008,11 +1050,12 @@ public class WfsSourceTest {
     QueryImpl inQuery = new QueryImpl(totalFilter);
     inQuery.setPageSize(MAX_FEATURES);
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(inQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, inQuery);
     getFeatureType.getQuery().sort(QUERY_TYPE_COMPARATOR);
     assertThat(TWO_FEATURES, is(getFeatureType.getQuery().size()));
@@ -1045,11 +1088,12 @@ public class WfsSourceTest {
 
     QueryImpl idQuery = new QueryImpl(builder.attribute(Core.ID).is().text(ORDER_PERSON));
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(idQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertThat(ONE_FEATURE, is(getFeatureType.getQuery().get(0).getFilter().getId().size()));
 
     assertThat(
@@ -1069,11 +1113,12 @@ public class WfsSourceTest {
 
     QueryImpl twoIDQuery = new QueryImpl(builder.anyOf(Arrays.asList(idFilter1, idFilter2)));
 
-    ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(twoIDQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertThat(TWO_FEATURES, is(getFeatureType.getQuery().get(0).getFilter().getId().size()));
 
     assertThat(
@@ -1143,11 +1188,11 @@ public class WfsSourceTest {
     final QueryRequest queryRequest = new QueryRequestImpl(query);
     source.query(queryRequest);
 
-    final ArgumentCaptor<GetFeatureType> getFeatureCaptor =
-        ArgumentCaptor.forClass(GetFeatureType.class);
+    final ArgumentCaptor<ExtendedGetFeatureType> getFeatureCaptor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     verify(mockWfs, times(2)).getFeature(getFeatureCaptor.capture());
 
-    GetFeatureType getFeatureType = getFeatureCaptor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = getFeatureCaptor.getAllValues().get(1);
     final String getFeatureXml = marshal(getFeatureType);
     assertThat(
         getFeatureXml,
@@ -1204,6 +1249,7 @@ public class WfsSourceTest {
             .put("receiveTimeout", receiveTimeout)
             .put("pollInterval", 1)
             .put("disableSorting", false)
+            .put("supportsStartIndex", false)
             .build();
     source.refresh(configuration);
 
@@ -1239,6 +1285,7 @@ public class WfsSourceTest {
             .put("receiveTimeout", receiveTimeout)
             .put("pollInterval", 1)
             .put("disableSorting", false)
+            .put("supportsStartIndex", false)
             .build();
     source.refresh(configuration);
 
@@ -1267,6 +1314,7 @@ public class WfsSourceTest {
             .put("receiveTimeout", receiveTimeout)
             .put("pollInterval", 1)
             .put("disableSorting", false)
+            .put("supportsStartIndex", false)
             .build();
     source.refresh(configuration);
 
@@ -1289,6 +1337,7 @@ public class WfsSourceTest {
             .put("disableCnCheck", false)
             .put("pollInterval", 1)
             .put("disableSorting", false)
+            .put("supportsStartIndex", false)
             .build();
     source.refresh(configuration);
 
@@ -1296,11 +1345,12 @@ public class WfsSourceTest {
         builder.attribute(Metacard.ANY_GEO).is().withinBuffer().wkt(POINT_WKT, 10.0);
     final Query withinQuery = new QueryImpl(withinFilter);
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    final ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(withinQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertThat(getFeatureType.getQuery(), hasSize(1));
 
     final QueryType query = getFeatureType.getQuery().get(0);
@@ -1331,6 +1381,7 @@ public class WfsSourceTest {
             .put("disableCnCheck", false)
             .put("pollInterval", 1)
             .put("disableSorting", false)
+            .put("supportsStartIndex", false)
             .build();
     source.refresh(configuration);
 
@@ -1338,11 +1389,12 @@ public class WfsSourceTest {
         builder.attribute(Metacard.ANY_GEO).is().withinBuffer().wkt(POINT_WKT, 10.0);
     final Query withinQuery = new QueryImpl(withinFilter);
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    final ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(withinQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    GetFeatureType getFeatureType = captor.getAllValues().get(1);
+    ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertThat(getFeatureType.getQuery(), hasSize(1));
 
     final QueryType query = getFeatureType.getQuery().get(0);
@@ -1365,20 +1417,21 @@ public class WfsSourceTest {
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     propertyIsLikeQuery.setPageSize(MAX_FEATURES);
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    final ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
 
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    final GetFeatureType getHits = captor.getAllValues().get(0);
+    final ExtendedGetFeatureType getHits = captor.getAllValues().get(0);
     assertThat(getHits.getResultType(), is(ResultTypeType.HITS));
     assertThat(getHits.getMaxFeatures(), is(nullValue()));
 
-    final GetFeatureType getResults = captor.getAllValues().get(1);
+    final ExtendedGetFeatureType getResults = captor.getAllValues().get(1);
     assertThat(getResults.getResultType(), is(ResultTypeType.RESULTS));
     assertMaxFeatures(getResults, propertyIsLikeQuery);
 
-    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+    for (final ExtendedGetFeatureType getFeatureType : captor.getAllValues()) {
       assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
       final QueryType query = getFeatureType.getQuery().get(0);
       assertThat(query.getTypeName().get(0), is(sampleFeatures.get(0)));
@@ -1398,13 +1451,14 @@ public class WfsSourceTest {
         new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
     propertyIsLikeQuery.setPageSize(1);
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    final ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    final GetFeatureType getResults = captor.getAllValues().get(1);
+    final ExtendedGetFeatureType getResults = captor.getAllValues().get(1);
     assertThat(getResults.getResultType(), is(ResultTypeType.RESULTS));
-    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+    for (final ExtendedGetFeatureType getFeatureType : captor.getAllValues()) {
       assertThat(getFeatureType.getQuery().size(), is(ONE_FEATURE));
       final QueryType queryType = getFeatureType.getQuery().get(0);
       assertThat(queryType.isSetSortBy(), is(false));
@@ -1431,11 +1485,12 @@ public class WfsSourceTest {
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.ASCENDING));
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    final ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+    for (final ExtendedGetFeatureType getFeatureType : captor.getAllValues()) {
       assertFeature(getFeatureType, true, MOCK_TEMPORAL_SORT_PROPERTY, "ASC");
     }
   }
@@ -1451,11 +1506,12 @@ public class WfsSourceTest {
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.DESCENDING));
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    final ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+    for (final ExtendedGetFeatureType getFeatureType : captor.getAllValues()) {
       assertFeature(getFeatureType, true, MOCK_TEMPORAL_SORT_PROPERTY, "DESC");
     }
   }
@@ -1472,11 +1528,12 @@ public class WfsSourceTest {
     source.setDisableSorting(true);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, SortOrder.ASCENDING));
 
-    final ArgumentCaptor<GetFeatureType> captor = ArgumentCaptor.forClass(GetFeatureType.class);
+    final ArgumentCaptor<ExtendedGetFeatureType> captor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
     verify(mockWfs, times(2)).getFeature(captor.capture());
 
-    for (final GetFeatureType getFeatureType : captor.getAllValues()) {
+    for (final ExtendedGetFeatureType getFeatureType : captor.getAllValues()) {
       assertFeature(getFeatureType, false, MOCK_TEMPORAL_SORT_PROPERTY, "ASC");
     }
   }
@@ -1557,7 +1614,7 @@ public class WfsSourceTest {
   }
 
   private void assertFeature(
-      GetFeatureType getFeatureType,
+      ExtendedGetFeatureType getFeatureType,
       boolean sortingEnabled,
       String sortProperty,
       String sortOrder) {
@@ -1600,7 +1657,7 @@ public class WfsSourceTest {
     return source.query(request);
   }
 
-  private void assertMaxFeatures(GetFeatureType getFeatureType, Query inQuery) {
+  private void assertMaxFeatures(ExtendedGetFeatureType getFeatureType, Query inQuery) {
     int pageSize = (inQuery.getStartIndex() / MAX_FEATURES + 1) * inQuery.getPageSize();
     assertThat(getFeatureType.getMaxFeatures(), is(BigInteger.valueOf(pageSize)));
   }
@@ -1615,18 +1672,18 @@ public class WfsSourceTest {
     }
   }
 
-  private String marshal(final GetFeatureType getFeatureType) throws JAXBException {
+  private String marshal(final ExtendedGetFeatureType getFeatureType) throws JAXBException {
     Writer writer = new StringWriter();
     Marshaller marshaller = jaxbContext.createMarshaller();
     marshaller.marshal(getGetFeatureTypeJaxbElement(getFeatureType), writer);
     return writer.toString();
   }
 
-  private JAXBElement<GetFeatureType> getGetFeatureTypeJaxbElement(
-      final GetFeatureType getFeatureType) {
+  private JAXBElement<ExtendedGetFeatureType> getGetFeatureTypeJaxbElement(
+      final ExtendedGetFeatureType getFeatureType) {
     return new JAXBElement<>(
         new QName("http://www.opengis.net/wfs", "GetFeature"),
-        GetFeatureType.class,
+        ExtendedGetFeatureType.class,
         getFeatureType);
   }
 
@@ -1675,12 +1732,12 @@ public class WfsSourceTest {
     }
   }
 
-  private static GetFeatureType withResultType(final ResultTypeType resultType) {
+  private static ExtendedGetFeatureType withResultType(final ResultTypeType resultType) {
     return argThat(new IsGetFeatureRequestWithResultType(resultType));
   }
 
   private static class IsGetFeatureRequestWithResultType
-      implements ArgumentMatcher<GetFeatureType> {
+      implements ArgumentMatcher<ExtendedGetFeatureType> {
     private final ResultTypeType resultType;
 
     private IsGetFeatureRequestWithResultType(final ResultTypeType resultType) {
@@ -1688,8 +1745,27 @@ public class WfsSourceTest {
     }
 
     @Override
-    public boolean matches(final GetFeatureType featureType) {
-      return featureType != null && Objects.equals(featureType.getResultType(), resultType);
+    public boolean matches(final ExtendedGetFeatureType featureType) {
+      return featureType != null
+          && Objects.equals(featureType.getResultType(), resultType)
+          && !featureType.isSetStartIndex()
+          && featureType.startIndex == null;
+    }
+  }
+
+  private static ExtendedGetFeatureType hasStartIndex() {
+    return argThat(new IsGetFeatureRequestWithStartIndex());
+  }
+
+  private static class IsGetFeatureRequestWithStartIndex
+      implements ArgumentMatcher<ExtendedGetFeatureType> {
+
+    @Override
+    public boolean matches(final ExtendedGetFeatureType featureType) {
+      return featureType != null
+          && Objects.equals(featureType.getResultType(), ResultTypeType.RESULTS)
+          && featureType.isSetStartIndex()
+          && featureType.startIndex.intValue() > 0;
     }
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Adds configuration to enable `startIndex` and deep paging on `GetFeature` requests for WFS 1.1 servers that support it like Geoserver.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@derekwilhelm 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->
@jlcsmith 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

- Setup Geoserver with test data with over 1000 results. 
- Configure a WFS 1.1.0 source for that Geoserver. 
- Set the `supportsStartIndex` config option. 
- Verify you can page past 1000 results.
- Disable the `supportsStartIndex` config option. 
- Verify you can page up to 1000 results but fails past 1000.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: n/a

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
