### PR TITLE
[2.26.x] DDF-6599 detect an ExceptionReport, log it, and set hit count to -1

### DIFF
--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-api/src/main/java/org/codice/ddf/spatial/ogc/wfs/featuretransformer/ExceptionReportException.java
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-api/src/main/java/org/codice/ddf/spatial/ogc/wfs/featuretransformer/ExceptionReportException.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.spatial.ogc.wfs.featuretransformer;
+
+public class ExceptionReportException extends Exception {
+
+  public ExceptionReportException(String xmlBody) {
+    super(String.format("WFS returned an exception report: %s", xmlBody));
+  }
+}

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer/src/main/java/org/codice/ddf/spatial/ogc/wfs/featuretransformer/impl/WfsRouteBuilder.java
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer/src/main/java/org/codice/ddf/spatial/ogc/wfs/featuretransformer/impl/WfsRouteBuilder.java
@@ -24,6 +24,7 @@ import org.apache.camel.language.xpath.XPathBuilder;
 import org.apache.camel.processor.aggregate.AbstractListAggregationStrategy;
 import org.codice.ddf.spatial.ogc.wfs.catalog.WfsFeatureCollection;
 import org.codice.ddf.spatial.ogc.wfs.catalog.common.WfsFeatureCollectionImpl;
+import org.codice.ddf.spatial.ogc.wfs.featuretransformer.ExceptionReportException;
 
 public final class WfsRouteBuilder extends RouteBuilder {
 
@@ -49,6 +50,12 @@ public final class WfsRouteBuilder extends RouteBuilder {
         // copy that cache to the header so we can access it later.
         .setBody(simple("${body[0]}"))
         .setHeader("xml", body())
+        .choice()
+        .when(
+            XPathBuilder.xpath("/ows:ExceptionReport")
+                .namespace("ows", "http://www.opengis.net/ows"))
+        .bean(ExceptionFactory.class, "throwExceptionReportException(${bodyOneLine})")
+        .otherwise()
         .setHeader(
             "numberOfFeatures",
             XPathBuilder.xpath("/wfs:FeatureCollection/@numberOfFeatures", Long.class)
@@ -109,15 +116,28 @@ public final class WfsRouteBuilder extends RouteBuilder {
     }
   }
 
+  public static class ExceptionFactory {
+
+    private ExceptionFactory() {}
+
+    @SuppressWarnings("unused" /* used in camel route */)
+    public static Object throwExceptionReportException(String body)
+        throws ExceptionReportException {
+      throw new ExceptionReportException(body);
+    }
+  }
+
   // Must be public for Camel bean binding
   public static class WfsCollectionFactory {
 
     private WfsCollectionFactory() {}
 
+    @SuppressWarnings("unused" /* used in camel route */)
     public static WfsFeatureCollection createEmptyWfsCollection() {
       return new WfsFeatureCollectionImpl(0);
     }
 
+    @SuppressWarnings("unused" /* used in camel route */)
     public static WfsFeatureCollection createWfsCollection(
         final List<Metacard> featureMembers, final Long numberOfFeatures) {
       if (numberOfFeatures != null) {


### PR DESCRIPTION
What does this PR do?

Note: This PR is a redo of the origin PR https://github.com/codice/ddf/pull/6600, because the PR was accidentally merged prematurely. 

Update the camel route used for WFS to detect the ExceptionReport and throw it so callers can handle it. Update WfsSource to catch the exception, log it, and set the hit count to -1 as per the SourceResponse API.

Who is reviewing it?

@jlcsmith
@derekwilhelm

Select relevant component teams:

@codice/ogc

Ask 2 committers to review/merge the PR and tag them here.

@brendan-hofmann
@pklinef

How should this be tested?

This can only be tested if you have a WFS server that returns an ExceptionReport for the hit count, but sends valid objects for the results query. I do not have a publicly available server for this. However, there is a mock server and test in TestSpatial that reproduces the scenario.

Any background context you want to provide?

This affects a downstream project.

What are the relevant tickets?

Fixes: #6599

Screenshots

Checklist:

  Documentation Updated
  Update / Add Threat Dragon models
  Update / Add Unit Tests
  Update / Add Integration Tests
Notes on Review Process

Please see Notes on Review Process for further guidance on requirements for merging and abbreviated reviews.

Review Comment Legend:

✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist.
❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.