### PR TITLE
[2.26.x] DDF-4729 Handles WFS sortBy null property

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -794,7 +794,10 @@ public class WfsSource extends AbstractWfsSource {
           if (areAnyFiltersSet(filter)) {
             wfsQuery.setFilter(filter);
           }
-          if (!this.disableSorting && query.getSortBy() != null) {
+          if (!this.disableSorting
+              && query.getSortBy() != null
+              && query.getSortBy().getPropertyName() != null
+              && query.getSortBy().getPropertyName().getPropertyName() != null) {
             SortByType sortByType = buildSortBy(filterDelegateEntry.getKey(), query.getSortBy());
             if (sortByType != null
                 && sortByType.getSortProperty() != null
@@ -809,12 +812,10 @@ public class WfsSource extends AbstractWfsSource {
                   "Source "
                       + this.getId()
                       + " does not support specified sort property "
-                      + query.getSortBy().getPropertyName().getPropertyName()
-                      + " with sort order "
-                      + query.getSortBy().getSortOrder());
+                      + query.getSortBy().getPropertyName().getPropertyName());
             }
           } else {
-            LOGGER.debug("Sorting is disabled.");
+            LOGGER.debug("Sorting is disabled or sort not specified.");
           }
           queries.add(wfsQuery);
         } else {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -39,6 +39,7 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.filter.impl.PropertyNameImpl;
 import ddf.catalog.filter.impl.SortByImpl;
 import ddf.catalog.filter.proxy.adapter.GeotoolsFilterAdapterImpl;
 import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
@@ -1591,8 +1592,7 @@ public class WfsSourceTest {
   public void testSortingNoSortOrder() throws Exception {
     // if sort order is missing, throw UnsupportedQueryException
     expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage(
-        "Source WFS_ID does not support specified sort property TEMPORAL with sort order null");
+    expectedEx.expectMessage("Source WFS_ID does not support specified sort property TEMPORAL");
 
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
     setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
@@ -1608,11 +1608,7 @@ public class WfsSourceTest {
 
   @Test
   public void testSortingNoSortProperty() throws Exception {
-    // if sort property is missing, throw UnsupportedQueryException
-    expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage(
-        "Source WFS_ID does not support specified sort property null with sort order SortOrder[ASCENDING]");
-
+    // query is still valid even if sort property is missing
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
     setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
     final QueryImpl propertyIsLikeQuery =
@@ -1626,11 +1622,24 @@ public class WfsSourceTest {
   }
 
   @Test
+  public void testNullSortProperty() throws Exception {
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(new PropertyNameImpl(null), null));
+
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  @Test
   public void testSortingBadSortOrder() throws Exception {
     // if sort order is invalid throw UnsupportedQueryException
     expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage(
-        "Source WFS_ID does not support specified sort property TEMPORAL with sort order SortOrder[foo]");
+    expectedEx.expectMessage("Source WFS_ID does not support specified sort property TEMPORAL");
 
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
     setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);


### PR DESCRIPTION
#### What does this PR do?
When the WFS Source receives a query with a null sort property ignore it and continue

#### Who is reviewing it? 
@derekwilhelm @pklinef 

#### Ask 2 committers to review/merge the PR and tag them here.
@derekwilhelm @pklinef 

#### How should this be tested?

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
