### PR TITLE
Prevent AND queries containing invalid filters from running against WFS 1.1.0 sources

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -268,7 +268,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.78</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegate.java
@@ -168,7 +168,18 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
 
   @Override
   public FilterType and(List<FilterType> filtersToBeAnded) {
-    filtersToBeAnded.removeAll(Collections.singleton(null));
+    final boolean isAnyNull = filtersToBeAnded.removeAll(Collections.singleton(null));
+
+    if (filtersToBeAnded.isEmpty()) {
+      LOGGER.debug("Attempted to AND some filters, but none were valid.");
+      return null;
+    }
+
+    if (isAnyNull) {
+      LOGGER.debug(
+          "Attempted to AND some filters, but at least one was invalid. As a result, the entire AND will be dropped from the query. ");
+      return null;
+    }
 
     return buildAndOrFilter(
         filtersToBeAnded, filterObjectFactory.createAnd(new BinaryLogicOpType()));
@@ -177,6 +188,11 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
   @Override
   public FilterType or(List<FilterType> filtersToBeOred) {
     filtersToBeOred.removeAll(Collections.singleton(null));
+
+    if (filtersToBeOred.isEmpty()) {
+      LOGGER.debug("Attempted to OR some filters, but none were valid.");
+      return null;
+    }
 
     return buildAndOrFilter(filtersToBeOred, filterObjectFactory.createOr(new BinaryLogicOpType()));
   }
@@ -246,9 +262,6 @@ public class WfsFilterDelegate extends SimpleFilterDelegate<FilterType> {
   private FilterType buildAndOrFilter(
       List<FilterType> filters, JAXBElement<BinaryLogicOpType> andOrFilter) {
 
-    if (filters.isEmpty()) {
-      return null;
-    }
     removeEmptyFilters(filters);
 
     // Check if these filters contain featureID(s)

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -445,12 +445,42 @@ public class WfsFilterDelegateTest {
   }
 
   @Test
+  public void testAndNoValidFilters() {
+    final WfsFilterDelegate delegate = createTextualDelegate();
+    final ArrayList<FilterType> filters = new ArrayList<>();
+    filters.add(null);
+    filters.add(null);
+    final FilterType filterToCheck = delegate.and(filters);
+    assertThat(filterToCheck, is(nullValue()));
+  }
+
+  @Test
+  public void testAndContainsInvalidFilter() {
+    final WfsFilterDelegate delegate = createDelegate();
+    final List<FilterType> filters = new ArrayList<>();
+    filters.add(new FilterType());
+    filters.add(null);
+    final FilterType filterToCheck = delegate.and(filters);
+    assertThat(filterToCheck, is(nullValue()));
+  }
+
+  @Test
   public void testOr() {
     WfsFilterDelegate delegate = createTextualDelegate();
     FilterType filter = delegate.propertyIsEqualTo(Metacard.ANY_TEXT, LITERAL, true);
     FilterType filterToCheck = delegate.or(asList(filter, filter));
     assertThat(filterToCheck, notNullValue());
     assertThat(filterToCheck.isSetLogicOps(), is(true));
+  }
+
+  @Test
+  public void testOrNoValidFilters() {
+    final WfsFilterDelegate delegate = createTextualDelegate();
+    final ArrayList<FilterType> filters = new ArrayList<>();
+    filters.add(null);
+    filters.add(null);
+    final FilterType filterToCheck = delegate.or(filters);
+    assertThat(filterToCheck, is(nullValue()));
   }
 
   @Test


### PR DESCRIPTION
### Forward port of https://github.com/codice/ddf/pull/6736

#### What does this PR do?
Now, the WfsFilterDelegate will return null when ANDing filters and at least one is null. This means any AND group will be dropped if it contains a feature property not understood by the source being queried. If this results in no filter for the query at all, then it will not be run against the source.

Also, note that test coverage did not actually decrease with this change. The instruction coverage was updated to reflect its true value; LenientLimit has prevented this from failing the build.
#### Who is reviewing it? 
@derekwilhelm  
@alexabird 

#### Select relevant component teams: 
@codice/core-apis 
@codice/ogc 

#### Ask 2 committers to review/merge the PR and tag them here.
@glenhein  
@jlcsmith

#### How should this be tested?
Test in downstsream

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.