### PR TITLE
[2.26.x] Added query metrics to the QueryRequest and converted to ns timing

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/TimedSource.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/TimedSource.java
@@ -19,7 +19,11 @@ import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.source.Source;
 import ddf.catalog.source.SourceMonitor;
 import ddf.catalog.source.UnsupportedQueryException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,15 +56,27 @@ public class TimedSource implements Source {
 
   @Override
   public SourceResponse query(QueryRequest request) throws UnsupportedQueryException {
-    long startTime = System.currentTimeMillis();
+    long startTime = System.nanoTime();
     SourceResponse result = source.query(request);
-    long endTime = System.currentTimeMillis();
+    long endTime = System.nanoTime();
 
-    int elapsedTime = Math.toIntExact(endTime - startTime);
-    String sourceLatencyMetricKey = METRICS_SOURCE_ELAPSED_PREFIX_API + source.getId();
-
-    result.getProperties().put(sourceLatencyMetricKey, elapsedTime);
+    // get the elapsed time in ms (rounded by adding 1/2 a ms -> 500000)
+    int elapsedTime = Math.toIntExact(((endTime + 500000) - startTime) / 1000000);
     LOGGER.trace("Query latency for source [{}] was {}ms.", source.getId(), elapsedTime);
+    String sourceLatencyMetricKey = METRICS_SOURCE_ELAPSED_PREFIX_API + source.getId();
+    Map<String, Serializable> props = result.getProperties();
+    props.put(sourceLatencyMetricKey, elapsedTime);
+    props.put("qm.timedsource.elapsed", endTime - startTime);
+
+    // copy over all the original query metrics along with the new solr metrics
+    Map<String, Serializable> requestProps = result.getRequest().getProperties();
+    List<String> keys =
+        requestProps.keySet().stream()
+            .filter(e -> e.startsWith("qm."))
+            .collect(Collectors.toList());
+    for (String key : keys) {
+      props.put(key, requestProps.get(key));
+    }
 
     return result;
   }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/TimedSource.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/TimedSource.java
@@ -69,13 +69,16 @@ public class TimedSource implements Source {
     props.put("qm.timedsource.elapsed", endTime - startTime);
 
     // copy over all the original query metrics along with the new solr metrics
-    Map<String, Serializable> requestProps = result.getRequest().getProperties();
-    List<String> keys =
-        requestProps.keySet().stream()
-            .filter(e -> e.startsWith("qm."))
-            .collect(Collectors.toList());
-    for (String key : keys) {
-      props.put(key, requestProps.get(key));
+    QueryRequest qr = result.getRequest();
+    if (qr != null) {
+      Map<String, Serializable> requestProps = result.getRequest().getProperties();
+      List<String> keys =
+          requestProps.keySet().stream()
+              .filter(e -> e.startsWith("qm."))
+              .collect(Collectors.toList());
+      for (String key : keys) {
+        props.put(key, requestProps.get(key));
+      }
     }
 
     return result;

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -512,11 +512,6 @@ public class QueryOperations extends DescribableImpl {
         long elapsedTime = System.nanoTime() - start;
         putMetricsDuration(
             queryResponse, getMetric(QM_POSTQUERY, service, QM_ELAPSED), elapsedTime);
-        LOGGER.trace(
-            "After PostQueryPlugin: trace-id {}, plugin {}, duration {}",
-            traceId,
-            service,
-            elapsedTime);
       } catch (PluginExecutionException see) {
         LOGGER.debug("Error executing PostQueryPlugin: {}", see.getMessage(), see);
       } catch (StopProcessingException e) {
@@ -536,11 +531,6 @@ public class QueryOperations extends DescribableImpl {
         long elapsedTime = System.nanoTime() - start;
         putMetricsDuration(
             queryResponse, getMetric(QM_POSTQUERYACCESS, plugin, QM_ELAPSED), elapsedTime);
-        LOGGER.trace(
-            "After post-query AccessPlugin: trace-id {}, plugin {}, duration {}",
-            traceId,
-            plugin,
-            elapsedTime);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -566,11 +556,6 @@ public class QueryOperations extends DescribableImpl {
           long elapsedTime = System.nanoTime() - start;
           putMetricsDuration(
               queryResponse, getMetric(QM_RESPONSE_POLICYMAP, plugin, QM_ELAPSED), elapsedTime);
-          LOGGER.trace(
-              "After post-query PolicyPlugin: trace-id {}, plugin {}, duration {}",
-              traceId,
-              plugin,
-              elapsedTime);
         } catch (StopProcessingException e) {
           throw new FederationException("Query could not be executed.", e);
         }
@@ -590,11 +575,6 @@ public class QueryOperations extends DescribableImpl {
         queryReq = service.process(queryReq);
         long elapsedTime = System.nanoTime() - start;
         putMetricsDuration(queryReq, getMetric(QM_PREQUERY, service, QM_ELAPSED), elapsedTime);
-        LOGGER.trace(
-            "After PreQueryPlugin: trace-id {}, plugin {}, duration {}",
-            traceId,
-            service,
-            elapsedTime);
       } catch (PluginExecutionException see) {
         LOGGER.debug("Error executing PreQueryPlugin: {}", see.getMessage(), see);
       } catch (StopProcessingException e) {
@@ -613,11 +593,6 @@ public class QueryOperations extends DescribableImpl {
         queryReq = plugin.processPreQuery(queryReq);
         long elapsedTime = System.nanoTime() - start;
         putMetricsDuration(queryReq, getMetric(QM_POSTQUERY, plugin, QM_ELAPSED), elapsedTime);
-        LOGGER.trace(
-            "After pre-query AccessPlugin: trace-id {}, plugin {}, duration {}",
-            traceId,
-            plugin,
-            elapsedTime);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -634,12 +609,6 @@ public class QueryOperations extends DescribableImpl {
         queryRequest = plugin.processPreQuery(queryRequest);
         long elapsedTime = System.nanoTime() - start;
         putMetricsDuration(queryRequest, getMetric(QM_PREAUTH, plugin, QM_ELAPSED), elapsedTime);
-
-        LOGGER.trace(
-            "After pre-query PreAuthorizationPlugin: trace-id {}, plugin {}, duration {}",
-            traceId,
-            plugin,
-            elapsedTime);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -656,12 +625,6 @@ public class QueryOperations extends DescribableImpl {
         queryResponse = plugin.processPostQuery(queryResponse);
         long elapsedTime = System.nanoTime() - start;
         putMetricsDuration(queryResponse, getMetric(QM_PREAUTH, plugin, QM_ELAPSED), elapsedTime);
-
-        LOGGER.trace(
-            "After post-query PreAuthorizationPlugin: trace-id {}, plugin {}, duration {}",
-            traceId,
-            plugin,
-            elapsedTime);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }
@@ -685,12 +648,6 @@ public class QueryOperations extends DescribableImpl {
         long elapsedTime = System.nanoTime() - start;
         putMetricsDuration(
             queryReq, getMetric(QM_REQUEST_POLICYMAP, plugin, QM_ELAPSED), elapsedTime);
-
-        LOGGER.trace(
-            "After pre-query PolicyPlugin: trace-id {}, plugin {}, duration {}",
-            traceId,
-            plugin,
-            elapsedTime);
       } catch (StopProcessingException e) {
         throw new FederationException("Query could not be executed.", e);
       }

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/impl/operations/QueryOperations.java
@@ -272,14 +272,14 @@ public class QueryOperations extends DescribableImpl {
       }
     }
     if (LOGGER.isDebugEnabled()) {
-      Map<String, Serializable> req_metrics = queryResponse.getRequest().getProperties();
-      Map<String, Serializable> resp_metrics = queryResponse.getProperties();
+      Map<String, Serializable> reqMetrics = queryResponse.getRequest().getProperties();
+      Map<String, Serializable> respMetrics = queryResponse.getProperties();
       // Combine the request and response metrics to log
-      Map<String, Serializable> all_metrics = new HashMap<>();
-      all_metrics.putAll(filterMetrics(req_metrics, QMB));
-      all_metrics.putAll(filterMetrics(resp_metrics, QMB));
+      Map<String, Serializable> allMetrics = new HashMap<>();
+      allMetrics.putAll(filterMetrics(reqMetrics, QMB));
+      allMetrics.putAll(filterMetrics(respMetrics, QMB));
 
-      LOGGER.debug("QueryMetrics: {}", serializeMetrics(all_metrics, QMB));
+      LOGGER.debug("QueryMetrics: {}", serializeMetrics(allMetrics, QMB));
     }
   }
 

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrCatalogProviderImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrCatalogProviderImpl.java
@@ -187,9 +187,11 @@ public class SolrCatalogProviderImpl extends MaskableImpl implements CatalogProv
 
   @Override
   public SourceResponse query(QueryRequest request) throws UnsupportedQueryException {
-    long startTime = System.currentTimeMillis();
+    Serializable traceId = request.getProperties().get("metrics.query.trace-id");
+    long startTime = System.nanoTime();
     SourceResponse response = client.query(request);
-    LOGGER.debug("Time elapsed for Query {} ms", System.currentTimeMillis() - startTime);
+    LOGGER.debug(
+        "Time elapsed for Query with trace-id {} - {} ns", traceId, System.nanoTime() - startTime);
     return response;
   }
 
@@ -224,7 +226,7 @@ public class SolrCatalogProviderImpl extends MaskableImpl implements CatalogProv
       output.add(metacard);
     }
 
-    long startTime = System.currentTimeMillis();
+    long startTime = System.nanoTime();
     try {
       client.add(output, isForcedAutoCommit());
     } catch (SolrServerException | SolrException | IOException | MetacardCreationException e) {
@@ -232,9 +234,9 @@ public class SolrCatalogProviderImpl extends MaskableImpl implements CatalogProv
       throw new IngestException("Could not ingest metacard(s).", e);
     }
     LOGGER.debug(
-        "Time elapsed to create {} metacards is {} ms",
+        "Time elapsed to create {} metacards is {} ns",
         metacards.size(),
-        System.currentTimeMillis() - startTime);
+        System.nanoTime() - startTime);
 
     return new CreateResponseImpl(request, request.getProperties(), output);
   }

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrCatalogProviderImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrCatalogProviderImpl.java
@@ -77,6 +77,10 @@ public class SolrCatalogProviderImpl extends MaskableImpl implements CatalogProv
 
   private static final String DESCRIBABLE_PROPERTIES_FILE = "/describable.properties";
 
+  private static final String SQMB = "qm.sp."; // query metric base for solr provider
+  private static final String QM_TRACEID = "qm.trace-id";
+  private static final String QM_ELAPSED = ".elapsed";
+
   private static final String REQUEST_MUST_NOT_BE_NULL_MESSAGE = "Request must not be null";
 
   static final int MAX_BOOLEAN_CLAUSES = 1024;
@@ -187,11 +191,12 @@ public class SolrCatalogProviderImpl extends MaskableImpl implements CatalogProv
 
   @Override
   public SourceResponse query(QueryRequest request) throws UnsupportedQueryException {
-    Serializable traceId = request.getProperties().get("metrics.query.trace-id");
+    Serializable traceId = request.getProperties().get(QM_TRACEID);
     long startTime = System.nanoTime();
     SourceResponse response = client.query(request);
-    LOGGER.debug(
-        "Time elapsed for Query with trace-id {} - {} ns", traceId, System.nanoTime() - startTime);
+    long elapsedTime = System.nanoTime() - startTime;
+    LOGGER.debug("Time elapsed for Query with trace-id {} - {} ns", traceId, elapsedTime);
+    response.getProperties().put(SQMB + "query" + QM_ELAPSED, elapsedTime);
     return response;
   }
 

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrCatalogProviderImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrCatalogProviderImpl.java
@@ -191,7 +191,11 @@ public class SolrCatalogProviderImpl extends MaskableImpl implements CatalogProv
 
   @Override
   public SourceResponse query(QueryRequest request) throws UnsupportedQueryException {
-    Serializable traceId = request.getProperties().get(QM_TRACEID);
+    Serializable traceId = "none";
+    if (request != null) {
+      Map<String, Serializable> props = request.getProperties();
+      traceId = props == null ? "none" : request.getProperties().get(QM_TRACEID);
+    }
     long startTime = System.nanoTime();
     SourceResponse response = client.query(request);
     long elapsedTime = System.nanoTime() - startTime;

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -197,12 +197,12 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         filterDelegateFactory.newInstance(resolver, request.getProperties());
 
     LOGGER.trace("Generate solr query for {}: query request {}", traceSource, request);
-    long start_query = System.nanoTime();
-    long start = start_query;
+    long startQuery = System.nanoTime();
+    long start = startQuery;
     SolrQuery query = getSolrQuery(request, solrFilterDelegate);
     long timer1 = System.nanoTime();
     LOGGER.trace("Done generating solr query for {}: solr query {}", traceSource, query);
-    metrics.put(SQCMB + "getsolrquery" + QM_ELAPSED, timer1 - start_query);
+    metrics.put(SQCMB + "getsolrquery" + QM_ELAPSED, timer1 - startQuery);
     boolean isFacetedQuery = handleFacetRequest(query, request);
     long timer2 = System.nanoTime();
     metrics.put(SQCMB + "handleFacetReq" + QM_ELAPSED, timer2 - timer1);
@@ -267,7 +267,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     }
 
     // add in all the solr query metrics to return
-    metrics.put(SQCMB + "solrquery" + QM_ELAPSED, System.nanoTime() - start_query);
+    metrics.put(SQCMB + "solrquery" + QM_ELAPSED, System.nanoTime() - startQuery);
     responseProps.putAll(metrics);
     return new SourceResponseImpl(request, responseProps, results, totalHits);
   }
@@ -766,7 +766,8 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     query.setRows(0);
     QueryResponse solrResponse = client.query(query, METHOD.POST);
     numRows = Math.toIntExact(solrResponse.getResults().getNumFound());
-    LOGGER.debug("Solr client - query for num rows - elapsed time: {}", System.nanoTime() - timer0);
+    LOGGER.debug(
+        "Solr client - query for num rows - elapsed time: {}ns", System.nanoTime() - timer0);
     return numRows;
   }
 

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -157,7 +157,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
   private final int queryTimeAllowedMs =
       Math.max(NumberUtils.toInt(accessProperty(SOLR_QUERY_TIMEALLOWEDMS, "0")), 0);
 
-  private static final String SQMB = "qm.s."; // query metric base for solr
+  private static final String SQCMB = "qm.sc."; // query metric base for solr client
   private static final String QM_TRACEID = "qm.trace-id";
   private static final String QM_ELAPSED = ".elapsed";
 
@@ -196,16 +196,18 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     SolrFilterDelegate solrFilterDelegate =
         filterDelegateFactory.newInstance(resolver, request.getProperties());
 
+    LOGGER.trace("Generate solr query for {}: query request {}", traceSource, request);
     long start_query = System.nanoTime();
     long start = start_query;
-    LOGGER.trace("Generate solr query for {}: query request {}", traceSource, request);
     SolrQuery query = getSolrQuery(request, solrFilterDelegate);
+    long timer1 = System.nanoTime();
     LOGGER.trace("Done generating solr query for {}: solr query {}", traceSource, query);
-    metrics.put(SQMB + "gensolrquery" + QM_ELAPSED, System.nanoTime() - start_query);
+    metrics.put(SQCMB + "getsolrquery" + QM_ELAPSED, timer1 - start_query);
     boolean isFacetedQuery = handleFacetRequest(query, request);
-    start = System.nanoTime();
+    long timer2 = System.nanoTime();
+    metrics.put(SQCMB + "handleFacetReq" + QM_ELAPSED, timer2 - timer1);
     query = handleSuggestionQuery(query, request);
-    metrics.put(SQMB + "handleSuggestion" + QM_ELAPSED, System.nanoTime() - start);
+    metrics.put(SQCMB + "handleSuggestion" + QM_ELAPSED, System.nanoTime() - timer2);
     boolean userSpellcheckIsOn = userSpellcheckIsOn(request);
 
     try {
@@ -216,7 +218,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         LOGGER.debug("Performing real time query for {}", traceSource);
         SolrQuery realTimeQuery = getRealTimeQuery(query, solrFilterDelegate.getIds());
         solrResponse = client.query(realTimeQuery, METHOD.POST);
-        metrics.put(SQMB + "realtimeQuery" + QM_ELAPSED, System.nanoTime() - start);
+        metrics.put(SQCMB + "realtimeQuery" + QM_ELAPSED, System.nanoTime() - start);
       } else {
         if (userSpellcheckIsOn) {
           query.setParam("spellcheck", true);
@@ -224,11 +226,11 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         LOGGER.debug("Highlighter pre-query processing for {}", traceSource);
         highlighter.processPreQuery(request, query);
         long currentTime = System.nanoTime();
-        metrics.put(SQMB + "hilighterPreQuery" + QM_ELAPSED, currentTime - start);
+        metrics.put(SQCMB + "hilighterPreQuery" + QM_ELAPSED, currentTime - start);
         start = currentTime;
         LOGGER.debug("Performing query for {}", traceSource);
         solrResponse = client.query(query, METHOD.POST);
-        metrics.put(SQMB + "normalQuery" + QM_ELAPSED, System.nanoTime() - start);
+        metrics.put(SQCMB + "normalQuery" + QM_ELAPSED, System.nanoTime() - start);
       }
       LOGGER.trace("End executing solr query for {}", traceSource);
 
@@ -236,25 +238,25 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
         start = System.nanoTime();
         handleFacetResponse(solrResponse, responseProps);
         LOGGER.trace("Completed handleFacetResponse for {}", traceSource);
-        metrics.put(SQMB + "facetHandling" + QM_ELAPSED, System.nanoTime() - start);
+        metrics.put(SQCMB + "facetHandling" + QM_ELAPSED, System.nanoTime() - start);
       }
 
       start = System.nanoTime();
       handleSuggestionResponse(solrResponse, responseProps);
       LOGGER.trace("Complete handling suggestions for {}", traceSource);
       long currentTime = System.nanoTime();
-      metrics.put(SQMB + "suggestionHandling" + QM_ELAPSED, currentTime - start);
+      metrics.put(SQCMB + "suggestionHandling" + QM_ELAPSED, currentTime - start);
 
       handlePartialResults(solrResponse, responseProps);
       LOGGER.trace("Complete handling partial results for {}", traceSource);
       start = System.nanoTime();
-      metrics.put(SQMB + "partialHandling" + QM_ELAPSED, start - currentTime);
+      metrics.put(SQCMB + "partialHandling" + QM_ELAPSED, start - currentTime);
 
       SolrDocumentList docs = solrResponse.getResults();
       docs =
           handleSpellcheck(request, solrResponse, responseProps, query, docs, userSpellcheckIsOn);
       LOGGER.trace("Handled spellcheck for {}", traceSource);
-      metrics.put(SQMB + "spellcheckHandling" + QM_ELAPSED, System.nanoTime() - start);
+      metrics.put(SQCMB + "spellcheckHandling" + QM_ELAPSED, System.nanoTime() - start);
       if (docs != null) {
         addDocsToResults(docs, results);
         totalHits = docs.getNumFound();
@@ -265,7 +267,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     }
 
     // add in all the solr query metrics to return
-    metrics.put(SQMB + "solrquery" + QM_ELAPSED, System.nanoTime() - start_query);
+    metrics.put(SQCMB + "solrquery" + QM_ELAPSED, System.nanoTime() - start_query);
     responseProps.putAll(metrics);
     return new SourceResponseImpl(request, responseProps, results, totalHits);
   }
