### PR TITLE
[2.26.x] Fixes build failures due to incompatible cxf-wadl2java-plugin version

### DIFF
--- a/catalog/confluence/catalog-confluence-common/pom.xml
+++ b/catalog/confluence/catalog-confluence-common/pom.xml
@@ -35,6 +35,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-wadl2java-plugin</artifactId>
+                <version>${cxf.version}</version>
                 <executions>
                     <execution>
                         <id>generate-sources</id>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -195,6 +195,7 @@
                 <plugin>
                     <groupId>org.apache.cxf</groupId>
                     <artifactId>cxf-codegen-plugin</artifactId>
+                    <version>${cxf.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
#### What does this PR do?
The 2.26.x build is failing due to the build pulling in an incompatible version of the cxf-wadl2java-plugin library.  This PR specifies the correct cxf version for the plugin that is compatible with java 8.

#### Who is reviewing it? 
@glenhein 
@pklinef 

#### Select relevant component teams: 
@codice/build 

#### Ask 2 committers to review/merge the PR and tag them here.
@glenhein 
@pklinef 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
