### PR TITLE
[2.19.x] CsvMetacardTransformer excludes binary and object attributes

### DIFF
--- a/catalog/transformer/catalog-transformer-csv-queryresponse/pom.xml
+++ b/catalog/transformer/catalog-transformer-csv-queryresponse/pom.xml
@@ -46,17 +46,22 @@
             <artifactId>platform-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -93,17 +98,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvMetacardTransformer.java
+++ b/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvMetacardTransformer.java
@@ -13,25 +13,15 @@
  */
 package ddf.catalog.transformer.csv;
 
-import static ddf.catalog.transformer.csv.common.CsvTransformer.createResponse;
-import static ddf.catalog.transformer.csv.common.CsvTransformer.writeMetacardsToCsv;
+import static java.util.Collections.singletonList;
 
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.MetacardTransformer;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,33 +38,7 @@ public class CsvMetacardTransformer implements MetacardTransformer {
       throw new CatalogTransformerException("Unable to transform null metacard");
     }
 
-    Map<String, String> aliases =
-        (Map<String, String>)
-            arguments.getOrDefault(CsvQueryResponseTransformer.COLUMN_ALIAS_KEY, new HashMap<>());
-    List<String> attributes = getColumnOrder(arguments);
-
-    List<AttributeDescriptor> allAttributes =
-        new ArrayList<AttributeDescriptor>(metacard.getMetacardType().getAttributeDescriptors());
-    List<AttributeDescriptor> descriptors =
-        CollectionUtils.isEmpty(attributes)
-            ? allAttributes
-            : allAttributes
-                .stream()
-                .filter(attr -> attributes.contains(attr.getName()))
-                .collect(Collectors.toList());
-    Appendable appendable =
-        writeMetacardsToCsv(Collections.singletonList(metacard), descriptors, aliases);
-    return createResponse(appendable);
-  }
-
-  private List<String> getColumnOrder(Map<String, Serializable> arguments) {
-    Object columnOrder = arguments.get(CsvQueryResponseTransformer.COLUMN_ORDER_KEY);
-    if (columnOrder instanceof String && StringUtils.isNotBlank((String) columnOrder)) {
-      return Arrays.asList(((String) columnOrder).split(","));
-    }
-    return Optional.ofNullable(columnOrder)
-        .filter(value -> value instanceof List)
-        .map(value -> (List<String>) value)
-        .orElse(new ArrayList<>());
+    final List<Metacard> metacards = singletonList(metacard);
+    return CsvTransformerSupport.transformWithArguments(metacards, arguments);
   }
 }

--- a/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformer.java
+++ b/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvQueryResponseTransformer.java
@@ -14,13 +14,6 @@
 
 package ddf.catalog.transformer.csv;
 
