### PR TITLE
DDF-6673 / G-10028 upgrades pax-logging to 1.11.13

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -46,6 +46,12 @@
         <bundle originalUri="mvn:org.apache.aries.proxy/org.apache.aries.proxy/1.1.3"
                 replacement="mvn:org.apache.aries.proxy/org.apache.aries.proxy/1.1.4"
                 mode="maven"/>
+        <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/1.11.6"
+                replacement="mvn:org.ops4j.pax.logging/pax-logging-api/${pax-logging.version}"
+                mode="maven"/>
+        <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.11.6"
+                replacement="mvn:org.ops4j.pax.logging/pax-logging-log4j2/${pax-logging.version}"
+                mode="maven"/>
     </bundleReplacements>
 
     <!-- A list of feature replacements that allows changing external feature definitions -->

--- a/distribution/ddf-common/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -47,10 +47,10 @@
                 replacement="mvn:org.apache.aries.proxy/org.apache.aries.proxy/1.1.4"
                 mode="maven"/>
         <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/1.11.6"
-                replacement="mvn:org.ops4j.pax.logging/pax-logging-api/${pax-logging.version}"
+                replacement="mvn:org.ops4j.pax.logging/pax-logging-api/${pax.logging.version}"
                 mode="maven"/>
         <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.11.6"
-                replacement="mvn:org.ops4j.pax.logging/pax-logging-log4j2/${pax-logging.version}"
+                replacement="mvn:org.ops4j.pax.logging/pax-logging-log4j2/${pax.logging.version}"
                 mode="maven"/>
     </bundleReplacements>
 

--- a/distribution/ddf-common/src/main/resources-filtered/etc/startup.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/startup.properties
@@ -8,8 +8,8 @@ mvn\:org.apache.felix/org.apache.felix.metatype/1.2.2=5
 mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/${karaf.version}=5
 mvn\:org.ops4j.pax.url/pax-url-aether/${pax.url.version}=5
 mvn\:org.fusesource.jansi/jansi/1.18 = 8
-mvn\:org.ops4j.pax.logging/pax-logging-api/1.10.2=8
-mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.10.2=8
+mvn\:org.ops4j.pax.logging/pax-logging-api/${pax.logging.version}=8
+mvn\:org.ops4j.pax.logging/pax-logging-log4j2/${pax.logging.version}=8
 mvn\:org.apache.felix/org.apache.felix.coordinator/1.0.2 = 9
 # These two osgi bundles need to start before configadmin in order to register
 # DDF's custom PersistenceManager.

--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -384,15 +384,15 @@
             </includes>
         </dependencySet>
         <dependencySet>
-            <outputDirectory>system/org/ops4j/pax/logging/pax-logging-log4j2/${pax-logging.version}</outputDirectory>
+            <outputDirectory>system/org/ops4j/pax/logging/pax-logging-log4j2/${pax.logging.version}</outputDirectory>
             <includes>
-                <include>org.ops4j.pax.logging:pax-logging-log4j2:jar:${pax-logging.version}</include>
+                <include>org.ops4j.pax.logging:pax-logging-log4j2:jar:${pax.logging.version}</include>
             </includes>
         </dependencySet>
         <dependencySet>
-            <outputDirectory>system/org/ops4j/pax/logging/pax-logging-api/${pax-logging.version}</outputDirectory>
+            <outputDirectory>system/org/ops4j/pax/logging/pax-logging-api/${pax.logging.version}</outputDirectory>
             <includes>
-                <include>org.ops4j.pax.logging:pax-logging-api:jar:${pax-logging.version}</include>
+                <include>org.ops4j.pax.logging:pax-logging-api:jar:${pax.logging.version}</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -96,6 +96,7 @@
                 and introduces vulnerability CVE-2016-4970.
                 -->
                 <exclude>**/org/ops4j/pax/transx/pax-transx-tm-narayana/**/*</exclude>
+                <exclude>**/org/ops4j/pax/logging/**/*</exclude>
             </excludes>
         </fileSet>
 
@@ -380,6 +381,18 @@
                 <include>
                     org.apache.aries.proxy:org.apache.aries.proxy:jar:${org.apache.aries.version}
                 </include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>system/org/ops4j/pax/logging/pax-logging-log4j2/${pax-logging.version}</outputDirectory>
