### PR TITLE
Documentation edits to rephrase optional plurals (#6643)

### DIFF
--- a/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-api.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-api.adoc
@@ -105,7 +105,7 @@ The Endpoint bundle contains a Web service that exposes the interface to retriev
 The Endpoint calls the `CatalogFramework` to execute the operations of its specification.
 The `CatalogFramework` relies on the Sources to execute the actual resource retrieval.
 Optional `PreResource` and `PostResource` Catalog Plugins may be invoked by the `CatalogFramework` to modify the resource retrieval request/response prior to the Catalog Provider processing the request and providing the response.
-It is possible to retrieve resources from specific remote Sources by specifying the site name(s) in the request.
+It is possible to retrieve resources from specific remote Sources by specifying the site names in the request.
 
 .Product Caching
 Product Caching is enabled by default.

--- a/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-framework-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/catalog-framework-intro.adoc
@@ -160,9 +160,9 @@ The Query Service Endpoint, the Catalog Framework, and the `CatalogProvider` are
 The Endpoint bundle contains a Web service that exposes the interface to query for `Metacards`.
 The Endpoint calls the `CatalogFramework` to execute the operations of its specification.
 The `CatalogFramework` relies on the `CatalogProvider` to execute the actual query.
-Optional PreQuery and PostQuery Catalog Plugins may be invoked by the `CatalogFramework` to modify the query request/response prior to the Catalog Provider processing the query request and providing the query response.
-If a `CatalogProvider` is not configured and no other remote Sources are configured, a fault will be returned.
-It is possible to have only remote Sources configured and no local `CatalogProvider` configured and be able to execute queries to specific remote Sources by specifying the site name(s) in the query request.
+Optional PreQuery and PostQuery Catalog Plugins may be invoked by the `CatalogFramework` to modify the query request/response prior to the Catalog Provider processing the query request and providing the query response.
+If a `CatalogProvider` is not configured, and no other remote Sources are configured, a fault is returned.
+It is possible to have only remote Sources configured and no local `CatalogProvider` configured and be able to execute queries to specific remote Sources by specifying the site names in the query request.
 
 ==== Product Caching
 

--- a/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/standard-catalog-framework.adoc
+++ b/distribution/docs/src/main/resources/content/_architectures/_catalogFrameworks/standard-catalog-framework.adoc
@@ -18,12 +18,12 @@ Use this framework if:
 * queries to specific sites are required.
 * queries to only the local provider are required.
 
-It is possible to have only remote Sources configured with no local `CatalogProvider` configured and be able to execute queries to specific remote sources by specifying the site name(s) in the query request.
+It is possible to have only remote Sources configured with no local `CatalogProvider` configured and be able to execute queries to specific remote sources by specifying the site names in the query request.
 
 The Standard Catalog Framework also maintains a list of `ResourceReaders` for resource retrieval operations.
 A resource reader is matched to the scheme (the protocol, such as `file://`) in the URI of the resource specified in the request to be retrieved.
 
-Site information about the catalog provider and/or any federated source(s) can be retrieved using the Standard Catalog Framework.
+Site information about the catalog provider and/or any federated sources can be retrieved using the Standard Catalog Framework.
 Site information includes the source's name, version, availability, and the list of unique content types currently stored in the source (such as NITF).
 If no local catalog provider is configured, the site information returned includes site info for the catalog framework with no content types included.
 

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-applications.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/custom-applications.adoc
@@ -87,7 +87,7 @@ The URL to the application's KAR file in this Maven repository should be the ins
 
 == Including Data Files in a KAR File
 
-The developer may need to include data or configuration file(s) in a KAR file.
+The developer may need to include data or configuration files in a KAR file.
 An example of this is a properties file for the JDBC connection properties of a catalog provider.
 
 It is recommended that:
@@ -100,7 +100,7 @@ Sub-directories under `src/main/resources` can be used, for example, `etc/securi
 == Installing a KAR File
 
 When the user downloads an application by clicking on the *Installation* link, the application's KAR file is downloaded.
-To install manually, the KAR file can be placed in the `${home_directory}/deploy` directory of the running ${branding} instance. ${branding} then detects that a file with a `.kar` file extension has been placed in this monitored directory, unzips the KAR file into the `${home_directory}/system` directory, and installs the bundle(s) listed in the KAR file's feature descriptor file.
+To install manually, the KAR file can be placed in the `${home_directory}/deploy` directory of the running ${branding} instance. ${branding} then detects that a file with a `.kar` file extension has been placed in this monitored directory, unzips the KAR file into the `${home_directory}/system` directory, and installs the bundles listed in the KAR file's feature descriptor file.
 To install via the ${admin-console}:
 . Navigate to the *${admin-console}*.
 . Select *Manage* button.
@@ -162,7 +162,7 @@ public class SourcesPlugin extends AbstractApplicationPlugin {
 
 === Including KAR Files
 
-Sometimes a developer may need to include data or configuration file(s) in a KAR file.
+Sometimes a developer may need to include data or configuration files in a KAR file.
 An example of this would be a properties file for the JDBC connection properties of a catalog provider.
 
 It is recommended that:

--- a/distribution/docs/src/main/resources/content/_developing/_devComponents/global-attribute-validators.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devComponents/global-attribute-validators.adoc
@@ -70,7 +70,7 @@ The `validator` key must have a value of one of the following:
  - `enumeration`
  * `arguments`: (unlimited) [list of strings: each argument is one case-sensitive, valid enumeration value]
  - `relationship`
- * `arguments`: (4+) [attribute value or null, one of mustHave|cannotHave|canOnlyHave, target attribute name, null or target attribute value(s) as additional arguments]
+ * `arguments`: (4+) [attribute value or null, one of mustHave|cannotHave|canOnlyHave, target attribute name, null or target attribute values as additional arguments]
  - `match_any`
  * `validators`: (unlimited) [list of previously defined validators: valid if any validator succeeds]
 ====

--- a/distribution/docs/src/main/resources/content/_developing/_devGuidelines/osgi-basics.adoc
+++ b/distribution/docs/src/main/resources/content/_developing/_devGuidelines/osgi-basics.adoc
@@ -46,7 +46,7 @@ Many alternative tools exist, and OSGi manifest files can also be created by han
 
 Avoid creating bundles by hand or editing a manifest file:: Many tools exist for creating bundles, notably the Maven Bundle plugin, which handle the details of OSGi configuration and automate the bundling process including generation of the manifest file.
 Always make a distinction on which imported packages are `optional` or `required`:: Requiring every package when not necessary can cause an unnecessary dependency ripple effect among bundles.
-Embedding is an implementation detail:: Using the `Embed-Dependency` instruction provided by the `maven-bundle-plugin` will insert the specified jar(s) into the target archive and add them to the `Bundle-ClassPath`. These jars and their contained packages/classes are not for public consumption; they are for the internal implementation of this service implementation only.
+Embedding is an implementation detail:: Using the `Embed-Dependency` instruction provided by the `maven-bundle-plugin` will insert the specified jars into the target archive and add them to the `Bundle-ClassPath`. These jars and their contained packages/classes are not for public consumption; they are for the internal implementation of this service implementation only.
 Bundles should never be embedded:: Bundles expose service implementations; they do not provide arbitrary classes to be used by other bundles.
 Bundles should expose service implementations:: This is the corollary to the previous rule. Bundles should not be created when arbitrary concrete classes are being extracted to a library. In that case, a library/jar is the appropriate module packaging type.
 Bundles should generally _only_ export service packages:: If there are packages internal to a bundle that comprise its implementation but not its public manifestation of the API, they should be excluded from export and kept as private packages.
@@ -97,7 +97,7 @@ However, the distributions frequently upgrade CXF between releases to take advan
 If building on these components, be aware of the version upgrades with each distribution release.
 
 Instead, component developers should package and deliver their own dependencies to ensure future compatibility.
-For example, if re-using a bundle, the specific bundle version that you are depending on should be included in your packaged release, and the proper versions should be referenced in your bundle(s).
+For example, if re-using a bundle, the specific bundle version that you are depending on should be included in your packaged release, and the proper versions should be referenced in your bundles.
 
 === Deploying a Bundle
 

--- a/distribution/docs/src/main/resources/content/_integrating/_endpoints/csw-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_endpoints/csw-endpoint.adoc
@@ -198,7 +198,7 @@ Optionally, set the `ElementSetName` to determine how much detail to return.
 
 * Brief: the least possible detail.
 * Summary: (Default)
-* Full:  All metadata elements for the record(s).
+* Full:  All metadata elements for the records.
 
 Within the `Constraint` element, define the query as an OSG or CQL filter.
 

--- a/distribution/docs/src/main/resources/content/_integrating/_endpoints/endpoint-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_endpoints/endpoint-intro.adoc
@@ -4,7 +4,7 @@
 :operations: na
 :order: 00
 
-(((Federation))) with ${branding} is primarily accomplished through <<{integrating-prefix}endpoints,Endpoints>> accessible through http(s) requests and responses.
+(((Federation))) with ${branding} is primarily accomplished through <<{integrating-prefix}endpoints,Endpoints>> accessible through https requests and responses.
 
 [NOTE]
 ====

--- a/distribution/docs/src/main/resources/content/_integrating/_eventing/subscriptions.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_eventing/subscriptions.adoc
@@ -31,8 +31,8 @@ Notably, the Catalog allows event evaluation on both the previous value (if avai
 
 Subscription durability is not provided by the Event Processor.
 Thus, all subscriptions are transient and will not be recreated in the event of a system restart.
-It is the responsibility of Endpoints using subscriptions to persist and re-establish the subscription on startup.
-This decision was made for the sake of simplicity, flexibility, and the inability of the Event Processor to recreate a fully-configured Delivery Method without being overly restrictive.
+It is the responsibility of Endpoints using subscriptions to persist and re-establish the subscription on startup.
+This decision was made for the sake of simplicity and flexibility, and due to the inability of the Event Processor to recreate a fully configured Delivery Method without being overly restrictive.
 
 [IMPORTANT]
 ====

--- a/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/search-intro.adoc
+++ b/distribution/docs/src/main/resources/content/_introduction/_coreConcepts/search-intro.adoc
@@ -31,4 +31,4 @@ Temporal searches can use the `created` or `modified` date attributes.
 Datatype Search:: A datatype search is used to search for metadata based on the datatype of the resource.
 Wildcards (*) can be used in both the datatype and version fields.
 Metadata that matches any of the datatypes (and associated versions if specified) will be returned.
-If a version is not specified, then all metadata records for the specified datatype(s) regardless of version will be returned.
+If a version is not specified, then all metadata records for the specified datatypes regardless of version will be returned.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/enforcing-errors.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/enforcing-errors.adoc
@@ -13,6 +13,6 @@ Prevent data with errors or warnings from being ingested at all.
 . Select the *${ddf-catalog}* application.
 . Select *Configuration*.
 . Select *Metacard Validation Marker Plugin*.
-. Enter *ID* of validator(s) to enforce.
+. Enter *ID* of each validator to enforce.
 . Select *Enforce errors* to prevent ingest for errors.
 . Select *Enforce warnings* to prevent ingest for warnings.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/http-port.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/http-port.adoc
@@ -10,7 +10,7 @@
 To change HTTP or HTTPS ports from the default values, edit the `custom.system.properties` file.
 
 . Open the file at ${home_directory}/etc/custom.system.properties
-. Change the value after the `=` to the desired port number(s):
+. Change the value after the `=` to the desired port numbers:
 .. `org.codice.ddf.system.httpsPort=8993` to `org.codice.ddf.system.httpsPort=<PORT>`
 .. `org.codice.ddf.system.httpPort=8181` to `org.codice.ddf.system.httpPort=<PORT>`
 . Restart ${branding} for changes to take effect.

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/landing-page.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/landing-page.adoc
@@ -8,7 +8,7 @@
 == {title}
 
 The ((Landing Page)) is the first page presented to users of ${branding}.
-It is customizable to allow adding organizationally-relevant content.
+It is customizable to allow adding organizationally relevant content.
 
 === Installing the Landing Page
 

--- a/distribution/docs/src/main/resources/content/_managing/_datamanagement/overriding-attributes.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_datamanagement/overriding-attributes.adoc
@@ -25,4 +25,4 @@ Attribute overrides are available for the following ingest methods:
 .. *Confluence Connected Source*.
 .. *Confluence Federated Source*.
 . Select *Attribute Overrides*.
-. Enter the key-value pair for the attribute to override and the value(s) to set.
+. Enter the key-value pair for the attribute to override and the values to set.

--- a/distribution/docs/src/main/resources/content/_managing/_running/directory-monitor-ingest.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/directory-monitor-ingest.adoc
@@ -11,7 +11,7 @@ The ${ddf-catalog} application contains a ((Content Directory Monitor)) feature 
 For more information about configuring a directory to be monitored, see <<{managing-prefix}configuring_the_content_directory_monitor,Configuring the Content Directory Monitor>>.
 
 Files placed in the monitored directory will be ingested automatically.
-If a file cannot be ingested, they will be moved to an automatically-created directory named `.errors`.
+If a file cannot be ingested, they will be moved to an automatically created directory named `.errors`.
 More information about the ingest operations can be found in the ingest log.
 The default location of the log is `${home_directory}/data/log/ingest_error.log`.
 Optionally, ingested files can be automatically moved to a directory called `.ingested`.

--- a/distribution/docs/src/main/resources/content/_managing/_running/ingest-command.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/ingest-command.adoc
@@ -20,7 +20,7 @@ The syntax for the ingest command is
 
 `ingest -t <transformer type> <file path>`
 
-Select the `<transformer type>` based on the type of file(s) ingested.
+Select the `<transformer type>` based on the type of files ingested.
 Metadata will be extracted if it exists in a format compatible with the transformer.
 The default transformer is the <<{developing-prefix}xml_input_transformer,XML input transformer>>, which supports the metadata schema `catalog:metacard`.
 To see a list of all transformers currently installed, and the file types supported by each, run the `catalog:transformers` command.

--- a/distribution/docs/src/main/resources/content/_managing/_running/ingesting.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/ingesting.adoc
@@ -6,7 +6,7 @@
 
 == {title}
 
-((Ingesting)) is the process of getting metacard(s) into the Catalog Framework.
+((Ingesting)) is the process of getting metacards into the Catalog Framework.
 Ingested files are "transformed" into a neutral format that can be searched against as well as migrated to other formats and systems.
 There are multiple methods available for ingesting files into the ${branding}.
 

--- a/distribution/docs/src/main/resources/content/_managing/_running/subscription-commands.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/subscription-commands.adoc
@@ -21,10 +21,10 @@ The subscriptions commands are installed when the Catalog application is install
 |Description
 
 |subscriptions:delete
-|Deletes the subscription(s) specified by the search phrase or LDAP filter.
+|Deletes the subscriptions specified by the search phrase or LDAP filter.
 
 |subscriptions:list
-|List the subscription(s) specified by the search phrase or LDAP filter.
+|List the subscriptions specified by the search phrase or LDAP filter.
 |===
 
 .subscriptions:list Command Usage Examples

--- a/distribution/docs/src/main/resources/content/_managing/_running/troubleshooting-ui.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/troubleshooting-ui.adoc
@@ -26,7 +26,7 @@ https://{FQDN}:{PORT}/solr/metacard_cache/update?stream.body=<delete><query>*:*<
 ----
 https://{FQDN}:{PORT}/solr/metacard_cache/update?stream.body=<delete><query>original_id_txt:50ffd32b21254c8a90c15fccfb98f139</query></delete>&commit=true
 ----
-* To delete record(s) in the Solr cache using a query on a field in the record(s) - in this example, the `title_txt` field is being used with wildcards to search for any records with word remote in the title:
+* To delete records in the Solr cache using a query on a field in the records - in this example, the `title_txt` field is being used with wildcards to search for any records with word remote in the title:
 
 .Deletion of records in Solr query cache using search criteria
 ----

--- a/distribution/docs/src/main/resources/content/_managing/_running/validator-plugins.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_running/validator-plugins.adoc
@@ -24,15 +24,15 @@ ingested is valid. Below is a list of the validators run against the data ingest
 
 === Validators run on ingest
 
-* *((Size Validator))*: Validates the size of an attribute's value(s).
-* *((Range Validator))*: Validates an attribute's value(s) against an *inclusive* numeric range.
-* *((Enumeration Validator))*: Validates an attribute's value(s) against a set of acceptable values.
-* *((Future Date Validator))*: Validates an attribute's value(s) against the current date and time,
+* *((Size Validator))*: Validates the size of an attribute's values.
+* *((Range Validator))*: Validates an attribute's values against an *inclusive* numeric range.
+* *((Enumeration Validator))*: Validates an attribute's values against a set of acceptable values.
+* *((Future Date Validator))*: Validates an attribute's values against the current date and time,
 validating that they are in the future.
-* *((Past Date Validator))*: Validates an attribute's value(s) against the current date and time,
+* *((Past Date Validator))*: Validates an attribute's values against the current date and time,
 validating that they are in the past.
-* *((ISO3 Country Code Validator))*: Validates an attribute's value(s) against the ISO_3166-1 Alpha3 country codes.
-* *((Pattern Validator))*: Validates an attribute's value(s) against a regular expression.
+* *((ISO3 Country Code Validator))*: Validates an attribute's values against the ISO_3166-1 Alpha3 country codes.
+* *((Pattern Validator))*: Validates an attribute's values against a regular expression.
 * *((Required Attributes Metacard Validator))*: Validates that a metacard contains certain attributes.
 - ID: *ddf.catalog.validation.impl.validator.RequiredAttributesMetacardValidator*
 * *((Duplication Validator))*: Validates metacard against the local catalog for duplicates based on configurable attributes.

--- a/distribution/docs/src/main/resources/content/_managing/_securing/managing-crl.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_securing/managing-crl.adoc
@@ -12,7 +12,7 @@
 For hardening purposes, it is recommended to implement a way to verify a ((Certificate Revocation List)) (CRL) at least daily or an ((Online Certificate Status Protocol (OCSP) server)).
 
 === Managing a Certificate Revocation List (CRL)
-A Certificate Revocation List is a collection of formerly-valid certificates that should explicitly _not_ be accepted.
+A Certificate Revocation List is a collection of formerly valid certificates that should explicitly _not_ be accepted.
 
 ==== Creating a CRL
 

--- a/distribution/docs/src/main/resources/content/_metadataReference/contact-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataReference/contact-attributes-table.adoc
@@ -17,99 +17,99 @@
 |Example Value
 
 |[[_contact.creator-name]]contact.creator-name
-|The name(s) of this metacard’s creator(s).
+|The names of this metacard’s creators.
 |List of Strings
 |< 1024 characters per entry
 |
  
 |[[_contact.creator-address]]contact.creator-address
-|The physical address(es) of this metacard’s creator(s).
+|The physical addresses of this metacard’s creators.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.creator-email]]contact.creator-email
-|The email address(es) of this metacard’s creator(s).
+|The email addresses of this metacard’s creators.
 |List of Strings
 |A valid email address per RFC 5322.
 | 
  
 |[[_contact.creator-phone]]contact.creator-phone
-|The phone number(s) of this metacard’s creator(s).
+|The phone numbers of this metacard’s creators.
 |List of Strings
 |< 1024 characters per entry
 |
  
 |[[_contact.publisher-name]]contact.publisher-name
-| The name(s) of this metacard’s publisher(s).
+| The names of this metacard’s publishers.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.publisher-address]]contact.publisher-address
-| The physical address(es) of this metacard’s publisher(s).
+| The physical addresses of this metacard’s publishers.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.publisher-email]]contact.publisher-email
-| The email address(es) of this metacard’s publisher(s).
+| The email addresses of this metacard’s publishers.
 |List of Strings
 |A valid email address per RFC 5322.
 | 
  
 |[[_contact.publisher-phone]]contact.publisher-phone
-| The phone number(s) of this metacard’s publisher(s).
+| The phone numbers of this metacard’s publishers.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.contributor-name]]contact.contributor-name
-| The name of the contributor(s) to this metacard.
+| The name of the contributors to this metacard.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.contributor-address]]contact.contributor-address
-| The physical address(es) of the contributor(s) to this metacard.
+| The physical addresses of the contributors to this metacard.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.contributor-email]]contact.contributor-email
-| The email address(es) of the contributor(s) to this metacard.
+| The email addresses of the contributors to this metacard.
 |List of Strings
 |A valid email address per RFC 5322.
 | 
  
 |[[_contact.contributor-phone]]contact.contributor-phone
-| The phone number(s) of the contributor(s) to this metacard.
+| The phone numbers of the contributors to this metacard.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.point-of-contact-name]]contact.point-of-contact-name
-| The name(s) of the point(s) of contact for this metacard.
+| The names of the points of contact for this metacard.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.point-of-contact-address]]contact.point-of-contact-address
-|The physical address(es) of a point(s) of contact for this
+|The physical addresses of the points of contact for this
 metacard.
 |List of Strings
 |< 1024 characters per entry
 | 
  
 |[[_contact.point-of-contact-email]]contact.point-of-contact-email
-|The email address(es) of the point(s) of contact for this
+|The email addresses of the points of contact for this
 metacard.
 |List of Strings
 |A valid email address per RFC 5322.
 | 
 
 |[[_contact.point-of-contact-phone]]contact.point-of-contact-phone
-|The phone number(s) of the point(s) of contact for this metacard.
+|The phone numbers of the points of contact for this metacard.
 |List of Strings
 |< 1024 characters per entry
 |

--- a/distribution/docs/src/main/resources/content/_metadataReference/core-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataReference/core-attributes-table.adoc
@@ -133,25 +133,25 @@ a|The modification date of the resource http://dublincore.org/documents/dcmi-ter
 |
 
 |[[_language]]language
-|The language(s) of the resource. http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#language[Dublin Core language] {external-link}.
+|The languages of the resource. http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#language[Dublin Core language] {external-link}.
 |List of Strings
-|Alpha-3 language code(s) per ISO_639-2
+|Alpha-3 language codes per ISO_639-2
 |
 
 |[[_resource.derived-uri]]resource.derived-uri
-|Catalog-specific Location(s) for accessing the resources derived from another source (for example, an overlay of a larger image). This URI is used for internal catalog requests.
+|Catalog-specific Locations for accessing the resources derived from another source (for example, an overlay of a larger image). This URI is used for internal catalog requests.
 |List of Strings
 |Valid URI per RFC 2396
 |
 
 |[[_resource.derived-download-url]]resource.derived-download-url
-|Download URL(s) for accessing the resources derived from another source (for example, an overlay of a larger image). Clients should use this URL for download requests.
+|Download URLs for accessing the resources derived from another source (for example, an overlay of a larger image). Clients should use this URL for download requests.
 |List of Strings
-|Valid URL(s) per RFC 2396
+|Valid URLs per RFC 2396
 |
 
 |[[_datatype]]datatype
-a|The generic type(s) of the resource including the http://dublincore.org/documents/dcmi-type-vocabulary/[Dublin Core terms-type] {external-link}. DCMI Type term labels are expected here as opposed to term names.
+a|The generic types of the resource including the http://dublincore.org/documents/dcmi-type-vocabulary/[Dublin Core terms-type] {external-link}. DCMI Type term labels are expected here as opposed to term names.
 |List of Strings
 |`Collection`, `Dataset`, `Event`, `Image`, `Interactive Resource`, `Moving Image`, `Physical Object`, `Service`, `Software`, `Sound`, `Still Image`, and/or `Text`
 |

--- a/distribution/docs/src/main/resources/content/_metadataReference/datetime-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataReference/datetime-attributes-table.adoc
@@ -17,13 +17,13 @@
 |Example Value
  
 |[[_datetime.start]]datetime.start
-|Start time(s) for the resource.
+|Start times for the resource.
 |List of Dates
 | 
 | 
 
 |[[_datetime.end]]datetime.end
-|End time(s) for the resource.
+|End times for the resource.
 |List of Dates
 | 
 | 

--- a/distribution/docs/src/main/resources/content/_quickstart/quickstart-certificates.adoc
+++ b/distribution/docs/src/main/resources/content/_quickstart/quickstart-certificates.adoc
@@ -19,7 +19,7 @@ To test federation using 2-way TLS, the default keystore certificates will need 
 If the installer was used to install the ${branding} and a hostname other than "localhost" was given, the user will be prompted to upload new trust/key stores.
 
 If the hostname is `localhost` or, if the hostname was changed _after_ installation, the default certificates will not allow access to the ${branding} instance from another machine over HTTPS (now the default for many services).
-The Demo Certificate Authority will need to be replaced with certificates that use the fully-qualified hostname of the server running the ${branding} instance.
+The Demo Certificate Authority will need to be replaced with certificates that use the fully qualified hostname of the server running the ${branding} instance.
 
 === Demo Certificate Authority (CA)
 

--- a/distribution/docs/src/main/resources/content/_reference/_tables/Metacard_File_Storage_Route.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/Metacard_File_Storage_Route.adoc
@@ -37,7 +37,7 @@
 |true
 |true
 
-|Metacard Backup Output Provider(s)
+|Metacard Backup Output Providers
 |metacardOutputProviderIds
 |Comma delimited list of metacard output provider IDs.
 |Metacard Backup Provider IDs to use for this backup plugin.


### PR DESCRIPTION
**PORT to MASTER of #6643**

#### What does this PR do?

updates documentation to remove parens from optional plurals. 

Aligns with Google Developer documentation style guidance on [Optional Plurals](https://developers.google.com/style/plurals-parentheses?hl=en).

#### Who is reviewing it? 
@shaundmorris 
@jaymcnallie 
@sgalla 
@rececoffin 

#### Select relevant component teams: 

@codice/docs 



#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
