### PR TITLE
DDF-6587 - Manually associate cached jetty sessions

### DIFF
--- a/platform/security/core/security-core-services/pom.xml
+++ b/platform/security/core/security-core-services/pom.xml
@@ -205,6 +205,10 @@
             <groupId>ddf.security.handler</groupId>
             <artifactId>security-handler-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
#### What does this PR do?

Forward port of PR #6588 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@stustison
@pklinef

#### Select relevant component teams: 
@codice/security

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewkfiedler
@jlcsmith

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Upload several images that will have thumbnails generated
2. Log out
3. Log back in
4. Run a search for the uploaded images
5. Verify that all of the thumbnails are returned as expected and there are no exceptions in the logs indicating that the session was already in the cache or an NPE
6. Attempt steps 2 - 5 several times as this is a race condition
7. Other endpoints can be tested as well

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6587

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
