### PR TITLE
[2.19.x] G-9437 Include the cacheId for table exports

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/extension-points/table-export/table-export.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/extension-points/table-export/table-export.tsx
@@ -134,6 +134,7 @@ function getSearches(
   count: any,
   selectionInterface: any
 ): any {
+  const cacheId = selectionInterface.getCurrentQuery().get('cacheId')
   if (exportSize !== 'visible') {
     return srcs.length > 0
       ? [
@@ -141,6 +142,7 @@ function getSearches(
             srcs,
             cql,
             count,
+            cacheId,
           },
         ]
       : []
@@ -153,6 +155,7 @@ function getSearches(
       cql,
       start,
       count: srcCount,
+      cacheId,
     }
   })
 }


### PR DESCRIPTION
#### What does this PR do?
Downstream projects need the cacheId, since they may have sources that cache results by the ID.

#### Who is reviewing it? 
@shaundmorris 
@samuelechu 
@kcwire 
@millerw8 

#### Select relevant component teams: 
@codice/ui 

#### How should this be tested?
Will have to be tested downstream.