### PR TITLE
[2.26.x] Support default sort parameters for WFS 1.1.0 sources.

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
@@ -57,7 +57,7 @@ public class Wfs11Constants extends WfsConstants {
 
   /**
    * This is a list of sort-by attribute names that were removed from the query because they are
-   * known to be unsupported by the source. In practice, this value will be appended with
+   * known to be unsupported by the source. In practice, this value will be suffixed with
    * ".SOURCE_ID".
    */
   public static final String UNSUPPORTED_SORT_BY_REMOVED = "unsupported-sort-by-removed";

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
@@ -55,6 +55,13 @@ public class Wfs11Constants extends WfsConstants {
 
   public static final QName MULTI_POLYGON = new QName(GML_3_1_1_NAMESPACE, "MultiPolygon");
 
+  /**
+   * This is a list of sort-by attribute names that were removed from the query because they are
+   * known to be unsupported by the source. In practice, this value will be appended with
+   * ".SOURCE_ID".
+   */
+  public static final String UNSUPPORTED_SORT_BY_REMOVED = "unsupported-sort-by-removed";
+
   public static List<QName> wktOperandsAsList() {
     return Arrays.asList(
         LINEAR_RING,

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -274,7 +274,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.68</minimum>
+                                            <minimum>0.69</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -97,6 +97,12 @@
         <AD description="Forces the source to support all geometry operands."
             name="Force All Geometry Operands" id="forceAllGeometryOperands" required="false"
             type="Boolean" default="false"/>
+        <AD description="Set the default sort attribute name (optional). If the default sort attribute is set, then the default sort order must be set."
+            name="Default Sort Attribute" id="defaultSortName" required="false"
+            type="String"/>
+        <AD description="Set the default sort order (optional). If the default sort order is set, then the default sort attribute must be set. Allowed values: ASCENDING, DESCENDING"
+            name="Default Sort Order" id="defaultSortOrder" required="false"
+            type="String"/>
     </OCD>
 
     <Designate pid="Wfs_v110_Federated_Source" factoryPid="Wfs_v110_Federated_Source">

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -261,27 +261,28 @@ public class WfsSourceTest {
 
   private final GeotoolsFilterBuilder builder = new GeotoolsFilterBuilder();
 
-  private ExtendedWfs mockWfs = mock(ExtendedWfs.class);
+  private final ExtendedWfs mockWfs = mock(ExtendedWfs.class);
 
-  private WFSCapabilitiesType mockCapabilities = new WFSCapabilitiesType();
+  private final WFSCapabilitiesType mockCapabilities = new WFSCapabilitiesType();
 
-  private BundleContext mockContext = mock(BundleContext.class);
+  private final BundleContext mockContext = mock(BundleContext.class);
 
   private List<QName> sampleFeatures;
 
-  private WfsUriResolver wfsUriResolver = new WfsUriResolver();
+  private final WfsUriResolver wfsUriResolver = new WfsUriResolver();
 
   private WfsSource source;
 
-  private ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
+  private final ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
 
-  private EncryptionService encryptionService = mock(EncryptionService.class);
+  private final EncryptionService encryptionService = mock(EncryptionService.class);
 
-  private WfsMetacardTypeRegistry mockWfsMetacardTypeRegistry = mock(WfsMetacardTypeRegistry.class);
+  private final WfsMetacardTypeRegistry mockWfsMetacardTypeRegistry =
+      mock(WfsMetacardTypeRegistry.class);
 
   private ClientBuilderFactory clientBuilderFactory = mock(ClientBuilderFactory.class);
 
-  private List<MetacardMapper> metacardMappers = new ArrayList<>();
+  private final List<MetacardMapper> metacardMappers = new ArrayList<>();
 
   private boolean forceAllGeometryOperands = false;
 
@@ -778,7 +779,7 @@ public class WfsSourceTest {
     ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, propertyIsLikeQuery);
     assertThat(getFeatureType.getQuery().size(), is(TWO_FEATURES));
-    Collections.sort(getFeatureType.getQuery(), QUERY_TYPE_COMPARATOR);
+    getFeatureType.getQuery().sort(QUERY_TYPE_COMPARATOR);
     QueryType query = getFeatureType.getQuery().get(0);
     assertThat(query.getTypeName().get(0), is(sampleFeatures.get(0)));
     assertThat(query.getFilter().isSetComparisonOps(), is(true));
@@ -1670,42 +1671,6 @@ public class WfsSourceTest {
   }
 
   @Test
-  public void testSortingNoSortMapping() throws Exception {
-    // if sorting is enabled but there is no sort mapping, throw an UnsupportedQueryException
-    expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage("Source WFS_ID does not support specified sort property title");
-
-    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
-    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
-    final QueryImpl propertyIsLikeQuery =
-        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
-    setupMapper(null, null, null);
-    source.setMetacardMappers(metacardMappers);
-    source.setDisableSorting(false);
-    propertyIsLikeQuery.setSortBy(new SortByImpl("title", SortOrder.ASCENDING));
-
-    source.query(new QueryRequestImpl(propertyIsLikeQuery));
-  }
-
-  @Test
-  public void testSortingNoSortOrder() throws Exception {
-    // if sort order is missing, throw UnsupportedQueryException
-    expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage("Source WFS_ID does not support specified sort property TEMPORAL");
-
-    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
-    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
-    final QueryImpl propertyIsLikeQuery =
-        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
-    setupMapper(
-        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
-    source.setMetacardMappers(metacardMappers);
-    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, (String) null));
-
-    source.query(new QueryRequestImpl(propertyIsLikeQuery));
-  }
-
-  @Test
   public void testSortingNoSortProperty() throws Exception {
     // query is still valid even if sort property is missing
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
@@ -1735,10 +1700,46 @@ public class WfsSourceTest {
   }
 
   @Test
-  public void testSortingBadSortOrder() throws Exception {
+  public void testSortingBadSortOrderWithoutDefault() throws Exception {
+
+    // query is still valid even if sort property bad
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
+
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  @Test
+  public void testSortingBadSortOrderWithDefault() throws Exception {
+
+    // query is still valid even if sort property bad
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
+
+    source.setDefaultSortName(Result.TEMPORAL);
+    source.setDefaultSortOrder(SortOrder.ASCENDING.name());
+
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  @Test
+  public void testSortingBadSortOrderWithBadDefault() throws Exception {
+
     // if sort order is invalid throw UnsupportedQueryException
     expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage("Source WFS_ID does not support specified sort property TEMPORAL");
+    expectedEx.expectMessage("Source WFS_ID does not support the default sort property xyz");
 
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
     setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
@@ -1748,6 +1749,9 @@ public class WfsSourceTest {
         MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
+
+    source.setDefaultSortName("xyz");
+    source.setDefaultSortOrder(SortOrder.ASCENDING.name());
 
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
   }


### PR DESCRIPTION
#### What does this PR do?
Support default sort parameters for WFS 1.1.0 sources.

#### Who is reviewing it? 
@derekwilhelm 
@jlcsmith 

#### How should this be tested?
Configure a WFS source that does not support RELEVANCE. Leave the default sort property and default sort order blank in the config. Confirm that a search that sorts by RELEVANCE returns unsorted results. Change the config to use "name" and "ASCENDING" for the default property and order. Confirm that a search that sorts by RELEVANCE returns results sorted by name.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
