### PR TITLE
[2.26.x] Update downloadability endpoint to return checksum

### DIFF
--- a/catalog/rest/catalog-rest-api/src/main/java/org/codice/ddf/rest/api/CatalogService.java
+++ b/catalog/rest/catalog-rest-api/src/main/java/org/codice/ddf/rest/api/CatalogService.java
@@ -111,7 +111,7 @@ public interface CatalogService {
   String getFileExtensionForMimeType(String mimeType);
 
   /**
-   * Returns true if the local resource exists for the metacardId. Otherwise, false. Throws
+   * Returns checksum if the local resource exists for the metacardId. Otherwise, null. Throws
    * CatalogServiceException
    *
    * @param metacardId
@@ -119,5 +119,5 @@ public interface CatalogService {
    * @return
    * @throws CatalogServiceException
    */
-  boolean doesLocalResourceExist(String metacardId, String sourceId) throws CatalogServiceException;
+  String doesLocalResourceExist(String metacardId, String sourceId) throws CatalogServiceException;
 }

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTEndpoint.java
@@ -277,9 +277,10 @@ public class RESTEndpoint implements RESTService {
       String id = URLDecoder.decode(encodedId, CharEncoding.UTF_8);
       String sourceId = URLDecoder.decode(encodedSourceId, CharEncoding.UTF_8);
 
-      boolean doesExist = catalogService.doesLocalResourceExist(id, sourceId);
+      String checksum = catalogService.doesLocalResourceExist(id, sourceId);
 
-      responseBuilder = doesExist ? Response.ok() : Response.status(Status.NOT_FOUND);
+      responseBuilder =
+          checksum != null ? Response.ok(checksum) : Response.status(Status.NOT_FOUND);
 
       return responseBuilder.build();
     } catch (UnsupportedEncodingException | CatalogServiceException e) {

--- a/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTService.java
+++ b/catalog/rest/catalog-rest-endpoint/src/main/java/org/codice/ddf/endpoints/rest/RESTService.java
@@ -84,7 +84,7 @@ public interface RESTService {
       @Context HttpServletRequest httpRequest);
 
   /**
-   * REST Get. Returns HTTP 200 if the local resource can be downloaded. Otherwise, HTTP 404.
+   * REST Get. Returns HTTP 200 with checksum if the local resource can be downloaded. Otherwise, HTTP 404.
    * Returns HTTP 500 if unable to determine if the resource can be downloaded.
    *
    * @param id

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RESTEndpointTest.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/RESTEndpointTest.java
@@ -51,6 +51,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.apache.tika.io.IOUtils;
 import org.codice.ddf.attachment.impl.AttachmentParserImpl;
+import org.codice.ddf.checksum.ChecksumProvider;
 import org.codice.ddf.rest.service.impl.CatalogServiceImpl;
 import org.junit.Test;
 
@@ -169,7 +170,8 @@ public class RESTEndpointTest {
             framework,
             new AttachmentParserImpl(mimeTypeMapper),
             mock(AttributeRegistry.class),
-            Collections.emptyList());
+            Collections.emptyList(),
+            mock(ChecksumProvider.class));
     catalogServiceImpl.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
     FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
     catalogServiceImpl.setFilterBuilder(filterBuilder);
@@ -384,7 +386,8 @@ public class RESTEndpointTest {
             framework,
             new AttachmentParserImpl(mimeTypeMapper),
             mock(AttributeRegistry.class),
-            Collections.emptyList());
+            Collections.emptyList(),
+            mock(ChecksumProvider.class));
 
     catalogServiceImpl.setTikaMimeTypeResolver(new TikaMimeTypeResolver());
     FilterBuilder filterBuilder = new GeotoolsFilterBuilder();

--- a/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/it/RestEndpointIT.java
+++ b/catalog/rest/catalog-rest-endpoint/src/test/java/org/codice/ddf/endpoints/rest/it/RestEndpointIT.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.Map;
 import javax.inject.Inject;
 import org.codice.ddf.attachment.AttachmentParser;
+import org.codice.ddf.checksum.ChecksumProvider;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.test.common.AbstractComponentTest;
@@ -104,6 +105,8 @@ public class RestEndpointIT extends AbstractComponentTest {
   @MockOsgiService private MimeTypeToTransformerMapper mimeTypeToTransformerMapper;
 
   @MockOsgiService private AttributeRegistry attributeRegistry;
+
+  @MockOsgiService private ChecksumProvider checksumProvider;
 
   @MockOsgiService(answer = Answers.RETURNS_DEEP_STUBS)
   private FilterBuilder filterBuilder;
@@ -204,7 +207,8 @@ public class RestEndpointIT extends AbstractComponentTest {
             .add("ddf.catalog.core", "catalog-core-attachment")
             .add("ddf.catalog.rest", "catalog-rest-api")
             .add("ddf.catalog.rest", "catalog-rest-service-impl")
-            .add("ddf.catalog.rest", "catalog-rest-impl");
+            .add("ddf.catalog.rest", "catalog-rest-impl")
+            .add("org.codice.ddf", "checksum");
       }
 
       @Override

--- a/catalog/rest/catalog-rest-service-impl/src/main/java/org/codice/ddf/rest/service/impl/CatalogServiceImpl.java
+++ b/catalog/rest/catalog-rest-service-impl/src/main/java/org/codice/ddf/rest/service/impl/CatalogServiceImpl.java
@@ -31,6 +31,7 @@ import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
 import org.codice.ddf.attachment.AttachmentParser;
+import org.codice.ddf.checksum.ChecksumProvider;
 import org.codice.ddf.rest.service.AbstractCatalogService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,8 +44,9 @@ public class CatalogServiceImpl extends AbstractCatalogService {
       CatalogFramework framework,
       AttachmentParser attachmentParser,
       AttributeRegistry attributeRegistry,
-      List<StorageProvider> storageProviders) {
-    super(framework, attachmentParser, attributeRegistry, storageProviders);
+      List<StorageProvider> storageProviders,
+      ChecksumProvider checksumProvider) {
+    super(framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider);
   }
 
   @Override

--- a/catalog/rest/catalog-rest-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/rest/catalog-rest-service-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,6 +22,7 @@
     <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
     <reference id="attachmentParser" interface="org.codice.ddf.attachment.AttachmentParser"/>
     <reference id="attributeRegistry" interface="ddf.catalog.data.AttributeRegistry"/>
+    <reference id="checksumProvider" interface="org.codice.ddf.checksum.ChecksumProvider"/>
 
     <bean id="storageProviderSortedList" class="org.codice.ddf.platform.util.SortedServiceList"/>
 
@@ -35,6 +36,7 @@
         <argument ref="attachmentParser"/>
         <argument ref="attributeRegistry" />
         <argument ref="storageProviderSortedList" />
+        <argument ref="checksumProvider" />
         <property name="filterBuilder" ref="filterBuilder"/>
         <property name="mimeTypeToTransformerMapper" ref="transformerMapper"/>
         <property name="tikaMimeTypeResolver" ref="tikaMimeTypeResolver"/>

--- a/catalog/rest/catalog-rest-service-impl/src/test/java/org/codice/ddf/rest/service/impl/CatalogServiceImplTest.java
+++ b/catalog/rest/catalog-rest-service-impl/src/test/java/org/codice/ddf/rest/service/impl/CatalogServiceImplTest.java
@@ -99,6 +99,7 @@ import org.apache.tika.io.IOUtils;
 import org.codice.ddf.attachment.AttachmentInfo;
 import org.codice.ddf.attachment.AttachmentParser;
 import org.codice.ddf.attachment.impl.AttachmentParserImpl;
+import org.codice.ddf.checksum.ChecksumProvider;
 import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.rest.api.CatalogServiceException;
 import org.codice.ddf.rest.service.AbstractCatalogService;
@@ -126,6 +127,8 @@ public class CatalogServiceImplTest {
 
   private AttributeRegistry attributeRegistry;
 
+  private ChecksumProvider checksumProvider;
+
   private final List<StorageProvider> storageProviders = Collections.emptyList();
 
   @Before
@@ -137,6 +140,8 @@ public class CatalogServiceImplTest {
     attachmentParser = new AttachmentParserImpl(mimeTypeMapper);
 
     attributeRegistry = mock(AttributeRegistry.class);
+
+    checksumProvider = mock(ChecksumProvider.class);
   }
 
   @Test
@@ -145,7 +150,8 @@ public class CatalogServiceImplTest {
     CatalogFramework framework = mock(CatalogFramework.class);
 
     CatalogServiceImpl catalogService =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders);
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider);
 
     HttpHeaders headers = mock(HttpHeaders.class);
 
@@ -180,7 +186,8 @@ public class CatalogServiceImplTest {
     HttpHeaders headers = createHeaders(Collections.singletonList(MediaType.APPLICATION_JSON));
 
     CatalogServiceImpl catalogService =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders);
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider);
 
     addMatchingService(catalogService, Collections.singletonList(getSimpleTransformer()));
 
@@ -220,7 +227,8 @@ public class CatalogServiceImplTest {
     when(attributeRegistry.lookup("custom.attribute")).thenReturn(Optional.of(descriptor));
 
     CatalogServiceImpl catalogService =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders) {
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider) {
           @Override
           protected BundleContext getBundleContext() {
             return bundleContext;
@@ -291,7 +299,8 @@ public class CatalogServiceImplTest {
         .thenReturn(serviceReferences);
 
     CatalogServiceImpl catalogService =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders) {
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider) {
           @Override
           protected BundleContext getBundleContext() {
             return bundleContext;
@@ -392,7 +401,8 @@ public class CatalogServiceImplTest {
         .thenReturn(serviceReferences);
 
     CatalogServiceImpl catalogServiceImpl =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders) {
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider) {
           @Override
           protected BundleContext getBundleContext() {
             return bundleContext;
@@ -464,7 +474,8 @@ public class CatalogServiceImplTest {
         .thenReturn(serviceReferences);
 
     CatalogServiceImpl catalogServiceImpl =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders) {
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider) {
           @Override
           protected BundleContext getBundleContext() {
             return bundleContext;
@@ -523,7 +534,8 @@ public class CatalogServiceImplTest {
       throws IngestException, SourceUnavailableException {
     CatalogFramework framework = givenCatalogFramework();
     CatalogServiceImpl catalogServiceImpl =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders);
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider);
 
     when(attributeRegistry.lookup(Topic.KEYWORD))
         .thenReturn(Optional.of(new TopicAttributes().getAttributeDescriptor(Topic.KEYWORD)));
@@ -574,7 +586,8 @@ public class CatalogServiceImplTest {
   public void testParsePartsWithAttributeOverrides() throws Exception {
     CatalogFramework framework = givenCatalogFramework();
     CatalogServiceImpl catalogServiceImpl =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders);
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider);
 
     when(attributeRegistry.lookup(Topic.KEYWORD))
         .thenReturn(Optional.of(new TopicAttributes().getAttributeDescriptor(Topic.KEYWORD)));
@@ -639,7 +652,8 @@ public class CatalogServiceImplTest {
         .thenReturn(serviceReferences);
 
     CatalogServiceImpl catalogServiceImpl =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders) {
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider) {
           @Override
           protected BundleContext getBundleContext() {
             return bundleContext;
@@ -712,7 +726,8 @@ public class CatalogServiceImplTest {
         .thenReturn(serviceReferences);
 
     CatalogServiceImpl catalogServiceImpl =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders) {
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider) {
           @Override
           protected BundleContext getBundleContext() {
             return bundleContext;
@@ -815,7 +830,8 @@ public class CatalogServiceImplTest {
         .thenReturn(sourceInfoResponse);
 
     CatalogServiceImpl catalogService =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders);
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider);
 
     BinaryContent content = catalogService.getSourcesInfo();
     assertEquals(jsonMimeTypeString, content.getMimeTypeValue());
@@ -876,7 +892,8 @@ public class CatalogServiceImplTest {
     when(framework.transform(isA(Metacard.class), anyString(), isNull())).thenReturn(content);
 
     CatalogServiceImpl catalogService =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders);
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider);
 
     // Add a MimeTypeToINputTransformer that the REST endpoint will call to create the metacard
     addMatchingService(catalogService, Collections.singletonList(getSimpleTransformer()));
@@ -951,7 +968,8 @@ public class CatalogServiceImplTest {
         .thenReturn(serviceReferences);
 
     CatalogServiceImpl catalogService =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders) {
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider) {
           @Override
           protected BundleContext getBundleContext() {
             return bundleContext;
@@ -1002,7 +1020,8 @@ public class CatalogServiceImplTest {
     HttpHeaders headers = createHeaders(Collections.singletonList(MediaType.APPLICATION_JSON));
 
     CatalogServiceImpl catalogService =
-        new CatalogServiceImpl(framework, attachmentParser, attributeRegistry, storageProviders);
+        new CatalogServiceImpl(
+            framework, attachmentParser, attributeRegistry, storageProviders, checksumProvider);
 
     addMatchingService(catalogService, Collections.singletonList(getSimpleTransformer()));
 

--- a/catalog/rest/catalog-rest-service/pom.xml
+++ b/catalog/rest/catalog-rest-service/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>catalog-core-attachment</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>checksum</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Unit Tests -->
         <dependency>

--- a/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/AbstractCatalogService.java
+++ b/catalog/rest/catalog-rest-service/src/main/java/org/codice/ddf/rest/service/AbstractCatalogService.java
@@ -379,7 +379,7 @@ public abstract class AbstractCatalogService implements CatalogService {
       LOGGER.debug("Unable to generate checksum for resource {}", resourceUri);
     }
 
-    return null;
+    return "";
   }
 
   public boolean containsErrors(ReadStorageResponse response) {


### PR DESCRIPTION
#### What does this PR do?
Updates `doesExist` endpoint to return a checksum representing the resource if able.

#### Who is reviewing it? 

#### Select relevant component teams: 

#### Ask 2 committers to review/merge the PR and tag them here.

#### How should this be tested?
- Start the application
- Upload a product
- Send a `GET` request to `https://localhost:8993/services/catalog/doesExist/<metacardID>/<sourceID>`. You should receive a `200` response from the endpoint along with a checksum string in the body.
- Find the resource's metacard in solr and ensure the checksum matches the one on the metacard.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