+            <includes>
+                <include>org.ops4j.pax.logging:pax-logging-log4j2:jar:${pax-logging.version}</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>system/org/ops4j/pax/logging/pax-logging-api/${pax-logging.version}</outputDirectory>
+            <includes>
+                <include>org.ops4j.pax.logging:pax-logging-api:jar:${pax-logging.version}</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -343,12 +343,32 @@
             <artifactId>apache-karaf</artifactId>
             <version>${karaf.version}</version>
             <type>tar.gz</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-log4j2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>
             <artifactId>apache-karaf</artifactId>
             <version>${karaf.version}</version>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-log4j2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
@@ -356,6 +376,26 @@
             <version>${karaf.version}</version>
             <type>xml</type>
             <classifier>features</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-log4j2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+            <version>${pax.logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-log4j2</artifactId>
+            <version>${pax.logging.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.distribution</groupId>

--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -25,8 +25,8 @@
     <packaging>bundle</packaging>
 
     <properties>
-        <!-- Override Log4J because pax-logging-api 1.10.1 uses 2.8.2 -->
-        <apache-log4j.version>2.8.2</apache-log4j.version>
+        <!-- Override Log4J because pax-logging-api 1.11.13 uses 2.17.1 -->
+        <apache-log4j.version>2.17.1</apache-log4j.version>
     </properties>
 
     <dependencies>

--- a/platform/solr/solr-logging/pom.xml
+++ b/platform/solr/solr-logging/pom.xml
@@ -83,7 +83,7 @@
                         <configuration>
                             <rules>
                                 <ArtifactSizeEnforcerRule implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
-                                    <maxArtifactSize>2.6_MB</maxArtifactSize>
+                                    <maxArtifactSize>2.7_MB</maxArtifactSize>
                                 </ArtifactSizeEnforcerRule>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <mockito-core.version>2.8.47</mockito-core.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <pax.exam.version>4.13.2.CODICE</pax.exam.version>
+        <pax.logging.version>1.11.13</pax.logging.version>
         <pax.url.version>2.6.1</pax.url.version>
         <pax.transx.version>0.4.1</pax.transx.version>
         <pax.web.version>7.2.11</pax.web.version>
@@ -245,7 +246,7 @@
         <karaf.version>4.2.6</karaf.version>
         <la4j.version>0.6.0</la4j.version>
         <log4j.version>1.2.17</log4j.version>
-        <apache-log4j.version>2.11.2</apache-log4j.version>
+        <apache-log4j.version>2.17.1</apache-log4j.version>
         <logback.classic.version>1.2.3</logback.classic.version>
         <logback.version>1.2.3</logback.version>
         <lucene.version>7.7.2</lucene.version>
@@ -295,7 +296,7 @@
         <solr.httpclient.version>4.5.12</solr.httpclient.version>
         <solr.httpcore.version>4.4.13</solr.httpcore.version>
         <solr.httpmime.version>4.5.12</solr.httpmime.version>
-        <solr.log4j.version>2.13.2</solr.log4j.version>
+        <solr.log4j.version>2.17.1</solr.log4j.version>
         <solr.zookeeper.version>3.6.2</solr.zookeeper.version>
         <solr.spatial4j.version>0.7</solr.spatial4j.version>
 


### PR DESCRIPTION
#### What does this PR do?
Upgrades pax-logging to 1.11.13 to resolve CVE-2021-44228 

Note - this does not resolve the vulnerable log4j jars bundled in Solr.  That will be addressed separately.

#### Who is reviewing it? 
@brendan-hofmann 
@millerw8 
@jrnorth 
@beyelerb 

#### Select relevant component teams: 
@codice/security 

#### Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann 
@millerw8 
@jrnorth 
@beyelerb 


#### How should this be tested?
Run a vulnerability scanner against the exploded distro (eg, [lunasec log4shell scan](https://github.com/lunasec-io/lunasec/releases)).  The only log4j vulnerabilities identified should be coming from solr:

- solr/contrib/prometheus-exporter/lib/log4j-core-2.13.2.jar
- /solr/server/lib/ext/log4j-core-2.13.2.jar

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6673 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
