### PR TITLE
[WIP] Experiment with new preferences storage

### DIFF
--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -73,6 +73,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>preferences-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
             <version>${project.version}</version>

--- a/catalog/catalog-app/src/main/resources/features.xml
+++ b/catalog/catalog-app/src/main/resources/features.xml
@@ -277,6 +277,7 @@
         <feature>catalog-plugin-oauth</feature>
         <feature>catalog-security-policyplugin</feature>
         <feature>catalog-transformer-thumbnail</feature>
+        <bundle>mvn:ddf.platform/preferences-impl/${project.version}</bundle>
     </feature>
 
     <!-- Start of app features -->

--- a/distribution/ddf-common/src/main/resources-filtered/etc/custom.system.properties
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/custom.system.properties
@@ -90,7 +90,7 @@ solr.username=admin
 solr.query.anytext.fields=metadata,title,description,ext.extracted.text
 
 # Comma-separated list of metacard types that do not support optimistic updates.
-solr.commit.nrt.metacardTypes=workspace,metacard.query,metacard.list,query-template,attribute-group,resource-note
+solr.commit.nrt.metacardTypes=workspace,metacard.query,metacard.list,query-template,attribute-group,resource-note,ddf.preferences
 
 # Comma-separated list of metacard fields that should never show up as search result highlights
 solr.highlight.blacklist=metacard-tags

--- a/distribution/ddf-common/src/main/resources/etc/definitions/preferences.json
+++ b/distribution/ddf-common/src/main/resources/etc/definitions/preferences.json
@@ -1,0 +1,451 @@
+{
+  "metacardTypes": [
+    {
+      "type": "ddf.preferences",
+      "extendsTypes": [ "core" ],
+      "attributes": {
+        "user": {
+          "required": false
+        },
+        "mapLayers": {
+          "required": false
+        },
+        "resultDisplay": {
+          "required": false
+        },
+        "resultPreview": {
+          "required": false
+        },
+        "resultFilter": {
+          "required": false
+        },
+        "resultSort": {
+          "required": false
+        },
+        "inspector-summaryShown": {
+          "required": false
+        },
+        "inspector-summaryOrder": {
+          "required": false
+        },
+        "inspector-detailsOrder": {
+          "required": false
+        },
+        "inspector-detailsHidden": {
+          "required": false
+        },
+        "results-attributesShownTable": {
+          "required": false
+        },
+        "results-attributesShownList": {
+          "required": false
+        },
+        "homeFilter": {
+          "required": false
+        },
+        "homeSort": {
+          "required": false
+        },
+        "homeDisplay": {
+          "required": false
+        },
+        "alerts": {
+          "required": false
+        },
+        "alertPersistence": {
+          "required": false
+        },
+        "alertExpiration": {
+          "required": false
+        },
+        "visualization": {
+          "required": false
+        },
+        "columnHide": {
+          "required": false
+        },
+        "columnOrder": {
+          "required": false
+        },
+        "hasSelectedColumns": {
+          "required": false
+        },
+        "uploads": {
+          "required": false
+        },
+        "oauth": {
+          "required": false
+        },
+        "fontSize": {
+          "required": false
+        },
+        "resultCount": {
+          "required": false
+        },
+        "dateTimeFormat": {
+          "required": false
+        },
+        "timeZone": {
+          "required": false
+        },
+        "coordinateFormat": {
+          "required": false
+        },
+        "autoPan": {
+          "required": false
+        },
+        "goldenLayout": {
+          "required": false
+        },
+        "goldenLayoutUpload": {
+          "required": false
+        },
+        "goldenLayoutMetacard": {
+          "required": false
+        },
+        "goldenLayoutAlert": {
+          "required": false
+        },
+        "theme": {
+          "required": false
+        },
+        "animation": {
+          "required": false
+        },
+        "hoverPreview": {
+          "required": false
+        },
+        "querySettings": {
+          "required": false
+        },
+        "mapHome": {
+          "required": false
+        },
+        "actingRole": {
+          "required": false
+        },
+        "columnWidths": {
+          "required": false
+        },
+        "inspector-hideEmpty": {
+          "required": false
+        },
+        "layoutId": {
+          "required": false
+        }
+      }
+    }
+  ],
+  "attributeTypes": {
+    "layoutId": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "columnWidths": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "inspector-hideEmpty": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "user": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "mapLayers": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "resultDisplay": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "resultPreview": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": true
+    },
+    "resultFilter": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "resultSort": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "inspector-summaryShown": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "inspector-summaryOrder": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "inspector-detailsOrder": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": true
+    },
+    "inspector-detailsHidden": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "results-attributesShownTable": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "results-attributesShownList": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "homeFilter": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "homeSort": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "homeDisplay": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "alerts": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "alertPersistence": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "alertExpiration": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "visualization": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "columnHide": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "columnOrder": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "hasSelectedColumns": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "uploads": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "oauth": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "fontSize": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "resultCount": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "dateTimeFormat": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "timeZone": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "coordinateFormat": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "autoPan": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "goldenLayout": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "goldenLayoutUpload": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "goldenLayoutMetacard": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "goldenLayoutAlert": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "theme": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "animation": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "hoverPreview": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "querySettings": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "mapHome": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "actingRole": {
+      "type": "STRING",
+      "stored": true,
+      "indexed": true,
+      "tokenized": false,
+      "multivalued": false
+    }
+  },
+  "defaults": [
+    {
+      "attribute": "metacard-tags",
+      "value": "ddf-preferences",
+      "metacardTypes": [
+        "ddf.preferences"
+      ]
+    }
+  ]
+}

