### PR TITLE
[2.26.x] Added ability to generate known uuid

### DIFF
--- a/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
@@ -37,6 +37,10 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StandardMetacardGroomerPlugin.class);
 
+  private static final String PREFERENCES_TAG = "ddf-preferences";
+
+  private static final String USER_ATTRIBUTE = "user";
+
   private UuidGenerator uuidGenerator;
 
   public void setUuidGenerator(UuidGenerator uuidGenerator) {
@@ -49,7 +53,13 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
     LOGGER.debug("Applying standard rules on CreateRequest");
     if ((aMetacard.getResourceURI() != null && !isCatalogResourceUri(aMetacard.getResourceURI()))
         || !uuidGenerator.validateUuid(aMetacard.getId())) {
-      aMetacard.setAttribute(new AttributeImpl(Metacard.ID, uuidGenerator.generateUuid()));
+      if (isPreferenceMetacard(aMetacard)) {
+        String userId = (String) aMetacard.getAttribute(USER_ATTRIBUTE).getValue();
+        aMetacard.setAttribute(
+            new AttributeImpl(Metacard.ID, uuidGenerator.generateKnownId(PREFERENCES_TAG, userId)));
+      } else {
+        aMetacard.setAttribute(new AttributeImpl(Metacard.ID, uuidGenerator.generateUuid()));
+      }
     }
 
     if (aMetacard.getCreatedDate() == null) {
@@ -135,5 +145,9 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
   private boolean isDateAttributeEmpty(Metacard metacard, String attribute) {
     Attribute origAttribute = metacard.getAttribute(attribute);
     return (origAttribute == null || !(origAttribute.getValue() instanceof Date));
+  }
+
+  private boolean isPreferenceMetacard(Metacard metacard) {
+    return metacard.getTags().contains(PREFERENCES_TAG);
   }
 }

--- a/platform/preferences/preferences-impl/pom.xml
+++ b/platform/preferences/preferences-impl/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>gson-support</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>util-uuidgenerator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/platform/preferences/preferences-impl/src/main/java/org/codice/ddf/preferences/impl/PreferencesImpl.java
+++ b/platform/preferences/preferences-impl/src/main/java/org/codice/ddf/preferences/impl/PreferencesImpl.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.preferences.DefaultPreferencesSupplier;
 import org.codice.ddf.preferences.PostRetrievalPlugin;
 import org.codice.ddf.preferences.Preferences;
@@ -75,6 +76,8 @@ public class PreferencesImpl implements Preferences {
 
   private final FilterBuilder filterBuilder;
 
+  private final UuidGenerator uuidGenerator;
+
   /** These are the attributes that will be ignored from being added to the preferences metacard. */
   private static final Set<String> IGNORED_ATTRIBUTES =
       new HashSet<>(Arrays.asList(PreferencesMetacardType.USER_ATTRIBUTE, Metacard.ID));
@@ -88,11 +91,13 @@ public class PreferencesImpl implements Preferences {
   public PreferencesImpl(
       CatalogFramework catalogFramework,
       FilterBuilder filterBuilder,
+      UuidGenerator uuidGenerator,
       List<PostRetrievalPlugin> postRetrievalPlugins,
       List<DefaultPreferencesSupplier> defaultPreferencesSuppliers,
       List<InjectableAttribute> injectableAttributes) {
     this.catalogFramework = catalogFramework;
     this.filterBuilder = filterBuilder;
+    this.uuidGenerator = uuidGenerator;
     this.postRetrievalPlugins = postRetrievalPlugins;
     this.defaultPreferencesSuppliers = defaultPreferencesSuppliers;
     this.injectableAttributes = injectableAttributes;
@@ -124,8 +129,9 @@ public class PreferencesImpl implements Preferences {
   }
 
   private Filter createFilter(String userId) {
+    String metacardId = uuidGenerator.generateKnownId(PreferencesMetacardType.TAG, userId);
     return filterBuilder.allOf(
-        filterBuilder.attribute(PreferencesMetacardType.USER_ATTRIBUTE).is().equalTo().text(userId),
+        filterBuilder.attribute(Metacard.ID).is().equalTo().text(metacardId),
         filterBuilder.attribute(Metacard.TAGS).is().equalTo().text(PreferencesMetacardType.TAG));
   }
 

--- a/platform/preferences/preferences-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/preferences/preferences-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,6 +20,9 @@
 
   <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
 
+  <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator"
+             filter="(id=uuidGenerator)"/>
+
   <reference-list id="postRetrievalPlugins" interface="org.codice.ddf.preferences.PostRetrievalPlugin" availability="optional"/>
 
   <reference-list id="defaultPreferenceSettings" interface="org.codice.ddf.preferences.DefaultPreferencesSupplier" availability="optional"/>
@@ -27,6 +30,7 @@
   <bean id="preferences" class="org.codice.ddf.preferences.impl.PreferencesImpl">
     <argument ref="catalogFramework"/>
     <argument ref="filterBuilder"/>
+    <argument ref="uuidGenerator"/>
     <argument ref="postRetrievalPlugins"/>
     <argument ref="defaultPreferenceSettings"/>
     <argument>

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-api/src/main/java/org/codice/ddf/platform/util/uuidgenerator/UuidGenerator.java
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-api/src/main/java/org/codice/ddf/platform/util/uuidgenerator/UuidGenerator.java
@@ -28,6 +28,14 @@ public interface UuidGenerator {
   String generateUuid();
 
   /**
+   * @param metacardTag tag of metacard to generate ID for
+   * @param userId user the metacard is being created for
+   * @param additionalInput any additional properties
+   * @return UUID
+   */
+  String generateKnownId(String metacardTag, String userId, String... additionalInput);
+
+  /**
    * Returns true if the UUID format is correct
    *
    * @param uuid - the given UUID

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/main/java/org/codice/ddf/platform/util/uuidgenerator/impl/UuidGeneratorImpl.java
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/main/java/org/codice/ddf/platform/util/uuidgenerator/impl/UuidGeneratorImpl.java
@@ -42,6 +42,26 @@ public class UuidGeneratorImpl implements UuidGenerator {
   }
 
   @Override
+  public String generateKnownId(String metacardTag, String userId, String... additionalInput) {
+    String input = getInputString(metacardTag, userId, additionalInput);
+    String uuid = UUID.nameUUIDFromBytes(input.getBytes()).toString();
+    if (!useHyphens) {
+      uuid = uuid.replace("-", "");
+    }
+    return uuid;
+  }
+
+  private String getInputString(String metacardTag, String userId, String... additionalInput) {
+    String input = String.format("%s-%s", metacardTag, userId);
+    if (additionalInput != null) {
+      for (String additional : additionalInput) {
+        input = input + "-" + additional;
+      }
+    }
+    return input;
+  }
+
+  @Override
   public boolean validateUuid(String uuid) {
     if (StringUtils.isEmpty(uuid)) {
       return false;

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/test/java/org/codice/ddf/platform/util/uuidgenerator/impl/UuidGeneratorImplTest.java
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/src/test/java/org/codice/ddf/platform/util/uuidgenerator/impl/UuidGeneratorImplTest.java
@@ -15,6 +15,7 @@ package org.codice.ddf.platform.util.uuidgenerator.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +42,12 @@ public class UuidGeneratorImplTest {
           "fc3f1798fe1766fbbcc39dcfcb232e6---1",
           "fc3f1798fe17166fbbcc39dcfcb2232e61234");
 
+  private static final String TAG_ONE = "tag-one";
+
+  private static final String TAG_TWO = "tag-two";
+
+  private static final String USER_ID = "user1";
+
   @Before
   public void setUp() {
     uuidGenerator = new UuidGeneratorImpl();
@@ -59,6 +66,47 @@ public class UuidGeneratorImplTest {
     String uuid = uuidGenerator.generateUuid();
     assertThat(uuid.length(), is(36));
     assertThat(uuidGenerator.validateUuid(uuid), is(true));
+  }
+
+  @Test
+  public void testGenerateKnownIdRemoveHyphens() {
+    String uuid1 = uuidGenerator.generateKnownId(TAG_ONE, USER_ID, null);
+    String uuid2 = uuidGenerator.generateKnownId(TAG_ONE, USER_ID, null);
+    assertThat(uuidGenerator.validateUuid(uuid1), is(true));
+    assertThat(uuidGenerator.validateUuid(uuid2), is(true));
+    assertThat(uuid1, is(uuid2));
+
+    String uuid3 = uuidGenerator.generateKnownId(TAG_TWO, USER_ID, null);
+    assertThat(uuidGenerator.validateUuid(uuid3), is(true));
+    assertThat(uuid3, is(not(uuid1)));
+  }
+
+  @Test
+  public void testGenerateKnownIdHyphens() {
+    uuidGenerator.setUseHyphens(true);
+    String uuid1 = uuidGenerator.generateKnownId(TAG_ONE, USER_ID);
+    String uuid2 = uuidGenerator.generateKnownId(TAG_ONE, USER_ID);
+    assertThat(uuidGenerator.validateUuid(uuid1), is(true));
+    assertThat(uuidGenerator.validateUuid(uuid2), is(true));
+    assertThat(uuid1, is(uuid2));
+
+    String uuid3 = uuidGenerator.generateKnownId(TAG_TWO, USER_ID);
+    assertThat(uuidGenerator.validateUuid(uuid3), is(true));
+    assertThat(uuid3, is(not(uuid1)));
+  }
+
+  @Test
+  public void testGenerateKnownIdAdditional() {
+    uuidGenerator.setUseHyphens(true);
+    String uuid1 = uuidGenerator.generateKnownId(TAG_ONE, USER_ID, "additionalInput");
+    String uuid2 = uuidGenerator.generateKnownId(TAG_ONE, USER_ID, "additionalInput");
+    assertThat(uuidGenerator.validateUuid(uuid1), is(true));
+    assertThat(uuidGenerator.validateUuid(uuid2), is(true));
+    assertThat(uuid1, is(uuid2));
+
+    String uuid3 = uuidGenerator.generateKnownId(TAG_TWO, USER_ID, "differentInput");
+    assertThat(uuidGenerator.validateUuid(uuid3), is(true));
+    assertThat(uuid3, is(not(uuid1)));
   }
 
   @Test


### PR DESCRIPTION
#### What does this PR do?
Adds a known UUID to preference metacards, in order to prevent multiple appearing in the system for the same user

#### Who is reviewing it? 
@jlcsmith 
@glenhein 

#### Select relevant component teams: 
@codice/core-apis 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@derekwilhelm 
@jlcsmith 

#### How should this be tested?
1. Sign in an check solr for a ddf-preference metacard being created
2. Not the ID of the preference metacard, remove it from solr using `catalog:remove`
3. Wait for another ddf-preference metacard to be created for the same user
4. Ensure the new metacard has the same ID as the previously removed one

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
