### PR TITLE
[2.26.x] Upgrade Tika to 1.26

### DIFF
--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -16,7 +16,6 @@ package ddf.catalog.transformer.input.tika;
 import static java.util.stream.Collectors.toList;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -26,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -476,7 +476,7 @@ public class TikaInputTransformerTest {
     assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(SOUND));
     assertThat(
         metacard.getMetadata(), containsString("<meta name=\"xmpDM:duration\" content=\"2.4"));
-    assertTrue(metacard.getAttribute(Media.DURATION).getValue().toString().startsWith("2.4"));
+    assertEquals((Double) metacard.getAttribute(Media.DURATION).getValue(), 2.4, 0.1);
   }
 
   @Test

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -16,6 +16,7 @@ package ddf.catalog.transformer.input.tika;
 import static java.util.stream.Collectors.toList;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -50,6 +51,7 @@ import ddf.catalog.data.impl.types.LocationAttributes;
 import ddf.catalog.data.impl.types.MediaAttributes;
 import ddf.catalog.data.impl.types.ValidationAttributes;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Media;
 import ddf.catalog.data.types.Validation;
 import ddf.catalog.data.types.constants.core.DataType;
 import ddf.catalog.data.types.experimental.Extracted;
@@ -474,6 +476,7 @@ public class TikaInputTransformerTest {
     assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(SOUND));
     assertThat(
         metacard.getMetadata(), containsString("<meta name=\"xmpDM:duration\" content=\"2.4"));
+    assertTrue(metacard.getAttribute(Media.DURATION).getValue().toString().startsWith("2.4"));
   }
 
   @Test

--- a/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-tika-input/src/test/java/ddf/catalog/transformer/input/tika/TikaInputTransformerTest.java
@@ -472,6 +472,8 @@ public class TikaInputTransformerTest {
         containsString("<meta name=\"xmpDM:artist\" content=\"Test Artist\" />"));
     assertThat(metacard.getContentTypeName(), is("audio/mpeg"));
     assertThat(metacard.getAttribute(Core.DATATYPE).getValue(), is(SOUND));
+    assertThat(
+        metacard.getMetadata(), containsString("<meta name=\"xmpDM:duration\" content=\"2.4"));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -304,8 +304,8 @@
         <spatial4j.version>0.7</spatial4j.version>
         <spring.version>5.2.5.RELEASE</spring.version>
         <spring-osgi.version>1.2.1</spring-osgi.version>
-        <tika.thirdparty.bundle.version>1.24.1_1</tika.thirdparty.bundle.version>
-        <tika.version>1.24.1</tika.version>
+        <tika.thirdparty.bundle.version>1.26.0_1</tika.thirdparty.bundle.version>
+        <tika.version>1.26</tika.version>
         <usng4j.version>0.4</usng4j.version>
         <validation.version>1.1.0.Final</validation.version>
         <woodstox.core.version>6.2.1</woodstox.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <abdera.version>1.1.3</abdera.version>
         <antlr.version>4.3</antlr.version>
         <apache.shiro.version>1.6.0</apache.shiro.version>
-        <asm.version>8.0.1</asm.version>
+        <asm.version>9.0</asm.version>
         <awaitility.version>3.1.5</awaitility.version>
         <bouncy.version>1.66</bouncy.version>
         <c3p0.version>0.9.5.5</c3p0.version>
@@ -274,7 +274,7 @@
         <ogc-filter-v_1_1_0-schema.thirdparty.version>1.1.0_5</ogc-filter-v_1_1_0-schema.thirdparty.version>
         <openjson.version>1.0.12</openjson.version>
         <pac4j.version>4.0.1</pac4j.version>
-        <pdfbox.version>2.0.19</pdfbox.version>
+        <pdfbox.version>2.0.23</pdfbox.version>
         <poi.version>4.1.2</poi.version>
         <xlsx.transformer.poi.version>4.1.2</xlsx.transformer.poi.version>
         <protobuf.version>3.12.4</protobuf.version>
@@ -308,7 +308,7 @@
         <tika.version>1.26</tika.version>
         <usng4j.version>0.4</usng4j.version>
         <validation.version>1.1.0.Final</validation.version>
-        <woodstox.core.version>6.2.1</woodstox.core.version>
+        <woodstox.core.version>6.2.4</woodstox.core.version>
         <woodstox.stax2-api.version>4.2.1</woodstox.stax2-api.version>
         <wss4j.neethi.version>3.1.1</wss4j.neethi.version>
         <wss4j.version>2.3.0</wss4j.version>
@@ -325,7 +325,7 @@
         <micrometer.hdrhistogram.version>2.1.12</micrometer.hdrhistogram.version>
         <micrometer.latencyutils.version>2.0.3</micrometer.latencyutils.version>
         <micrometer.prometheus-client.version>0.8.1</micrometer.prometheus-client.version>
-        <zstd-jni.version>1.4.5-4</zstd-jni.version>
+        <zstd-jni.version>1.4.9-1</zstd-jni.version>
 
         <!-- Command line argument properties for the maven-surefire-plugin -->
         <surefire.argline.append />


### PR DESCRIPTION
#### What does this PR do?
This PR upgrades Tika from version 1.24 to version 1.26, in order to [addresses an inconsistency](https://issues.apache.org/jira/browse/TIKA-3318) regarding MP3 format duration units.

#### Who is reviewing it? 
@alexabird 
@jrnorth
@jlcsmith

#### How should this be tested?
Verify that the metacard for any ingested MP3 file should have the duration in seconds and not in milliseconds.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