--- a/features/solr/pom.xml
+++ b/features/solr/pom.xml
@@ -54,6 +54,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>preferences-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.codice.thirdparty</groupId>
             <artifactId>jts</artifactId>
             <version>${jts.bundle.version}</version>

--- a/features/solr/src/main/feature/feature.xml
+++ b/features/solr/src/main/feature/feature.xml
@@ -83,6 +83,7 @@
         <bundle>mvn:javax.measure/unit-api/1.0</bundle>
         <bundle>mvn:org.codice.thirdparty/geotools-suite/${org.geotools.bundle.version}</bundle>
         <bundle>mvn:ddf.persistence.core/persistence-core-impl/${project.version}</bundle>
+        <bundle>mvn:ddf.platform/preferences-api/${project.version}</bundle>
         <bundle>mvn:ddf.persistence.core/persistence-core-commands/${project.version}</bundle>
         <bundle>mvn:org.codice.thirdparty/gt-opengis/${opengis.bundle.version}</bundle>
 

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -238,5 +238,6 @@
         <module>sync-installer</module>
         <module>resource-bundle-locator</module>
         <module>http-filter-api</module>
+        <module>preferences</module>
     </modules>
 </project>

--- a/platform/preferences/pom.xml
+++ b/platform/preferences/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.platform</groupId>
+        <artifactId>platform</artifactId>
+        <version>2.26.24</version>
+    </parent>
+    <groupId>ddf.platform</groupId>
+    <artifactId>preferences</artifactId>
+    <name>DDF Preferences</name>
+    <packaging>pom</packaging>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.cxf</groupId>
+                    <artifactId>cxf-codegen-plugin</artifactId>
+                    <version>${cxf.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+    <modules>
+        <module>preferences-api</module>
+        <module>preferences-impl</module>
+    </modules>
+</project>

--- a/platform/preferences/preferences-api/pom.xml
+++ b/platform/preferences/preferences-api/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.platform</groupId>
+        <artifactId>preferences</artifactId>
+        <version>2.26.24</version>
+    </parent>
+    <artifactId>preferences-api</artifactId>
+    <name>DDF :: Preferences :: API</name>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/preferences/preferences-api/src/main/java/org/codice/ddf/preferences/Preferences.java
+++ b/platform/preferences/preferences-api/src/main/java/org/codice/ddf/preferences/Preferences.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.preferences;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public interface Preferences {
+
+  // TODO need a "patch" method so individual prefs can be updated
+
+  /**
+   * Adds item with the specified properties.
+   *
+   * @param properties A map of properties making up the item. Property keys must have a suffix that
+   *     identifies the type of value for the entry. The PersistentItem class should be used for
+   *     creating this map.
+   * @throws PreferencesException If the type is empty or there was an issue persisting the item.
+   */
+  void add(Map<String, Object> properties) throws PreferencesException;
+
+  /**
+   * Adds a collection of items.
+   *
+   * @param items A list of map properties making up the items. Property keys must have a suffix
+   *     that identifies the type of value for the entry. The PersistentItem class should be used
+   *     for creating these maps.
+   * @throws PreferencesException If the type is empty or there was an issue persisting the item.
+   */
+  void add(Collection<Map<String, Object>> items) throws PreferencesException;
+
+  /**
+   * Get all items.
+   *
+   * @return
+   * @throws PreferencesException
+   */
+  List<Map<String, Object>> get() throws PreferencesException;
+
+  /**
+   * Get items matching the ECQL query criteria.
+   *
+   * @param ecql
+   * @return
+   * @throws PreferencesException
+   */
+  List<Map<String, Object>> get(String ecql) throws PreferencesException;
+
+  /**
+   * Get all items matching the ECQL query criteria.
+   *
+   * @param ecql Query criteria.
+   * @param startIndex Index to start query at.
+   * @param pageSize Max number of results to return in single query.
+   * @throws PreferencesException
+   * @throws IllegalArgumentException if startIndex is less than 0 or if pageSize is greater than
+   *     the max allowed.
+   */
+  List<Map<String, Object>> get(String ecql, int startIndex, int pageSize)
+      throws PreferencesException;
+
+  /**
+   * Delete items matching the ECQL query criteria.
+   *
+   * @param ecql
+   * @return Count of the items deleted
+   * @throws PreferencesException
+   */
+  int delete(String ecql) throws PreferencesException;
+
+  /**
+   * @param ecql Query criteria.
+   * @param startIndex Index to start query at.
+   * @param pageSize Max number of results to return in single query.
+   * @return Count of the items deleted
+   * @throws PreferencesException
+   * @throws IllegalArgumentException if startIndex is less than 0 or if pageSize is greater than
+   *     the max allowed.
+   */
+  int delete(String ecql, int startIndex, int pageSize) throws PreferencesException;
+}

--- a/platform/preferences/preferences-api/src/main/java/org/codice/ddf/preferences/PreferencesException.java
+++ b/platform/preferences/preferences-api/src/main/java/org/codice/ddf/preferences/PreferencesException.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.preferences;
+
+public class PreferencesException extends Exception {
+  public PreferencesException() {
+    super();
+  }
+
+  public PreferencesException(Throwable e) {
+    super(e);
+  }
+}

--- a/platform/preferences/preferences-impl/pom.xml
+++ b/platform/preferences/preferences-impl/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version. 
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ddf.platform</groupId>
+        <artifactId>preferences</artifactId>
+        <version>2.26.24</version>
+    </parent>
+    <artifactId>preferences-impl</artifactId>
+    <name>DDF :: Preferences :: Impl</name>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>preferences-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.persistence.core</groupId>
+            <artifactId>persistence-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>gson-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            gson-support,
+                            catalog-core-api-impl;scope=!test
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/platform/preferences/preferences-impl/src/main/java/org/codice/ddf/preferences/impl/PreferencesImpl.java
+++ b/platform/preferences/preferences-impl/src/main/java/org/codice/ddf/preferences/impl/PreferencesImpl.java
@@ -1,0 +1,316 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.preferences.impl;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.nio.charset.Charset;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.codice.ddf.persistence.PersistenceException;
+import org.codice.ddf.persistence.PersistentStore;
+import org.codice.ddf.preferences.Preferences;
+import org.codice.ddf.preferences.PreferencesException;
+import org.codice.gsonsupport.GsonTypeAdapters;
+import org.opengis.filter.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PreferencesImpl implements Preferences {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PreferencesImpl.class);
+
+  private static final String TYPE = PersistentStore.PersistenceType.PREFERENCES_TYPE.toString();
+
+  private static final Gson GSON =
+      new GsonBuilder()
+          .disableHtmlEscaping()
+          .registerTypeAdapterFactory(GsonTypeAdapters.LongDoubleTypeAdapter.FACTORY)
+          .create();
+
+  private final PersistentStore persistentStore;
+
+  private final List<MetacardType> metacardTypes;
+
+  private final CatalogFramework catalogFramework;
+
+  private final FilterBuilder filterBuilder;
+
+  public PreferencesImpl(
+      PersistentStore persistentStore,
+      List<MetacardType> metacardTypes,
+      CatalogFramework catalogFramework,
+      FilterBuilder filterBuilder) {
+    this.persistentStore = persistentStore;
+    this.metacardTypes = metacardTypes;
+    this.catalogFramework = catalogFramework;
+    this.filterBuilder = filterBuilder;
+  }
+
+  @Override
+  public void add(Map<String, Object> properties) throws PreferencesException {
+    //    try {
+    //      persistentStore.add(TYPE, properties);
+    //    } catch (PersistenceException e) {
+    //      throw new PreferencesException(e);
+    //    }
+
+    Optional<MetacardType> optionalDdfPreferencesMetacardType =
+        metacardTypes.stream()
+            .filter(metacardType -> metacardType.getName().equals("ddf.preferences"))
+            .findFirst();
+
+    if (optionalDdfPreferencesMetacardType.isPresent()) {
+
+      String json =
+          new String(Base64.getDecoder().decode(properties.get("preferences_json_bin").toString()));
+
+      Map<Object, Object> originalPreferences = GSON.fromJson(json, Map.class);
+
+      Set<String> availableAttributes =
+          optionalDdfPreferencesMetacardType.get().getAttributeDescriptors().stream()
+              .map(AttributeDescriptor::getName)
+              .collect(Collectors.toSet());
+
+      Metacard metacard = new MetacardImpl(optionalDdfPreferencesMetacardType.get());
+      metacard.setAttribute(new AttributeImpl("user", properties.get("user_txt").toString()));
+      originalPreferences.forEach(
+          (key, value) -> {
+            if (availableAttributes.contains(key.toString())) {
+              String json2 = GSON.toJson(value);
+              // value.getClass().getName() + ":" +
+              metacard.setAttribute(new AttributeImpl(key.toString(), json2));
+            } else {
+              LOGGER.debug(
+                  "Unable to save the preference attribute {} because it is not defined on the MetacardType",
+                  key);
+            }
+          });
+
+      Filter filter =
+          filterBuilder.allOf(
+              filterBuilder
+                  .attribute("user")
+                  .is()
+                  .equalTo()
+                  .text(properties.get("user_txt").toString()),
+              filterBuilder.attribute("metacard-tags").is().equalTo().text("ddf-preferences"));
+
+      QueryResponse queryResponse = null;
+      try {
+        queryResponse = catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter)));
+      } catch (UnsupportedQueryException | SourceUnavailableException | FederationException e) {
+        throw new PreferencesException(e);
+      }
+
+      for (String id :
+          queryResponse.getResults().stream()
+              .map(Result::getMetacard)
+              .map(Metacard::getId)
+              .collect(Collectors.toList())) {
+        try {
+          catalogFramework.delete(new DeleteRequestImpl(id));
+        } catch (IngestException | SourceUnavailableException e) {
+          throw new PreferencesException(e);
+        }
+      }
+
+      try {
+        catalogFramework.create(new CreateRequestImpl(metacard));
+      } catch (IngestException | SourceUnavailableException e) {
+        throw new PreferencesException(e);
+      }
+
+      LOGGER.info("metacard: {}", metacard);
+    }
+  }
+
+  @Override
+  public void add(Collection<Map<String, Object>> items) throws PreferencesException {
+    try {
+      persistentStore.add(TYPE, items);
+    } catch (PersistenceException e) {
+      throw new PreferencesException(e);
+    }
+  }
+
+  @Override
+  public List<Map<String, Object>> get() throws PreferencesException {
+    try {
+      return persistentStore.get(TYPE);
+    } catch (PersistenceException e) {
+      throw new PreferencesException(e);
+    }
+  }
+
+  @Override
+  public List<Map<String, Object>> get(String ecql) throws PreferencesException {
+
+    Map<String, Object> results = new HashMap<>();
+
+    String user = null;
+
+    Pattern pattern = Pattern.compile("^user = '(.*)'$");
+
+    Matcher matcher = pattern.matcher(ecql);
+
+    if (matcher.matches()) {
+      user = matcher.group(1);
+    }
+
+    Filter filter =
+        filterBuilder.allOf(
+            filterBuilder.attribute("user").is().equalTo().text(user),
+            filterBuilder.attribute("metacard-tags").is().equalTo().text("ddf-preferences"));
+
+    QueryResponse queryResponse = null;
+    try {
+      queryResponse = catalogFramework.query(new QueryRequestImpl(new QueryImpl(filter)));
+    } catch (UnsupportedQueryException | SourceUnavailableException | FederationException e) {
+      throw new PreferencesException(e);
+    }
+
+    if (queryResponse.getResults().isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Optional<MetacardType> optionalDdfPreferencesMetacardType =
+        metacardTypes.stream()
+            .filter(metacardType -> metacardType.getName().equals("ddf.preferences"))
+            .findFirst();
+
+    if (optionalDdfPreferencesMetacardType.isPresent()) {
+
+      Map<String, Object> preferences = new HashMap<>();
+
+      Metacard metacard = queryResponse.getResults().get(0).getMetacard();
+
+      Set<String> coreAttributes =
+          new CoreAttributes()
+              .getAttributeDescriptors().stream()
+                  .map(AttributeDescriptor::getName)
+                  .collect(Collectors.toSet());
+      coreAttributes.add("effective");
+
+      optionalDdfPreferencesMetacardType.get().getAttributeDescriptors().stream()
+          .map(attributeDescriptor -> metacard.getAttribute(attributeDescriptor.getName()))
+          .filter(Objects::nonNull)
+          .filter(attribute -> !coreAttributes.contains(attribute.getName()))
+          .forEach(
+              attribute -> {
+                String value = attribute.getValue().toString();
+                // Pattern p = Pattern.compile("([^:]+):(.*)");
+                // Matcher m = p.matcher(value);
+                // if (m.matches()) {
+                // String clazz = m.group(1);
+                // String json = m.group(2);
+                try {
+                  preferences.put(attribute.getName(), GSON.fromJson(value, Object.class));
+                } catch (JsonSyntaxException e) {
+                  // throw new RuntimeException(e);
+                  LOGGER.info(
+                      "failed to parse json: name={} value={}", attribute.getName(), value, e);
+                }
+                // }
+              });
+
+      String json = GSON.toJson(preferences);
+
+      results.put("preferences_json_bin", json.getBytes(Charset.defaultCharset()));
+      results.put("id_txt", user);
+      results.put(
+          "ext.security-filter-match-all-count_int",
+          metacard.getAttribute("ext.security-filter-match-all-count").getValue());
+      results.put(
+          "ext.replication-node-id_txt",
+          metacard.getAttribute("ext.replication-node-id").getValue());
+      results.put("createdate_tdt", metacard.getCreatedDate());
+      results.put("user_txt", user);
+      results.put(
+          "ext.security-redaction-match-all-count_int",
+          metacard.getAttribute("ext.security-redaction-match-all-count").getValue());
+      results.put(
+          "ext.replication-timestamp_lng",
+          metacard.getAttribute("ext.replication-timestamp").getValue());
+
+      return Collections.singletonList(results);
+    }
+
+    //    try {
+    //      List<Map<String, Object>> tmp = persistentStore.get(TYPE, ecql);
+    //      return tmp;
+    //    } catch (PersistenceException e) {
+    //      throw new PreferencesException(e);
+    //    }
+
+    throw new PreferencesException();
+  }
+
+  @Override
+  public List<Map<String, Object>> get(String ecql, int startIndex, int pageSize)
+      throws PreferencesException {
+    try {
+      return persistentStore.get(TYPE, ecql, startIndex, pageSize);
+    } catch (PersistenceException e) {
+      throw new PreferencesException(e);
+    }
+  }
+
+  @Override
+  public int delete(String ecql) throws PreferencesException {
+    try {
+      return persistentStore.delete(TYPE, ecql);
+    } catch (PersistenceException e) {
+      throw new PreferencesException(e);
+    }
+  }
+
+  @Override
+  public int delete(String ecql, int startIndex, int pageSize) throws PreferencesException {
+    try {
+      return persistentStore.delete(TYPE, ecql, startIndex, pageSize);
+    } catch (PersistenceException e) {
+      throw new PreferencesException(e);
+    }
+  }
+}

