### PR TITLE
[2.26.x] Update to pax logging 1.11.17

### DIFF
--- a/distribution/ddf-common/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/distribution/ddf-common/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -46,6 +46,12 @@
         <bundle originalUri="mvn:org.apache.felix/org.apache.felix.scr/2.1.20"
                 replacement="mvn:org.apache.felix/org.apache.felix.scr/${felix.scr.version}"
                 mode="maven"/>
+        <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/1.11.6"
+                replacement="mvn:org.ops4j.pax.logging/pax-logging-api/${pax.logging.version}"
+                mode="maven"/>
+        <bundle originalUri="mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.11.6"
+                replacement="mvn:org.ops4j.pax.logging/pax-logging-log4j2/${pax.logging.version}"
+                mode="maven"/>
     </bundleReplacements>
 
     <!-- A list of feature replacements that allows changing external feature definitions -->

--- a/distribution/ddf-common/src/main/resources/common-bin.xml
+++ b/distribution/ddf-common/src/main/resources/common-bin.xml
@@ -81,6 +81,7 @@
                 Vulnerabilities: CVE-2008-0732, CVE-2011-5034
                 -->
                 <exclude>**/org/apache/geronimo/bundles/commons-discovery/**/*</exclude>
+                <exclude>**/org/ops4j/pax/logging/**/*</exclude>
             </excludes>
         </fileSet>
 
@@ -383,6 +384,18 @@
                 <include>
                     org.apache.servicemix.bundles:org.apache.servicemix.bundles.jaxb-runtime:jar:${servicemix.bundles.jaxb.version}
                 </include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>system/org/ops4j/pax/logging/pax-logging-log4j2/${pax.logging.version}</outputDirectory>
+            <includes>
+                <include>org.ops4j.pax.logging:pax-logging-log4j2:jar:${pax.logging.version}</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>system/org/ops4j/pax/logging/pax-logging-api/${pax.logging.version}</outputDirectory>
+            <includes>
+                <include>org.ops4j.pax.logging:pax-logging-api:jar:${pax.logging.version}</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -351,12 +351,32 @@
             <artifactId>apache-karaf</artifactId>
             <version>${karaf.version}</version>
             <type>tar.gz</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-log4j2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>
             <artifactId>apache-karaf</artifactId>
             <version>${karaf.version}</version>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-log4j2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
@@ -364,6 +384,26 @@
             <version>${karaf.version}</version>
             <type>xml</type>
             <classifier>features</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-log4j2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ops4j.pax.logging</groupId>
+                    <artifactId>pax-logging-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+            <version>${pax.logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-log4j2</artifactId>
+            <version>${pax.logging.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.distribution</groupId>

--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -25,8 +25,8 @@
     <packaging>bundle</packaging>
 
     <properties>
-        <!-- Override Log4J because pax-logging-api 1.10.1 uses 2.8.2 -->
-        <apache-log4j.version>2.8.2</apache-log4j.version>
+        <!-- Override Log4J because pax-logging-api 1.11.17 uses 2.17.1 -->
+        <apache-log4j.version>2.17.1</apache-log4j.version>
     </properties>
 
     <dependencies>

--- a/platform/solr/solr-logging/pom.xml
+++ b/platform/solr/solr-logging/pom.xml
@@ -83,7 +83,7 @@
                         <configuration>
                             <rules>
                                 <ArtifactSizeEnforcerRule implementation="org.codice.maven.artifactsize.ArtifactSizeEnforcerRule">
-                                    <maxArtifactSize>2.6_MB</maxArtifactSize>
+                                    <maxArtifactSize>2.7_MB</maxArtifactSize>
                                 </ArtifactSizeEnforcerRule>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <junit.version>4.12</junit.version>
         <mockito.version>2.8.47</mockito.version>
         <pax.exam.version>4.13.2.CODICE</pax.exam.version>
-        <pax.logging.version>1.11.6</pax.logging.version>
+        <pax.logging.version>1.11.17</pax.logging.version>
         <pax.url.version>2.6.2</pax.url.version>
         <pax.web.version>7.2.16</pax.web.version>
         <pax.web.jsp.version>7.2.18</pax.web.jsp.version>
@@ -239,7 +239,7 @@
         <jwnl.version>1.3.3</jwnl.version>
         <karaf.version>4.2.9</karaf.version>
         <la4j.version>0.6.0</la4j.version>
-        <apache-log4j.version>2.11.2</apache-log4j.version>
+        <apache-log4j.version>2.17.1</apache-log4j.version>
         <logback.classic.version>1.2.3</logback.classic.version>
         <logback.version>1.2.3</logback.version>
         <lucene.version>7.7.2</lucene.version>
@@ -297,7 +297,7 @@
         <solr.httpclient.version>4.5.10</solr.httpclient.version>
         <solr.httpcore.version>4.4.12</solr.httpcore.version>
         <solr.httpmime.version>4.5.10</solr.httpmime.version>
-        <solr.log4j.version>2.13.2</solr.log4j.version>
+        <solr.log4j.version>2.17.1</solr.log4j.version>
         <solr.zookeeper.version>3.5.7</solr.zookeeper.version>
         <solr.spatial4j.version>0.7</solr.spatial4j.version>
         <spark.version>2.9.2</spark.version>


### PR DESCRIPTION
#### What does this PR do?
Upgrades pax-logging to 1.11.17 to resolve https://github.com/advisories/GHSA-jfh8-c2jp-5v3q

#### Who is reviewing it?
@brendan-hofmann
@derekwilhelm 

#### Select relevant component teams:
@codice/security

#### Ask 2 committers to review/merge the PR and tag them here.
@brendan-hofmann
@derekwilhelm 

#### How should this be tested?
Run a vulnerability scanner against the exploded distro (eg, [lunasec log4shell scan](https://github.com/lunasec-io/lunasec/releases)). 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
