### PR TITLE
[2.26.x] Ensure SortedQueryMonitor uses query ThreadContext

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedQueryMonitor.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedQueryMonitor.java
@@ -102,142 +102,146 @@ class SortedQueryMonitor implements Runnable {
 
   @Override
   public void run() {
-    if (originalThreadResources != null) {
-      ThreadContext.remove();
-      ThreadContext.setResources(originalThreadResources);
-    }
-
-    List<SortBy> sortBys = new ArrayList<>();
-    SortBy sortBy = query.getSortBy();
-    if (sortBy != null && sortBy.getPropertyName() != null) {
-      sortBys.add(sortBy);
-    }
-    Serializable sortBySer = request.getPropertyValue(ADDITIONAL_SORT_BYS);
-    if (sortBySer instanceof SortBy[]) {
-      SortBy[] extSortBys = (SortBy[]) sortBySer;
-      if (extSortBys.length > 0) {
-        sortBys.addAll(Arrays.asList(extSortBys));
+    try {
+      if (originalThreadResources != null) {
+        ThreadContext.remove();
+        ThreadContext.setResources(originalThreadResources);
+      } else {
+        LOGGER.warn("SortedQueryMonitor executing without a security thread context");
       }
-    }
 
-    // Prepare the Comparators that we will use
-    CollectionResultComparator resultComparator = new CollectionResultComparator();
-    if (!sortBys.isEmpty()) {
-      for (SortBy sort : sortBys) {
-        Comparator<Result> comparator = null;
-
-        PropertyName sortingProp = sort.getPropertyName();
-        String sortType = sortingProp.getPropertyName();
-        SortOrder sortOrder =
-            (sort.getSortOrder() == null) ? SortOrder.DESCENDING : sort.getSortOrder();
-        LOGGER.debug("Sorting type: {}", sortType);
-        LOGGER.debug("Sorting order: {}", sortOrder);
-
-        // Temporal searches are currently sorted by the effective time
-        if (Metacard.EFFECTIVE.equals(sortType) || Result.TEMPORAL.equals(sortType)) {
-          comparator = new TemporalResultComparator(sortOrder);
-        } else if (Result.DISTANCE.equals(sortType)) {
-          comparator = new DistanceResultComparator(sortOrder);
-        } else if (Result.RELEVANCE.equals(sortType)) {
-          comparator = new RelevanceResultComparator(sortOrder);
-        } else {
-          Comparator<Result> fallback =
-              Comparator.comparing(
-                  r -> getAttributeValue((Result) r, sortType),
-                  ((sortOrder == SortOrder.ASCENDING)
-                      ? Comparator.nullsLast(Comparator.<Comparable>naturalOrder())
-                      : Comparator.nullsLast(Comparator.<Comparable>reverseOrder())));
-          comparator = new CaseInsensitiveIfStringComparator(sortOrder, sortType, fallback);
+      List<SortBy> sortBys = new ArrayList<>();
+      SortBy sortBy = query.getSortBy();
+      if (sortBy != null && sortBy.getPropertyName() != null) {
+        sortBys.add(sortBy);
+      }
+      Serializable sortBySer = request.getPropertyValue(ADDITIONAL_SORT_BYS);
+      if (sortBySer instanceof SortBy[]) {
+        SortBy[] extSortBys = (SortBy[]) sortBySer;
+        if (extSortBys.length > 0) {
+          sortBys.addAll(Arrays.asList(extSortBys));
         }
-        resultComparator.addComparator(comparator);
       }
-    } else {
-      Comparator<Result> coreComparator = SortedFederationStrategy.DEFAULT_COMPARATOR;
-      resultComparator.addComparator(coreComparator);
-    }
 
-    List<Result> resultList = new ArrayList<>();
-    long totalHits = 0;
-    Set<ProcessingDetails> detailsOfReturnResults = returnResults.getProcessingDetails();
+      // Prepare the Comparators that we will use
+      CollectionResultComparator resultComparator = new CollectionResultComparator();
+      if (!sortBys.isEmpty()) {
+        for (SortBy sort : sortBys) {
+          Comparator<Result> comparator = null;
 
-    Map<String, Map<String, Serializable>> sourceProperties = new HashMap<>();
+          PropertyName sortingProp = sort.getPropertyName();
+          String sortType = sortingProp.getPropertyName();
+          SortOrder sortOrder =
+              (sort.getSortOrder() == null) ? SortOrder.DESCENDING : sort.getSortOrder();
+          LOGGER.debug("Sorting type: {}", sortType);
+          LOGGER.debug("Sorting order: {}", sortOrder);
 
-    Map<String, Serializable> returnProperties = returnResults.getProperties();
-    HashMap<String, Long> hitsPerSource = new HashMap<>();
-
-    for (int i = futures.size(); i > 0; i--) {
-      String sourceId = "Unknown Source";
-      QueryRequest queryRequest = null;
-      SourceResponse sourceResponse = null;
-      try {
-        Future<SourceResponse> future;
-        if (query.getTimeoutMillis() < 1) {
-          future = completionService.take();
-        } else {
-          future = completionService.poll(getTimeRemaining(deadline), TimeUnit.MILLISECONDS);
-          if (future == null) {
-            timeoutRemainingSources(detailsOfReturnResults);
-            break;
+          // Temporal searches are currently sorted by the effective time
+          if (Metacard.EFFECTIVE.equals(sortType) || Result.TEMPORAL.equals(sortType)) {
+            comparator = new TemporalResultComparator(sortOrder);
+          } else if (Result.DISTANCE.equals(sortType)) {
+            comparator = new DistanceResultComparator(sortOrder);
+          } else if (Result.RELEVANCE.equals(sortType)) {
+            comparator = new RelevanceResultComparator(sortOrder);
+          } else {
+            Comparator<Result> fallback =
+                Comparator.comparing(
+                    r -> getAttributeValue((Result) r, sortType),
+                    ((sortOrder == SortOrder.ASCENDING)
+                        ? Comparator.nullsLast(Comparator.<Comparable>naturalOrder())
+                        : Comparator.nullsLast(Comparator.<Comparable>reverseOrder())));
+            comparator = new CaseInsensitiveIfStringComparator(sortOrder, sortType, fallback);
           }
+          resultComparator.addComparator(comparator);
         }
+      } else {
+        Comparator<Result> coreComparator = SortedFederationStrategy.DEFAULT_COMPARATOR;
+        resultComparator.addComparator(coreComparator);
+      }
 
-        queryRequest = futures.remove(future);
-        if (queryRequest == null) {
-          LOGGER.debug("Couldn't get completed federated query. Skipping {}", sourceId);
-          continue;
-        }
-        sourceId = getSourceIdFromRequest(queryRequest);
+      List<Result> resultList = new ArrayList<>();
+      long totalHits = 0;
+      Set<ProcessingDetails> detailsOfReturnResults = returnResults.getProcessingDetails();
 
-        sourceResponse = future.get();
-        if (sourceResponse == null) {
-          LOGGER.debug("Source {} returned null response", sourceId);
-          sourceResponse =
-              executePostFederationQueryPluginsWithSourceError(
-                  queryRequest, sourceId, new NullPointerException());
-        } else {
-          sourceResponse =
-              executePostFederationQueryPlugins(sourceResponse, queryRequest, sourceId);
-        }
-      } catch (InterruptedException e) {
-        if (queryRequest != null) {
-          // First, add interrupted processing detail for this source
-          LOGGER.debug("Search interrupted for {}", sourceId);
+      Map<String, Map<String, Serializable>> sourceProperties = new HashMap<>();
+
+      Map<String, Serializable> returnProperties = returnResults.getProperties();
+      HashMap<String, Long> hitsPerSource = new HashMap<>();
+
+      for (int i = futures.size(); i > 0; i--) {
+        String sourceId = "Unknown Source";
+        QueryRequest queryRequest = null;
+        SourceResponse sourceResponse = null;
+        try {
+          Future<SourceResponse> future;
+          if (query.getTimeoutMillis() < 1) {
+            future = completionService.take();
+          } else {
+            future = completionService.poll(getTimeRemaining(deadline), TimeUnit.MILLISECONDS);
+            if (future == null) {
+              timeoutRemainingSources(detailsOfReturnResults);
+              break;
+            }
+          }
+
+          queryRequest = futures.remove(future);
+          if (queryRequest == null) {
+            LOGGER.debug("Couldn't get completed federated query. Skipping {}", sourceId);
+            continue;
+          }
+          sourceId = getSourceIdFromRequest(queryRequest);
+
+          sourceResponse = future.get();
+          if (sourceResponse == null) {
+            LOGGER.debug("Source {} returned null response", sourceId);
+            sourceResponse =
+                executePostFederationQueryPluginsWithSourceError(
+                    queryRequest, sourceId, new NullPointerException());
+          } else {
+            sourceResponse =
+                executePostFederationQueryPlugins(sourceResponse, queryRequest, sourceId);
+          }
+        } catch (InterruptedException e) {
+          if (queryRequest != null) {
+            // First, add interrupted processing detail for this source
+            LOGGER.debug("Search interrupted for {}", sourceId);
+            sourceResponse =
+                executePostFederationQueryPluginsWithSourceError(queryRequest, sourceId, e);
+          }
+
+          // Then add the interrupted exception for the remaining sources
+          interruptRemainingSources(detailsOfReturnResults, e);
+          Thread.currentThread().interrupt();
+          break;
+        } catch (ExecutionException e) {
+          LOGGER.info(
+              "Couldn't get results from completed federated query for sourceId = {}", sourceId, e);
           sourceResponse =
               executePostFederationQueryPluginsWithSourceError(queryRequest, sourceId, e);
         }
+        resultList.addAll(sourceResponse.getResults());
+        long hits = sourceResponse.getHits();
+        totalHits += hits;
+        hitsPerSource.merge(sourceId, hits, (l1, l2) -> l1 + l2);
 
-        // Then add the interrupted exception for the remaining sources
-        interruptRemainingSources(detailsOfReturnResults, e);
-        Thread.currentThread().interrupt();
-        break;
-      } catch (ExecutionException e) {
-        LOGGER.info(
-            "Couldn't get results from completed federated query for sourceId = {}", sourceId, e);
-        sourceResponse =
-            executePostFederationQueryPluginsWithSourceError(queryRequest, sourceId, e);
+        Map<String, Serializable> properties = sourceResponse.getProperties();
+        sourceProperties.put(sourceId, properties);
+
+        returnProperties.putAll(properties);
+        detailsOfReturnResults.addAll(
+            sourceProcessingDetailsToProcessingDetails(sourceId, sourceResponse));
       }
-      resultList.addAll(sourceResponse.getResults());
-      long hits = sourceResponse.getHits();
-      totalHits += hits;
-      hitsPerSource.merge(sourceId, hits, (l1, l2) -> l1 + l2);
 
-      Map<String, Serializable> properties = sourceResponse.getProperties();
-      sourceProperties.put(sourceId, properties);
+      returnProperties.put("hitsPerSource", hitsPerSource);
+      returnProperties.put(
+          ORIGINAL_SOURCE_PROPERTIES, (Serializable) Collections.unmodifiableMap(sourceProperties));
+      LOGGER.debug("All sources finished returning results: {}", resultList.size());
 
-      returnProperties.putAll(properties);
-      detailsOfReturnResults.addAll(
-          sourceProcessingDetailsToProcessingDetails(sourceId, sourceResponse));
+      returnResults.setHits(totalHits);
+      returnResults.addResults(sortedResults(resultList, resultComparator), true);
+    } finally {
+      ThreadContext.remove();
     }
-
-    returnProperties.put("hitsPerSource", hitsPerSource);
-    returnProperties.put(
-        ORIGINAL_SOURCE_PROPERTIES, (Serializable) Collections.unmodifiableMap(sourceProperties));
-    LOGGER.debug("All sources finished returning results: {}", resultList.size());
-
-    returnResults.setHits(totalHits);
-    returnResults.addResults(sortedResults(resultList, resultComparator), true);
-
-    ThreadContext.remove();
   }
 
   private Set<ProcessingDetails> sourceProcessingDetailsToProcessingDetails(

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedQueryMonitorFactory.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/federation/impl/SortedQueryMonitorFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.Future;
+import org.apache.shiro.util.ThreadContext;
 
 class SortedQueryMonitorFactory {
 
@@ -31,6 +32,12 @@ class SortedQueryMonitorFactory {
       final QueryRequest request,
       List<PostFederatedQueryPlugin> postQuery) {
 
-    return new SortedQueryMonitor(completionService, futures, returnResults, request, postQuery);
+    return new SortedQueryMonitor(
+        ThreadContext.getResources(),
+        completionService,
+        futures,
+        returnResults,
+        request,
+        postQuery);
   }
 }


### PR DESCRIPTION
#### What does this PR do?
When performing a query, the QueryOperations hands off the source execution of the queries to the SortedFederationStrategy.  This class uses an ExecutorService to run the source queries in parallel within a thread pool where the results are gathered and processed with PostFederatedQueryPlugins in the SortedQueryMonitor class.  Since these run in separate threads, they don't share the same thread context as the original query.  This means that things like `trace-id` in the thread context are lost.  Furthermore, if any of the PostFederatedQueryPlugins perform an action that sets or binds a user subject to the thread, then the thread in the thread pool will now have that user defined in its thread context going forward, including when it gets reused.  This may easily happen if a PostFederatedQueryPlugin issues a new QueryRequest to the CatalogFramework.  When multiple users are using the system, this has the effect of the source queries and PostFederatedQueryPlugins running in a thread with a different user than what issued the original request.

This PR fixes this issue by retrieving the original ThreadContext resources from the original query thread and passing them to the SortedQueryMonitor instance that is submitted to the ExecutorService.  When the SortedQueryMonitor runs, it clears the thread context of the executor thread and resets it to original thread context resources from the original query thread.  This maintains the user subject across the threads along with any other thread context variables that may be important.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@jlcsmith 
@pklinef 

#### Select relevant component teams: 

@codice/core-apis 
@codice/security 


#### Ask 2 committers to review/merge the PR and tag them here.

@andrewkfiedler
@glenhein 


#### How should this be tested?
<!--(List steps with links to updated documentation)-->
This is rather difficult to test with base DDF.  You need to have a PostFederatedQueryPlugin that issues a query to the catalog framework to force it to modify the thread context.  Then you can verify that the searches are executing as expected when querying against data that should be filtered out for some users but not others.

Alternatively,  you can connect the debugger and set a break point in the SortedQueryMonitor class.  
log in as two different users
Create two different queries, one for each user (e.g. `anyText like FOO`  and `anyText like BAR`)
Submit the queries for the two different users
When the break point hits in the SortedQueryMonitor, verify that the thread context while running contains the correct user for the query that matches the user submitting the original query
Execute the query multiple times and verify the user subject in the SortedQueryMonitor's thread context is set appropriately each time

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
