### PR TITLE
[2.19.x] Simplify the results export format filtering

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/results-export/container.tsx
@@ -20,7 +20,6 @@ import { exportResultSet } from '../utils/export'
 import { getResultSetCql } from '../utils/cql'
 import saveFile from '../utils/save-file'
 import withListenTo, { WithBackboneProps } from '../backbone-container'
-const _ = require('lodash')
 const announcement = require('../../component/announcement/index.jsx')
 const properties = require('../../js/properties.js')
 
@@ -82,32 +81,27 @@ class ResultsExport extends React.Component<Props, State> {
     fetch(`./internal/transformers/${this.getTransformerType()}`)
       .then(response => response.json())
       .then((exportFormats: ExportFormat[]) => {
-        const resultsAttributes: any = {}
-        this.props.results.map((result: Result) => {
-          result.attributes.forEach((attr: any) => {
-            if (resultsAttributes[attr] === undefined) {
-              resultsAttributes[attr] = [result.id]
-            } else {
-              resultsAttributes[attr].push(result.id)
-            }
-          })
-        })
+        const attributesByResult = this.props.results.reduce(
+          (acc, result) => {
+            const attributes = new Set(result.attributes)
+            acc.push(attributes)
+            return acc
+          },
+          [] as Array<Set<string>>
+        )
         return exportFormats.filter(exportFormat => {
-          const requiredAttr = exportFormat['required-attributes']
-          if (!Array.isArray(requiredAttr) || requiredAttr.length == 0) {
+          const requiredAttributes = exportFormat['required-attributes']
+          const attributesNotRequired =
+            !Array.isArray(requiredAttributes) ||
+            requiredAttributes.length === 0
+          if (attributesNotRequired) {
             return true
           }
-          let resultIds = resultsAttributes[requiredAttr[0]]
-          if (resultIds && resultIds.length > 0) {
-            for (let index = 1; index < requiredAttr.length; index++) {
-              const currResultIds = resultsAttributes[requiredAttr[index]]
-              if (_.intersection(resultIds, currResultIds).length == 0) {
-                return false
-              }
-              resultIds = currResultIds
-            }
-            return true
-          }
+          return attributesByResult.some(resultAttributes =>
+            requiredAttributes.every(attribute =>
+              resultAttributes.has(attribute)
+            )
+          )
         })
       })
       .then((exportFormats: ExportFormat[]) => {


### PR DESCRIPTION
#### What does this PR do?
* Simplifies the results export format filtering code.
* Updates the filtering behavior to handle zipped and unzipped exports differently. Zipped exports require only one result in the set to have the required attributes for that export type to be available. Unzipped exports require every result in the set to have the required attributes for that export type to be available.

#### Who is reviewing it? 
@shaundmorris 
@kcwire 
@millerw8 
@samuelechu 

#### Select relevant component teams: 
@codice/ui 

#### How should this be tested?
Should be tested downstream, I can provide instructions.