### PR TITLE
[2.26.x] updated RTF transformer formatting and now omits null attributes from…

### DIFF
--- a/catalog/transformer/catalog-transformer-rtf/src/main/java/ddf/catalog/transformer/output/rtf/RtfTemplate.java
+++ b/catalog/transformer/catalog-transformer-rtf/src/main/java/ddf/catalog/transformer/output/rtf/RtfTemplate.java
@@ -25,6 +25,7 @@ import com.tutego.jrtf.Rtf;
 import com.tutego.jrtf.RtfPara;
 import com.tutego.jrtf.RtfPicture;
 import com.tutego.jrtf.RtfRow;
+import com.tutego.jrtf.RtfSectionFormatAndHeaderFooter;
 import com.tutego.jrtf.RtfText;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.transformer.output.rtf.model.ExportCategory;
@@ -51,8 +52,87 @@ public class RtfTemplate {
   private static final Logger LOGGER = LoggerFactory.getLogger(RtfTemplate.class);
 
   private static final int MINIMUM_VALID_IMAGE_DATA_SIZE = 10;
+  private final List<RtfCategory> categories;
+  private final Metacard metacard;
+  private Function<String, Function<byte[], InputStream>> memoizeForImageData =
+      metacardId -> data -> fromBytes(metacardId, data);
+  private Function<String, Function<Map.Entry, RtfRow>> memoizeForRowData =
+      metacardId -> entry -> appendProperty(metacardId, entry);
+
+  private RtfTemplate(List<RtfCategory> categories, Metacard metacard) {
+    this.categories = categories;
+    this.metacard = metacard;
+  }
+
+  public Rtf rtf(Rtf doc) {
+    doc.section(
+        RtfSectionFormatAndHeaderFooter.noBreak(),
+        p(font(1, bold(this.metacard.getTitle()))).alignCentered());
+
+    this.categories.forEach(exportCategory -> appendSection(doc, exportCategory, this.metacard));
+    doc.p();
+    return doc;
+  }
+
+  private void appendSection(Rtf rtf, RtfCategory category, Metacard metacard) {
+    Function<Map.Entry, RtfRow> appendPropertyFunction = memoizeForRowData.apply(metacard.getId());
+    Collection<RtfPara> rows =
+        category.toExportMap(metacard).entrySet().stream()
+            .map(appendPropertyFunction)
+            .collect(Collectors.toList());
+
+    if (rows.isEmpty()) {
+      return;
+    }
+    rtf.p();
+    rtf.p(bold(category.getTitle()));
+    rtf.section(RtfSectionFormatAndHeaderFooter.noBreak(), rows.toArray(new RtfPara[rows.size()]));
+  }
+
+  private RtfRow appendProperty(
+      String metacardId, Map.Entry<String, ExportCategory.ExportValue> entry) {
+    if (ExportCategory.ValueType.MEDIA.equals(entry.getValue().getType())) {
+      ExportCategory.ExportValue<byte[], ExportCategory.ValueType> value = entry.getValue();
+
+      Function<byte[], InputStream> fromByteArrayFunction = memoizeForImageData.apply(metacardId);
+
+      RtfText picture =
+          Optional.of(value.getValue())
+              .map(fromByteArrayFunction)
+              .map(this::imageFromStream)
+              .orElse(text(EMPTY_VALUE));
+
+      return row(entry.getKey(), picture)
+          .topCellBorder()
+          .rightCellBorder()
+          .leftCellBorder()
+          .bottomCellBorder();
+    }
+
+    return row(entry.getKey(), entry.getValue().getValue())
+        .bottomCellBorder()
+        .leftCellBorder()
+        .rightCellBorder()
+        .topCellBorder();
+  }
+
+  private RtfText imageFromStream(InputStream stream) {
+    return picture(stream).type(RtfPicture.PictureType.AUTOMATIC);
+  }
+
+  private InputStream fromBytes(String metacardId, byte[] data) {
+    if (data == null || data.length < MINIMUM_VALID_IMAGE_DATA_SIZE) {
+      LOGGER.debug(
+          "Image cannot be exported in RTF format, malformed thumbnail data for metacard id: {}",
+          metacardId);
+      return null;
+    }
+
+    return new ByteArrayInputStream(data);
+  }
 
   static class Builder {
+
     private List<RtfCategory> categories;
     private Metacard metacard;
 
@@ -71,75 +151,5 @@ public class RtfTemplate {
     public RtfTemplate build() {
       return new RtfTemplate(this.categories, this.metacard);
     }
-  }
-
-  private final List<RtfCategory> categories;
-  private final Metacard metacard;
-
-  private RtfTemplate(List<RtfCategory> categories, Metacard metacard) {
-    this.categories = categories;
-    this.metacard = metacard;
-  }
-
-  public Rtf rtf(Rtf doc) {
-    doc.section(p(), p(), p(font(1, bold(this.metacard.getTitle()))).alignCentered());
-
-    this.categories.forEach(exportCategory -> appendSection(doc, exportCategory, this.metacard));
-
-    return doc;
-  }
-
-  private Function<String, Function<Map.Entry, RtfRow>> memoizeForRowData =
-      metacardId -> entry -> appendProperty(metacardId, entry);
-
-  private Function<String, Function<byte[], InputStream>> memoizeForImageData =
-      metacardId -> data -> fromBytes(metacardId, data);
-
-  private void appendSection(Rtf rtf, RtfCategory category, Metacard metacard) {
-    rtf.p();
-    rtf.p(bold(category.getTitle()));
-
-    Function<Map.Entry, RtfRow> appendPropertyFunction = memoizeForRowData.apply(metacard.getId());
-
-    Collection<RtfPara> rows =
-        category.toExportMap(metacard).entrySet().stream()
-            .map(appendPropertyFunction)
-            .collect(Collectors.toList());
-
-    rtf.section(rows);
-  }
-
-  private RtfRow appendProperty(
-      String metacardId, Map.Entry<String, ExportCategory.ExportValue> entry) {
-    if (ExportCategory.ValueType.MEDIA.equals(entry.getValue().getType())) {
-      ExportCategory.ExportValue<byte[], ExportCategory.ValueType> value = entry.getValue();
-
-      Function<byte[], InputStream> fromByteArrayFunction = memoizeForImageData.apply(metacardId);
-
-      RtfText picture =
-          Optional.of(value.getValue())
-              .map(fromByteArrayFunction)
-              .map(this::imageFromStream)
-              .orElse(text(EMPTY_VALUE));
-
-      return row(entry.getKey(), picture);
-    }
-
-    return row(entry.getKey(), entry.getValue().getValue());
-  }
-
-  private RtfText imageFromStream(InputStream stream) {
-    return picture(stream).type(RtfPicture.PictureType.AUTOMATIC);
-  }
-
-  private InputStream fromBytes(String metacardId, byte[] data) {
-    if (data == null || data.length < MINIMUM_VALID_IMAGE_DATA_SIZE) {
-      LOGGER.debug(
-          "Image cannot be exported in RTF format, malformed thumbnail data for metacard id: {}",
-          metacardId);
-      return null;
-    }
-
-    return new ByteArrayInputStream(data);
   }
 }

--- a/catalog/transformer/catalog-transformer-rtf/src/main/java/ddf/catalog/transformer/output/rtf/model/ExportCategory.java
+++ b/catalog/transformer/catalog-transformer-rtf/src/main/java/ddf/catalog/transformer/output/rtf/model/ExportCategory.java
@@ -89,6 +89,7 @@ public class ExportCategory implements RtfCategory {
   @Override
   public Map<String, ExportValue> toExportMap(Metacard metacard) {
     return attributes.stream()
+        .filter(s -> metacard.getAttribute(s) != null)
         .map(
             key ->
                 new AbstractMap.SimpleEntry<>(

--- a/catalog/transformer/catalog-transformer-rtf/src/main/java/ddf/catalog/transformer/output/rtf/model/ExportCategory.java
+++ b/catalog/transformer/catalog-transformer-rtf/src/main/java/ddf/catalog/transformer/output/rtf/model/ExportCategory.java
@@ -14,6 +14,7 @@
 package ddf.catalog.transformer.output.rtf.model;
 
 import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.types.Core;
 import java.util.AbstractMap;
@@ -22,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
 
 public class ExportCategory implements RtfCategory {
@@ -89,7 +91,7 @@ public class ExportCategory implements RtfCategory {
   @Override
   public Map<String, ExportValue> toExportMap(Metacard metacard) {
     return attributes.stream()
-        .filter(s -> metacard.getAttribute(s) != null)
+        .filter(a -> isNonEmptyValue(metacard, a))
         .map(
             key ->
                 new AbstractMap.SimpleEntry<>(
@@ -112,10 +114,6 @@ public class ExportCategory implements RtfCategory {
   }
 
   private ExportValue attributeExportValueFrom(String attributeKey, Attribute attribute) {
-    if (attributeKey == null || attribute == null) {
-      return emptyValue();
-    }
-
     if (attributeKey.equals(Core.THUMBNAIL)) {
       byte[] image = (byte[]) attribute.getValue();
 
@@ -137,5 +135,28 @@ public class ExportCategory implements RtfCategory {
     return new JustValue(
         Optional.ofNullable(attribute.getValue()).map(Object::toString).orElse(null),
         ValueType.SIMPLE);
+  }
+
+  private static boolean isNonEmptyValue(Metacard metacard, String attrName) {
+    final AttributeDescriptor descriptor =
+        metacard.getMetacardType().getAttributeDescriptor(attrName);
+    final Attribute attribute = metacard.getAttribute(attrName);
+    switch (descriptor.getType().getAttributeFormat()) {
+      case STRING:
+      case XML:
+      case GEOMETRY:
+        return attribute != null && StringUtils.isNotEmpty((String) attribute.getValue());
+      case INTEGER:
+      case LONG:
+      case DOUBLE:
+      case FLOAT:
+      case SHORT:
+      case DATE:
+      case BOOLEAN:
+      case BINARY:
+        return attribute != null && attribute.getValue() != null;
+      default:
+        return false;
+    }
   }
 }

--- a/catalog/transformer/catalog-transformer-rtf/src/test/java/ddf/catalog/transformer/output/rtf/BaseTestConfiguration.java
+++ b/catalog/transformer/catalog-transformer-rtf/src/test/java/ddf/catalog/transformer/output/rtf/BaseTestConfiguration.java
@@ -17,7 +17,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.transformer.output.rtf.model.ExportCategory;
 import ddf.catalog.transformer.output.rtf.model.RtfCategory;
@@ -121,6 +125,8 @@ public abstract class BaseTestConfiguration {
 
   Metacard createMockMetacard(String title, Attribute mediaAttribute) {
     Metacard metacard = mock(Metacard.class);
+    MetacardType mockMetacardType = createMockMetacardType();
+    when(metacard.getMetacardType()).thenReturn(mockMetacardType);
     when(metacard.getTitle()).thenReturn(title);
 
     when(metacard.getId()).thenReturn("mock-id");
@@ -167,5 +173,31 @@ public abstract class BaseTestConfiguration {
     when(mockAttribute.getValue()).thenReturn("Simple value");
 
     return mockAttribute;
+  }
+
+  MetacardType createMockMetacardType() {
+    MetacardType mockType = mock(MetacardType.class);
+    AttributeDescriptor mockThumbnailDesc =
+        createMockAttributeDescriptor(Core.THUMBNAIL, BasicTypes.BINARY_TYPE);
+    when(mockType.getAttributeDescriptor(Core.THUMBNAIL)).thenReturn(mockThumbnailDesc);
+    AttributeDescriptor mockEmptyDesc =
+        createMockAttributeDescriptor(EMPTY_ATTRIBUTE, BasicTypes.STRING_TYPE);
+    when(mockType.getAttributeDescriptor(EMPTY_ATTRIBUTE)).thenReturn(mockEmptyDesc);
+    AttributeDescriptor mockSimpleDesc =
+        createMockAttributeDescriptor(SIMPLE_ATTRIBUTE, BasicTypes.STRING_TYPE);
+    when(mockType.getAttributeDescriptor(SIMPLE_ATTRIBUTE)).thenReturn(mockSimpleDesc);
+    AttributeDescriptor mockExtendedDesc =
+        createMockAttributeDescriptor(EXTENDED_ATTRIBUTE, BasicTypes.STRING_TYPE);
+    when(mockType.getAttributeDescriptor(EXTENDED_ATTRIBUTE)).thenReturn(mockExtendedDesc);
+    AttributeDescriptor mockUnknownDesc =
+        createMockAttributeDescriptor(UNKNOWN_ATTRIBUTE, BasicTypes.INTEGER_TYPE);
+    when(mockType.getAttributeDescriptor(UNKNOWN_ATTRIBUTE)).thenReturn(mockUnknownDesc);
+    return mockType;
+  }
+
+  AttributeDescriptor createMockAttributeDescriptor(String name, AttributeType type) {
+    AttributeDescriptor mockDescriptor = mock(AttributeDescriptor.class);
+    when(mockDescriptor.getType()).thenReturn(type);
+    return mockDescriptor;
   }
 }

--- a/catalog/transformer/catalog-transformer-rtf/src/test/java/ddf/catalog/transformer/output/rtf/RtfTemplateTest.java
+++ b/catalog/transformer/catalog-transformer-rtf/src/test/java/ddf/catalog/transformer/output/rtf/RtfTemplateTest.java
@@ -15,12 +15,15 @@ package ddf.catalog.transformer.output.rtf;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 import com.tutego.jrtf.Rtf;
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.types.Core;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,5 +59,49 @@ public class RtfTemplateTest extends BaseTestConfiguration {
         String.format("RTF document must contain section with title: %s", METACARD_TITLE),
         finishedDoc,
         containsString(METACARD_TITLE));
+  }
+
+  @Test
+  public void testBuildingRtfWithEmptyCategoryFromTemplate() {
+    when(mockMetacard.getAttribute(Core.THUMBNAIL)).thenReturn(null);
+    when(mockMetacard.getAttribute(EMPTY_ATTRIBUTE)).thenReturn(null);
+    when(mockMetacard.getAttribute(SIMPLE_ATTRIBUTE)).thenReturn(null);
+    when(mockMetacard.getAttribute(EXTENDED_ATTRIBUTE)).thenReturn(null);
+    RtfTemplate template =
+        new RtfTemplate.Builder().withMetacard(mockMetacard).withCategories(MOCK_CATEGORY).build();
+
+    assertThat("Template cannot be null", template, notNullValue());
+    assertThat("There should be 5 categories", MOCK_CATEGORY.get(0).getAttributes(), hasSize(5));
+
+    Rtf doc = Rtf.rtf();
+
+    Rtf generatedTemplate = template.rtf(doc);
+
+    assertThat("Rtf template instance cannot be null", generatedTemplate, notNullValue());
+
+    String finishedDoc = generatedTemplate.out().toString();
+
+    assertThat("RTF output cannot be null", finishedDoc, notNullValue());
+    assertThat("RTF document must start with {\\rtf1", finishedDoc, startsWith("{\\rtf1"));
+    assertThat(
+        String.format("RTF document must contain section with title: %s", METACARD_TITLE),
+        finishedDoc,
+        containsString(METACARD_TITLE));
+    assertThat(
+        String.format("RTF document must NOT contain section with title: %s", Core.THUMBNAIL),
+        finishedDoc,
+        not(containsString(Core.THUMBNAIL)));
+    assertThat(
+        String.format("RTF document must NOT contain section with title: %s", EMPTY_ATTRIBUTE),
+        finishedDoc,
+        not(containsString(EMPTY_ATTRIBUTE)));
+    assertThat(
+        String.format("RTF document must NOT contain section with title: %s", SIMPLE_ATTRIBUTE),
+        finishedDoc,
+        not(containsString(SIMPLE_ATTRIBUTE)));
+    assertThat(
+        String.format("RTF document must NOT contain section with title: %s", EXTENDED_ATTRIBUTE),
+        finishedDoc,
+        not(containsString(EXTENDED_ATTRIBUTE)));
   }
 }

--- a/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-metacard-with-empty-thumbnail.rtf
+++ b/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-metacard-with-empty-thumbnail.rtf
@@ -1,43 +1,36 @@
 {\rtf1\ansi\deff0
 {\fonttbl{\f0\fmodern\fcharset0 Arial;}{\f1\fnil\fcharset0 Times New Roman;}}
-\par\par{\qc
+\sbknone{\qc
 {\f1 {\b Test Metacard With Bad Image}}\par}
 \sect
 {\par}
 \sect
 {{\b Associations}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -47,37 +40,30 @@
 \sect
 {{\b Contact}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -87,37 +73,30 @@
 \sect
 {{\b Core}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -127,37 +106,30 @@
 \sect
 {{\b DateTime}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -167,37 +139,30 @@
 \sect
 {{\b Extended}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -207,37 +172,30 @@
 \sect
 {{\b Location}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -247,37 +205,30 @@
 \sect
 {{\b Media}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -287,37 +238,30 @@
 \sect
 {{\b Security}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -327,37 +271,30 @@
 \sect
 {{\b Topic}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -367,37 +304,30 @@
 \sect
 {{\b Validation}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -407,39 +337,34 @@
 \sect
 {{\b Version}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {--}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
 \cell
-\row}}
+\row}\sect
+{\par}
+}

--- a/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-metacard-with-empty-thumbnail.rtf
+++ b/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-metacard-with-empty-thumbnail.rtf
@@ -8,13 +8,6 @@
 {{\b Associations}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -41,13 +34,6 @@
 {{\b Contact}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -74,13 +60,6 @@
 {{\b Core}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -107,13 +86,6 @@
 {{\b DateTime}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -140,13 +112,6 @@
 {{\b Extended}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -173,13 +138,6 @@
 {{\b Location}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -206,13 +164,6 @@
 {{\b Media}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -239,13 +190,6 @@
 {{\b Security}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -272,13 +216,6 @@
 {{\b Topic}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -305,13 +242,6 @@
 {{\b Validation}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -338,13 +268,6 @@
 {{\b Version}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}

--- a/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-metacard.rtf
+++ b/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-metacard.rtf
@@ -8,13 +8,6 @@
 {{\b Associations}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -302,13 +295,6 @@ d9}}
 {{\b Contact}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -596,13 +582,6 @@ d9}}
 {{\b Core}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -890,13 +869,6 @@ d9}}
 {{\b DateTime}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -1184,13 +1156,6 @@ d9}}
 {{\b Extended}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -1478,13 +1443,6 @@ d9}}
 {{\b Location}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -1772,13 +1730,6 @@ d9}}
 {{\b Media}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -2066,13 +2017,6 @@ d9}}
 {{\b Security}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -2360,13 +2304,6 @@ d9}}
 {{\b Topic}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -2654,13 +2591,6 @@ d9}}
 {{\b Validation}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -2948,13 +2878,6 @@ d9}}
 {{\b Version}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}

--- a/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-metacard.rtf
+++ b/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-metacard.rtf
@@ -1,29 +1,22 @@
 {\rtf1\ansi\deff0
 {\fonttbl{\f0\fmodern\fcharset0 Arial;}{\f1\fnil\fcharset0 Times New Roman;}}
-\par\par{\qc
+\sbknone{\qc
 {\f1 {\b Test Metacard Title}}\par}
 \sect
 {\par}
 \sect
 {{\b Associations}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -290,15 +283,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -308,23 +301,16 @@ d9}}
 \sect
 {{\b Contact}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -591,15 +577,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -609,23 +595,16 @@ d9}}
 \sect
 {{\b Core}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -892,15 +871,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -910,23 +889,16 @@ d9}}
 \sect
 {{\b DateTime}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -1193,15 +1165,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -1211,23 +1183,16 @@ d9}}
 \sect
 {{\b Extended}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -1494,15 +1459,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -1512,23 +1477,16 @@ d9}}
 \sect
 {{\b Location}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -1795,15 +1753,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -1813,23 +1771,16 @@ d9}}
 \sect
 {{\b Media}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -2096,15 +2047,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -2114,23 +2065,16 @@ d9}}
 \sect
 {{\b Security}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -2397,15 +2341,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -2415,23 +2359,16 @@ d9}}
 \sect
 {{\b Topic}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -2698,15 +2635,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -2716,23 +2653,16 @@ d9}}
 \sect
 {{\b Validation}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -2999,15 +2929,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -3017,23 +2947,16 @@ d9}}
 \sect
 {{\b Version}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -3300,17 +3223,19 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
 \cell
-\row}}
+\row}\sect
+{\par}
+}

--- a/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-source-response.rtf
+++ b/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-source-response.rtf
@@ -8,13 +8,6 @@
 {{\b Associations}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -302,13 +295,6 @@ d9}}
 {{\b Contact}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -596,13 +582,6 @@ d9}}
 {{\b Core}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -890,13 +869,6 @@ d9}}
 {{\b DateTime}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -1184,13 +1156,6 @@ d9}}
 {{\b Extended}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -1478,13 +1443,6 @@ d9}}
 {{\b Location}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -1772,13 +1730,6 @@ d9}}
 {{\b Media}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -2066,13 +2017,6 @@ d9}}
 {{\b Security}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -2360,13 +2304,6 @@ d9}}
 {{\b Topic}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -2654,13 +2591,6 @@ d9}}
 {{\b Validation}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -2948,13 +2878,6 @@ d9}}
 {{\b Version}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -3247,13 +3170,6 @@ d9}}
 {{\b Associations}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -3541,13 +3457,6 @@ d9}}
 {{\b Contact}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -3835,13 +3744,6 @@ d9}}
 {{\b Core}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -4129,13 +4031,6 @@ d9}}
 {{\b DateTime}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -4423,13 +4318,6 @@ d9}}
 {{\b Extended}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -4717,13 +4605,6 @@ d9}}
 {{\b Location}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -5011,13 +4892,6 @@ d9}}
 {{\b Media}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -5305,13 +5179,6 @@ d9}}
 {{\b Security}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -5599,13 +5466,6 @@ d9}}
 {{\b Topic}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -5893,13 +5753,6 @@ d9}}
 {{\b Validation}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -6187,13 +6040,6 @@ d9}}
 {{\b Version}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -6486,13 +6332,6 @@ d9}}
 {{\b Associations}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -6780,13 +6619,6 @@ d9}}
 {{\b Contact}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -7074,13 +6906,6 @@ d9}}
 {{\b Core}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -7368,13 +7193,6 @@ d9}}
 {{\b DateTime}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -7662,13 +7480,6 @@ d9}}
 {{\b Extended}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -7956,13 +7767,6 @@ d9}}
 {{\b Location}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -8250,13 +8054,6 @@ d9}}
 {{\b Media}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -8544,13 +8341,6 @@ d9}}
 {{\b Security}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -8838,13 +8628,6 @@ d9}}
 {{\b Topic}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -9132,13 +8915,6 @@ d9}}
 {{\b Validation}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -9426,13 +9202,6 @@ d9}}
 {{\b Version}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -9725,13 +9494,6 @@ d9}}
 {{\b Associations}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -10019,13 +9781,6 @@ d9}}
 {{\b Contact}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -10313,13 +10068,6 @@ d9}}
 {{\b Core}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -10607,13 +10355,6 @@ d9}}
 {{\b DateTime}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -10901,13 +10642,6 @@ d9}}
 {{\b Extended}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -11195,13 +10929,6 @@ d9}}
 {{\b Location}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -11489,13 +11216,6 @@ d9}}
 {{\b Media}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -11783,13 +11503,6 @@ d9}}
 {{\b Security}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -12077,13 +11790,6 @@ d9}}
 {{\b Topic}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -12371,13 +12077,6 @@ d9}}
 {{\b Validation}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
@@ -12665,13 +12364,6 @@ d9}}
 {{\b Version}\par}
 \sect
 \sbknone{\trowd\trautofit1\intbl
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
-\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
-{Empty}
-\cell
-{}
-\cell
-\row}{\trowd\trautofit1\intbl
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
 \clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}

