### PR TITLE
2.25.x address download status info memory leak

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.shiro.SecurityUtils;
 import org.codice.ddf.activities.ActivityEvent;
 import org.osgi.service.event.Event;
@@ -34,9 +35,10 @@ public class DownloadStatusInfoImpl implements DownloadStatusInfo {
 
   private static final String UNKNOWN = "UNKNOWN";
 
-  private Map<String, ReliableResourceDownloader> downloaders = new HashMap<>();
+  private Map<String, ReliableResourceDownloader> downloaders =
+      new ConcurrentHashMap<String, ReliableResourceDownloader>();
 
-  private Map<String, String> downloadUsers = new HashMap<>();
+  private Map<String, String> downloadUsers = new ConcurrentHashMap<String, String>();
 
   private EventAdmin eventAdmin;
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
@@ -35,9 +35,9 @@ public class DownloadStatusInfoImpl implements DownloadStatusInfo {
   private static final String UNKNOWN = "UNKNOWN";
 
   private Map<String, ReliableResourceDownloader> downloaders =
-      new HashMap<String, ReliableResourceDownloader>();
+          new HashMap<>();
 
-  private Map<String, String> downloadUsers = new HashMap<String, String>();
+  private Map<String, String> downloadUsers = new HashMap<>();
 
   private EventAdmin eventAdmin;
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.shiro.SecurityUtils;
 import org.codice.ddf.activities.ActivityEvent;
 import org.osgi.service.event.Event;
@@ -36,9 +35,9 @@ public class DownloadStatusInfoImpl implements DownloadStatusInfo {
   private static final String UNKNOWN = "UNKNOWN";
 
   private Map<String, ReliableResourceDownloader> downloaders =
-      new ConcurrentHashMap<String, ReliableResourceDownloader>();
+      new HashMap<String, ReliableResourceDownloader>();
 
-  private Map<String, String> downloadUsers = new ConcurrentHashMap<String, String>();
+  private Map<String, String> downloadUsers = new HashMap<String, String>();
 
   private EventAdmin eventAdmin;
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
@@ -34,8 +34,7 @@ public class DownloadStatusInfoImpl implements DownloadStatusInfo {
 
   private static final String UNKNOWN = "UNKNOWN";
 
-  private Map<String, ReliableResourceDownloader> downloaders =
-          new HashMap<>();
+  private Map<String, ReliableResourceDownloader> downloaders = new HashMap<>();
 
   private Map<String, String> downloadUsers = new HashMap<>();
 

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/event/retrievestatus/DownloadStatusInfoImpl.java
@@ -58,6 +58,7 @@ public class DownloadStatusInfoImpl implements DownloadStatusInfo {
       ReliableResourceDownloader downloader,
       ResourceResponse resourceResponse) {
     downloaders.put(downloadIdentifier, downloader);
+    LOGGER.debug("Added download info for {}", downloadIdentifier);
     org.apache.shiro.subject.Subject shiroSubject = null;
     try {
       shiroSubject = SecurityUtils.getSubject();
@@ -125,6 +126,8 @@ public class DownloadStatusInfoImpl implements DownloadStatusInfo {
   public void removeDownloadInfo(String downloadIdentifier) {
     downloaders.remove(downloadIdentifier);
     downloadUsers.remove(downloadIdentifier);
+    LOGGER.debug("Deleted download info for {}", downloadIdentifier);
+    LOGGER.debug("downloaders: count={} users: count={}", downloaders.size(), downloadUsers.size());
   }
 
   @Override

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloadManager.java
@@ -204,9 +204,14 @@ public class ReliableResourceDownloadManager implements DownloadManager {
     AtomicBoolean downloadStarted = new AtomicBoolean(Boolean.FALSE);
     ReliableResourceDownloader downloader =
         new ReliableResourceDownloader(
-            downloaderConfig, downloadStarted, downloadIdentifier, resourceResponse, retriever);
+            downloaderConfig,
+            downloadStarted,
+            downloadIdentifier,
+            resourceResponse,
+            retriever,
+            downloadStatusInfo);
 
-    ResourceResponse response = downloader.setupDownload(metacard, downloadStatusInfo);
+    ResourceResponse response = downloader.setupDownload(metacard);
     response.getProperties().put(DOWNLOAD_ID_PROPERTY_KEY, downloadIdentifier);
 
     // Start download in separate thread so can return ResourceResponse with

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -587,8 +587,8 @@ public class ReliableResourceDownloader implements Runnable {
         // successful downloads since client reading from this InputStream will lag when
         // Callable finishes reading product's InputStream
       }
-      downloadStatusInfo.removeDownloadInfo(downloadIdentifier);
     }
+
     IOUtils.closeQuietly(countingFbos);
     if (doCaching) {
       IOUtils.closeQuietly(fos);
@@ -596,6 +596,7 @@ public class ReliableResourceDownloader implements Runnable {
     LOGGER.debug("Closing source InputStream");
     IOUtils.closeQuietly(resourceInputStream);
     LOGGER.debug("Closed source InputStream");
+    downloadStatusInfo.removeDownloadInfo(downloadIdentifier);
   }
 
   private void delay() throws InterruptedException {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -509,7 +509,6 @@ public class ReliableResourceDownloader implements Runnable {
       postFailedDownloadState(reliableResourceStatus);
     } finally {
       cleanupAfterDownload(reliableResourceStatus);
-      downloadStatusInfo.removeDownloadInfo(downloadIdentifier);
       downloadExecutor.shutdown();
     }
   }
@@ -588,6 +587,7 @@ public class ReliableResourceDownloader implements Runnable {
         // successful downloads since client reading from this InputStream will lag when
         // Callable finishes reading product's InputStream
       }
+      downloadStatusInfo.removeDownloadInfo(downloadIdentifier);
     }
     IOUtils.closeQuietly(countingFbos);
     if (doCaching) {

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/resource/download/ReliableResourceDownloader.java
@@ -103,6 +103,8 @@ public class ReliableResourceDownloader implements Runnable {
 
   private ResourceRetriever retriever;
 
+  private DownloadStatusInfo downloadStatusInfo;
+
   /**
    * Only set to true if cacheEnabled is true *AND* product being downloaded is not already pending
    * caching, e.g., another client has already started downloading and caching it.
@@ -114,12 +116,14 @@ public class ReliableResourceDownloader implements Runnable {
       AtomicBoolean downloadStarted,
       String downloadIdentifier,
       ResourceResponse resourceResponse,
-      ResourceRetriever retriever) {
+      ResourceRetriever retriever,
+      DownloadStatusInfo downloadStatusInfo) {
     this.downloadStarted = downloadStarted;
     this.downloaderConfig = downloaderConfig;
     this.downloadIdentifier = downloadIdentifier;
     this.resourceResponse = resourceResponse;
     this.retriever = retriever;
+    this.downloadStatusInfo = downloadStatusInfo;
 
     this.downloadState = new DownloadManagerState();
     this.downloadState.setDownloadState(DownloadManagerState.DownloadState.NOT_STARTED);
@@ -134,7 +138,7 @@ public class ReliableResourceDownloader implements Runnable {
     this.downloadState.setContinueCaching(this.downloaderConfig.isCacheWhenCanceled());
   }
 
-  public ResourceResponse setupDownload(Metacard metacard, DownloadStatusInfo downloadStatusInfo) {
+  public ResourceResponse setupDownload(Metacard metacard) {
     Resource resource = resourceResponse.getResource();
     MimeType mimeType = resource.getMimeType();
     String resourceName = resource.getName();
@@ -505,6 +509,7 @@ public class ReliableResourceDownloader implements Runnable {
       postFailedDownloadState(reliableResourceStatus);
     } finally {
       cleanupAfterDownload(reliableResourceStatus);
+      downloadStatusInfo.removeDownloadInfo(downloadIdentifier);
       downloadExecutor.shutdown();
     }
   }

--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceDownloaderTest.java
@@ -34,7 +34,6 @@ import ddf.catalog.cache.MockInputStream;
 import ddf.catalog.cache.impl.ResourceCacheImpl;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.event.retrievestatus.DownloadStatusInfo;
 import ddf.catalog.event.retrievestatus.DownloadStatusInfoImpl;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventListener;
 import ddf.catalog.event.retrievestatus.DownloadsStatusEventPublisher;


### PR DESCRIPTION
#### What does this PR do?

Removes entries from the `downloaders` map inside of `DownloadStatusInfoImple.java` in the `cleanupAfterDownload` method call from  `ReliableResourceDownloader`.

Whatever gets merged from this PR should go into release/2.15.x as well.  

#### Who is reviewing it? 

@dcruver @pklinef @middlets719 @jhunzik @figliold @mcalcote
 @rzwiefel  @stustison @kcwire @djblue @emmberk @mojogitoverhere @rodgersh @oconnormi @coyotesqrl @cmthom10 @lessarderic 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Ask 2 committers to review/merge the PR and tag them here.

@pklinef
@figliold 
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?

Contact me privately for steps for testing.

#### Any background context you want to provide?

My project ran into a case where it was reported that the container running ddf would eventually crash due to the main process throwing an `OutOfMemoryError`. I was able to replicate the problem and upon inspecting the heap afterwards found that the entries `downloaders` map inside of `DownloadStatusInfoImple.java` were never being removed. This occurred in `2.15.x` and `2.25.x`.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
