### PR TITLE
Add Exiftool and configurable mappings to Tika InputTransformer

### DIFF
--- a/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
+++ b/catalog/transformer/catalog-transformer-common/src/main/java/ddf/catalog/transformer/common/tika/MetacardCreator.java
@@ -13,6 +13,9 @@
  */
 package ddf.catalog.transformer.common.tika;
 
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType.AttributeFormat;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
@@ -21,9 +24,20 @@ import ddf.catalog.data.types.Contact;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.Media;
 import ddf.catalog.data.types.Topic;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.metadata.DublinCore;
 import org.apache.tika.metadata.Metadata;
@@ -45,6 +59,31 @@ public class MetacardCreator {
   public static final String COMPRESSION_TYPE_METADATA_KEY = "Compression Type";
 
   public static final String DURATION_METDATA_KEY = "xmpDM:duration";
+
+  public static final String ALTERNATE_MAPPING_OVERRIDE_FILE_KEY = "tika.metadata.mapping.file";
+
+  static final Map<String, List<String>> ALTERNATE_METADATA_KEY_MAPPING;
+
+  private static final Pattern DURATION_SECONDS = Pattern.compile("([+-]?\\s*\\d*\\.?\\d+)\\s*s");
+
+  private static final Pattern DURATION_HMS = Pattern.compile("(\\d+):(\\d+):(\\d*\\.?\\d+).*");
+
+  static {
+    ALTERNATE_METADATA_KEY_MAPPING = new HashMap<>();
+
+    try (InputStream mappingStream = getAlternateMappings()) {
+      Properties properties = new Properties();
+      properties.load(mappingStream);
+      properties.entrySet().stream()
+          .forEach(
+              entry ->
+                  ALTERNATE_METADATA_KEY_MAPPING.put(
+                      entry.getKey().toString(),
+                      Arrays.asList(entry.getValue().toString().split("\\s*,\\s*"))));
+    } catch (Exception e) {
+      LOGGER.warn("Unable to load tika additional metadata mapping file", e);
+    }
+  }
 
   private MetacardCreator() {}
 
@@ -153,7 +192,68 @@ public class MetacardCreator {
     setAttribute(
         metacard, Mp4MetacardType.AUDIO_SAMPLE_RATE, metadata.get(XMPDM.AUDIO_SAMPLE_RATE));
 
+    applyAlternateMappings(metadata, metacard);
+
     return metacard;
+  }
+
+  private static void applyAlternateMappings(final Metadata metadata, Metacard metacard) {
+    MetacardType metacardType = metacard.getMetacardType();
+    for (Map.Entry<String, List<String>> entry : ALTERNATE_METADATA_KEY_MAPPING.entrySet()) {
+      String attributeName = entry.getKey();
+      if (StringUtils.isBlank(attributeName)) {
+        continue;
+      }
+
+      Attribute attribute = metacard.getAttribute(attributeName);
+      if (attribute == null) {
+        for (String mapping : entry.getValue()) {
+          String[] values = metadata.getValues(mapping);
+          List<Serializable> attrValues = new ArrayList<>();
+          for (String value : values) {
+            Serializable result = getMetadataValue(attributeName, value, metacardType);
+            if (result != null) {
+              attrValues.add(result);
+            }
+          }
+          if (!attrValues.isEmpty()) {
+            metacard.setAttribute(new AttributeImpl(attributeName, attrValues));
+          }
+        }
+      }
+    }
+  }
+
+  private static Serializable getMetadataValue(
+      String attributeName, String value, MetacardType metacardType) {
+    Serializable result = null;
+    if (StringUtils.isNotBlank(value)) {
+      AttributeDescriptor descriptor = metacardType.getAttributeDescriptor(attributeName);
+
+      if (descriptor != null) {
+        AttributeFormat attributeFormat = descriptor.getType().getAttributeFormat();
+
+        if (attributeFormat == AttributeFormat.INTEGER) {
+          try {
+            result = Integer.valueOf(value.trim());
+          } catch (NumberFormatException nfe) {
+            LOGGER.debug(
+                "Expected integer but was not integer. This is expected behavior when "
+                    + "a defined integer attribute does not exist on the ingested product.");
+          }
+        } else if (attributeFormat == AttributeFormat.DOUBLE) {
+          result = getDoubleFromString(value);
+        } else if (attributeFormat == AttributeFormat.DATE) {
+          result = convertDate(value);
+        } else {
+          result = value;
+        }
+      } else {
+        result = value;
+      }
+    }
+
+    return result;
   }
 
   private static void setAttribute(Metacard metacard, String attributeName, String attributeValue) {
@@ -192,6 +292,40 @@ public class MetacardCreator {
     }
   }
 
+  private static Double getDoubleFromString(String value) {
+    Double result = null;
+
+    if (StringUtils.isNotBlank(value)) {
+      String trimmedValue = value.trim();
+      try {
+        result = Double.valueOf(trimmedValue);
+      } catch (NumberFormatException nfe) {
+        Matcher matcher = DURATION_SECONDS.matcher(trimmedValue);
+        if (matcher.matches()) {
+          try {
+            result = Double.valueOf(matcher.group(1));
+          } catch (NumberFormatException nfe2) {
+            LOGGER.debug("Unable to parse double", nfe2);
+          }
+        } else {
+          matcher = DURATION_HMS.matcher(trimmedValue);
+          if (matcher.matches()) {
+            try {
+              double hours = Double.valueOf(matcher.group(1));
+              double minutes = Double.valueOf(matcher.group(2));
+              double seconds = Double.valueOf(matcher.group(3));
+              result = seconds + 60.0 * minutes + 3600.0 * hours;
+            } catch (NumberFormatException nfe3) {
+              LOGGER.debug("Unable to construct duration", nfe3);
+            }
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+
   private static String toWkt(final String lon, final String lat) {
     if (StringUtils.isBlank(lon) || StringUtils.isBlank(lat)) {
       return null;
@@ -214,5 +348,15 @@ public class MetacardCreator {
     }
 
     return date;
+  }
+
+  private static InputStream getAlternateMappings() throws IOException {
+    String overrideFile = System.getProperty(ALTERNATE_MAPPING_OVERRIDE_FILE_KEY);
+    if (StringUtils.isNotBlank(overrideFile)) {
+      return new FileInputStream(overrideFile);
+    } else {
+      return MetacardCreator.class.getResourceAsStream(
+          "/tika-additional-metadata-mapping.properties");
+    }
   }
 }

--- a/catalog/transformer/catalog-transformer-common/src/main/resources/tika-additional-metadata-mapping.properties
+++ b/catalog/transformer/catalog-transformer-common/src/main/resources/tika-additional-metadata-mapping.properties
@@ -1,0 +1,10 @@
+media.format=File Type
+media.type=MIME Type
+media.bits-per-sample=Bits Per Sample
+media.height-pixels=Image Height,Image Length
+media.width-pixels=Image Width
+media.compression=Compression
+media.duration=Duration,Media Duration
+ext.mp4.audio-sample-rate=Audio Sample Rate
+media.encoding=Encoding,Encoding Process,Video Codec,Encoder
+media.frame-rate=Frame Rate

--- a/catalog/transformer/catalog-transformer-common/src/test/java/ddf/catalog/transformer/common/tika/MetacardCreatorTest.java
+++ b/catalog/transformer/catalog-transformer-common/src/test/java/ddf/catalog/transformer/common/tika/MetacardCreatorTest.java
@@ -29,6 +29,7 @@ import ddf.catalog.data.types.Contact;
 import ddf.catalog.data.types.Media;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -212,6 +213,56 @@ public class MetacardCreatorTest {
         MetacardCreator.createMetacard(metadata, null, null, MetacardImpl.BASIC_METACARD, false);
 
     assertThat(metacard.getAttribute(Contact.CONTRIBUTOR_NAME), nullValue());
+  }
+
+  @Test
+  public void testAdditionalKeyMappings() {
+    Metadata metadata = new Metadata();
+    String imageLength = "14";
+    String imageWidth = "18";
+    String duration = "12.5 s";
+    String durationHms = "00:01:30.5";
+    String customImageWidthKey = "Width_Of_Image";
+    String customDurationKey = "Media_Duration";
+    String customDurationMetacardKey = "ext.media.duration";
+    metadata.add(TIFF.IMAGE_LENGTH, imageLength);
+    metadata.add(customImageWidthKey, imageWidth);
+    metadata.add("Duration", duration);
+    metadata.add(customDurationKey, durationHms);
+
+    MetacardCreator.ALTERNATE_METADATA_KEY_MAPPING.put(
+        Media.WIDTH, Arrays.asList("Image Width", customImageWidthKey));
+    MetacardCreator.ALTERNATE_METADATA_KEY_MAPPING.put(
+        customDurationMetacardKey, Arrays.asList(customDurationKey));
+
+    final String id = "id";
+    final String metadataXml = "<xml>test</xml>";
+
+    Set<AttributeDescriptor> extraAttributes = new HashSet<>();
+    extraAttributes.add(
+        new AttributeDescriptorImpl(
+            Media.HEIGHT, false, false, false, false, BasicTypes.INTEGER_TYPE));
+    extraAttributes.add(
+        new AttributeDescriptorImpl(
+            Media.WIDTH, false, false, false, false, BasicTypes.INTEGER_TYPE));
+    extraAttributes.add(
+        new AttributeDescriptorImpl(
+            Media.DURATION, false, false, false, false, BasicTypes.DOUBLE_TYPE));
+    extraAttributes.add(
+        new AttributeDescriptorImpl(
+            customDurationMetacardKey, false, false, false, false, BasicTypes.DOUBLE_TYPE));
+
+    MetacardTypeImpl extendedMetacardType =
+        new MetacardTypeImpl(
+            MetacardImpl.BASIC_METACARD.getName(), MetacardImpl.BASIC_METACARD, extraAttributes);
+
+    final Metacard metacard =
+        MetacardCreator.createMetacard(metadata, id, metadataXml, extendedMetacardType);
+
+    assertThat(metacard.getAttribute(Media.HEIGHT).getValue(), is(Integer.valueOf(imageLength)));
+    assertThat(metacard.getAttribute(Media.WIDTH).getValue(), is(Integer.valueOf(imageWidth)));
+    assertThat(metacard.getAttribute(Media.DURATION).getValue(), is(12.5));
+    assertThat(metacard.getAttribute(customDurationMetacardKey).getValue(), is(90.5));
   }
 
   private AttributeDescriptorImpl createObjectAttr(String name) {

--- a/catalog/transformer/catalog-transformer-pptx/src/test/java/ddf/catalog/transformer/input/pptx/PptxInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-pptx/src/test/java/ddf/catalog/transformer/input/pptx/PptxInputTransformerTest.java
@@ -76,7 +76,7 @@ public class PptxInputTransformerTest {
       assertThat(metacard, notNullValue());
       assertThat(metacard.getThumbnail(), nullValue());
       MatcherAssert.assertThat(
-          metacard.getAttribute(Core.DATATYPE).getValue(), Matchers.is("Dataset"));
+          metacard.getAttribute(Core.DATATYPE).getValue(), Matchers.is("Text"));
     }
   }
 

--- a/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/main/java/ddf/catalog/transformer/input/tika/TikaInputTransformer.java
@@ -319,6 +319,9 @@ public class TikaInputTransformer implements InputTransformer {
     // .xltm
     mimeTypeToMetacardTypeMap.put(
         "application/vnd.ms-excel.template.macroenabled.12", fallbackExcelMetacardType);
+    // .avi
+    mimeTypeToMetacardTypeMap.put("video/avi", fallbackMp4MetacardType);
+    mimeTypeToMetacardTypeMap.put("video/x-msvideo", fallbackMp4MetacardType);
   }
 
   /**
@@ -370,7 +373,7 @@ public class TikaInputTransformer implements InputTransformer {
       }
 
       if (extractor != null) {
-        metadataText = extractor.getMetadataXml();
+        metadataText = getMetadataXml(extractor.getMetadataXml());
         Attribute validationAttribute = null;
         if (metadataText.equals(TikaMetadataExtractor.METADATA_LIMIT_REACHED_MSG)) {
           validationAttribute =
@@ -404,6 +407,14 @@ public class TikaInputTransformer implements InputTransformer {
       LOGGER.debug("Finished transforming input stream using Tika.");
       return metacard;
     }
+  }
+
+  private String getMetadataXml(String extractorMetadataXml) {
+    if (extractorMetadataXml != null && extractorMetadataXml.trim().endsWith("?>")) {
+      // Contains just the prolog, use empty string instead
+      return "";
+    }
+    return extractorMetadataXml;
   }
 
   private void processMetadataExtractors(String metadataText, Metacard metacard) {

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -622,7 +622,7 @@ public class TikaInputTransformerTest {
     Metacard metacard = transform(stream);
     assertNotNull(metacard);
     assertNull(metacard.getMetadata());
-    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is("Dataset"));
+    assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is("Text"));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?

This is a forward port of PRs #6569 and #6579 and adds Exiftool and configurable properties to the Tika InputTransformer.

#### Who is reviewing it? 
@pklinef 

#### Select relevant component teams: 

@codice/data 


#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith 
@andrewkfiedler 

#### How should this be tested?
Same test steps as in #6569 :

Install exiftool and make sure it is in the path for the user running DDF.
Start DDF
Ingest an AVI file
Verify that the created metacard has additional data that was not normally present, such as media.width-pixels and media.height-pixels
Verify that the settings can be overridden
- edit the custom.system.properties file and add the key: tika.metadata.mapping.file and point it to a properties file.
- In the properties file, add some mappings that are different than the provided mappings (e.g. description=MIME Type)
- Update the security policy file to grant read permissions to the file for: codeBase "file:/org.apache.tika.core/video-input-transformer/tika-input-transformer/catalog-transformer-pdf/catlog-transformer-pptx"
- Restart DDF
- Ingest another AVI file and verify the new mapping is applied

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6568 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
