### PR TITLE
[2.26.x] Disallow unauthenticated LDAP login attempts

### DIFF
--- a/platform/security/security-jaas-ldap/src/main/java/ddf/ldap/ldaplogin/SslLdapLoginModule.java
+++ b/platform/security/security-jaas-ldap/src/main/java/ddf/ldap/ldaplogin/SslLdapLoginModule.java
@@ -169,6 +169,13 @@ public class SslLdapLoginModule extends AbstractKarafLoginModule {
       tmpPassword = new char[0];
     }
 
+    if (tmpPassword.length == 0 || StringUtils.isBlank(new String(tmpPassword))) {
+      LOGGER.info(
+          "No password supplied for LDAP login for user {}. Unauthenticated LDAP bind not allowed",
+          user);
+      return false;
+    }
+
     // ---------------------------------------------------------------------
     // RESET OBJECT STATE AND DECLARE LOCAL VARS
     principals = new HashSet<>();


### PR DESCRIPTION
#### What does this PR do?
The LDAP login module allows a password to be empty when attempting to authenticate a user.  This leaves the authentication decision up to the LDAP server as to how to process an empty password.  If the LDAP server allows unauthenticated bind operations, this will make the LDAP login module assume the password was correct and the user is authorized for login even though the password was not correct/supplied.  This means that any user would be able to login as another valid LDAP user without supplying a password.  While most LDAP servers should not be configured with this enabled, if it is enabled then this would be a security hole and DDF should not allow unauthenticated access.  Guest access should be utilized instead.

This PR changes the SslLdapLoginModule to short circuit the login process if a password is not supplied or is blank.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@alexabird 
@jlcsmith 

#### Select relevant component teams: 

@codice/security 


#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@pklinef


#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Set up an LDAP server (i.e. OpenLDAP) and configure some users (create an ssh group and add at least one user to it)
Configure the Security JAAS LDAP configuration to point to the LDAP server
Configure the Karaf console login to use ldap
Restart DDF
Using the client script in the DDF bin directory, attempt to login using a user defined in LDAP
Supply the proper password and verify the user is allowed to login
Attempt the login again but this time don't supply a password (or type spaces)
Verify that the user is not allowed to login and that an INFO log is generated in the ddf log that looks like:

`12:21:55,279 | INFO  | 5]-nio2-thread-2 | ddf.ldap.ldaplogin.SslLdapLoginModule     173 | security-jaas-ldap   | No password supplied for LDAP login for user user01. Unauthenticated LDAP bind not allowed`

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
