### PR TITLE
[2.19.x] Notification setting labels' font size is different from rest of settings

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/alert-settings/presentation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/alert-settings/presentation.tsx
@@ -32,7 +32,6 @@ const Root = styled.div`
   width: 100%;
   height: 100%;
   overflow: auto;
-  font-size: ${props => props.theme.minimumFontSize};
   padding: ${props => props.theme.minimumSpacing};
 
   .editor-properties {


### PR DESCRIPTION
#### What does this PR do?
Matches notification setting labels' font size to other user setting labels' font size.


#### Screenshots
<!--(if appropriate)-->
Before:
![image](https://user-images.githubusercontent.com/4467636/123154836-377c5500-d41c-11eb-85e1-e4e8523ba290.png)
After:
![image](https://user-images.githubusercontent.com/4467636/123154852-3cd99f80-d41c-11eb-8564-d3d9db58498e.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
