### PR TITLE
G-10122 Fix issues related to geometry buffering

### DIFF
--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -763,6 +763,10 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
             envelope.getWidth() >= 180
                 || (envelope.getMinX() <= 180 && envelope.getMaxX() > 180)
                 || (envelope.getMinX() < -180 && envelope.getMaxX() >= -180);
+        // When spatial4j's JtsGeometry unwraps polygons that cross the dateline, it checks that all
+        // interior rings of the polygon are subsets of the exterior ring, which means polygons with
+        // holes will throw an exception. Remove any holes from polygons that cross the dateline to
+        // prevent that exception from being thrown.
         if (crossesDateline) {
           bufferGeo = removeHoles(bufferGeo);
         }

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
@@ -28,6 +28,10 @@ import java.util.Date;
 import java.util.TimeZone;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.junit.Test;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.operation.union.UnaryUnionOp;
 
 public class SolrFilterDelegateTest {
 
@@ -141,17 +145,19 @@ public class SolrFilterDelegateTest {
   }
 
   @Test
-  public void multiPolygon() {
+  public void multiPolygon() throws ParseException {
     String wkt =
         "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))";
     when(mockResolver.getField(
             "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .thenReturn("testProperty_geohash_index");
     SolrQuery query = toTest.contains("testProperty", wkt);
+    MultiPolygon multiPolygon = (MultiPolygon) new WKTReader().read(wkt);
+    // Need to use union since allowMultiOverlap is enabled
+    MultiPolygon unioned = (MultiPolygon) new UnaryUnionOp(multiPolygon).union();
     assertThat(
         query.getQuery(),
-        startsWith(
-            "testProperty_geohash_index:\"Contains(MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5))))\""));
+        startsWith(String.format("testProperty_geohash_index:\"Contains(%s)\"", unioned.toText())));
   }
 
   @Test
@@ -165,6 +171,51 @@ public class SolrFilterDelegateTest {
         query.getQuery(),
         startsWith(
             "testProperty_geohash_index:\"Contains(POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30)))\""));
+  }
+
+  @Test
+  public void bufferedPolygonHolesRemovedIfCrossingDateline() {
+    String wkt =
+        "POLYGON ((170 10, -170 10, -170 0, 170 0, 170 10), (171 9, 172 9, 172 8, 172 8, 171 9))";
+    when(mockResolver.getField(
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
+        .thenReturn("testProperty_geohash_index");
+    // buffer of 0 so the final WKT is easy to calculate
+    SolrQuery query = toTest.dwithin("testProperty", wkt, 0);
+    assertThat(
+        query.getQuery(),
+        startsWith(
+            "testProperty_geohash_index:\"Intersects(MULTIPOLYGON (((-180 0, -180 10, -170 10, -170 0, -180 0)), ((180 10, 180 0, 170 0, 170 10, 180 10))))\""));
+  }
+
+  @Test
+  public void bufferedMultiPolygonHolesRemovedIfCrossingDateline() {
+    String wkt =
+        "MULTIPOLYGON (((170 10, -170 10, -170 0, 170 0, 170 10), (171 9, 172 9, 172 8, 172 8, 171 9)), ((170 30, -170 30, -170 20, 170 20, 170 30), (171 29, 172 29, 172 28, 172 28, 171 29)))";
+    when(mockResolver.getField(
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
+        .thenReturn("testProperty_geohash_index");
+    // buffer of 0 so the final WKT is easy to calculate
+    SolrQuery query = toTest.dwithin("testProperty", wkt, 0);
+    assertThat(
+        query.getQuery(),
+        startsWith(
+            "testProperty_geohash_index:\"Intersects(MULTIPOLYGON (((-180 0, -180 10, -170 10, -170 0, -180 0)), ((180 10, 180 0, 170 0, 170 10, 180 10)), ((-180 20, -180 30, -170 30, -170 20, -180 20)), ((180 30, 180 20, 170 20, 170 30, 180 30))))\""));
+  }
+
+  @Test
+  public void bufferedGeometryCollectionHolesRemovedIfCrossingDateline() {
+    String wkt =
+        "GEOMETRYCOLLECTION (POLYGON ((170 10, -170 10, -170 0, 170 0, 170 10), (171 9, 172 9, 172 8, 172 8, 171 9)), POLYGON ((170 30, -170 30, -170 20, 170 20, 170 30), (171 29, 172 29, 172 28, 172 28, 171 29)))";
+    when(mockResolver.getField(
+            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
+        .thenReturn("testProperty_geohash_index");
+    // buffer of 0 so the final WKT is easy to calculate
+    SolrQuery query = toTest.dwithin("testProperty", wkt, 0);
+    assertThat(
+        query.getQuery(),
+        startsWith(
+            "testProperty_geohash_index:\"Intersects(MULTIPOLYGON (((-180 0, -180 10, -170 10, -170 0, -180 0)), ((180 10, 180 0, 170 0, 170 10, 180 10)), ((-180 20, -180 30, -170 30, -170 20, -180 20)), ((180 30, 180 20, 170 20, 170 30, 180 30))))\""));
   }
 
   @Test

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
@@ -153,7 +153,8 @@ public class SolrFilterDelegateTest {
         .thenReturn("testProperty_geohash_index");
     SolrQuery query = toTest.contains("testProperty", wkt);
     MultiPolygon multiPolygon = (MultiPolygon) new WKTReader().read(wkt);
-    // Need to use union since allowMultiOverlap is enabled
+    // allowMultiOverlap is enabled, so spatial4j will calculate the union of any MultiPolygon.
+    // This means we need to calculate the union of the expected WKT for the assertion.
     MultiPolygon unioned = (MultiPolygon) new UnaryUnionOp(multiPolygon).union();
     assertThat(
         query.getQuery(),
@@ -192,21 +193,6 @@ public class SolrFilterDelegateTest {
   public void bufferedMultiPolygonHolesRemovedIfCrossingDateline() {
     String wkt =
         "MULTIPOLYGON (((170 10, -170 10, -170 0, 170 0, 170 10), (171 9, 172 9, 172 8, 172 8, 171 9)), ((170 30, -170 30, -170 20, 170 20, 170 30), (171 29, 172 29, 172 28, 172 28, 171 29)))";
-    when(mockResolver.getField(
-            "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
-        .thenReturn("testProperty_geohash_index");
-    // buffer of 0 so the final WKT is easy to calculate
-    SolrQuery query = toTest.dwithin("testProperty", wkt, 0);
-    assertThat(
-        query.getQuery(),
-        startsWith(
-            "testProperty_geohash_index:\"Intersects(MULTIPOLYGON (((-180 0, -180 10, -170 10, -170 0, -180 0)), ((180 10, 180 0, 170 0, 170 10, 180 10)), ((-180 20, -180 30, -170 30, -170 20, -180 20)), ((180 30, 180 20, 170 20, 170 30, 180 30))))\""));
-  }
-
-  @Test
-  public void bufferedGeometryCollectionHolesRemovedIfCrossingDateline() {
-    String wkt =
-        "GEOMETRYCOLLECTION (POLYGON ((170 10, -170 10, -170 0, 170 0, 170 10), (171 9, 172 9, 172 8, 172 8, 171 9)), POLYGON ((170 30, -170 30, -170 20, 170 20, 170 30), (171 29, 172 29, 172 28, 172 28, 171 29)))";
     when(mockResolver.getField(
             "testProperty", AttributeFormat.GEOMETRY, false, Collections.emptyMap()))
         .thenReturn("testProperty_geohash_index");

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/Library.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/Library.java
@@ -57,6 +57,9 @@ public class Library {
       "POLYGON ((175 30, -175 30, -175 25, 175 25, 175 30))";
   public static final String ACROSS_INTERNATIONAL_DATELINE_LARGE_CCW_WKT =
       "POLYGON ((175 30, 175 25, -175 25, -175 30, 175 30))";
+  public static final String ON_INTERNATIONAL_DATELINE_CW_WKT =
+      "POLYGON ((175 75, 180 75, 180 70, 175 70, 175 75))";
+  public static final String ARCTIC_OCEAN_POINT_WKT = "POINT (-179.9 75.1)";
   public static final String MIDWAY_ISLANDS_POINT_WKT = "POINT (-177.372736 28.208365)";
   public static final String LAS_VEGAS_POINT_WKT = "POINT (-115.136389 36.175)";
   public static final String ARABIAN_SEA_POINT_WKT = "POINT (62.5 14)";

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSpatial.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSpatial.java
@@ -19,6 +19,7 @@ import static ddf.catalog.source.solr.provider.SolrProviderTestUtil.getFilterBui
 import static ddf.catalog.source.solr.provider.SolrProviderTestUtil.update;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -546,6 +547,33 @@ public class SolrProviderSpatial {
     sourceResponse = provider.query(new QueryRequestImpl(new QueryImpl(filter)));
 
     assertEquals("Should not find a record. ", 0, sourceResponse.getResults().size());
+  }
+
+  @Test
+  public void testSpatialQueryBufferedAcrossDateline() throws Exception {
+    deleteAll(provider);
+
+    MetacardImpl metacard = new MockMetacard(Library.getFlagstaffRecord());
+    metacard.setLocation(Library.ARCTIC_OCEAN_POINT_WKT);
+    List<Metacard> list = Collections.singletonList(metacard);
+
+    create(list, provider);
+
+    Filter filter =
+        getFilterBuilder()
+            .attribute(Metacard.GEOGRAPHY)
+            .is()
+            .withinBuffer()
+            .wkt(Library.ON_INTERNATIONAL_DATELINE_CW_WKT, 25_000);
+    SourceResponse sourceResponse = provider.query(new QueryRequestImpl(new QueryImpl(filter)));
+
+    assertThat("Failed to find the correct record.", sourceResponse.getResults(), hasSize(1));
+
+    for (Result r : sourceResponse.getResults()) {
+      assertTrue(
+          "Wrong record, Flagstaff keyword was not found.",
+          r.getMetacard().getMetadata().contains(Library.FLAGSTAFF_QUERY_PHRASE));
+    }
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
- `SolrFilterDelegate` will remove holes from polygons and multipolygons that cross the antimeridian. When handling polygons that cross the antimeridian, spatial4j requires any interior rings to be subsets of the exterior ring, which seems wrong (see https://github.com/locationtech/spatial4j/blob/2926812ae302c6e0f24fb5995b1fd24be7fe0b56/src/main/java/org/locationtech/spatial4j/shape/jts/JtsGeometry.java#L482). Removing any holes means this check won't fail.
- Enables `normWrapLongitude` in `SolrFilterDelegate`'s `SpatialContext`. If a shape near the antimeridian is buffered, then it may have points that end up outside the range [-180, 180]. Enabling this allows spatial4j to handle those points correctly.
- Enables `allowMultiOverlap` in `SolrFilterDelegate`'s `SpatialContext`. Sometimes, we have polygons that share a border, such as the polygons of the Russia WKT on the antimeridian:
![Screen Shot 2022-05-23 at 1 29 47 PM](https://user-images.githubusercontent.com/4495447/169900893-eef12bfc-0520-40a9-9c27-61a1b56a1db3.jpg)
Adding a buffer causes them to overlap, so enabling this allows spatial4j to handle those points correctly.

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith
@kcwire 
@millerw8

#### How should this be tested?
1. Run `gazetteer:update` with https://github.com/codice/ddf/blob/03be912e331024f3bc6856d5e87f8e3b7db0b392/distribution/ddf-common/src/main/resources/data/countries.geo.json
2. Run `gazetteer:build-suggester-index`
3. Ingest the following files:
`russia1.json`
```
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [-179.9375, 69.116389]
  },
  "properties": {
    "title": "Russia 1"
  }
}
```
`russia2.json`
```
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [179.900833, 71.637778]
  },
  "properties": {
    "title": "Russia 2"
  }
}
```
These locations are both within a 25km buffer of the Russia polygon, close to the antimeridian.
4. Open Intrigue and create an anyGeo query with the keyword 'Russia'. Run it and verify you get no results.
5. Add a buffer of 25km and verify you get both results.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.