### PR TITLE
[2.26.x] DDF-6568 - Add null check for attribute descriptor

### DIFF
--- a/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
+++ b/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
@@ -229,20 +229,25 @@ public class MetacardCreator {
     Serializable result = null;
     if (StringUtils.isNotBlank(value)) {
       AttributeDescriptor descriptor = metacardType.getAttributeDescriptor(attributeName);
-      AttributeFormat attributeFormat = descriptor.getType().getAttributeFormat();
 
-      if (attributeFormat == AttributeFormat.INTEGER) {
-        try {
-          result = Integer.valueOf(value.trim());
-        } catch (NumberFormatException nfe) {
-          LOGGER.debug(
-              "Expected integer but was not integer. This is expected behavior when "
-                  + "a defined integer attribute does not exist on the ingested product.");
+      if (descriptor != null) {
+        AttributeFormat attributeFormat = descriptor.getType().getAttributeFormat();
+
+        if (attributeFormat == AttributeFormat.INTEGER) {
+          try {
+            result = Integer.valueOf(value.trim());
+          } catch (NumberFormatException nfe) {
+            LOGGER.debug(
+                "Expected integer but was not integer. This is expected behavior when "
+                    + "a defined integer attribute does not exist on the ingested product.");
+          }
+        } else if (attributeFormat == AttributeFormat.DOUBLE) {
+          result = getDoubleFromString(value);
+        } else if (attributeFormat == AttributeFormat.DATE) {
+          result = convertDate(value);
+        } else {
+          result = value;
         }
-      } else if (attributeFormat == AttributeFormat.DOUBLE) {
-        result = getDoubleFromString(value);
-      } else if (attributeFormat == AttributeFormat.DATE) {
-        result = convertDate(value);
       } else {
         result = value;
       }


### PR DESCRIPTION
#### What does this PR do?
Adds a null check for the attribute descriptor in case the configured attribute name is not found in the metacard type.
#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@pklinef 
#### Select relevant component teams: 

@codice/data 

#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler 
@jlcsmith 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
See steps in #6569 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
