### PR TITLE
[2.26.x] updated historian to check for the skip-versioning flag from the request properties instead of the response properties

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -664,16 +664,6 @@ public class Historian {
     return systemSubject.execute(func);
   }
 
-  //  private boolean doSkip(@Nullable Operation op) {
-  //    return !historyEnabled
-  //        || op == null
-  //        || ((boolean)
-  //            Optional.of(op)
-  //                .map(Operation::getProperties)
-  //                .orElse(Collections.emptyMap())
-  //                .getOrDefault(SKIP_VERSIONING, false));
-  //  }
-
   private boolean doSkip(@Nullable Response response) {
     return !historyEnabled
         || response == null

--- a/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
+++ b/catalog/core/catalog-core-standardframework/src/main/java/ddf/catalog/history/Historian.java
@@ -41,6 +41,7 @@ import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteResponse;
 import ddf.catalog.operation.Operation;
+import ddf.catalog.operation.Response;
 import ddf.catalog.operation.SourceResponse;
 import ddf.catalog.operation.Update;
 import ddf.catalog.operation.UpdateResponse;
@@ -663,11 +664,22 @@ public class Historian {
     return systemSubject.execute(func);
   }
 
-  private boolean doSkip(@Nullable Operation op) {
+  //  private boolean doSkip(@Nullable Operation op) {
+  //    return !historyEnabled
+  //        || op == null
+  //        || ((boolean)
+  //            Optional.of(op)
+  //                .map(Operation::getProperties)
+  //                .orElse(Collections.emptyMap())
+  //                .getOrDefault(SKIP_VERSIONING, false));
+  //  }
+
+  private boolean doSkip(@Nullable Response response) {
     return !historyEnabled
-        || op == null
+        || response == null
         || ((boolean)
-            Optional.of(op)
+            Optional.of(response)
+                .map(Response::getRequest)
                 .map(Operation::getProperties)
                 .orElse(Collections.emptyMap())
                 .getOrDefault(SKIP_VERSIONING, false));


### PR DESCRIPTION
#### What does this PR do?
The Historian will not actually skip versioning for update or delete requests as it ignores the properties that would contain that flag. This corrects that to allow metacards to be deleted or updated and have no versions created. 

#### Who is reviewing it? 
@jlcsmith 
@derekwilhelm 
@alexabird 