--- a/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-source-response.rtf
+++ b/catalog/transformer/catalog-transformer-rtf/src/test/resources/reference-source-response.rtf
@@ -1,29 +1,22 @@
 {\rtf1\ansi\deff0
 {\fonttbl{\f0\fmodern\fcharset0 Arial;}{\f1\fnil\fcharset0 Times New Roman;}}
-\par\par{\qc
+\sbknone{\qc
 {\f1 {\b Metacard 1}}\par}
 \sect
 {\par}
 \sect
 {{\b Associations}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -290,15 +283,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -308,23 +301,16 @@ d9}}
 \sect
 {{\b Contact}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -591,15 +577,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -609,23 +595,16 @@ d9}}
 \sect
 {{\b Core}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -892,15 +871,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -910,23 +889,16 @@ d9}}
 \sect
 {{\b DateTime}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -1193,15 +1165,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -1211,23 +1183,16 @@ d9}}
 \sect
 {{\b Extended}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -1494,15 +1459,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -1512,23 +1477,16 @@ d9}}
 \sect
 {{\b Location}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -1795,15 +1753,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -1813,23 +1771,16 @@ d9}}
 \sect
 {{\b Media}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -2096,15 +2047,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -2114,23 +2065,16 @@ d9}}
 \sect
 {{\b Security}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -2397,15 +2341,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -2415,23 +2359,16 @@ d9}}
 \sect
 {{\b Topic}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -2698,15 +2635,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -2716,23 +2653,16 @@ d9}}
 \sect
 {{\b Validation}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -2999,15 +2929,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -3017,23 +2947,16 @@ d9}}
 \sect
 {{\b Version}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -3300,44 +3223,39 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
 \cell
 \row}\sect
