### PR TITLE
[2.19.x] G-10004 Store import command can import numbers and arrays

### DIFF
--- a/platform/persistence/platform-persistence-commands/pom.xml
+++ b/platform/persistence/platform-persistence-commands/pom.xml
@@ -51,6 +51,12 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -84,17 +90,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.30</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.30</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0</minimum>
+                                            <minimum>0.31</minimum>
                                         </limit>
 
                                     </limits>

--- a/platform/persistence/platform-persistence-commands/src/test/java/org/codice/ddf/persistence/commands/StoreImportCommandTest.java
+++ b/platform/persistence/platform-persistence-commands/src/test/java/org/codice/ddf/persistence/commands/StoreImportCommandTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.persistence.commands;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.codice.ddf.persistence.PersistenceException;
+import org.codice.ddf.persistence.PersistentStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StoreImportCommandTest {
+  @Mock private PersistentStore persistentStore;
+
+  @Captor private ArgumentCaptor<List<Map<String, Object>>> itemsCaptor;
+
+  private final StoreImportCommand command = new StoreImportCommand();
+
+  @Before
+  public void setUp() {
+    command.persistentStore = persistentStore;
+  }
+
+  @Test
+  public void testImportFile() throws PersistenceException {
+    command.type = "metacard";
+    command.filePath = getClass().getResource("/test.json").getPath();
+    command.storeCommand();
+
+    verify(persistentStore).add(eq("metacard"), itemsCaptor.capture());
+
+    final List<Map<String, Object>> items = itemsCaptor.getValue();
+    assertThat(items, hasSize(1));
+
+    final Map<String, Object> item = items.get(0);
+    assertThat(item, hasEntry("test_bin", new byte[] {102, 111, 111, 98, 97, 114}));
+    assertThat(item, hasEntry("test_tdt", new Date(1639676820000L)));
+    assertThat(item, hasEntry("test_lng", 1L));
+    assertThat(item, hasEntry("test_int", 2));
+    assertThat(item, hasEntry("test_txt", "Some text"));
+    assertThat(item, hasEntry("test_xml", "<xml>test</xml>"));
+    assertThat(item, hasEntry("test_arr_lng", Arrays.asList(3L, 4L)));
+  }
+}

--- a/platform/persistence/platform-persistence-commands/src/test/resources/test.json
+++ b/platform/persistence/platform-persistence-commands/src/test/resources/test.json
@@ -1,0 +1,12 @@
+{
+  "test_bin": "Zm9vYmFy",
+  "test_tdt": "Thu, 16 Dec 2021 11:47:00 CST",
+  "test_lng": 1,
+  "test_int": 2,
+  "test_txt": "Some text",
+  "test_xml": "<xml>test</xml>",
+  "test_arr_lng": [
+    3,
+    4
+  ]
+}


### PR DESCRIPTION
#### What does this PR do?
Fixes the persistent store import command so it can handle numbers and arrays. Previously, the import command assumed all values were strings even though the export command does not export that way.

#### Select relevant component teams: 
@codice/core-apis 

#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith
@shaundmorris

#### How should this be tested?
Coming soon

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.