### PR TITLE
[2.19.x] G-10122 Fix buffering across the antimeridian

### DIFF
--- a/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/core/catalog-core-solr/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -819,6 +819,10 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
             envelope.getWidth() >= 180
                 || (envelope.getMinX() <= 180 && envelope.getMaxX() > 180)
                 || (envelope.getMinX() < -180 && envelope.getMaxX() >= -180);
+        // When spatial4j's JtsGeometry unwraps polygons that cross the dateline, it checks that all
+        // interior rings of the polygon are subsets of the exterior ring, which means polygons with
+        // holes will throw an exception. Remove any holes from polygons that cross the dateline to
+        // prevent that exception from being thrown.
         if (crossesDateline) {
           bufferGeo = removeHoles(bufferGeo);
         }

--- a/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/Library.java
+++ b/catalog/core/catalog-core-solr/src/test/java/ddf/catalog/source/solr/provider/Library.java
@@ -57,6 +57,9 @@ public class Library {
       "POLYGON ((175 30, -175 30, -175 25, 175 25, 175 30))";
   public static final String ACROSS_INTERNATIONAL_DATELINE_LARGE_CCW_WKT =
       "POLYGON ((175 30, 175 25, -175 25, -175 30, 175 30))";
+  public static final String ON_INTERNATIONAL_DATELINE_CW_WKT =
+      "POLYGON ((175 75, 180 75, 180 70, 175 70, 175 75))";
+  public static final String ARCTIC_OCEAN_POINT_WKT = "POINT (-179.9 75.1)";
   public static final String MIDWAY_ISLANDS_POINT_WKT = "POINT (-177.372736 28.208365)";
   public static final String LAS_VEGAS_POINT_WKT = "POINT (-115.136389 36.175)";
   public static final String ARABIAN_SEA_POINT_WKT = "POINT (62.5 14)";

--- a/platform/solr/solr-schema/src/main/resources/solr/conf/schema.xml
+++ b/platform/solr/solr-schema/src/main/resources/solr/conf/schema.xml
@@ -118,6 +118,7 @@
                class="solr.RptWithGeometrySpatialField"
                spatialContextFactory="JTS"
                distanceUnits="degrees"
+               normWrapLongitude="true"
                format="WKT"
                autoIndex="true"
                allowMultiOverlap="true" />


### PR DESCRIPTION
#### What does this PR do?
- Enables `normWrapLongitude` in the Solr schema. Running a DWITHIN query (i.e., a buffered geometry) near the antimeridian often results in a Solr error because the resulting geometry contains points outside the valid longitude range of [-180,180]. The SolrFilterDelegate uses JTS to calculate the buffered geometry but does not enforce the longitude range on the result so it is passed to Solr with out-of-range values. Enabling `normWrapLongitude` means that Solr will wrap longitudes outside of the range into it.
- Removes holes from polygons and multipolygons that cross the antimeridian. When handling polygons that cross the antimeridian, spatial4j requires any interior rings to be subsets of the exterior ring, which seems wrong (see https://github.com/locationtech/spatial4j/blob/2926812ae302c6e0f24fb5995b1fd24be7fe0b56/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java#L482).

#### Who is reviewing it? 
@jlcsmith 
@kcwire 
@millerw8 

#### Select relevant component teams: 
@codice/solr 

#### How should this be tested?
1. Run `gazetteer:update` with https://github.com/codice/ddf/blob/03be912e331024f3bc6856d5e87f8e3b7db0b392/distribution/ddf-common/src/main/resources/data/countries.geo.json
2. Run `gazetteer:build-suggester-index`
3. Ingest the following files:
`russia1.json`
```
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [-179.9375, 69.116389]
  },
  "properties": {
    "title": "Russia 1"
  }
}
```
`russia2.json`
```
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [179.900833, 71.637778]
  },
  "properties": {
    "title": "Russia 2"
  }
}
```
These locations are both within a 25km buffer of the Russia polygon, close to the antimeridian.
4. Open Intrigue and create an anyGeo query with the keyword 'Russia'. Run it and verify you get no results.
5. Add a buffer of 25km and verify you get both results.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.