### PR TITLE
[2.26.x] DDF-6587 - Manually associate cached jetty sessions

### DIFF
--- a/platform/security/core/security-core-services/pom.xml
+++ b/platform/security/core/security-core-services/pom.xml
@@ -201,6 +201,10 @@
             <groupId>ddf.security.handler</groupId>
             <artifactId>security-handler-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/platform/security/core/security-core-services/src/main/java/ddf/security/http/impl/HttpSessionFactory.java
+++ b/platform/security/core/security-core-services/src/main/java/ddf/security/http/impl/HttpSessionFactory.java
@@ -72,7 +72,7 @@ public class HttpSessionFactory implements SessionFactory {
    * attempt to recreate the same session object and fail, causing the second request to fail.
    */
   private HttpSession getCachedSession(HttpServletRequest httpRequest) {
-    if (httpRequest instanceof Request) {
+    if (httpRequest instanceof Request && hasValidDependencies((Request) httpRequest)) {
       try {
         Request request = (Request) httpRequest;
         SessionHandler sessionHandler = request.getSessionHandler();
@@ -93,6 +93,13 @@ public class HttpSessionFactory implements SessionFactory {
       }
     }
     return null;
+  }
+
+  private boolean hasValidDependencies(Request request) {
+    SessionHandler handler = request.getSessionHandler();
+    return handler != null
+        && handler.getSessionCache() != null
+        && handler.getSessionIdManager() != null;
   }
 
   public void setExpirationTime(int expirationTime) {


### PR DESCRIPTION
#### What does this PR do?
Fixes the bug when multiple requests from the same user to the same context are received too close together for the first time that the context is accessed.  In this scenario, jetty cannot associate a session object to the request when they are received because one does not exist yet.  Since both requests are received at basically the same time, both (or more) requests are in the same state and will attempt to create a new session object.  Since the HttpSessionFactory is synchronized, whichever request is received first will create the session object.  Prior to this fix, the second request would then also attempt to create the session object but would fail.  This PR checks the jetty session cache to see if the session was already created and is valid.  If it was, it joins the request to the cached session rather than attempting to create a new one.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@stustison 
@pklinef 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@jlcsmith

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Upload several images that will have thumbnails generated
2. Log out 
3. Log back in
4. Run a search for the uploaded images
5. Verify that all of the thumbnails are returned as expected and there are no exceptions in the logs indicating that the session was already in the cache or an NPE
6. Attempt steps 2 - 5 several times as this is a race condition
7. Other endpoints can be tested as well

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6587 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