-\par\par{\qc
+{\par}
+\sect
+\sbknone{\qc
 {\f1 {\b Metacard 2}}\par}
 \sect
 {\par}
 \sect
 {{\b Associations}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -3604,15 +3522,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -3622,23 +3540,16 @@ d9}}
 \sect
 {{\b Contact}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -3905,15 +3816,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -3923,23 +3834,16 @@ d9}}
 \sect
 {{\b Core}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -4206,15 +4110,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -4224,23 +4128,16 @@ d9}}
 \sect
 {{\b DateTime}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -4507,15 +4404,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -4525,23 +4422,16 @@ d9}}
 \sect
 {{\b Extended}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -4808,15 +4698,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -4826,23 +4716,16 @@ d9}}
 \sect
 {{\b Location}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -5109,15 +4992,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -5127,23 +5010,16 @@ d9}}
 \sect
 {{\b Media}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -5410,15 +5286,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -5428,23 +5304,16 @@ d9}}
 \sect
 {{\b Security}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -5711,15 +5580,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -5729,23 +5598,16 @@ d9}}
 \sect
 {{\b Topic}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -6012,15 +5874,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -6030,23 +5892,16 @@ d9}}
 \sect
 {{\b Validation}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -6313,15 +6168,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -6331,23 +6186,16 @@ d9}}
 \sect
 {{\b Version}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -6614,44 +6462,39 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
 \cell
 \row}\sect
