### PR TITLE
[2.26.x] Provide better transform failure message

### DIFF
--- a/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/AbstractCatalogService.java
+++ b/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/AbstractCatalogService.java
@@ -246,6 +246,12 @@ public abstract class AbstractCatalogService implements CatalogService {
         throw new InternalServerErrorException(exceptionMessage);
       } catch (CatalogTransformerException e) {
         String exceptionMessage = "Unable to transform Metacard.  Try different transformer: ";
+        Throwable cause = e.getCause();
+        if (cause instanceof ResourceNotFoundException) {
+          exceptionMessage = "Resource file is not available";
+        } else if (cause instanceof IOException) {
+          exceptionMessage = "Unable to read resource file";
+        }
         LOGGER.info(exceptionMessage, e);
         throw new InternalServerErrorException(exceptionMessage);
       } catch (SourceUnavailableException e) {

--- a/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/AbstractCatalogService.java
+++ b/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/AbstractCatalogService.java
@@ -47,6 +47,7 @@ import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.plugin.OAuthPluginException;
 import ddf.catalog.resource.DataUsageLimitExceededException;
+import ddf.catalog.resource.ResourceNotFoundException;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.InternalIngestException;
 import ddf.catalog.source.SourceUnavailableException;
@@ -362,6 +363,12 @@ public abstract class AbstractCatalogService implements CatalogService {
         throw new InternalServerErrorException(exceptionMessage);
       } catch (CatalogTransformerException e) {
         String exceptionMessage = "Unable to transform Metacard.  Try different transformer: ";
+        Throwable cause = e.getCause();
+        if (cause instanceof ResourceNotFoundException) {
+          exceptionMessage = "Resource file is not available";
+        } else if (cause instanceof IOException) {
+          exceptionMessage = "Unable to read resource file";
+        }
         LOGGER.info(exceptionMessage, e);
         throw new InternalServerErrorException(exceptionMessage);
       } catch (SourceUnavailableException e) {

--- a/distribution/docs/src/main/resources/content/_integrating/_endpoints/catalog-rest-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_endpoints/catalog-rest-endpoint.adoc
@@ -221,11 +221,13 @@ If the metacard or resource is not returned successfully, check for these errors
 |`<pre>Unable to retrieve requested metacard.</pre>`
 |Invalid Metacard ID
 
-.3+.^|`500 Server Error`
+.4+.^|`500 Server Error`
 |`<pre>Unknown error occurred while processing request.</pre>`
 |Transformer is invalid, unsupported, or not configured.
 |`<pre>Unable to transform Metacard.  Try different transformer: </pre>`
 |Metacard does not have an associated resource (is metadata only).
+|`<pre>Resource file not available</pre>`
+|The resource file/data is not accessible or doesn't exist
 |`<pre>READ failed due to unexpected exception: </pre>`
 |Invalid source ID, or source unavailable.
 

--- a/distribution/docs/src/main/resources/content/_integrating/_endpoints/catalog-rest-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_integrating/_endpoints/catalog-rest-endpoint.adoc
@@ -226,7 +226,7 @@ If the metacard or resource is not returned successfully, check for these errors
 |Transformer is invalid, unsupported, or not configured.
 |`<pre>Unable to transform Metacard.  Try different transformer: </pre>`
 |Metacard does not have an associated resource (is metadata only).
-|`<pre>Resource file not available</pre>`
+|`<pre>Resource file is not available</pre>`
 |The resource file/data is not accessible or doesn't exist
 |`<pre>READ failed due to unexpected exception: </pre>`
 |Invalid source ID, or source unavailable.

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -640,7 +640,7 @@ public class TestFederation extends AbstractIntegrationTest {
         .assertThat()
         .contentType("text/html")
         .statusCode(equalTo(500))
-        .body(containsString("Resource file not available"));
+        .body(containsString("Resource file is not available"));
   }
 
   @Test

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestFederation.java
@@ -640,7 +640,7 @@ public class TestFederation extends AbstractIntegrationTest {
         .assertThat()
         .contentType("text/html")
         .statusCode(equalTo(500))
-        .body(containsString("Unable to transform Metacard."));
+        .body(containsString("Resource file not available"));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
When attempting to download a resource as part of a transform request, if the resource cannot be found or cannot be read for some reason, the transform endpoint will return a generic "Unable to transform Metacard. Try differen transformer" message.  While this message may be valid in some cases, the resource transformer and any other transformer that requires the file data could provide a much better message considering this message usually ends up back to the user.  In the case of a download from the UI, this is definitely true and shows within the browser window that opens.  This PR checks the transformers failure cause and provides a better message for when the resource file can either not be found or not be read.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@jlcsmith 
@andrewkfiedler 

#### Select relevant component teams: 

@codice/core-apis 
@codice/ui 

#### Ask 2 committers to review/merge the PR and tag them here.

@glenhein 
@jlcsmith


#### How should this be tested?
<!--(List steps with links to updated documentation)-->
1. Build and deploy DDF and add DDF-UI to it
2. Using the UI, upload a file
3. Create another metacard that doesn't have a file
4. Go to the file system and move/delete the stored file
5. Either using the UI or by going to the transform endpoint, attempt to retrieve the uploaded file using the resource transformer
6. Verify that the response message indicates "Resource file is not available"
7. Using the resource transformer and going to the metacard endpoint for the non-resource file metacard, verify that the response message indicates "Resource file is not available"

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
