### PR TITLE
[2.26.x] Normalize Coordinates For WFS 1.1.0 Sources

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/test/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsFilterDelegateTest.java
@@ -2015,6 +2015,17 @@ public class WfsFilterDelegateTest {
     assertXMLEqual(propertyIsLikeXmlEmpty, marshal(filter));
   }
 
+  @Test
+  public void testNormalizeWktCoordinates() {
+    WfsFilterDelegate delegate = createTextualDelegate();
+    String originalWkt =
+        "POLYGON ((162.421875 68.656555, 226.757813 69.037142, 226.757813 26.431228, 154.6875 27.994401, 162.421875 68.656555))";
+    String expectedWkt =
+        "POLYGON ((162.421875 68.656555, -133.242187 69.037142, -133.242187 26.431228, 154.6875 27.994401, 162.421875 68.656555))";
+    String actualWkt = delegate.normalizeWktCoordinates(originalWkt);
+    assertThat(actualWkt, is(expectedWkt));
+  }
+
   private JAXBElement<FilterType> getFilterTypeJaxbElement(FilterType filterType) {
     return new JAXBElement<>(
         new QName("http://www.opengis.net/ogc", FILTER_QNAME_LOCAL_PART),


### PR DESCRIPTION
#### What does this PR do?
For WFS 1.1.0, adjusts the coordinates in a wkt to conform to the range [-180, 180] before a filter is created. This is necessary because that's the range supported by WFS. 

#### Who is reviewing it? 
@alexabird  
@malmgrens4  

#### Select relevant component teams: 
@codice/ogc 


#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith 
@glenhein 

#### How should this be tested?
Ensure any outgoing WFS requests containing geo filters that overlap with the antimeridian are not outside the range [-180, 180], and that the request is successful.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