-\par\par{\qc
+{\par}
+\sect
+\sbknone{\qc
 {\f1 {\b Metacard 3}}\par}
 \sect
 {\par}
 \sect
 {{\b Associations}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -6918,15 +6761,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -6936,23 +6779,16 @@ d9}}
 \sect
 {{\b Contact}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -7219,15 +7055,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -7237,23 +7073,16 @@ d9}}
 \sect
 {{\b Core}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -7520,15 +7349,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -7538,23 +7367,16 @@ d9}}
 \sect
 {{\b DateTime}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -7821,15 +7643,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -7839,23 +7661,16 @@ d9}}
 \sect
 {{\b Extended}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -8122,15 +7937,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -8140,23 +7955,16 @@ d9}}
 \sect
 {{\b Location}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -8423,15 +8231,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -8441,23 +8249,16 @@ d9}}
 \sect
 {{\b Media}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -8724,15 +8525,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -8742,23 +8543,16 @@ d9}}
 \sect
 {{\b Security}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -9025,15 +8819,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -9043,23 +8837,16 @@ d9}}
 \sect
 {{\b Topic}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -9326,15 +9113,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -9344,23 +9131,16 @@ d9}}
 \sect
 {{\b Validation}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -9627,15 +9407,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -9645,23 +9425,16 @@ d9}}
 \sect
 {{\b Version}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -9928,44 +9701,39 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
 \cell
 \row}\sect