@@ -303,7 +305,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
       TermFacetProperties textFacetProp = (TermFacetProperties) textFacetPropRaw;
       isFacetedQuery = true;
       if (LOGGER.isDebugEnabled()) {
-        Serializable traceId = request.getProperties().get("metrics.query.trace-id");
+        Serializable traceId = request.getProperties().get(QM_TRACEID);
         String sourceId = request.getSourceIds().stream().collect(Collectors.joining(","));
         LOGGER.debug(
             "Enabling faceted query for trace-id {} source {} request [{}] on field {}",
@@ -423,12 +425,19 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     SolrDocumentList resultDocs = originalDocs;
     if (userSpellcheckIsOn && solrSpellcheckHasResults(solrResponse)) {
       LOGGER.trace("Begin solr spellcheck: query request {}", request);
+      long time0 = System.nanoTime();
       Collation collation = getCollationToResend(query, solrResponse);
       query.set("q", collation.getCollationQueryString());
       query.set("spellcheck", false);
+      long time1 = System.nanoTime();
+      responseProps.put(SQCMB + "collation" + QM_ELAPSED, time1 - time0);
       highlighter.processPreQuery(request, query);
+      long time2 = System.nanoTime();
+      responseProps.put(SQCMB + "highlighter.processPreQuery" + QM_ELAPSED, time2 - time1);
       QueryResponse solrResponseRequery = client.query(query, METHOD.POST);
       SolrDocumentList docs = solrResponseRequery.getResults();
+      long time3 = System.nanoTime();
+      responseProps.put(SQCMB + "highlighter.respRequery" + QM_ELAPSED, time3 - time2);
       if (docs != null && docs.size() > originalDocs.size()) {
         resultDocs = docs;
         highlightResponse = solrResponseRequery;
@@ -448,7 +457,10 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     }
     if (highlightResponse.getHighlighting() != null) {
       LOGGER.trace("Starting highlight extraction.");
+      long time0 = System.nanoTime();
       highlighter.processPostQuery(highlightResponse, responseProps);
+      responseProps.put(
+          SQCMB + "highlighter.processPostQuery" + QM_ELAPSED, System.nanoTime() - time0);
       LOGGER.trace("Ending highlight extraction.");
     }
     return resultDocs;
@@ -581,6 +593,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
     query.addFacetField(contentTypeField);
     query.addFacetPivotField(contentTypeField + "," + contentTypeVersionField);
 
+    long timer0 = System.nanoTime();
     try {
       QueryResponse solrResponse = client.query(query, METHOD.POST);
       List<FacetField> facetFields = solrResponse.getFacetFields();
@@ -636,10 +649,10 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
           }
         }
       }
-
     } catch (SolrServerException | SolrException | IOException e) {
       LOGGER.info("Solr exception getting content types", e);
     }
