### PR TITLE
[2.25.x] Fix people claims lookup for LdapClaimsHandler

### DIFF
--- a/platform/security/claims/security-claims-ldap/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
+++ b/platform/security/claims/security-claims-ldap/src/main/java/ddf/security/sts/claimsHandler/ClaimsHandlerManager.java
@@ -79,7 +79,9 @@ public class ClaimsHandlerManager {
 
   public static final String USER_BASE_DN = "userBaseDn";
 
-  public static final String OBJECT_CLASS = "objectClass";
+  public static final String GROUP_OBJECT_CLASS = "groupObjectClass";
+
+  public static final String PERSON_OBJECT_CLASS = "personObjectClass";
 
   public static final String MEMBER_NAME_ATTRIBUTE = "memberNameAttribute";
 
@@ -134,7 +136,8 @@ public class ClaimsHandlerManager {
     String userDn = (String) props.get(ClaimsHandlerManager.LDAP_BIND_USER_DN);
     String password = (String) props.get(ClaimsHandlerManager.PASSWORD);
     String userBaseDn = (String) props.get(ClaimsHandlerManager.USER_BASE_DN);
-    String objectClass = (String) props.get(ClaimsHandlerManager.OBJECT_CLASS);
+    String groupObjectClass = (String) props.get(ClaimsHandlerManager.GROUP_OBJECT_CLASS);
+    String personObjectClass = (String) props.get(ClaimsHandlerManager.PERSON_OBJECT_CLASS);
     String memberNameAttribute = (String) props.get(ClaimsHandlerManager.MEMBER_NAME_ATTRIBUTE);
     String groupBaseDn = (String) props.get(ClaimsHandlerManager.GROUP_BASE_DN);
     String loginUserAttribute = (String) props.get(ClaimsHandlerManager.LOGIN_USER_ATTRIBUTE);
@@ -180,7 +183,7 @@ public class ClaimsHandlerManager {
           userBaseDn,
           loginUserAttribute,
           membershipUserAttribute,
-          objectClass,
+          groupObjectClass,
           memberNameAttribute,
           groupBaseDn,
           userDn,
@@ -194,6 +197,7 @@ public class ClaimsHandlerManager {
           propertyFileLocation,
           userBaseDn,
           loginUserAttribute,
+          personObjectClass,
           userDn,
           password,
           overrideCertDn,
@@ -344,6 +348,7 @@ public class ClaimsHandlerManager {
       String propertyFileLoc,
       String userBaseDn,
       String userNameAttr,
+      String objectClass,
       String userDn,
       String password,
       boolean overrideCertDn,
@@ -356,6 +361,7 @@ public class ClaimsHandlerManager {
     ldapHandler.setPropertyFileLocation(propertyFileLoc);
     ldapHandler.setUserBaseDN(userBaseDn);
     ldapHandler.setUserNameAttribute(userNameAttr);
+    ldapHandler.setObjectClass(objectClass);
     ldapHandler.setBindUserDN(userDn);
     ldapHandler.setBindUserCredentials(password);
     ldapHandler.setOverrideCertDn(overrideCertDn);
@@ -445,9 +451,14 @@ public class ClaimsHandlerManager {
     ldapProperties.put(USER_BASE_DN, userBaseDn);
   }
 
-  public void setObjectClass(String objectClass) {
-    LOGGER.trace("Setting objectClass: {}", objectClass);
-    ldapProperties.put(OBJECT_CLASS, objectClass);
+  public void setGroupObjectClass(String objectClass) {
+    LOGGER.trace("Setting group objectClass: {}", objectClass);
+    ldapProperties.put(GROUP_OBJECT_CLASS, objectClass);
+  }
+
+  public void setPersonObjectClass(String objectClass) {
+    LOGGER.trace("Setting person objectClass: {}", objectClass);
+    ldapProperties.put(PERSON_OBJECT_CLASS, objectClass);
   }
 
   public void setMemberNameAttribute(String memberNameAttribute) {

--- a/platform/security/claims/security-claims-ldap/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
+++ b/platform/security/claims/security-claims-ldap/src/main/java/ddf/security/sts/claimsHandler/LdapClaimsHandler.java
@@ -64,7 +64,7 @@ public class LdapClaimsHandler implements ClaimsHandler {
 
   private boolean overrideCertDn = false;
 
-  private String objectClass;
+  private String objectClass = "person";
 
   private String userNameAttribute;
 

--- a/platform/security/claims/security-claims-ldap/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/security/claims/security-claims-ldap/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -64,7 +64,8 @@
             <property name="membershipUserAttribute" value="uid"/>
             <property name="loginUserAttribute" value="uid" />
             <property name="userBaseDn" value="ou=users,dc=example,dc=com"/>
-            <property name="objectClass" value="groupOfNames"/>
+            <property name="groupObjectClass" value="groupOfNames"/>
+            <property name="personObjectClass" value="person"/>
             <property name="memberNameAttribute" value="member"/>
             <property name="groupBaseDn" value="ou=groups,dc=example,dc=com"/>
             <property name="propertyFileLocation" value="${ddf.etc}/ws-security/attributeMap.properties"/>

--- a/platform/security/claims/security-claims-ldap/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/platform/security/claims/security-claims-ldap/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -81,10 +81,15 @@
 			description="When checked, this setting will ignore the DN of a user and instead use the LDAP Base User DN value.">
 		</AD>
 
-        <AD name="LDAP Group ObjectClass:" id="objectClass" required="true" type="String"
+        <AD name="LDAP Group ObjectClass:" id="groupObjectClass" required="true" type="String"
             default="groupOfNames"
             description="ObjectClass that defines structure for group membership in LDAP. Usually this is groupOfNames or groupOfUniqueNames.">
         </AD>
+
+		<AD name="LDAP Person ObjectClass:" id="personObjectClass" required="true" type="String"
+			default="person"
+			description="ObjectClass that defines structure for people in LDAP. Usually this is person or organizationalPerson.">
+		</AD>
 
         <AD name="LDAP Membership Attribute:" id="memberNameAttribute" required="true" type="String"
             default="member"

--- a/platform/security/claims/security-claims-ldap/src/test/java/ddf/security/sts/claimsHandler/ClaimsHandlerManagerTest.java
+++ b/platform/security/claims/security-claims-ldap/src/test/java/ddf/security/sts/claimsHandler/ClaimsHandlerManagerTest.java
@@ -80,7 +80,7 @@ public class ClaimsHandlerManagerTest {
     manager.setUrl("ldap://ldap:1389");
     manager.setStartTls(false);
     manager.setLdapBindUserDn("cn=admin");
-    manager.setObjectClass("ou=users,dc=example,dc=com");
+    manager.setGroupObjectClass("ou=users,dc=example,dc=com");
     manager.setMemberNameAttribute("member");
     manager.setPassword("secret");
     manager.setPropertyFileLocation("etc/ws-security/attributeMap.properties");

--- a/platform/security/claims/security-claims-ldap/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
+++ b/platform/security/claims/security-claims-ldap/src/test/java/ddf/security/sts/claimsHandler/LdapClaimsHandlerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import ddf.security.SubjectOperations;
@@ -58,6 +59,8 @@ public class LdapClaimsHandlerTest {
   public static final String ATTRIBUTE_NAME = "cn";
 
   public static final String USER_BASE_DN = "ou=avengers,dc=marvel,dc=com";
+
+  private static final String USER_ATTRIBUTE = "uid";
 
   public static final String DUMMY_VALUE = "Tony Stark";
 
@@ -116,6 +119,7 @@ public class LdapClaimsHandlerTest {
     claimsHandler.setBindUserCredentials(BIND_USER_CREDENTIALS);
     claimsHandler.setKdcAddress(KCD);
     claimsHandler.setUserBaseDN(USER_BASE_DN);
+    claimsHandler.setUserNameAttribute(USER_ATTRIBUTE);
   }
 
   @Test
@@ -140,5 +144,12 @@ public class LdapClaimsHandlerTest {
     assertThat(processedClaims, hasSize(1));
     Claim claim = processedClaims.get(0);
     assertThat(claim.getValues(), contains(DUMMY_VALUE));
+
+    verify(mockConnection)
+        .search(
+            eq(USER_BASE_DN),
+            any(),
+            eq("(&(objectclass=person)(uid=cn=Tony Stark,ou=avengers,dc=marvel,dc=com))"),
+            eq(ATTRIBUTE_NAME));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
         <surefire.argline>${jacoco.argline} ${surefire.argline.append} -Xmx1024m -Djava.awt.headless=true -noverify</surefire.argline>
         <failsafe.argline>${jacoco.argline}</failsafe.argline>
 
-        <fabric8.docker.plugin.version>0.27.1</fabric8.docker.plugin.version>
+        <fabric8.docker.plugin.version>0.36.1</fabric8.docker.plugin.version>
         <tink.version>1.2.2</tink.version>
         <org.json.version>20170516</org.json.version>
         <ehcache.version>2.10.6</ehcache.version>


### PR DESCRIPTION
#### What does this PR do?
After STS removal, LdapClaimsHandler was using null as the object class to do LDAP queries for people. Any additional claims on the person were missing from the subject due to this. Now it will send `people` as the object class in the LDAP query or the configured value.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@dcruver 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->
@mcalcote 
@stustison

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

- Configure DDF to an LDAP server with people objects with additional attributes
- Configure DDF to support those additional person attributes
- ddf.security.sts.attributequery config PID has `supportedClaims` value
- ddf.security.guest.realm config PID has `attributes` value
- etc/ws-security/attributeMap.properties needs a mapping for the new attribute
- Claims_Handler_Manager factory PID has `personObjectClass` if the person object needs a value other than `person`
- Log in with a user that has those additional attributes
- Verify they have the additional claims by using https://localhost:8993/whoami

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: n/a

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
