### PR TITLE
[2.19.x] G-9901 Remove error banners on navigation

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/actions.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/actions.js
@@ -60,3 +60,11 @@ exports.announce = function(announcement, timeout) {
     }
   }
 }
+
+exports.removeAll = function() {
+  return function(dispatch, getState) {
+    getState()
+      .map(a => a.id)
+      .forEach(id => dispatch(remove(id)))
+  }
+}

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/announcements.jsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/announcements.jsx
@@ -15,7 +15,6 @@
 
 var React = require('react')
 var actions = require('./actions')
-var $ = require('jquery')
 var connect = require('react-redux').connect
 
 var dim = function(Component) {

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/index.jsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/announcement/index.jsx
@@ -18,6 +18,8 @@ var React = require('react')
 var render = require('react-dom').render
 var Provider = require('react-redux').Provider
 
+const wreqr = require('../../js/wreqr.js')
+
 var actions = require('./actions')
 var configureStore = require('./configureStore')
 
@@ -38,6 +40,12 @@ render(
 exports.announce = function(announcement, timeout) {
   store.dispatch(actions.announce(announcement, timeout))
 }
+
+const removeAll = (exports.removeAll = function() {
+  store.dispatch(actions.removeAll())
+})
+
+wreqr.vent.on('router:navigate', removeAll)
 
 if (process.env.NODE_ENV !== 'production' && module.hot) {
   module.hot.accept()


### PR DESCRIPTION
#### What does this PR do?
Error banners are not automatically closed, and they will persist until the page is refreshed, or until the user closes them. This change will remove the banners when the user navigates to another page in the app.

#### Who is reviewing it? 
@maiiiiiiii 
@rymach 
@kcwire 

#### Select relevant component teams: 
@codice/ui 

#### How should this be tested?
1. Perform an action that results in an error banner being displayed, such as attempting to save a search form without filling in anything.
2. Navigate to another page of Intrigue using the left navigation bar.
3. Verify the error banner disappears.

#### Screenshots
##### Current Behavior
![ErrorBannerOld](https://user-images.githubusercontent.com/4495447/127235250-9e831e26-d39e-4f27-b387-5b0c7a49713c.gif)
##### New Behavior
![ErrorBannerNew](https://user-images.githubusercontent.com/4495447/127235265-55ba3eb5-01e8-4609-988e-4a8c0e5a27bb.gif)

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.