### PR TITLE
[2.19.x] G-10041 Add support for old CQL result filters

### DIFF
--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.js
@@ -207,9 +207,14 @@ User.Preferences = Backbone.AssociatedModel.extend({
     this.listenTo(this, 'change:mapHome', this.savePreferences)
   },
   get(attr) {
-    const value = Backbone.AssociatedModel.prototype.get.call(this, attr)
-    if (attr === 'resultFilter' && value && value.type === 'NOT') {
-      return cql.simplify(value)
+    let value = Backbone.AssociatedModel.prototype.get.call(this, attr)
+    if (attr === 'resultFilter') {
+      if (typeof value === 'string') {
+        value = cql.read(value)
+      }
+      if (value && value.type === 'NOT') {
+        return cql.simplify(value)
+      }
     }
     return value
   },

--- a/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.spec.js
+++ b/ui/packages/catalog-ui-search/src/main/webapp/js/model/User.spec.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+import { expect } from 'chai'
+import User from './User'
+
+describe('User Model', () => {
+  describe('Preferences', () => {
+    it('get() converts a CQL resultFilter to a filter tree', () => {
+      const preferences = new User.Preferences({
+        resultFilter: '("anyText" ILIKE \'foo\') OR ("anyText" ILIKE \'bar\')',
+      })
+      const resultFilter = preferences.get('resultFilter')
+      expect(resultFilter).to.be.an('object')
+      expect(resultFilter).to.have.property('type', 'OR')
+      expect(resultFilter).to.have.deep.property('filters', [
+        { type: 'ILIKE', property: 'anyText', value: 'foo' },
+        { type: 'ILIKE', property: 'anyText', value: 'bar' },
+      ])
+    })
+    it('get() converts a CQL resultFilter containing NOT to a simplified filter tree', () => {
+      const preferences = new User.Preferences({
+        resultFilter:
+          'NOT (("anyText" ILIKE \'foo\') OR ("anyText" ILIKE \'bar\'))',
+      })
+      const resultFilter = preferences.get('resultFilter')
+      expect(resultFilter).to.be.an('object')
+      expect(resultFilter).to.have.property('type', 'NOT OR')
+      expect(resultFilter).to.have.deep.property('filters', [
+        { type: 'ILIKE', property: 'anyText', value: 'foo' },
+        { type: 'ILIKE', property: 'anyText', value: 'bar' },
+      ])
+    })
+    it('get() returns a filter tree resultFilter as-is', () => {
+      const originalFilter = {
+        type: 'OR',
+        filters: [
+          { type: 'ILIKE', property: 'anyText', value: 'foo' },
+          { type: 'ILIKE', property: 'anyText', value: 'bar' },
+        ],
+      }
+      const preferences = new User.Preferences({
+        resultFilter: originalFilter,
+      })
+      const resultFilter = preferences.get('resultFilter')
+      expect(resultFilter).to.deep.equal(originalFilter)
+    })
+  })
+})


### PR DESCRIPTION
#### What does this PR do?
The User.Preferences model will now convert old-style CQL result filters to filter trees on the fly.

#### Who is reviewing it? 
@millerw8
@kcwire 
@shaundmorris 

#### How should this be tested?
1. Open the Solr Admin UI and query the `preferences` core.
2. Copy the `preferences_json_bin` for your user.
3. Base64 decode that string to a JSON file and create a `resultFilter` key with a CQL string value if no such key exists, or replace the existing value with a CQL string value.
a. The CQL string can be as simple as `(\"anyText\" ILIKE '')`, or it can be a more complex query.
4. Base64 encode that JSON file and update your user preferences via the `Documents` page in the Solr Admin UI, filling in the ID of your preferences and your base64-encoded JSON:
![Screen Shot 2022-02-16 at 5 59 50 PM](https://user-images.githubusercontent.com/4495447/154377861-30a65897-002e-443d-a95d-66e83150d1c1.jpg)
5. Open Intrigue, click on your result filter, and verify that the CQL you added in step 3 was parsed correctly into the result filter.
6. Run some queries and verify your results appear to be filtered correctly by the result filter.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.