-import static ddf.catalog.transformer.csv.common.CsvTransformer.createResponse;
-import static ddf.catalog.transformer.csv.common.CsvTransformer.getAllCsvAttributeDescriptors;
-import static ddf.catalog.transformer.csv.common.CsvTransformer.getOnlyRequestedAttributes;
-import static ddf.catalog.transformer.csv.common.CsvTransformer.sortAttributes;
-import static ddf.catalog.transformer.csv.common.CsvTransformer.writeMetacardsToCsv;
-
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.BinaryContent;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
@@ -28,12 +21,8 @@ import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.QueryResponseTransformer;
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -42,13 +31,6 @@ import java.util.stream.Collectors;
  * @see ddf.catalog.transform.QueryResponseTransformer
  */
 public class CsvQueryResponseTransformer implements QueryResponseTransformer {
-
-  public static final String COLUMN_ORDER_KEY = "columnOrder";
-
-  public static final String COLUMN_ALIAS_KEY = "aliases";
-
-  private static final String HIDDEN_FIELDS_KEY = "hiddenFields";
-
   /**
    * @param upstreamResponse the SourceResponse to be converted.
    * @param arguments this transformer accepts 2 parameters in the 'arguments' map.
@@ -80,36 +62,6 @@ public class CsvQueryResponseTransformer implements QueryResponseTransformer {
             .map(Result::getMetacard)
             .collect(Collectors.toList());
 
-    Set<String> hiddenFields =
-        Optional.ofNullable((Set<String>) arguments.get(HIDDEN_FIELDS_KEY))
-            .orElse(Collections.emptySet());
-
-    List<String> attributeOrder =
-        Optional.ofNullable((List<String>) arguments.get(COLUMN_ORDER_KEY))
-            .orElse(Collections.emptyList());
-
-    Map<String, String> columnAliasMap =
-        Optional.ofNullable((Map<String, String>) arguments.get(COLUMN_ALIAS_KEY))
-            .orElse(Collections.emptyMap());
-
-    Set<String> requestedFields = new HashSet<>(attributeOrder);
-
-    Set<AttributeDescriptor> requestedAttributeDescriptors =
-        requestedFields.isEmpty()
-            ? getAllCsvAttributeDescriptors(metacards)
-            : getOnlyRequestedAttributes(metacards, requestedFields);
-
-    Set<AttributeDescriptor> filteredAttributeDescriptors =
-        requestedAttributeDescriptors
-            .stream()
-            .filter(desc -> !hiddenFields.contains(desc.getName()))
-            .collect(Collectors.toSet());
-
-    List<AttributeDescriptor> sortedAttributeDescriptors =
-        sortAttributes(filteredAttributeDescriptors, attributeOrder);
-
-    Appendable csv = writeMetacardsToCsv(metacards, sortedAttributeDescriptors, columnAliasMap);
-
-    return createResponse(csv);
+    return CsvTransformerSupport.transformWithArguments(metacards, arguments);
   }
 }

--- a/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvTransformerSupport.java
+++ b/catalog/transformer/catalog-transformer-csv-queryresponse/src/main/java/ddf/catalog/transformer/csv/CsvTransformerSupport.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.transformer.csv;
+
+import static ddf.catalog.transformer.csv.common.CsvTransformer.createResponse;
+import static ddf.catalog.transformer.csv.common.CsvTransformer.getAllCsvAttributeDescriptors;
+import static ddf.catalog.transformer.csv.common.CsvTransformer.getOnlyRequestedAttributes;
+import static ddf.catalog.transformer.csv.common.CsvTransformer.sortAttributes;
+import static ddf.catalog.transformer.csv.common.CsvTransformer.writeMetacardsToCsv;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.BinaryContent;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.transform.CatalogTransformerException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang.StringUtils;
+
+class CsvTransformerSupport {
+  static final String COLUMN_ORDER_KEY = "columnOrder";
+
+  static final String COLUMN_ALIAS_KEY = "aliases";
+
+  static final String HIDDEN_FIELDS_KEY = "hiddenFields";
+
+  private CsvTransformerSupport() {}
+
+  static BinaryContent transformWithArguments(
+      final List<Metacard> metacards, final Map<String, Serializable> arguments)
+      throws CatalogTransformerException {
+    final Set<String> hiddenFields =
+        Optional.ofNullable((Set<String>) arguments.get(HIDDEN_FIELDS_KEY))
+            .orElse(Collections.emptySet());
+
+    final List<String> attributeOrder = getColumnOrder(arguments);
+
+    final Map<String, String> columnAliasMap =
+        Optional.ofNullable((Map<String, String>) arguments.get(COLUMN_ALIAS_KEY))
+            .orElse(Collections.emptyMap());
+
+    final Set<String> requestedFields = new HashSet<>(attributeOrder);
+
+    final Set<AttributeDescriptor> requestedAttributeDescriptors =
+        requestedFields.isEmpty()
+            ? getAllCsvAttributeDescriptors(metacards)
+            : getOnlyRequestedAttributes(metacards, requestedFields);
+
+    final Set<AttributeDescriptor> filteredAttributeDescriptors =
+        requestedAttributeDescriptors
+            .stream()
+            .filter(desc -> !hiddenFields.contains(desc.getName()))
+            .collect(Collectors.toSet());
+
+    final List<AttributeDescriptor> sortedAttributeDescriptors =
+        sortAttributes(filteredAttributeDescriptors, attributeOrder);
+
+    final Appendable csv =
+        writeMetacardsToCsv(metacards, sortedAttributeDescriptors, columnAliasMap);
+
+    return createResponse(csv);
+  }
+
+  private static List<String> getColumnOrder(final Map<String, Serializable> arguments) {
+    final Object columnOrder = arguments.get(COLUMN_ORDER_KEY);
+    if (columnOrder instanceof String && StringUtils.isNotBlank((String) columnOrder)) {
+      return Arrays.asList(((String) columnOrder).split(","));
+    }
+    return Optional.ofNullable(columnOrder)
+        .filter(value -> value instanceof List)
+        .map(value -> (List<String>) value)
+        .orElse(new ArrayList<>());
+  }
+}

--- a/catalog/transformer/catalog-transformer-csv-queryresponse/src/test/java/ddf/catalog/transformer/csv/CsvMetacardTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-csv-queryresponse/src/test/java/ddf/catalog/transformer/csv/CsvMetacardTransformerTest.java
@@ -14,11 +14,22 @@
 
 package ddf.catalog.transformer.csv;
 
+import static ddf.catalog.data.impl.BasicTypes.BINARY_TYPE;
+import static ddf.catalog.data.impl.BasicTypes.DOUBLE_TYPE;
+import static ddf.catalog.data.impl.BasicTypes.INTEGER_TYPE;
+import static ddf.catalog.data.impl.BasicTypes.OBJECT_TYPE;
+import static ddf.catalog.data.impl.BasicTypes.STRING_TYPE;
+import static ddf.catalog.transformer.csv.CsvTransformerSupport.COLUMN_ORDER_KEY;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
@@ -27,95 +38,160 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.transform.CatalogTransformerException;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Before;
 import org.junit.Test;
 
 public class CsvMetacardTransformerTest {
 
-  private Map<String, Serializable> arguments;
-
-  private CsvMetacardTransformer transformer;
-
-  private Metacard normalMC, nullMC;
-
-  private static final Set<AttributeDescriptor> ATTRIBUTE_DESCRIPTORS =
-      ImmutableSet.of(
-          buildAttributeDescriptor("stringAtt", BasicTypes.STRING_TYPE),
-          buildAttributeDescriptor("intAtt", BasicTypes.INTEGER_TYPE),
-          buildAttributeDescriptor("doubleAtt", BasicTypes.DOUBLE_TYPE));
-
-  private static final List<String> VALUES = ImmutableList.of("stringVal", "101", "3.14159");
-
-  private static final List<Attribute> ATTRIBUTES =
-      ImmutableList.of(
-          new AttributeImpl("stringAtt", "stringVal"),
-          new AttributeImpl("intAtt", 101),
-          new AttributeImpl("doubleAtt", 3.14159));
-
-  @Before
-  public void setUp() {
-    this.transformer = new CsvMetacardTransformer();
-    this.arguments = new HashMap<>();
-    arguments.put(CsvQueryResponseTransformer.COLUMN_ORDER_KEY, "stringAtt,intAtt,doubleAtt");
-    normalMC = buildMetacard();
-  }
-
-  private static AttributeDescriptor buildAttributeDescriptor(String name, AttributeType type) {
-    return new AttributeDescriptorImpl(name, true, true, true, true, type);
-  }
+  private final CsvMetacardTransformer transformer = new CsvMetacardTransformer();
 
   @Test(expected = CatalogTransformerException.class)
   public void testTransformerWithNullMetacard() throws CatalogTransformerException {
-    transformer.transform(nullMC, arguments);
+    transformer.transform(null, new HashMap<>());
   }
 
   @Test
   public void testCsvMetacardTransformerNoArguments()
       throws CatalogTransformerException, IOException {
-    arguments.clear();
-    BinaryContent binaryContent = transformer.transform(normalMC, arguments);
+    String stringAtt = "stringAtt";
+    String intAtt = "intAtt";
+    String doubleAtt = "doubleAtt";
+    Metacard metacard =
+        buildMetacard(
+            Sets.newHashSet(
+                buildAttributeDescriptor(stringAtt, STRING_TYPE),
+                buildAttributeDescriptor(intAtt, INTEGER_TYPE),
+                buildAttributeDescriptor(doubleAtt, DOUBLE_TYPE)),
+            new AttributeImpl(stringAtt, "stringVal"),
+            new AttributeImpl(intAtt, 101),
+            new AttributeImpl(doubleAtt, 3.14159));
+    BinaryContent binaryContent = transformer.transform(metacard, new HashMap<>());
     assertThat(binaryContent.getMimeType().toString(), is("text/csv"));
 
-    List<String> attributes = Arrays.asList(new String(binaryContent.getByteArray()).split("\r\n"));
-    List<String> attNames = Arrays.asList(attributes.get(0).split(","));
-    List<String> attValues = Arrays.asList(attributes.get(1).split(","));
+    List<String> lines = Arrays.asList(new String(binaryContent.getByteArray()).split("\r\n"));
+    assertThat("The CSV didn't contain exactly two lines.", lines, hasSize(2));
 
-    for (int i = 0; i < attNames.size(); i++) {
-      String attributeValue = attValues.get(i);
-      assertThat(VALUES.contains(attributeValue), is(true));
+    List<String> attNames = Arrays.asList(lines.get(0).split(","));
+    List<String> attValues = Arrays.asList(lines.get(1).split(","));
+    assertThat(
+        "The headers and values had different lengths.", attNames, hasSize(attValues.size()));
+
+    final Map<String, String> headersToValues = new HashMap<>();
+    for (int i = 0; i < attNames.size(); ++i) {
+      headersToValues.put(attNames.get(i), attValues.get(i));
     }
+    assertThat(
+        headersToValues,
+        allOf(
+            hasEntry(stringAtt, "stringVal"),
+            hasEntry(intAtt, "101"),
+            hasEntry(doubleAtt, "3.14159")));
   }
 
   @Test
-  public void testCsvMetacardTransformer() throws CatalogTransformerException, IOException {
-    BinaryContent binaryContent = transformer.transform(normalMC, arguments);
+  public void testCsvMetacardTransformerSupportsColumnOrder()
+      throws CatalogTransformerException, IOException {
+    String stringAtt = "stringAtt";
+    String intAtt = "intAtt";
+    String doubleAtt = "doubleAtt";
+    Metacard metacard =
+        buildMetacard(
+            Sets.newHashSet(
+                buildAttributeDescriptor(stringAtt, STRING_TYPE),
+                buildAttributeDescriptor(intAtt, INTEGER_TYPE),
+                buildAttributeDescriptor(doubleAtt, DOUBLE_TYPE)),
+            new AttributeImpl(stringAtt, "stringVal"),
+            new AttributeImpl(intAtt, 101),
+            new AttributeImpl(doubleAtt, 3.14159));
+    BinaryContent binaryContent =
+        transformer.transform(
+            metacard, singletonMap(COLUMN_ORDER_KEY, "doubleAtt,stringAtt,intAtt"));
     assertThat(binaryContent.getMimeType().toString(), is("text/csv"));
 
-    List<String> attributes = Arrays.asList(new String(binaryContent.getByteArray()).split("\r\n"));
-    List<String> attNames = Arrays.asList(attributes.get(0).split(","));
-    List<String> attValues = Arrays.asList(attributes.get(1).split(","));
+    List<String> lines = Arrays.asList(new String(binaryContent.getByteArray()).split("\r\n"));
+    assertThat("The CSV didn't contain exactly two lines.", lines, hasSize(2));
 
-    for (int i = 0; i < attNames.size(); i++) {
-      String attributeValue = attValues.get(i);
-      assertThat(VALUES.contains(attributeValue), is(true));
-    }
+    List<String> attNames = Arrays.asList(lines.get(0).split(","));
+    List<String> attValues = Arrays.asList(lines.get(1).split(","));
+
+    assertThat(attNames, contains(doubleAtt, stringAtt, intAtt));
+    assertThat(attValues, contains("3.14159", "stringVal", "101"));
   }
 
-  private Metacard buildMetacard() {
-    MetacardType metacardType = new MetacardTypeImpl("", ATTRIBUTE_DESCRIPTORS);
+  @Test
+  public void testFieldsNotRequestedAreExcluded() throws CatalogTransformerException, IOException {
+    String stringAtt = "stringAtt";
+    String intAtt = "intAtt";
+    String doubleAtt = "doubleAtt";
+    Metacard metacard =
+        buildMetacard(
+            Sets.newHashSet(
+                buildAttributeDescriptor(stringAtt, STRING_TYPE),
+                buildAttributeDescriptor(intAtt, INTEGER_TYPE),
+                buildAttributeDescriptor(doubleAtt, DOUBLE_TYPE)),
+            new AttributeImpl(stringAtt, "stringVal"),
+            new AttributeImpl(intAtt, 101),
+            new AttributeImpl(doubleAtt, 3.14159));
+    BinaryContent binaryContent =
+        transformer.transform(
+            metacard, singletonMap(COLUMN_ORDER_KEY, Lists.newArrayList(stringAtt)));
+    assertThat(binaryContent.getMimeType().toString(), is("text/csv"));
+
+    List<String> lines = Arrays.asList(new String(binaryContent.getByteArray()).split("\r\n"));
+    assertThat("The CSV didn't contain exactly two lines.", lines, hasSize(2));
+
+    List<String> attNames = Arrays.asList(lines.get(0).split(","));
+    List<String> attValues = Arrays.asList(lines.get(1).split(","));
+
+    assertThat(attNames, contains(stringAtt));
+    assertThat(attValues, contains("stringVal"));
+  }
+
+  @Test
+  public void testBinaryAndObjectFieldsAreExcluded()
+      throws CatalogTransformerException, IOException {
+    String stringAtt = "stringAtt";
+    String binaryAtt = "binaryAtt";
+    String objectAtt = "objectAtt";
+    Metacard metacard =
+        buildMetacard(
+            Sets.newHashSet(
+                buildAttributeDescriptor(stringAtt, STRING_TYPE),
+                buildAttributeDescriptor(binaryAtt, BINARY_TYPE),
+                buildAttributeDescriptor(objectAtt, OBJECT_TYPE)),
+            new AttributeImpl(stringAtt, "stringVal"),
+            new AttributeImpl(binaryAtt, new byte[] {1, 0, 1}),
+            new AttributeImpl(objectAtt, new HashMap<>()));
+    BinaryContent binaryContent = transformer.transform(metacard, new HashMap<>());
+    assertThat(binaryContent.getMimeType().toString(), is("text/csv"));
+
+    List<String> lines = Arrays.asList(new String(binaryContent.getByteArray()).split("\r\n"));
+    assertThat("The CSV didn't contain exactly two lines.", lines, hasSize(2));
+
+    List<String> attNames = Arrays.asList(lines.get(0).split(","));
+    List<String> attValues = Arrays.asList(lines.get(1).split(","));
+
+    assertThat(attNames, contains(stringAtt));
+    assertThat(attValues, contains("stringVal"));
+  }
+
+  private static AttributeDescriptor buildAttributeDescriptor(String name, AttributeType<?> type) {
+    return new AttributeDescriptorImpl(name, true, true, true, true, type);
+  }
+
+  private Metacard buildMetacard(
+      final Set<AttributeDescriptor> attributeDescriptors, final Attribute... attributes) {
+    MetacardType metacardType = new MetacardTypeImpl("", attributeDescriptors);
     Metacard metacard = new MetacardImpl(metacardType);
-    for (Attribute attribute : ATTRIBUTES) {
+    for (Attribute attribute : attributes) {
       metacard.setAttribute(attribute);
     }
     return metacard;


### PR DESCRIPTION
#### What does this PR do?
`CsvMetacardTransformer` now uses the same transformation logic as `CsvQueryResponseTransformer`, which correctly excludes binary and object attributes. `CsvMetacardTransformer` now also supports column sorting and hiding.

#### Who is reviewing it? 
@kcwire 
@millerw8 
@shaundmorris 

#### Select relevant component teams: 
@codice/core-apis 
@codice/io 

#### How should this be tested?
![Screen Shot 2021-06-18 at 4 45 18 PM](https://user-images.githubusercontent.com/4495447/122618790-99237480-d054-11eb-8f3d-66bb1241e229.jpg)
To test the binary attribute filtering:
Upload some records with thumbnails. Search for them in Intrigue, select one or more of them and do a compressed export with CSV.
Unzip the exported file and open the CSV file(s) inside. Verify there is no `thumbnail` column.

To test the column sorting and hiding:
Use a REST client (e.g., Postman) to create a POST to `/search/catalog/internal/cql/transform/zipCompression` with the following body:
```json
{
  "searches": [
    {
      "srcs": [
        "ddf.distribution"
      ],
      "cql": "(((\"id\" ILIKE '8fac3064ac3c4caca1feead0a6431f40')))",
      "count": 1
    }
  ],
  "count": 1,
  "sorts": [
    {
      "attribute": "modified",
      "direction": "descending"
    }
  ],
  "args": {
    "columnOrder": [
      "id",
      "title"
    ],
    "columnAliasMap": {},
    "hiddenFields": [
      "title"
    ],
    "transformerId": "csv"
  }
}
```
You'll probably need to add the `X-Requested-With: XMLHttpRequest` and `Origin: https://localhost:8993` headers.
Replace the ID in the CQL with the ID of one of the metacards in your catalog. Try different sets of attributes for `columnOrder` and `hiddenFields`. `columnOrder` should determine which attributes are included in the CSV, and their order. `hiddenFields` should exclude the given attributes from the output, even if they are included in `columnOrder`.
Note: there is no way to test this in Intrigue (that I know of), since Intrigue does not support these options.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests