### PR TITLE
[2.19.x] Remove _root_ field from Solr schema

### DIFF
--- a/catalog/core/catalog-core-solrcommands/src/test/resources/configset/schema.xml
+++ b/catalog/core/catalog-core-solrcommands/src/test/resources/configset/schema.xml
@@ -19,7 +19,6 @@
     <dynamicField name="*" type="string" indexed="true" stored="true"/>
     <!-- for versioning -->
     <field name="_version_" type="long" indexed="true" stored="true"/>
-    <field name="_root_" type="string" indexed="true" stored="true" multiValued="false" required="false"/>
     <field name="id" type="string" indexed="true" stored="true"/>
     <uniqueKey>id</uniqueKey>
 </schema>

--- a/platform/solr/solr-schema/src/main/resources/solr/conf/schema.xml
+++ b/platform/solr/solr-schema/src/main/resources/solr/conf/schema.xml
@@ -35,7 +35,6 @@
 
     <!-- Fields -->
     <field name="_version_" type="plong" indexed="false" stored="false" docValues="true"/>
-    <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
     <field name="_text_" type="text" indexed="true" stored="false" multiValued="true"/>
 
     <field name="id_txt" type="string" indexed="true" stored="true" required="true" multiValued="false" docValues="true"/>


### PR DESCRIPTION
#### What does this PR do?
Solr 8.x will always populate the _root_ field with the unique key (which is id_txt for DDF), if that field is in the schema. When Solr 8.x detects the presence of the _root_ field in the schema, it will use that field to query for Lucene documents when making updates. Solr 7.x and earlier does not populate that field, so a Solr 7.x index will have the field in its schema but not in its Lucene index (assuming the nested documents feature is not being actively used, and DDF does not use it). This causes Solr 8.x to think the document does not exist, so it creates a new Lucene document with a different Lucene Doc ID but the same Solr ID. SolrCloud appears to de-duplicate by ID, so only the old stored document is returned when there is a match for either Lucene document.

This means that if you are upgrading a Solr 7.x or earlier to Solr 8.x, any existing documents cannot be updated if _root_ is in the schema, since a new document will be created for each on the first update, but queries will return the original documents.

Downstream projects will need to add the _root_ field back to the schema if they are using nested documents and are using DDF's schema.

#### Who is reviewing it? 
@pklinef 
@millerw8 
@kcwire 
@shaundmorris 

#### Select relevant component teams: 
@codice/solr 

#### How should this be tested?
Ingest some records, verify they can be queried, updated, and deleted.
Verify search and result forms can be created, updated, used in queries, and deleted.
Verify the original problem (upgrading from 7.x -> 8.x) was fixed:
1. Download [DDF 2.19.19](https://github.com/codice/ddf/releases/tag/ddf-2.19.19) (the last DDF 2.19.x version to use Solr 7.x).
2. Unzip it and move its `solr` folder to a different location. This and the following changes will simulate an external Solr installation that will be upgraded.
3. Open `etc/custom.system.properties` and edit `solr.data.dir`: change `${karaf.home}` to the folder you moved the `solr` folder to. Don't change the actual `karaf.home` property, just replace `${karaf.home}` in the `solr.data.dir` property.
4. Open `bin/ddfsolr` and edit `SOLR_EXEC`: change `${HOME_DIR}` to the folder you moved the `solr` folder to. Don't change the actual `HOME_DIR` property, just replace `${HOME_DIR}` in the `SOLR_EXEC` property.
5. Start DDF, install the `standard` profile, and ingest some data, like the `reuters-xml` or `articles` datasets.
6. Shut down DDF.
7. Go to the `solr` folder and copy the `server/solr` subfolder somewhere else. This folder contains the cores that will be migrated to the new Solr installation.
8. Build DDF from this PR branch and unzip it. Delete the `solr` folder from step 2 and replace it with the `solr` folder from this DDF installation. This is an 8.x version of Solr.
9. Open the `solr` folder and go into the `server` subfolder. Delete its `solr` folder and replace it with the `solr` folder you copied in step 7.
10. Repeat steps 3 and 4 for this DDF.
11. Start DDF and install the `standard` profile.
12. Open the [Solr admin console](https://localhost:8994/solr), select the `catalog` core, then `Schema`. Select the `_root_` field, then click `delete field`.
a. The `_root_` field is present, despite it being deleted from `schema.xml` in this PR, because we copied the cores from the old Solr. They still contain the old schemas, which contain `_root_`, so we need to delete that field. The change in this PR will prevent new installations from having this problem.
13. Search for anything in Intrigue and select a result. Open the Inspector view and click `Edit`. Change the title to something else, then click `Save`.
14. Copy the metacard ID from the inspector.
15. Go back to the Solr admin console and query the `catalog` core for `id_txt:<the value from step 14>`. Verify the query returns exactly one record and that it has the updated title. (Note: it may take 30 seconds or so for the update to show up here after performing it in Intrigue).
16. Rerun your search in Intrigue and find the same record (you could just search for the new title value). Verify it has the updated title.

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.