### PR TITLE
Match on any OR for TagsFilterDelegate 

### DIFF
--- a/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/filter/delegate/TagsFilterDelegate.java
+++ b/catalog/core/catalog-core-commons/src/main/java/ddf/catalog/filter/delegate/TagsFilterDelegate.java
@@ -57,7 +57,7 @@ public class TagsFilterDelegate extends SimpleFilterDelegate<Boolean> {
 
   @Override
   public Boolean or(List<Boolean> operands) {
-    return operands.stream().allMatch(op -> op);
+    return operands.stream().anyMatch(op -> op);
   }
 
   @Override

--- a/catalog/core/catalog-core-impl/filter-proxy/src/test/java/ddf/catalog/filter/delegate/TagsFilterDelegateTest.java
+++ b/catalog/core/catalog-core-impl/filter-proxy/src/test/java/ddf/catalog/filter/delegate/TagsFilterDelegateTest.java
@@ -45,19 +45,10 @@ public class TagsFilterDelegateTest {
   }
 
   @Test
-  public void testTagsInvalidOr() throws Exception {
-    Filter filter1 = builder.attribute("attribute1").is().like().text("value1");
-    Filter filter2 = builder.attribute(Metacard.TAGS).is().like().text("value2");
-    Filter filter = builder.anyOf(filter1, filter2);
-    assertThat(adapter.adapt(filter, new TagsFilterDelegate()), is(false));
-  }
-
-  @Test
   public void testTagsOr() throws Exception {
     Filter filter1 = builder.attribute("attribute1").is().like().text("value1");
     Filter filter2 = builder.attribute(Metacard.TAGS).is().like().text("value2");
-    Filter filter3 = builder.attribute(Metacard.TAGS).is().like().text("value3");
-    Filter filter = builder.anyOf(filter2, builder.allOf(filter1, filter3));
+    Filter filter = builder.anyOf(filter1, filter2);
     assertThat(adapter.adapt(filter, new TagsFilterDelegate()), is(true));
   }
 


### PR DESCRIPTION
#### What does this PR do?
This is a forward port of PR #6481 

The TagsFilterDelegate needs to allow for OR to match on any instances so users can query local sources and remote sources that don't have metacard-tags, like cached federated data, at the same time.

#### Who is reviewing it? 
@jlcsmith 
@glenhein 

#### Select relevant component teams: 

@codice/core-apis 


#### Ask 2 committers to review/merge the PR and tag them here.

@clockard
@andrewkfiedler 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
