### PR TITLE
Use processingDetails to generate sort warnings

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/common/Wfs11Constants.java
@@ -55,13 +55,6 @@ public class Wfs11Constants extends WfsConstants {
 
   public static final QName MULTI_POLYGON = new QName(GML_3_1_1_NAMESPACE, "MultiPolygon");
 
-  /**
-   * This is a list of sort-by attribute names that were removed from the query because they are
-   * known to be unsupported by the source. In practice, this value will be suffixed with
-   * ".SOURCE_ID".
-   */
-  public static final String UNSUPPORTED_SORT_BY_REMOVED = "unsupported-sort-by-removed";
-
   public static List<QName> wktOperandsAsList() {
     return Arrays.asList(
         LINEAR_RING,

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSourceTest.java
@@ -1724,11 +1724,7 @@ public class WfsSourceTest {
         ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
 
     SourceResponse sourceResponse = source.query(new QueryRequestImpl(propertyIsLikeQuery));
-    assertThat(
-        sourceResponse
-            .getProperties()
-            .get(Wfs11Constants.UNSUPPORTED_SORT_BY_REMOVED + "." + WFS_ID),
-        is(Result.TEMPORAL));
+    assertThat(sourceResponse.getProcessingDetails().size(), is(1));
 
     verify(mockWfs, times(2)).getFeature(argumentCaptor.capture());
 
@@ -1737,7 +1733,6 @@ public class WfsSourceTest {
 
   @Test
   public void testSortingBadSortOrderWithDefault() throws Exception {
-
     // query is still valid even if sort property bad
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
     setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
@@ -1755,11 +1750,7 @@ public class WfsSourceTest {
         ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
 
     SourceResponse sourceResponse = source.query(new QueryRequestImpl(propertyIsLikeQuery));
-    assertThat(
-        sourceResponse
-            .getProperties()
-            .get(Wfs11Constants.UNSUPPORTED_SORT_BY_REMOVED + "." + WFS_ID),
-        is(Result.TEMPORAL));
+    assertThat(sourceResponse.getProcessingDetails().size(), is(1));
 
     verify(mockWfs, times(2)).getFeature(argumentCaptor.capture());
 
@@ -1773,11 +1764,6 @@ public class WfsSourceTest {
 
   @Test
   public void testSortingBadSortOrderWithBadDefault() throws Exception {
-
-    // if sort order is invalid throw UnsupportedQueryException
-    expectedEx.expect(UnsupportedQueryException.class);
-    expectedEx.expectMessage("Source WFS_ID does not support the default sort property xyz");
-
     mapSchemaToFeatures(ONE_TEXT_PROPERTY_SCHEMA_PERSON, ONE_FEATURE);
     setUpMocks(null, null, ONE_FEATURE, ONE_FEATURE);
     final QueryImpl propertyIsLikeQuery =
@@ -1790,7 +1776,15 @@ public class WfsSourceTest {
     source.setDefaultSortName("xyz");
     source.setDefaultSortOrder(SortOrder.ASCENDING.name());
 
-    source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    ArgumentCaptor<ExtendedGetFeatureType> argumentCaptor =
+        ArgumentCaptor.forClass(ExtendedGetFeatureType.class);
+
+    SourceResponse sourceResponse = source.query(new QueryRequestImpl(propertyIsLikeQuery));
+    assertThat(sourceResponse.getProcessingDetails().size(), is(1));
+
+    verify(mockWfs, times(2)).getFeature(argumentCaptor.capture());
+
+    assertThat(argumentCaptor.getAllValues().get(1).getQuery().get(0).getSortBy(), is(nullValue()));
   }
 
   private void assertFeature(


### PR DESCRIPTION
#### What does this PR do?
* ProcessingDetails with null exceptions are shown as warnings in the UI
* Skip sorting (don't fail) if the admin configuration is bad

#### Who is reviewing it? 
@glenhein 
@jlcsmith 
@derekwilhelm 
@jrnorth 

#### Screenshots
<!--(if appropriate)-->

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