+    LOGGER.debug("Solr client - get content types - elapsed time: {}", System.nanoTime() - timer0);
 
     return finalSet;
   }
@@ -748,10 +761,12 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
   }
 
   private int queryForNumberOfRows(SolrQuery query) throws SolrServerException, IOException {
+    long timer0 = System.nanoTime();
     int numRows;
     query.setRows(0);
     QueryResponse solrResponse = client.query(query, METHOD.POST);
     numRows = Math.toIntExact(solrResponse.getResults().getNumFound());
+    LOGGER.debug("Solr client - query for num rows - elapsed time: {}", System.nanoTime() - timer0);
     return numRows;
   }
 
@@ -989,10 +1004,7 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
   }
 
   private QueryRequest putMetricsDuration(QueryRequest request, String key, long value) {
-    if (request != null) {
-      int elapsedTime = Math.toIntExact(value);
-      request.getProperties().put(key, elapsedTime);
-    }
+    request.getProperties().put(key, value);
     return request;
   }
 }

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrMetacardClientImpl.java
@@ -188,7 +188,11 @@ public class SolrMetacardClientImpl implements SolrMetacardClient {
 
     long totalHits = 0;
     Serializable traceId = request.getProperties().get(QM_TRACEID);
-    String sourceId = request.getSourceIds().stream().collect(Collectors.joining(","));
+    Set<String> ids = request.getSourceIds();
+    String sourceId = "<empty>";
+    if (ids != null) {
+      sourceId = ids.stream().collect(Collectors.joining(","));
+    }
     String traceSource = "trace-id " + traceId + "source " + sourceId;
     Map<String, Serializable> responseProps = new HashMap<>();
     List<Result> results = new ArrayList<>();


### PR DESCRIPTION

#### What does this PR do?
Updates the metrics for queries. Adds timing for the plugins, threads, and processing to the QueryRequest object. The resulting log statement prints out all the metrics. This log statement can then be extracted from the logs (grep for the word 'QueryMetrics') and converted to csv files for analysis in Excel.

The resulting log statement will include the following fields:

2023-08-08T08:47:17,949 | DEBUG | ... | QueryMetrics: trace-id: e67bee6eaaa3478a9d072f087099ab2f, qm.do-query.elapsed: 118220823, qm.postquery.AccessControlAccessPlugin.elapsed: 1022, qm.postquery.AccessControlPlugin.elapsed: 1656,  .... (another 70+ fields)

Each qm.XX.YYY field represents a specific plugin or span of code with the following value representing the elapsed execution time in nanoseconds for the corresponding plugin or code block.

This is meant to prove out the concept and provide some immediate timings for problematic queries. In the future, we might consider moving to a recognized standard such as OpenTelemetry with traces, spans, log statements etc in order to leverage existing toolsets (collectors, dashboards, visualizations, notifications, etc.)

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@jlcsmith 
@glenhein 

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->
@jlcsmith
@glenhein 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Build, enable logging at the specified levels for the following packages:
  echo "log:set WARN org.codice.ddf.security.handler.oauth" | $AUS_BIN/client
  echo "log:set ERROR org.codice.ddf.catalog.sourcepoller" | $AUS_BIN/client
  echo "log:set DEBUG com.connexta.isri.catalog.scheduling.query" | $AUS_BIN/client
  echo "log:set TRACE ddf.catalog.impl.operations" | /$AUS_BIN/client
  echo "log:set TRACE ddf.catalog.source.solr" | $AUS_BIN/client
  echo "log:set TRACE com.connexta.isri.catalog.dataload.endpoint" | $AUS_BIN/client

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