-\par\par{\qc
+{\par}
+\sect
+\sbknone{\qc
 {\f1 {\b Metacard 4}}\par}
 \sect
 {\par}
 \sect
 {{\b Associations}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -10232,15 +10000,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -10250,23 +10018,16 @@ d9}}
 \sect
 {{\b Contact}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -10533,15 +10294,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -10551,23 +10312,16 @@ d9}}
 \sect
 {{\b Core}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -10834,15 +10588,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -10852,23 +10606,16 @@ d9}}
 \sect
 {{\b DateTime}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -11135,15 +10882,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -11153,23 +10900,16 @@ d9}}
 \sect
 {{\b Extended}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -11436,15 +11176,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -11454,23 +11194,16 @@ d9}}
 \sect
 {{\b Location}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -11737,15 +11470,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -11755,23 +11488,16 @@ d9}}
 \sect
 {{\b Media}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -12038,15 +11764,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -12056,23 +11782,16 @@ d9}}
 \sect
 {{\b Security}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -12339,15 +12058,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -12357,23 +12076,16 @@ d9}}
 \sect
 {{\b Topic}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -12640,15 +12352,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -12658,23 +12370,16 @@ d9}}
 \sect
 {{\b Validation}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -12941,15 +12646,15 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
@@ -12959,23 +12664,16 @@ d9}}
 \sect
 {{\b Version}\par}
 \sect