--- a/platform/preferences/preferences-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/preferences/preferences-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+  xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+  <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType"/>
+
+  <reference id="persistentStore" interface="org.codice.ddf.persistence.PersistentStore"/>
+
+  <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
+
+  <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
+
+  <bean id="preferences" class="org.codice.ddf.preferences.impl.PreferencesImpl">
+    <argument ref="persistentStore"/>
+    <argument ref="metacardTypeList"/>
+    <argument ref="catalogFramework"/>
+    <argument ref="filterBuilder"/>
+  </bean>
+
+  <service ref="preferences" interface="org.codice.ddf.preferences.Preferences"/>
+
+</blueprint>


### PR DESCRIPTION
#### What does this PR do?

This is an exploration of changing preference storage to proper metacards. 

I started with a new interface named Preferences that is a close copy of the PersistentStore interface. Except that the methods no longer have a "type" parameter (the type indicated if the operation was for alerts, notifications, preferences etc), and the methods throw a PreferencesException. The idea was to make an almost-drop-in replacement for the persistent store used in ddf-ui. All of the PersistentStore methods were copied, but it turns only two ("add" and "get(ecql)") were actually used by ddf-ui. 

The original preference store contained a single attribute (preferences_json_bin) that contained all of the individual preferences settings. I defined a new metacard type (ddf.preferences) with separate attributes. To keep this first iteration as simple as possible, each attribute is stored as JSON regardless of its actual type (eg. integer, string, map). 

For storing, the code takes the single large JSON structure sent by the UI and breaks it down into separate attributes. For retrieval, the code recombines the separate attributes into a single JSON structure. The idea was not yet tackle the UI code. Also, for storing, the code deletes the previous preferences metacard and creates a new metacard. This is not ideal, but it replicates the original behavior. My idea is to add a "patch" method that will allow the UI to update a single preference on an existing preference metacard. That will require a substantial amount of UI work. 

There is a bug where a preference setting is getting lost intermittently. I would set the result count in the settings menu and refresh the page. The setting menu reflected the new value, but then sometimes it would revert to the default value. I'm guessing that there is a timing issue with storing the preferences metacard. I update the NRT configuration to include the preferences metacard, but the problem has been resolved. I'm confident that this problem can be solved. 

Next Task:

Update Preferences interface to include a "patch" method so the UI can update individual preference values. This is needed so that it plays nice with other parts of the system that eventually update preference settings as well. Once the UI is updated, then the current "add" method can be deleted.

