### PR TITLE
Support default sort parameters for WFS 1.1.0 sources.

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
@@ -57,7 +57,7 @@ public class Wfs11Constants extends WfsConstants {
 
   /**
    * This is a list of sort-by attribute names that were removed from the query because they are
-   * known to be unsupported by the source. In practice, this value will be appended with
+   * known to be unsupported by the source. In practice, this value will be suffixed with
    * ".SOURCE_ID".
    */
   public static final String UNSUPPORTED_SORT_BY_REMOVED = "unsupported-sort-by-removed";

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
@@ -55,6 +55,13 @@ public class Wfs11Constants extends WfsConstants {
 
   public static final QName MULTI_POLYGON = new QName(GML_3_1_1_NAMESPACE, "MultiPolygon");
 
+  /**
+   * This is a list of sort-by attribute names that were removed from the query because they are
+   * known to be unsupported by the source. In practice, this value will be appended with
+   * ".SOURCE_ID".
+   */
+  public static final String UNSUPPORTED_SORT_BY_REMOVED = "unsupported-sort-by-removed";
+
   public static List<QName> wktOperandsAsList() {
     return Arrays.asList(
         LINEAR_RING,

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -273,7 +273,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.68</minimum>
+                                            <minimum>0.69</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -845,7 +845,7 @@ public class WfsSource extends AbstractWfsSource {
       throws UnsupportedQueryException {
     List<ContentType> contentTypes = getContentTypesFromQuery(query);
     List<QueryType> queries = new ArrayList<>();
-    Map<String, Serializable> properties = Collections.emptyMap();
+    Map<String, Serializable> properties = null;
 
     for (Entry<QName, WfsFilterDelegate> filterDelegateEntry : featureTypeFilters.entrySet()) {
       if (contentTypes.isEmpty()
@@ -909,7 +909,7 @@ public class WfsSource extends AbstractWfsSource {
     if (isSortByValid(sortByType)) {
       logSortBy(sortByType);
       wfsQuery.setSortBy(sortByType);
-      return Collections.emptyMap();
+      return null;
     }
 
     Map<String, Serializable> properties = new HashMap<>();

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -23,6 +23,7 @@ import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.ContentTypeImpl;
 import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.filter.FilterAdapter;
+import ddf.catalog.filter.impl.SortByImpl;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.ResourceResponse;
@@ -86,6 +87,7 @@ import net.opengis.wfs.v_1_1_0.ResultTypeType;
 import net.opengis.wfs.v_1_1_0.WFSCapabilitiesType;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.cxf.jaxrs.provider.JAXBElementProvider;
 import org.apache.ws.commons.schema.XmlSchema;
 import org.codice.ddf.configuration.DictionaryMap;
@@ -194,6 +196,12 @@ public class WfsSource extends AbstractWfsSource {
   private final EncryptionService encryptionService;
 
   private final ClientBuilderFactory clientBuilderFactory;
+
+  // may be null
+  private String defaultSortName;
+
+  // may be null
+  private SortOrder defaultSortOrder;
 
   private String wfsUrl;
 
@@ -363,6 +371,14 @@ public class WfsSource extends AbstractWfsSource {
       availabilityPollFuture.cancel(true);
       setupAvailabilityPoll();
     }
+  }
+
+  public void setDefaultSortName(String name) {
+    this.defaultSortName = name;
+  }
+
+  public void setDefaultSortOrder(String order) {
+    this.defaultSortOrder = SortOrder.valueOf(order);
   }
 
   public void setAllowRedirects(Boolean allowRedirects) {
@@ -724,7 +740,8 @@ public class WfsSource extends AbstractWfsSource {
     }
 
     final ExtendedGetFeatureType getHits = buildGetFeatureRequestHits(modifiedQuery);
-    final ExtendedGetFeatureType getResults = buildGetFeatureRequestResults(modifiedQuery);
+    final Pair<ExtendedGetFeatureType, Map<String, Serializable>> getResults =
+        buildGetFeatureRequestResults(modifiedQuery);
 
     try {
       LOGGER.debug("WFS Source {}: Getting hits.", getId());
@@ -745,7 +762,7 @@ public class WfsSource extends AbstractWfsSource {
       LOGGER.debug("The query has {} hits.", totalHits);
 
       LOGGER.debug("WFS Source {}: Sending query ...", getId());
-      final WfsFeatureCollection featureCollection = wfs.getFeature(getResults);
+      final WfsFeatureCollection featureCollection = wfs.getFeature(getResults.getLeft());
 
       if (featureCollection == null) {
         throw new UnsupportedQueryException("Invalid results returned from server");
@@ -789,7 +806,8 @@ public class WfsSource extends AbstractWfsSource {
         }
       }
 
-      return new SourceResponseImpl(request, null, results, totalHits, sourceProcessingDetails);
+      return new SourceResponseImpl(
+          request, getResults.getRight(), results, totalHits, sourceProcessingDetails);
     } catch (WfsException wfse) {
       LOGGER.debug(WFS_ERROR_MESSAGE, wfse);
       throw new UnsupportedQueryException("Error received from WFS Server", wfse);
@@ -813,20 +831,21 @@ public class WfsSource extends AbstractWfsSource {
 
   private ExtendedGetFeatureType buildGetFeatureRequestHits(final Query query)
       throws UnsupportedQueryException {
-    return buildGetFeatureRequest(query, ResultTypeType.HITS, null);
+    return buildGetFeatureRequest(query, ResultTypeType.HITS, null).getLeft();
   }
 
-  private ExtendedGetFeatureType buildGetFeatureRequestResults(final Query query)
-      throws UnsupportedQueryException {
+  private Pair<ExtendedGetFeatureType, Map<String, Serializable>> buildGetFeatureRequestResults(
+      final Query query) throws UnsupportedQueryException {
     return buildGetFeatureRequest(
         query, ResultTypeType.RESULTS, BigInteger.valueOf(query.getPageSize()));
   }
 
-  private ExtendedGetFeatureType buildGetFeatureRequest(
+  private Pair<ExtendedGetFeatureType, Map<String, Serializable>> buildGetFeatureRequest(
       Query query, ResultTypeType resultType, BigInteger maxFeatures)
       throws UnsupportedQueryException {
     List<ContentType> contentTypes = getContentTypesFromQuery(query);
     List<QueryType> queries = new ArrayList<>();
+    Map<String, Serializable> properties = Collections.emptyMap();
 
     for (Entry<QName, WfsFilterDelegate> filterDelegateEntry : featureTypeFilters.entrySet()) {
       if (contentTypes.isEmpty()
@@ -845,22 +864,7 @@ public class WfsSource extends AbstractWfsSource {
               && query.getSortBy() != null
               && query.getSortBy().getPropertyName() != null
               && query.getSortBy().getPropertyName().getPropertyName() != null) {
-            SortByType sortByType = buildSortBy(filterDelegateEntry.getKey(), query.getSortBy());
-            if (sortByType != null
-                && sortByType.getSortProperty() != null
-                && sortByType.getSortProperty().size() > 0) {
-              LOGGER.debug(
-                  "Sorting using sort property [{}] and sort order [{}].",
-                  sortByType.getSortProperty().get(0).getPropertyName(),
-                  sortByType.getSortProperty().get(0).getSortOrder());
-              wfsQuery.setSortBy(sortByType);
-            } else {
-              throw new UnsupportedQueryException(
-                  "Source "
-                      + this.getId()
-                      + " does not support specified sort property "
-                      + query.getSortBy().getPropertyName().getPropertyName());
-            }
+            properties = setSortBy(query.getSortBy(), filterDelegateEntry.getKey(), wfsQuery);
           } else {
             LOGGER.debug("Sorting is disabled or sort not specified.");
           }
@@ -883,11 +887,68 @@ public class WfsSource extends AbstractWfsSource {
         getFeatureType.setStartIndex(BigInteger.valueOf(query.getStartIndex() - 1));
       }
       logMessage(getFeatureType);
-      return getFeatureType;
+      return Pair.of(getFeatureType, properties);
     } else {
       throw new UnsupportedQueryException(
           "Unable to build query. No filters could be created from query criteria.");
     }
+  }
+
+  /**
+   * If the query-supplied sort parameters are valid, then use them. If they are not valid, then
+   * fallback to the default sort parameters. If the default sort parameters are unset, then return
+   * without error. If the default sort parameters are valid, then use them. If the default sort
+   * parameters are invalid, then throw an exception.
+   *
+   * <p>Returns a properties map that includes information indicating if the sort parameters were
+   * changed to the default.
+   */
+  private Map<String, Serializable> setSortBy(SortBy sortBy, QName key, QueryType wfsQuery)
+      throws UnsupportedQueryException {
+    SortByType sortByType = buildSortBy(key, sortBy);
+    if (isSortByValid(sortByType)) {
+      logSortBy(sortByType);
+      wfsQuery.setSortBy(sortByType);
+      return Collections.emptyMap();
+    }
+
+    Map<String, Serializable> properties = new HashMap<>();
+    properties.put(
+        Wfs11Constants.UNSUPPORTED_SORT_BY_REMOVED + "." + getId(),
+        sortBy.getPropertyName().getPropertyName());
+
+    if (defaultSortName == null || defaultSortOrder == null) {
+      LOGGER.debug(
+          "Skipping sorting because the query-supplied sort property [{}] is not supported and the default sort property and default sort order are not set.",
+          sortBy.getPropertyName().getPropertyName());
+      return properties;
+    }
+
+    sortByType = buildSortBy(key, new SortByImpl(defaultSortName, defaultSortOrder));
+    if (isSortByValid(sortByType)) {
+      logSortBy(sortByType);
+      wfsQuery.setSortBy(sortByType);
+      return properties;
+    } else {
+      throw new UnsupportedQueryException(
+          "Source "
+              + this.getId()
+              + " does not support the default sort property "
+              + defaultSortName);
+    }
+  }
+
+  private void logSortBy(SortByType sortByType) {
+    LOGGER.debug(
+        "Sorting using sort property [{}] and sort order [{}].",
+        sortByType.getSortProperty().get(0).getPropertyName(),
+        sortByType.getSortProperty().get(0).getSortOrder());
+  }
+
+  private boolean isSortByValid(SortByType sortByType) {
+    return sortByType != null
+        && sortByType.getSortProperty() != null
+        && sortByType.getSortProperty().size() > 0;
   }
 
   private SortByType buildSortBy(QName featureType, SortBy incomingSortBy) {

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -97,6 +97,12 @@
         <AD description="Forces the source to support all geometry operands."
             name="Force All Geometry Operands" id="forceAllGeometryOperands" required="false"
             type="Boolean" default="false"/>
+        <AD description="Set the default sort attribute name (optional). If the default sort attribute is set, then the default sort order must be set."
+            name="Default Sort Attribute" id="defaultSortName" required="false"
+            type="String"/>
+        <AD description="Set the default sort order (optional). If the default sort order is set, then the default sort attribute must be set. Allowed values: ASCENDING, DESCENDING"
+            name="Default Sort Order" id="defaultSortOrder" required="false"
+            type="String"/>
     </OCD>
 
     <Designate pid="Wfs_v110_Federated_Source" factoryPid="Wfs_v110_Federated_Source">

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -80,6 +80,7 @@ import net.opengis.filter.v_1_1_0.FilterCapabilities;
 import net.opengis.filter.v_1_1_0.GeometryOperandsType;
 import net.opengis.filter.v_1_1_0.LogicOpsType;
 import net.opengis.filter.v_1_1_0.PropertyIsLikeType;
+import net.opengis.filter.v_1_1_0.SortPropertyType;
 import net.opengis.filter.v_1_1_0.SpatialCapabilitiesType;
 import net.opengis.filter.v_1_1_0.SpatialOperatorNameType;
 import net.opengis.filter.v_1_1_0.SpatialOperatorType;
@@ -1646,7 +1647,14 @@ public class WfsSourceTest {
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(null, "ASC"));
 
+    ArgumentCaptor<ExtendedGetFeatureType> argumentCaptor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
+
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
+
+    verify(mockWfs, times(2)).getFeature(argumentCaptor.capture());
+
+    assertThat(argumentCaptor.getAllValues().get(1).getQuery().get(0).getSortBy(), is(nullValue()));
   }
 
   @Test
@@ -1676,7 +1684,19 @@ public class WfsSourceTest {
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
 
-    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    ArgumentCaptor<ExtendedGetFeatureType> argumentCaptor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
+
+    SourceResponse sourceResponse = source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    assertThat(
+        sourceResponse
+            .getProperties()
+            .get(Wfs11Constants.UNSUPPORTED_SORT_BY_REMOVED + "." + WFS_ID),
+        is(Result.TEMPORAL));
+
+    verify(mockWfs, times(2)).getFeature(argumentCaptor.capture());
+
+    assertThat(argumentCaptor.getAllValues().get(1).getQuery().get(0).getSortBy(), is(nullValue()));
   }
 
   @Test
@@ -1695,7 +1715,24 @@ public class WfsSourceTest {
     source.setDefaultSortName(Result.TEMPORAL);
     source.setDefaultSortOrder(SortOrder.ASCENDING.name());
 
-    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    ArgumentCaptor<ExtendedGetFeatureType> argumentCaptor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
+
+    SourceResponse sourceResponse = source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    assertThat(
+        sourceResponse
+            .getProperties()
+            .get(Wfs11Constants.UNSUPPORTED_SORT_BY_REMOVED + "." + WFS_ID),
+        is(Result.TEMPORAL));
+
+    verify(mockWfs, times(2)).getFeature(argumentCaptor.capture());
+
+    SortPropertyType sortPropertyType =
+        argumentCaptor.getAllValues().get(1).getQuery().get(0).getSortBy().getSortProperty().get(0);
+
+    assertThat(
+        sortPropertyType.getPropertyName().getContent().get(0), is(MOCK_TEMPORAL_SORT_PROPERTY));
+    assertThat(sortPropertyType.getSortOrder().value(), is("ASC"));
   }
 
   @Test

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -261,27 +261,28 @@ public class WfsSourceTest {
 
   private final GeotoolsFilterBuilder builder = new GeotoolsFilterBuilder();
 
-  private ExtendedWfs mockWfs = mock(ExtendedWfs.class);
+  private final ExtendedWfs mockWfs = mock(ExtendedWfs.class);
 
-  private WFSCapabilitiesType mockCapabilities = new WFSCapabilitiesType();
+  private final WFSCapabilitiesType mockCapabilities = new WFSCapabilitiesType();
 
-  private BundleContext mockContext = mock(BundleContext.class);
+  private final BundleContext mockContext = mock(BundleContext.class);
 
   private List<QName> sampleFeatures;
 
-  private WfsUriResolver wfsUriResolver = new WfsUriResolver();
+  private final WfsUriResolver wfsUriResolver = new WfsUriResolver();
 
   private WfsSource source;
 
-  private ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
+  private final ScheduledExecutorService mockScheduler = mock(ScheduledExecutorService.class);
 
-  private EncryptionService encryptionService = mock(EncryptionService.class);
+  private final EncryptionService encryptionService = mock(EncryptionService.class);
 
-  private WfsMetacardTypeRegistry mockWfsMetacardTypeRegistry = mock(WfsMetacardTypeRegistry.class);
+  private final WfsMetacardTypeRegistry mockWfsMetacardTypeRegistry =
+      mock(WfsMetacardTypeRegistry.class);
 
   private ClientBuilderFactory clientBuilderFactory = mock(ClientBuilderFactory.class);
 
-  private List<MetacardMapper> metacardMappers = new ArrayList<>();
+  private final List<MetacardMapper> metacardMappers = new ArrayList<>();
 
   private boolean forceAllGeometryOperands = false;
 
@@ -742,7 +743,7 @@ public class WfsSourceTest {
     ExtendedGetFeatureType getFeatureType = captor.getAllValues().get(1);
     assertMaxFeatures(getFeatureType, propertyIsLikeQuery);
     assertThat(getFeatureType.getQuery().size(), is(TWO_FEATURES));
-    Collections.sort(getFeatureType.getQuery(), QUERY_TYPE_COMPARATOR);
+    getFeatureType.getQuery().sort(QUERY_TYPE_COMPARATOR);
     QueryType query = getFeatureType.getQuery().get(0);
     assertThat(query.getTypeName().get(0), is(sampleFeatures.get(0)));
     assertThat(query.getFilter().isSetComparisonOps(), is(true));
@@ -1634,42 +1635,6 @@ public class WfsSourceTest {
   }
 
   @Test
-  public void testSortingNoSortMapping() throws Exception {
-    // if sorting is enabled but there is no sort mapping, throw an UnsupportedQueryException
-    expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage("Source WFS_ID does not support specified sort property title");
-
-    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
-    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
-    final QueryImpl propertyIsLikeQuery =
-        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
-    setupMapper(null, null, null);
-    source.setMetacardMappers(metacardMappers);
-    source.setDisableSorting(false);
-    propertyIsLikeQuery.setSortBy(new SortByImpl("title", SortOrder.ASCENDING));
-
-    source.query(new QueryRequestImpl(propertyIsLikeQuery));
-  }
-
-  @Test
-  public void testSortingNoSortOrder() throws Exception {
-    // if sort order is missing, throw UnsupportedQueryException
-    expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage("Source WFS_ID does not support specified sort property TEMPORAL");
-
-    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
-    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
-    final QueryImpl propertyIsLikeQuery =
-        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
-    setupMapper(
-        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
-    source.setMetacardMappers(metacardMappers);
-    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, (String) null));
-
-    source.query(new QueryRequestImpl(propertyIsLikeQuery));
-  }
-
-  @Test
   public void testSortingNoSortProperty() throws Exception {
     // query is still valid even if sort property is missing
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
@@ -1699,10 +1664,46 @@ public class WfsSourceTest {
   }
 
   @Test
-  public void testSortingBadSortOrder() throws Exception {
+  public void testSortingBadSortOrderWithoutDefault() throws Exception {
+
+    // query is still valid even if sort property bad
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
+
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  @Test
+  public void testSortingBadSortOrderWithDefault() throws Exception {
+
+    // query is still valid even if sort property bad
+    mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
+    setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
+    final QueryImpl propertyIsLikeQuery =
+        new QueryImpl(builder.attribute(Metacard.ANY_TEXT).is().like().text("literal"));
+    setupMapper(
+        MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
+    source.setMetacardMappers(metacardMappers);
+    propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
+
+    source.setDefaultSortName(Result.TEMPORAL);
+    source.setDefaultSortOrder(SortOrder.ASCENDING.name());
+
+    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+  }
+
+  @Test
+  public void testSortingBadSortOrderWithBadDefault() throws Exception {
+
     // if sort order is invalid throw UnsupportedQueryException
     expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage("Source WFS_ID does not support specified sort property TEMPORAL");
+    expectedEx.expectMessage("Source WFS_ID does not support the default sort property xyz");
 
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
     setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
@@ -1712,6 +1713,9 @@ public class WfsSourceTest {
         MOCK_TEMPORAL_SORT_PROPERTY, MOCK_RELEVANCE_SORT_PROPERTY, MOCK_DISTANCE_SORT_PROPERTY);
     source.setMetacardMappers(metacardMappers);
     propertyIsLikeQuery.setSortBy(new SortByImpl(Result.TEMPORAL, "foo"));
+
+    source.setDefaultSortName("xyz");
+    source.setDefaultSortOrder(SortOrder.ASCENDING.name());
 
     source.query(new QueryRequestImpl(propertyIsLikeQuery));
   }


### PR DESCRIPTION
#### What does this PR do?
Support default sort parameters for WFS 1.1.0 sources.

Will add a response property listing the sort property name if it was removed as being unsupported.

<img width="811" alt="Screen Shot 2023-06-05 at 9 02 06 AM" src="https://github.com/codice/ddf/assets/17837152/5db2f061-48ea-4876-886f-8d24b90b4289">


#### Who is reviewing it? 
@derekwilhelm 
@jlcsmith 

#### How should this be tested?
Configure a WFS source that does not support RELEVANCE. Leave the default sort property and default sort order blank in the config. Confirm that a search that sorts by RELEVANCE returns unsorted results. Change the config to use "name" and "ASCENDING" for the default property and order. Confirm that a search that sorts by RELEVANCE returns results sorted by name.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
