### PR TITLE
[2.26.x] DDF-6704 improve query logging

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -449,9 +449,9 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (AccessPlugin plugin : frameworkProperties.getAccessPlugins()) {
       try {
-        LOGGER.trace("Before AccessPlugin (#2): trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace("Before post-query AccessPlugin: trace-id {}, plugin {}", traceId, plugin);
         queryResponse = plugin.processPostQuery(queryResponse);
-        LOGGER.trace("After AccessPlugin (#2): trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace("After post-query AccessPlugin: trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -469,12 +469,12 @@ public class QueryOperations extends DescribableImpl {
       HashMap<String, Set<String>> itemPolicyMap = new HashMap<>();
       for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {
         try {
-          LOGGER.trace("Before PolicyPlugin (#2): trace-id {}, plugin {}", traceId, plugin);
+          LOGGER.trace("Before post-query PolicyPlugin: trace-id {}, plugin {}", traceId, plugin);
           PolicyResponse policyResponse = plugin.processPostQuery(result, unmodifiableProperties);
           opsSecuritySupport.buildPolicyMap(itemPolicyMap, policyResponse.itemPolicy().entrySet());
           opsSecuritySupport.buildPolicyMap(
               responsePolicyMap, policyResponse.operationPolicy().entrySet());
-          LOGGER.trace("After PolicyPlugin (#2): trace-id {}, plugin {}", traceId, plugin);
+          LOGGER.trace("After post-query PolicyPlugin: trace-id {}, plugin {}", traceId, plugin);
         } catch (StopProcessingException e) {
           throw new FederationException("Query could not be executed.", e);
         }
@@ -507,9 +507,9 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (AccessPlugin plugin : frameworkProperties.getAccessPlugins()) {
       try {
-        LOGGER.trace("Before AccessPlugin (#1): trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace("Before pre-query AccessPlugin: trace-id {}, plugin {}", traceId, plugin);
         queryReq = plugin.processPreQuery(queryReq);
-        LOGGER.trace("After AccessPlugin (#1): trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace("After pre-query AccessPlugin: trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -522,9 +522,11 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthorizationPlugins()) {
       try {
-        LOGGER.trace("Before PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace(
+            "Before pre-query PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
         queryRequest = plugin.processPreQuery(queryRequest);
-        LOGGER.trace("After PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace(
+            "After pre-query PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -537,9 +539,11 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthorizationPlugins()) {
       try {
-        LOGGER.trace("Before PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace(
+            "Before post-query PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
         queryResponse = plugin.processPostQuery(queryResponse);
-        LOGGER.trace("After PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace(
+            "After post-query PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -555,12 +559,12 @@ public class QueryOperations extends DescribableImpl {
         Collections.unmodifiableMap(queryReq.getProperties());
     for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {
       try {
-        LOGGER.trace("Before PolicyPlugin (#1): trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace("Before pre-query PolicyPlugin: trace-id {}, plugin {}", traceId, plugin);
         PolicyResponse policyResponse =
             plugin.processPreQuery(queryReq.getQuery(), unmodifiableProperties);
         opsSecuritySupport.buildPolicyMap(
             requestPolicyMap, policyResponse.operationPolicy().entrySet());
-        LOGGER.trace("After PolicyPlugin (#1): trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace("After pre-query PolicyPlugin: trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -77,6 +77,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.codice.ddf.security.util.ThreadContextProperties;
 import org.opengis.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,6 +186,8 @@ public class QueryOperations extends DescribableImpl {
 
     queryRequest = setFlagsOnRequest(queryRequest);
 
+    String traceId = ThreadContextProperties.getTraceId();
+
     try {
       queryRequest = validateQueryRequest(queryRequest);
       queryRequest = getFanoutQuery(queryRequest, fanoutEnabled);
@@ -206,7 +209,9 @@ public class QueryOperations extends DescribableImpl {
         }
       }
 
+      LOGGER.trace("Before doQuery: trace-id {}", traceId);
       queryResponse = doQuery(queryRequest, fedStrategy);
+      LOGGER.trace("After doQuery: trace-id {}", traceId);
 
       // Allow callers to determine the total results returned from the query; this value
       // may differ from the number of filtered results after processing plugins have been run.
@@ -424,9 +429,12 @@ public class QueryOperations extends DescribableImpl {
 
   private QueryResponse processPostQueryPlugins(QueryResponse queryResponse)
       throws FederationException {
+    String traceId = ThreadContextProperties.getTraceId();
     for (PostQueryPlugin service : frameworkProperties.getPostQuery()) {
       try {
+        LOGGER.trace("Before PostQueryPlugin: trace-id {}, plugin {}", traceId, service);
         queryResponse = service.process(queryResponse);
+        LOGGER.trace("After PostQueryPlugin: trace-id {}, plugin {}", traceId, service);
       } catch (PluginExecutionException see) {
         LOGGER.debug("Error executing PostQueryPlugin: {}", see.getMessage(), see);
       } catch (StopProcessingException e) {
@@ -438,9 +446,12 @@ public class QueryOperations extends DescribableImpl {
 
   private QueryResponse processPostQueryAccessPlugins(QueryResponse queryResponse)
       throws FederationException {
+    String traceId = ThreadContextProperties.getTraceId();
     for (AccessPlugin plugin : frameworkProperties.getAccessPlugins()) {
       try {
+        LOGGER.trace("Before AccessPlugin (#2): trace-id {}, plugin {}", traceId, plugin);
         queryResponse = plugin.processPostQuery(queryResponse);
+        LOGGER.trace("After AccessPlugin (#2): trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -450,6 +461,7 @@ public class QueryOperations extends DescribableImpl {
 
   private QueryResponse populateQueryResponsePolicyMap(QueryResponse queryResponse)
       throws FederationException {
+    String traceId = ThreadContextProperties.getTraceId();
     HashMap<String, Set<String>> responsePolicyMap = new HashMap<>();
     Map<String, Serializable> unmodifiableProperties =
         Collections.unmodifiableMap(queryResponse.getProperties());
@@ -457,10 +469,12 @@ public class QueryOperations extends DescribableImpl {
       HashMap<String, Set<String>> itemPolicyMap = new HashMap<>();
       for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {
         try {
+          LOGGER.trace("Before PolicyPlugin (#2): trace-id {}, plugin {}", traceId, plugin);
           PolicyResponse policyResponse = plugin.processPostQuery(result, unmodifiableProperties);
           opsSecuritySupport.buildPolicyMap(itemPolicyMap, policyResponse.itemPolicy().entrySet());
           opsSecuritySupport.buildPolicyMap(
               responsePolicyMap, policyResponse.operationPolicy().entrySet());
+          LOGGER.trace("After PolicyPlugin (#2): trace-id {}, plugin {}", traceId, plugin);
         } catch (StopProcessingException e) {
           throw new FederationException("Query could not be executed.", e);
         }
@@ -473,9 +487,12 @@ public class QueryOperations extends DescribableImpl {
   }
 
   private QueryRequest processPreQueryPlugins(QueryRequest queryReq) throws FederationException {
+    String traceId = ThreadContextProperties.getTraceId();
     for (PreQueryPlugin service : frameworkProperties.getPreQuery()) {
       try {
+        LOGGER.trace("Before PreQueryPlugin: trace-id {}, plugin {}", traceId, service);
         queryReq = service.process(queryReq);
+        LOGGER.trace("After PreQueryPlugin: trace-id {}, plugin {}", traceId, service);
       } catch (PluginExecutionException see) {
         LOGGER.debug("Error executing PreQueryPlugin: {}", see.getMessage(), see);
       } catch (StopProcessingException e) {
@@ -487,9 +504,12 @@ public class QueryOperations extends DescribableImpl {
 
   private QueryRequest processPreQueryAccessPlugins(QueryRequest queryReq)
       throws FederationException {
+    String traceId = ThreadContextProperties.getTraceId();
     for (AccessPlugin plugin : frameworkProperties.getAccessPlugins()) {
       try {
+        LOGGER.trace("Before AccessPlugin (#1): trace-id {}, plugin {}", traceId, plugin);
         queryReq = plugin.processPreQuery(queryReq);
+        LOGGER.trace("After AccessPlugin (#1): trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -499,9 +519,12 @@ public class QueryOperations extends DescribableImpl {
 
   private QueryRequest preProcessPreAuthorizationPlugins(QueryRequest queryRequest)
       throws FederationException {
+    String traceId = ThreadContextProperties.getTraceId();
     for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthorizationPlugins()) {
       try {
+        LOGGER.trace("Before PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
         queryRequest = plugin.processPreQuery(queryRequest);
+        LOGGER.trace("After PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -511,9 +534,12 @@ public class QueryOperations extends DescribableImpl {
 
   private QueryResponse postProcessPreAuthorizationPlugins(QueryResponse queryResponse)
       throws FederationException {
+    String traceId = ThreadContextProperties.getTraceId();
     for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthorizationPlugins()) {
       try {
+        LOGGER.trace("Before PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
         queryResponse = plugin.processPostQuery(queryResponse);
+        LOGGER.trace("After PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -523,15 +549,18 @@ public class QueryOperations extends DescribableImpl {
 
   private QueryRequest populateQueryRequestPolicyMap(QueryRequest queryReq)
       throws FederationException {
+    String traceId = ThreadContextProperties.getTraceId();
     HashMap<String, Set<String>> requestPolicyMap = new HashMap<>();
     Map<String, Serializable> unmodifiableProperties =
         Collections.unmodifiableMap(queryReq.getProperties());
     for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {
       try {
+        LOGGER.trace("Before PolicyPlugin (#1): trace-id {}, plugin {}", traceId, plugin);
         PolicyResponse policyResponse =
             plugin.processPreQuery(queryReq.getQuery(), unmodifiableProperties);
         opsSecuritySupport.buildPolicyMap(
             requestPolicyMap, policyResponse.operationPolicy().entrySet());
+        LOGGER.trace("After PolicyPlugin (#1): trace-id {}, plugin {}", traceId, plugin);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -367,10 +367,10 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       boolean userSpellcheckIsOn)
       throws IOException, SolrServerException {
 
-    LOGGER.trace("Begin solr spellcheck: query request {}", request);
     QueryResponse highlightResponse = solrResponse;
     SolrDocumentList resultDocs = originalDocs;
     if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
+      LOGGER.trace("Begin solr spellcheck: query request {}", request);
       Collation collation = getCollationToResend(query, solrResponse);
       query.set("q", collation.getCollationQueryString());
       query.set("spellcheck", false);
@@ -392,10 +392,13 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         responseProps.put(DID_YOU_MEAN_KEY, new ArrayList<>(originals));
         responseProps.put(SHOWING_RESULTS_FOR_KEY, new ArrayList<>(corrections));
       }
+      LOGGER.trace("End solr spellcheck: query request {}", request);
     }
-    LOGGER.trace("End solr spellcheck/Starting highlight extraction: query request {}", request);
-    highlighter.processPostQuery(highlightResponse, responseProps);
-    LOGGER.trace("Ending highlight extraction: query request {}", request);
+    if (highlightResponse.getHighlighting() != null) {
+      LOGGER.trace("Starting highlight extraction: query request {}", request);
+      highlighter.processPostQuery(highlightResponse, responseProps);
+      LOGGER.trace("Ending highlight extraction: query request {}", request);
+    }
     return resultDocs;
   }
 

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -186,7 +186,9 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
 
     SolrFilterDelegate solrFilterDelegate =
         filterDelegateFactory.newInstance(resolver, request.getProperties());
+    LOGGER.trace("Generate solr query: query request {}", request);
     SolrQuery query = getSolrQuery(request, solrFilterDelegate);
+    LOGGER.trace("Done generating solr query: query request {}", request);
 
     boolean isFacetedQuery = handleFacetRequest(query, request);
     query = handleSuggestionQuery(query, request);
@@ -199,6 +201,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
               || BooleanUtils.toBoolean(
                   filterAdapter.adapt(request.getQuery(), new RealTimeGetDelegate()));
 
+      LOGGER.trace("Begin executing solr query: query request {}", request);
       if (doRealTimeGet) {
         LOGGER.debug("Performing real time query");
         SolrQuery realTimeQuery = getRealTimeQuery(query, solrFilterDelegate.getIds());
@@ -210,6 +213,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         highlighter.processPreQuery(request, query);
         solrResponse = client.query(query, METHOD.POST);
       }
+      LOGGER.trace("End executing solr query: query request {}", request);
 
       if (isFacetedQuery) {
         handleFacetResponse(solrResponse, responseProps);
@@ -363,6 +367,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       boolean userSpellcheckIsOn)
       throws IOException, SolrServerException {
 
+    LOGGER.trace("Begin solr spellcheck: query request {}", request);
     QueryResponse highlightResponse = solrResponse;
     SolrDocumentList resultDocs = originalDocs;
     if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
@@ -388,7 +393,9 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         responseProps.put(SHOWING_RESULTS_FOR_KEY, new ArrayList<>(corrections));
       }
     }
+    LOGGER.trace("End solr spellcheck/Starting highlight extraction: query request {}", request);
     highlighter.processPostQuery(highlightResponse, responseProps);
+    LOGGER.trace("Ending highlight extraction: query request {}", request);
     return resultDocs;
   }
 


### PR DESCRIPTION
#### What does this PR do?
Add detailed logging for the pre and post query plugins, and for the solr query code. 

Note: The original intent was to include the trace-id in the solr logging, however there is a problem in the code with the thread context getting passed through to the solr code. 

#### Who is reviewing it? 
@jlcsmith 
@derekwilhelm 

#### Select relevant component teams: 
@codice/io 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann
@clockard 

#### How should this be tested?
Enable trace logging:

log:set TRACE ddf.catalog.impl.operations
log:set TRACE ddf.catalog.source.solr

Perform a query in the UI. Check the DDF log file for the extra logging.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #6704 

#### Screenshots


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
