### PR TITLE
[2.19.x] G-9945 Allow empty location in search forms

### DIFF
--- a/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizer.java
+++ b/catalog/ui/catalog-ui-search/src/main/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizer.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.catalog.ui.forms.builder;
 
 import static ddf.catalog.data.AttributeType.AttributeFormat.DATE;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeRegistry;
@@ -108,7 +109,7 @@ class AttributeValueNormalizer {
    * @throws FilterProcessingException if the provided data is not valid.
    */
   public String normalizeForXml(String property, String value) {
-    if (eitherStringIsNull(property, value)) {
+    if (eitherStringIsNull(property, value) || isBlank(value)) {
       return value;
     }
     if (!EXPECTED_ATTRIBUTE_NAME_PATTERN.matcher(property).matches()) {

--- a/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizerTest.java
+++ b/catalog/ui/catalog-ui-search/src/test/java/org/codice/ddf/catalog/ui/forms/builder/AttributeValueNormalizerTest.java
@@ -136,6 +136,12 @@ public class AttributeValueNormalizerTest {
   }
 
   @Test
+  public void testEmptyDateValueToXml() {
+    when(registry.lookup(PROPERTY_NAME)).thenReturn(Optional.of(DATE_DESCRIPTOR));
+    assertThat(normalizer.normalizeForXml(PROPERTY_NAME, ""), is(equalTo("")));
+  }
+
+  @Test
   public void testEpochDateValueToXml() {
     when(registry.lookup(eq(PROPERTY_NAME))).thenReturn(Optional.of(DATE_DESCRIPTOR));
     assertThat(

--- a/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/component/query-advanced/query-advanced.view.js
@@ -22,7 +22,10 @@ const cql = require('../../js/cql.js')
 const store = require('../../js/store.js')
 const QuerySettingsView = require('../query-settings/query-settings.view.js')
 const properties = require('../../js/properties.js')
-import { getFilterErrors } from '../../react-component/utils/validation'
+import {
+  getFilterErrors,
+  getSearchFormFilterErrors,
+} from '../../react-component/utils/validation'
 
 import query from '../../react-component/utils/query'
 
@@ -199,13 +202,13 @@ module.exports = Marionette.LayoutView.extend({
     }
   },
   getErrorMessages() {
+    const filters = this.queryAdvanced.currentView.getFilters().filters || []
+    const filterErrors = this.options.isFormBuilder
+      ? getSearchFormFilterErrors(filters)
+      : getFilterErrors(filters)
     return this.querySettings.currentView
       .getErrorMessages()
-      .concat(
-        getFilterErrors(
-          this.queryAdvanced.currentView.getFilters().filters || []
-        )
-      )
+      .concat(filterErrors)
   },
   setDefaultTitle() {
     this.model.set('title', this.model.get('cql'))

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-input.js
@@ -41,12 +41,20 @@ const FilterInput = ({
   attribute,
   suggestions,
   onChange,
+  isFormBuilder,
 }) => {
   const type = getAttributeType(attribute)
   const Root = type === 'LOCATION' ? LocationRoot : BaseRoot
   return (
     <Root>
-      {determineInput(comparator, type, suggestions, value, onChange)}
+      {determineInput(
+        comparator,
+        type,
+        suggestions,
+        value,
+        onChange,
+        isFormBuilder
+      )}
     </Root>
   )
 }

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filter-location-input.js
@@ -192,6 +192,7 @@ class LocationInput extends React.Component {
           this.locationModel
         )
       },
+      isFormBuilder: this.props.isFormBuilder,
     }
     return (
       <LocationView

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filterInputHelper.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter-input/filterInputHelper.js
@@ -28,9 +28,10 @@ export const determineInput = (
   type,
   suggestions,
   value,
-  onChange
+  onChange,
+  isFormBuilder
 ) => {
-  const props = { value, onChange }
+  const props = { value, onChange, isFormBuilder }
   switch (comparator) {
     case 'IS EMPTY':
       return null

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/filter/filter.js
@@ -115,6 +115,7 @@ class Filter extends React.Component {
             this.setState({ value }, () => this.props.onChange(this.state))
           }}
           value={this.state.value}
+          isFormBuilder={this.props.isFormBuilder}
         />
       </Root>
     )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/location/location.js
@@ -86,11 +86,11 @@ const ErrorWrapper = styled.div`
 
 const Component = CustomElements.registerReact('location')
 const LocationInput = props => {
-  const { mode, setState } = props
+  const { mode, setState, isFormBuilder } = props
   const input = inputs[mode] || {}
   const { Component: Input = null } = input
   const locOptionError = {
-    error: input.label === undefined,
+    error: !isFormBuilder && input.label === undefined,
     message: 'Please select a Location',
   }
   return (
@@ -125,5 +125,10 @@ const LocationInput = props => {
 }
 
 module.exports = ({ state, setState, options }) => (
-  <LocationInput {...state} onDraw={options.onDraw} setState={setState} />
+  <LocationInput
+    {...state}
+    onDraw={options.onDraw}
+    setState={setState}
+    isFormBuilder={options.isFormBuilder}
+  />
 )

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/index.tsx
@@ -15,6 +15,7 @@
 export {
   showErrorMessages,
   getFilterErrors,
+  getSearchFormFilterErrors,
   ErrorComponent,
   validateGeo,
   initialErrorState,

--- a/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
+++ b/ui/packages/catalog-ui-search/src/main/webapp/react-component/utils/validation/validation.tsx
@@ -54,12 +54,20 @@ export function showErrorMessages(errors: any) {
 }
 
 export function getFilterErrors(filters: any) {
+  return _getFilterErrors(filters, false)
+}
+
+export function getSearchFormFilterErrors(filters: any) {
+  return _getFilterErrors(filters, true)
+}
+
+function _getFilterErrors(filters: any, allowEmptyGeo: boolean) {
   const errors = new Set()
   let geometryErrors = new Set<string>()
   let dateErrors = new Set<string>()
   for (let i = 0; i < filters.length; i++) {
     const filter = filters[i]
-    getGeometryErrors(filter).forEach(msg => {
+    getGeometryErrors(filter, allowEmptyGeo).forEach(msg => {
       geometryErrors.add(msg)
     })
     getDateErrors(filter).forEach(msg => {
@@ -67,16 +75,10 @@ export function getFilterErrors(filters: any) {
     })
   }
   geometryErrors.forEach(err => {
-    errors.add({
-      title: 'Invalid geometry filter',
-      body: err,
-    })
+    errors.add({ title: 'Invalid geometry filter', body: err })
   })
   dateErrors.forEach(err => {
-    errors.add({
-      title: 'Invalid date filter',
-      body: err,
-    })
+    errors.add({ title: 'Invalid date filter', body: err })
   })
   return Array.from(errors)
 }
@@ -198,11 +200,11 @@ function getDateErrors(filter: any): Set<string> {
   return errors
 }
 
-function getGeometryErrors(filter: any): Set<string> {
+function getGeometryErrors(filter: any, allowEmptyGeo: boolean): Set<string> {
   const geometry = filter.geojson && filter.geojson.geometry
   const errors = new Set<string>()
   if (!geometry) {
-    if (isGeoSearch(filter.type)) {
+    if (!allowEmptyGeo && isGeoSearch(filter.type)) {
       errors.add('Location Option must be selected')
     }
     return errors


### PR DESCRIPTION
#### What does this PR do?
This allows a search form to require a location without having to specify the location type, allowing the user to select their own when running a search.
#### Who is reviewing it? 
@kcwire 
@jMoneee 

#### Select relevant component teams: 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.
@andrewzimmer
@millerw8

#### How should this be tested?
Create a search form and add either the `anyGeo` or `location` field, or both. Do not select a location option. Verify no warnings are displayed and that you can save the search form.

Open a workspace and use the search form. Verify you can select a location option and that your search works as expected.

Use the advanced search and add either the `anyGeo` or `location` field, or both. Verify you are warned to select a location, and that you cannot run the search without selecting a location option.
#### Screenshots
##### Before
https://user-images.githubusercontent.com/4495447/134585250-486cf8b5-ec0e-4c11-9d5b-9b7abe654e74.mp4
##### After
https://user-images.githubusercontent.com/4495447/134585909-74e37b26-edf9-4248-a108-01cb52ffcb48.mp4
#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
