### PR TITLE
[2.19.x] DDF-6618 / G-9917 Adds proper namespace support to CSW GetRecordsMess…

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source-common/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-source-common/pom.xml
@@ -187,6 +187,12 @@
             <artifactId>common-system</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-ebrim-transformer</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/reader/GetRecordsMessageBodyReaderTest.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/reader/GetRecordsMessageBodyReaderTest.java
@@ -15,11 +15,13 @@ package org.codice.ddf.spatial.ogc.csw.catalog.common.source.reader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,25 +32,43 @@ import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.DateTimeAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.TopicAttributes;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.resource.Resource;
 import ddf.security.encryption.EncryptionService;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import org.codice.ddf.parser.xml.XmlParser;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.transformer.RegistryTransformer;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswAxisOrder;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswConstants;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswRecordCollection;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswSourceConfiguration;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.converter.DefaultCswRecordMap;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.transformer.TransformerManager;
+import org.codice.ddf.spatial.ogc.csw.catalog.converter.CswRecordConverter;
+import org.codice.ddf.spatial.ogc.csw.catalog.converter.CswTransformProvider;
+import org.codice.ddf.spatial.ogc.csw.catalog.converter.GetRecordsResponseConverter;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -75,14 +95,15 @@ public class GetRecordsMessageBodyReaderTest {
     config.putMetacardCswMapping(Core.RESOURCE_URI, CswConstants.CSW_SOURCE);
 
     GetRecordsMessageBodyReader reader = new GetRecordsMessageBodyReader(mockProvider, config);
-    InputStream is =
-        GetRecordsMessageBodyReaderTest.class.getResourceAsStream("/getRecordsResponse.xml");
-    MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
-
     ArgumentCaptor<UnmarshallingContext> captor =
         ArgumentCaptor.forClass(UnmarshallingContext.class);
 
-    reader.readFrom(CswRecordCollection.class, null, null, null, httpHeaders, is);
+    try (InputStream is =
+        GetRecordsMessageBodyReaderTest.class.getResourceAsStream("/getRecordsResponse.xml")) {
+      MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+
+      reader.readFrom(CswRecordCollection.class, null, null, null, httpHeaders, is);
+    }
 
     // Verify the context arguments were set correctly
     verify(mockProvider, times(1)).unmarshal(any(HierarchicalStreamReader.class), captor.capture());
@@ -112,38 +133,134 @@ public class GetRecordsMessageBodyReaderTest {
   }
 
   @Test
-  public void testFullThread() throws Exception {
-    List<Metacard> inputMetacards = new ArrayList<>();
-    MetacardImpl metacard = new MetacardImpl();
-    metacard.setId("metacard1");
-    metacard.setTitle("title1");
-    inputMetacards.add(metacard);
+  public void testFullThreadCswRecordCollection() throws Exception {
+    Metacard metacard = createMetacard();
+    List<Metacard> inputMetacards = Collections.singletonList(metacard);
     CswRecordCollection collection = new CswRecordCollection();
     collection.setCswRecords(inputMetacards);
-    when(mockProvider.unmarshal(any(), any())).thenReturn(collection);
 
-    CswSourceConfiguration config = new CswSourceConfiguration(encryptionService);
-    Map<String, String> mappings = new HashMap<>();
-    mappings.put(Core.CREATED, "dateSubmitted");
-    mappings.put(Metacard.EFFECTIVE, "created");
-    mappings.put(Core.MODIFIED, "modified");
-    mappings.put(Metacard.CONTENT_TYPE, "type");
-    config.setMetacardCswMappings(mappings);
-    config.setOutputSchema(CswConstants.CSW_OUTPUT_SCHEMA);
-    config.setCswAxisOrder(CswAxisOrder.LAT_LON);
-    config.putMetacardCswMapping(Core.THUMBNAIL, CswConstants.CSW_REFERENCES);
-    config.putMetacardCswMapping(Core.RESOURCE_URI, CswConstants.CSW_SOURCE);
+    MetacardType cswMetacardType =
+        new MetacardTypeImpl(
+            CswConstants.CSW_METACARD_TYPE_NAME,
+            Arrays.asList(
+                new ContactAttributes(),
+                new LocationAttributes(),
+                new MediaAttributes(),
+                new TopicAttributes(),
+                new AssociationsAttributes()));
 
-    GetRecordsMessageBodyReader reader = new GetRecordsMessageBodyReader(mockProvider, config);
-    InputStream is =
-        GetRecordsMessageBodyReaderTest.class.getResourceAsStream("/getRecordsResponse.xml");
-    MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+    CswRecordConverter recordConverter = new CswRecordConverter(cswMetacardType);
+    TransformerManager mockInputManager = mock(TransformerManager.class);
+    when(mockInputManager.getTransformerByProperty(anyString(), anyString()))
+        .thenReturn(recordConverter);
+    CswTransformProvider metacardProvider = new CswTransformProvider(null, mockInputManager);
+    GetRecordsResponseConverter provider = new GetRecordsResponseConverter(metacardProvider);
 
-    CswRecordCollection cswRecords =
-        reader.readFrom(CswRecordCollection.class, null, null, null, httpHeaders, is);
+    CswSourceConfiguration config = createConfig();
 
+    GetRecordsMessageBodyReader reader = new GetRecordsMessageBodyReader(provider, config);
+    CswRecordCollection cswRecords = null;
+
+    try (InputStream is =
+        GetRecordsMessageBodyReaderTest.class.getResourceAsStream("/getRecordsResponse.xml")) {
+
+      MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+
+      cswRecords = reader.readFrom(CswRecordCollection.class, null, null, null, httpHeaders, is);
+    }
     List<Metacard> metacards = cswRecords.getCswRecords();
-    assertThat(metacards, contains(metacard));
+    assertThat(metacards.size(), is(3));
+    assertThat(metacards.get(0).getMetacardType().getName(), is("csw:Record"));
+    assertThat(metacards.get(0).getAttribute(Core.TITLE), is(notNullValue()));
+    assertThat(metacards.get(0).getTitle(), containsString("title"));
+  }
+
+  @Test
+  public void testFullThreadCswRecordCollectionAltPrefixes() throws Exception {
+    Metacard metacard = createMetacard();
+    List<Metacard> inputMetacards = Collections.singletonList(metacard);
+    CswRecordCollection collection = new CswRecordCollection();
+    collection.setCswRecords(inputMetacards);
+
+    MetacardType cswMetacardType =
+        new MetacardTypeImpl(
+            CswConstants.CSW_METACARD_TYPE_NAME,
+            Arrays.asList(
+                new ContactAttributes(),
+                new LocationAttributes(),
+                new MediaAttributes(),
+                new TopicAttributes(),
+                new AssociationsAttributes()));
+
+    CswRecordConverter recordConverter = new CswRecordConverter(cswMetacardType);
+    TransformerManager mockInputManager = mock(TransformerManager.class);
+    when(mockInputManager.getTransformerByProperty(anyString(), anyString()))
+        .thenReturn(recordConverter);
+    CswTransformProvider metacardProvider = new CswTransformProvider(null, mockInputManager);
+    GetRecordsResponseConverter provider = new GetRecordsResponseConverter(metacardProvider);
+
+    CswSourceConfiguration config = createConfig();
+
+    GetRecordsMessageBodyReader reader = new GetRecordsMessageBodyReader(provider, config);
+    CswRecordCollection cswRecords = null;
+
+    try (InputStream is =
+        GetRecordsMessageBodyReaderTest.class.getResourceAsStream(
+            "/getRecordsResponse-alt-prefixes.xml")) {
+
+      MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+
+      cswRecords = reader.readFrom(CswRecordCollection.class, null, null, null, httpHeaders, is);
+    }
+    List<Metacard> metacards = cswRecords.getCswRecords();
+    assertThat(metacards.size(), is(3));
+    assertThat(metacards.get(0).getMetacardType().getName(), is("csw:Record"));
+    assertThat(metacards.get(0).getAttribute(Core.TITLE), is(notNullValue()));
+    assertThat(metacards.get(0).getTitle(), containsString("title"));
+  }
+
+  @Test
+  public void testFullThreadRegistryCollection() throws Exception {
+    Metacard metacard = createMetacard();
+    List<Metacard> inputMetacards = Collections.singletonList(metacard);
+    CswRecordCollection collection = new CswRecordCollection();
+    collection.setCswRecords(inputMetacards);
+
+    RegistryTransformer registryTransformer = new RegistryTransformer();
+    registryTransformer.setParser(new XmlParser());
+    List metacardTypes = new ArrayList<>();
+    metacardTypes.addAll(
+        Arrays.asList(
+            new RegistryObjectMetacardType(),
+            new TopicAttributes(),
+            new MediaAttributes(),
+            new ContactAttributes(),
+            new CoreAttributes(),
+            new DateTimeAttributes()));
+    MetacardType metacardType = new MetacardTypeImpl("registryMetacard", metacardTypes);
+    registryTransformer.setRegistryMetacardType(metacardType);
+    System.setProperty(RegistryConstants.REGISTRY_ID_PROPERTY, "identityRegistryId");
+    TransformerManager mockInputManager = mock(TransformerManager.class);
+    when(mockInputManager.getTransformerByProperty(anyString(), anyString()))
+        .thenReturn(registryTransformer);
+    CswTransformProvider metacardProvider = new CswTransformProvider(null, mockInputManager);
+    GetRecordsResponseConverter provider = new GetRecordsResponseConverter(metacardProvider);
+
+    CswSourceConfiguration config = createConfig();
+
+    GetRecordsMessageBodyReader reader = new GetRecordsMessageBodyReader(provider, config);
+    CswRecordCollection cswRecords = null;
+
+    try (InputStream is =
+        GetRecordsMessageBodyReaderTest.class.getResourceAsStream("/getRecordsResponseEbRim.xml")) {
+
+      MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+
+      cswRecords = reader.readFrom(CswRecordCollection.class, null, null, null, httpHeaders, is);
+    }
+    List<Metacard> metacards = cswRecords.getCswRecords();
+    assertThat(metacards.size(), is(1));
+    assertThat(metacards.get(0).getMetacardType().getName(), is("registryMetacard"));
   }
 
   // verifies UTF-8 encoding configured properly when XML includes foreign text with special
@@ -161,12 +278,13 @@ public class GetRecordsMessageBodyReaderTest {
     config.setOutputSchema(CswConstants.CSW_OUTPUT_SCHEMA);
     GetRecordsMessageBodyReader reader = new GetRecordsMessageBodyReader(mockProvider, config);
 
-    InputStream is =
+    CswRecordCollection cswRecords = null;
+    try (InputStream is =
         GetRecordsMessageBodyReaderTest.class.getResourceAsStream(
-            "/geomaticsGetRecordsResponse.xml");
-    MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
-    CswRecordCollection cswRecords =
-        reader.readFrom(CswRecordCollection.class, null, null, null, httpHeaders, is);
+            "/geomaticsGetRecordsResponse.xml")) {
+      MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+      cswRecords = reader.readFrom(CswRecordCollection.class, null, null, null, httpHeaders, is);
+    }
     List<Metacard> metacards = cswRecords.getCswRecords();
     assertThat(metacards, contains(metacard));
   }
@@ -180,16 +298,18 @@ public class GetRecordsMessageBodyReaderTest {
 
     String sampleData = "SampleData";
     byte[] data = sampleData.getBytes();
-    ByteArrayInputStream dataInputStream = new ByteArrayInputStream(data);
-    MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
-    httpHeaders.add(CswConstants.PRODUCT_RETRIEVAL_HTTP_HEADER, "TRUE");
-    httpHeaders.add(
-        HttpHeaders.CONTENT_DISPOSITION, String.format("inline; filename=ResourceName"));
-    MediaType mediaType = new MediaType("text", "plain");
+    CswRecordCollection cswRecords = null;
+    try (ByteArrayInputStream dataInputStream = new ByteArrayInputStream(data)) {
+      MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+      httpHeaders.add(CswConstants.PRODUCT_RETRIEVAL_HTTP_HEADER, "TRUE");
+      httpHeaders.add(
+          HttpHeaders.CONTENT_DISPOSITION, String.format("inline; filename=ResourceName"));
+      MediaType mediaType = new MediaType("text", "plain");
 
-    CswRecordCollection cswRecords =
-        reader.readFrom(
-            CswRecordCollection.class, null, null, mediaType, httpHeaders, dataInputStream);
+      cswRecords =
+          reader.readFrom(
+              CswRecordCollection.class, null, null, mediaType, httpHeaders, dataInputStream);
+    }
 
     Resource resource = cswRecords.getResource();
     assertThat(resource, notNullValue());
@@ -207,19 +327,21 @@ public class GetRecordsMessageBodyReaderTest {
 
     String sampleData = "SampleData";
     byte[] data = sampleData.getBytes();
-    ByteArrayInputStream dataInputStream = new ByteArrayInputStream(data);
-    MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
-    httpHeaders.add(CswConstants.PRODUCT_RETRIEVAL_HTTP_HEADER, "TRUE");
-    httpHeaders.add(
-        HttpHeaders.CONTENT_DISPOSITION, String.format("inline; filename=ResourceName"));
-    httpHeaders.add(
-        HttpHeaders.CONTENT_RANGE,
-        String.format("bytes 1-%d/%d", sampleData.length() - 1, sampleData.length()));
-    MediaType mediaType = new MediaType("text", "plain");
+    CswRecordCollection cswRecords = null;
+    try (ByteArrayInputStream dataInputStream = new ByteArrayInputStream(data)) {
+      MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+      httpHeaders.add(CswConstants.PRODUCT_RETRIEVAL_HTTP_HEADER, "TRUE");
+      httpHeaders.add(
+          HttpHeaders.CONTENT_DISPOSITION, String.format("inline; filename=ResourceName"));
+      httpHeaders.add(
+          HttpHeaders.CONTENT_RANGE,
+          String.format("bytes 1-%d/%d", sampleData.length() - 1, sampleData.length()));
+      MediaType mediaType = new MediaType("text", "plain");
 
-    CswRecordCollection cswRecords =
-        reader.readFrom(
-            CswRecordCollection.class, null, null, mediaType, httpHeaders, dataInputStream);
+      cswRecords =
+          reader.readFrom(
+              CswRecordCollection.class, null, null, mediaType, httpHeaders, dataInputStream);
+    }
 
     Resource resource = cswRecords.getResource();
 
@@ -243,16 +365,18 @@ public class GetRecordsMessageBodyReaderTest {
 
     String sampleData = "SampleData";
     byte[] data = sampleData.getBytes();
-    ByteArrayInputStream dataInputStream = new ByteArrayInputStream(data);
-    MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
-    httpHeaders.add(CswConstants.PRODUCT_RETRIEVAL_HTTP_HEADER, "TRUE");
-    httpHeaders.add(
-        HttpHeaders.CONTENT_DISPOSITION, String.format("inline; filename=ResourceName"));
-    MediaType mediaType = new MediaType("text", "plain");
+    CswRecordCollection cswRecords = null;
+    try (ByteArrayInputStream dataInputStream = new ByteArrayInputStream(data)) {
+      MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+      httpHeaders.add(CswConstants.PRODUCT_RETRIEVAL_HTTP_HEADER, "TRUE");
+      httpHeaders.add(
+          HttpHeaders.CONTENT_DISPOSITION, String.format("inline; filename=ResourceName"));
+      MediaType mediaType = new MediaType("text", "plain");
 
-    CswRecordCollection cswRecords =
-        reader.readFrom(
-            CswRecordCollection.class, null, null, mediaType, httpHeaders, dataInputStream);
+      cswRecords =
+          reader.readFrom(
+              CswRecordCollection.class, null, null, mediaType, httpHeaders, dataInputStream);
+    }
 
     Resource resource = cswRecords.getResource();
 
@@ -266,5 +390,27 @@ public class GetRecordsMessageBodyReaderTest {
     // the number
     // of bytes that was attempted to be skipped, the stream must be aligned there instead.
     assertThat(resource.getByteArray(), is(data));
+  }
+
+  private Metacard createMetacard() {
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setId("metacard1");
+    metacard.setTitle("title1");
+    return metacard;
+  }
+
+  private CswSourceConfiguration createConfig() {
+    CswSourceConfiguration config = new CswSourceConfiguration(encryptionService);
+    Map<String, String> mappings = new HashMap<>();
+    mappings.put(Core.CREATED, "dateSubmitted");
+    mappings.put(Metacard.EFFECTIVE, "created");
+    mappings.put(Core.MODIFIED, "modified");
+    mappings.put(Metacard.CONTENT_TYPE, "type");
+    config.setMetacardCswMappings(mappings);
+    config.setOutputSchema(CswConstants.CSW_OUTPUT_SCHEMA);
+    config.setCswAxisOrder(CswAxisOrder.LAT_LON);
+    config.putMetacardCswMapping(Core.THUMBNAIL, CswConstants.CSW_REFERENCES);
+    config.putMetacardCswMapping(Core.RESOURCE_URI, CswConstants.CSW_SOURCE);
+    return config;
   }
 }

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/resources/getRecordsResponse-alt-prefixes.xml
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/resources/getRecordsResponse-alt-prefixes.xml
@@ -1,0 +1,83 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<ns2:GetRecordsResponse xmlns:ns2="http://www.opengis.net/cat/csw/2.0.2" xmlns:terms="http://purl.org/dc/terms/" xmlns:ns3="http://www.opengis.net/gml">
+  <ns2:SearchStatus status="subset" timestamp="2013-05-01T02:13:36+0200"/>
+  <ns2:SearchResults elementSet="full" nextRecord="11" numberOfRecordsMatched="479"
+                     numberOfRecordsReturned="10" recordSchema="csw:Record">
+    <rec:Record xmlns:rec="http://www.opengis.net/cat/csw/2.0.2">
+      <terms:spatial>
+        <ns3:Polygon ns3:srsName="EPSG:4326" ns3:srsDimension="2"
+                     ns3:uomLabels="degrees degrees">
+          <ns3:exterior>
+            <ns3:LinearRing>
+              <ns3:posList>33.716944444444444 51.70333333333333 33.71666666666667
+                51.740833333333335 33.73166666666667 51.740833333333335
+                33.731944444444444 51.70333333333333 33.716944444444444
+                51.70333333333333</ns3:posList>
+            </ns3:LinearRing>
+          </ns3:exterior>
+        </ns3:Polygon>
+      </terms:spatial>
+      <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">{8C1F6297-EC96-4302-A01E-14988C9149FD}</dc:identifier>
+      <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">title 1</dc:title>
+      <terms:modified>2008-12-15</terms:modified>
+      <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">subject 1</dc:subject>
+      <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">second subject</dc:subject>
+      <terms:abstract>abstract 1</terms:abstract>
+      <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/">copyright 1</dc:rights>
+      <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/">copyright 2</dc:rights>
+      <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">english</dc:language>      
+      <ows:BoundingBox xmlns:ows="http://www.opengis.net/ows" crs="EPSG:RD_New (28992)">
+        <ows:LowerCorner>5.121 52.139</ows:LowerCorner>
+        <ows:UpperCorner>4.468 52.517</ows:UpperCorner>
+      </ows:BoundingBox>   
+      <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">dataset</dc:type>
+      <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">Shapefile</dc:format> 
+    </rec:Record>
+    <ns2:Record xmlns:ns2="http://www.opengis.net/cat/csw/2.0.2">
+      <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">{23362852-F370-4369-B0B2-BE74B2859614}</dc:identifier>
+      <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">mc2 title</dc:title>
+      <terms:modified>2010-12-15</terms:modified>
+      <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">first subject</dc:subject>
+      <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">subject 2</dc:subject>
+      <terms:description>mc2 abstract</terms:description>
+      <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/">first copyright</dc:rights>
+      <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/">second copyright</dc:rights>
+      <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">english</dc:language>
+      <ows:BoundingBox xmlns:ows="http://www.opengis.net/ows" crs="EPSG:RD_New (28992)">
+        <ows:LowerCorner>6.121 53.139</ows:LowerCorner>
+        <ows:UpperCorner>5.468 53.517</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">dataset 2</dc:type>
+      <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">Shapefile 2</dc:format>
+    </ns2:Record>
+    <ns2:Record xmlns:ns2="http://www.opengis.net/cat/csw/2.0.2">
+      <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">{23362852-F370-4369-B0B2-BE74B2859615}</dc:identifier>
+      <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">mc3 title</dc:title>
+      <terms:modified>2010-12-15</terms:modified>
+      <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">first subject</dc:subject>
+      <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">subject 3</dc:subject>
+      <terms:tableOfContents>mc3 abstract</terms:tableOfContents>
+      <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/">first copyright</dc:rights>
+      <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/">second copyright</dc:rights>
+      <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">english</dc:language>
+      <ows:BoundingBox xmlns:ows="http://www.opengis.net/ows" crs="EPSG:RD_New (28992)">
+        <ows:LowerCorner>6.121 53.139</ows:LowerCorner>
+        <ows:UpperCorner>5.468 53.517</ows:UpperCorner>
+      </ows:BoundingBox>
+      <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">dataset 3</dc:type>
+      <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">Shapefile 3</dc:format>
+    </ns2:Record>
+  </ns2:SearchResults>
+</ns2:GetRecordsResponse>

--- a/catalog/spatial/csw/spatial-csw-source-common/src/test/resources/getRecordsResponseEbRim.xml
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/test/resources/getRecordsResponseEbRim.xml
@@ -1,0 +1,56 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+
+<csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+                        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                        version="2.0.2">
+    <csw:SearchStatus timestamp="2017-01-17T09:34:28.597-07:00"/>
+    <csw:SearchResults numberOfRecordsMatched="1" numberOfRecordsReturned="1" nextRecord="0"
+                       recordSchema="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" elementSet="full">
+        <rim:RegistryPackage xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                             objectType="urn:registry:federation:node"
+                             id="urn:uuid:12121212121212121212121212121212">
+            <rim:ExternalIdentifier registryObject="urn:uuid:70809f17782c42b8ba15747b86b50ebf"
+                                    identificationScheme="MetacardId" value="11111111111111111111111111111111"
+                                    id="urn:registry:metacard:local-id"/>
+            <rim:ExternalIdentifier registryObject="urn:uuid:70809f17782c42b8ba15747b86b50ebf"
+                                    identificationScheme="MetacardId" value="11111111111111111111111111111111"
+                                    id="urn:registry:metacard:origin-id"/>
+            <rim:ExternalIdentifier registryObject="urn:uuid:70809f17782c42b8ba15747b86b50ebf"
+                                    identificationScheme="RegistryId" value="urn:uuid:12121212121212121212121212121212"
+                                    id="urn:registry:origin-id"/>
+            <rim:RegistryObjectList>
+                <rim:Identifiable xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+                                  xs:type="rim:ExtrinsicObjectType"
+                                  objectType="urn:registry:federation:node" id="someid"
+                                  home="https://localhost:8993">
+                    <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                        <rim:ValueList>
+                            <rim:Value>2018-02-26T17:16:34.996Z</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Slot name="liveDate" slotType="xs:dateTime">
+                        <rim:ValueList>
+                            <rim:Value>2017-01-17T16:28:38.071Z</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Name>
+                        <rim:LocalizedString value="RemoteRegistry"/>
+                    </rim:Name>
+                    <rim:VersionInfo versionName="2.10.0-SNAPSHOT"/>
+                </rim:Identifiable>
+            </rim:RegistryObjectList>
+        </rim:RegistryPackage>
+    </csw:SearchResults>
+</csw:GetRecordsResponse>


### PR DESCRIPTION
…ageBodyReader

#### What does this PR do?
Fixes a bug with the CSW Source in the case that the CSW server sends back a GetRecordsResponse with a non-"csw" namespace prefix.  Now the MessageBodyReader properly handles namespace prefix mappings.

#### Who is reviewing it? 
@jrnorth @millerw8 @maiiiiiiii 

#### Select relevant component teams: 
@codice/data 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@jrnorth @millerw8 

#### How should this be tested?
This condition is covered by the newly added unit tests.  So a successful CI should be sufficient.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6618

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