-{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\sbknone{\trowd\trautofit1\intbl
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Empty}
 \cell
 {}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
-{Unknown}
-\cell
-{--}
-\cell
-\row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx1
+\clbrdrt\brdrs\clbrdrr\brdrs\clbrdrl\brdrs\clbrdrb\brdrs\cellx2
 {Thumbnail}
 \cell
 {{\pict\jpegblip
@@ -13242,17 +12940,19 @@ c914283de6da9ef3334a4e4eed9a145455912a412100080040020010008004002001000800400200
 d9}}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Extended Attribute}
 \cell
 {Extended Value}
 \cell
 \row}{\trowd\trautofit1\intbl
-\cellx1
-\cellx2
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx1
+\clbrdrb\brdrs\clbrdrl\brdrs\clbrdrr\brdrs\clbrdrt\brdrs\cellx2
 {Simple}
 \cell
 {Simple value}
 \cell
-\row}}
+\row}\sect
+{\par}
+}


### PR DESCRIPTION
… output

#### What does this PR do?
Updates the RTF Transformers output formatting to include borders around the tables, removes the section breaks between each category, omits null valued attributes or the entire category if no attributes within a category have a value.

#### Who is reviewing it? 
@glenhein 
@jrnorth

#### How should this be tested?
Ingest a some data. Then export the results as RTF via the rest endpoint: 
https://localhost:8993/services/catalog/query?q=*&format=rtf
Verify the formatting is updated and null valued attributes are not present.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
