### PR TITLE
[2.26.x] DDF-6704 improve query logging

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -209,9 +209,10 @@ public class QueryOperations extends DescribableImpl {
         }
       }
 
-      LOGGER.trace("Before doQuery: trace-id {}", traceId);
+      long start = System.currentTimeMillis();
       queryResponse = doQuery(queryRequest, fedStrategy);
-      LOGGER.trace("After doQuery: trace-id {}", traceId);
+      LOGGER.trace(
+          "After doQuery: trace-id {}, duration {}", traceId, System.currentTimeMillis() - start);
 
       // Allow callers to determine the total results returned from the query; this value
       // may differ from the number of filtered results after processing plugins have been run.
@@ -432,9 +433,13 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (PostQueryPlugin service : frameworkProperties.getPostQuery()) {
       try {
-        LOGGER.trace("Before PostQueryPlugin: trace-id {}, plugin {}", traceId, service);
+        long start = System.currentTimeMillis();
         queryResponse = service.process(queryResponse);
-        LOGGER.trace("After PostQueryPlugin: trace-id {}, plugin {}", traceId, service);
+        LOGGER.trace(
+            "After PostQueryPlugin: trace-id {}, plugin {}, duration {}",
+            traceId,
+            service,
+            System.currentTimeMillis() - start);
       } catch (PluginExecutionException see) {
         LOGGER.debug("Error executing PostQueryPlugin: {}", see.getMessage(), see);
       } catch (StopProcessingException e) {
@@ -449,9 +454,13 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (AccessPlugin plugin : frameworkProperties.getAccessPlugins()) {
       try {
-        LOGGER.trace("Before post-query AccessPlugin: trace-id {}, plugin {}", traceId, plugin);
+        long start = System.currentTimeMillis();
         queryResponse = plugin.processPostQuery(queryResponse);
-        LOGGER.trace("After post-query AccessPlugin: trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace(
+            "After post-query AccessPlugin: trace-id {}, plugin {}, duration {}",
+            traceId,
+            plugin,
+            System.currentTimeMillis() - start);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -469,12 +478,16 @@ public class QueryOperations extends DescribableImpl {
       HashMap<String, Set<String>> itemPolicyMap = new HashMap<>();
       for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {
         try {
-          LOGGER.trace("Before post-query PolicyPlugin: trace-id {}, plugin {}", traceId, plugin);
+          long start = System.currentTimeMillis();
           PolicyResponse policyResponse = plugin.processPostQuery(result, unmodifiableProperties);
           opsSecuritySupport.buildPolicyMap(itemPolicyMap, policyResponse.itemPolicy().entrySet());
           opsSecuritySupport.buildPolicyMap(
               responsePolicyMap, policyResponse.operationPolicy().entrySet());
-          LOGGER.trace("After post-query PolicyPlugin: trace-id {}, plugin {}", traceId, plugin);
+          LOGGER.trace(
+              "After post-query PolicyPlugin: trace-id {}, plugin {}, duration {}",
+              traceId,
+              plugin,
+              System.currentTimeMillis() - start);
         } catch (StopProcessingException e) {
           throw new FederationException("Query could not be executed.", e);
         }
@@ -490,9 +503,13 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (PreQueryPlugin service : frameworkProperties.getPreQuery()) {
       try {
-        LOGGER.trace("Before PreQueryPlugin: trace-id {}, plugin {}", traceId, service);
+        long start = System.currentTimeMillis();
         queryReq = service.process(queryReq);
-        LOGGER.trace("After PreQueryPlugin: trace-id {}, plugin {}", traceId, service);
+        LOGGER.trace(
+            "After PreQueryPlugin: trace-id {}, plugin {}, duration {}",
+            traceId,
+            service,
+            System.currentTimeMillis() - start);
       } catch (PluginExecutionException see) {
         LOGGER.debug("Error executing PreQueryPlugin: {}", see.getMessage(), see);
       } catch (StopProcessingException e) {
@@ -507,9 +524,13 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (AccessPlugin plugin : frameworkProperties.getAccessPlugins()) {
       try {
-        LOGGER.trace("Before pre-query AccessPlugin: trace-id {}, plugin {}", traceId, plugin);
+        long start = System.currentTimeMillis();
         queryReq = plugin.processPreQuery(queryReq);
-        LOGGER.trace("After pre-query AccessPlugin: trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace(
+            "After pre-query AccessPlugin: trace-id {}, plugin {}, duration {}",
+            traceId,
+            plugin,
+            System.currentTimeMillis() - start);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -522,11 +543,13 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthorizationPlugins()) {
       try {
-        LOGGER.trace(
-            "Before pre-query PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
+        long start = System.currentTimeMillis();
         queryRequest = plugin.processPreQuery(queryRequest);
         LOGGER.trace(
-            "After pre-query PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
+            "After pre-query PreAuthorizationPlugin: trace-id {}, plugin {}, duration {}",
+            traceId,
+            plugin,
+            System.currentTimeMillis() - start);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -539,11 +562,13 @@ public class QueryOperations extends DescribableImpl {
     String traceId = ThreadContextProperties.getTraceId();
     for (PreAuthorizationPlugin plugin : frameworkProperties.getPreAuthorizationPlugins()) {
       try {
-        LOGGER.trace(
-            "Before post-query PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
+        long start = System.currentTimeMillis();
         queryResponse = plugin.processPostQuery(queryResponse);
         LOGGER.trace(
-            "After post-query PreAuthorizationPlugin: trace-id {}, plugin {}", traceId, plugin);
+            "After post-query PreAuthorizationPlugin: trace-id {}, plugin {}, duration {}",
+            traceId,
+            plugin,
+            System.currentTimeMillis() - start);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -559,12 +584,16 @@ public class QueryOperations extends DescribableImpl {
         Collections.unmodifiableMap(queryReq.getProperties());
     for (PolicyPlugin plugin : frameworkProperties.getPolicyPlugins()) {
       try {
-        LOGGER.trace("Before pre-query PolicyPlugin: trace-id {}, plugin {}", traceId, plugin);
+        long start = System.currentTimeMillis();
         PolicyResponse policyResponse =
             plugin.processPreQuery(queryReq.getQuery(), unmodifiableProperties);
         opsSecuritySupport.buildPolicyMap(
             requestPolicyMap, policyResponse.operationPolicy().entrySet());
-        LOGGER.trace("After pre-query PolicyPlugin: trace-id {}, plugin {}", traceId, plugin);
+        LOGGER.trace(
+            "After pre-query PolicyPlugin: trace-id {}, plugin {}, duration {}",
+            traceId,
+            plugin,
+            System.currentTimeMillis() - start);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }


### PR DESCRIPTION
#### What does this PR do?

Further fine tuning of trace statements for queries. The original approach of having a "before" and "after" log statement for each plugin was insufficient because there was not enough information to always match the two log lines together because a single trace-id may contain multiple queries. I changed it to a single "after" log statement that captures the difference of system time before the plugin executes and after.

#### Who is reviewing it? 
@clockard 
@derekwilhelm 

#### Select relevant component teams: 
#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith 

#### How should this be tested?
Enable trace logging for ddf.catalog.impl.operations and verify that the log statements appear.

#### Any background context you want to provide?
This is for a downstream project that needs to perform a detailed analysis of query execution times.

#### What are the relevant tickets?
Fixes: #6704 

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
