### PR TITLE
[2.29.x] Fix null check in MetacardImpl.setAttribute()

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/MetacardImpl.java
@@ -757,9 +757,9 @@ public class MetacardImpl implements Metacard {
       wrappedMetacard.setAttribute(attribute);
     } else {
       String name = attribute.getName();
-      Serializable value = attribute.getValue();
+      List<Serializable> values = attribute.getValues()
       if (name != null) {
-        if (value != null) {
+        if (values != null) {
           map.put(name, attribute);
         } else {
           map.remove(name);

--- a/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardImplTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/ddf/catalog/data/impl/MetacardImplTest.java
@@ -284,6 +284,7 @@ public class MetacardImplTest {
     metacard.setSourceId("mySourceId");
     metacard.setDescription("Northern Arizona City");
     metacard.setPointOfContact("poc");
+    metacard.setAttribute(new AttributeImpl("testList", (Serializable) Arrays.asList(null, "testValue1", "testValue2")));
     Serializer<Metacard> serializer = new Serializer<Metacard>();
 
     /* WRITE */
@@ -306,6 +307,7 @@ public class MetacardImplTest {
     assertEquals(metacard.getDescription(), readMetacard.getAttribute("description").getValue());
     assertEquals(
         metacard.getPointOfContact(), readMetacard.getAttribute("point-of-contact").getValue());
+    assertNotNull(metacard.getAttribute("testList"));
 
     MetacardType metacardType = metacard.getMetacardType();
     MetacardType readMetacardType = readMetacard.getMetacardType();


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where `MetacardImpl.setAttribute()` would only check if an attribute's first item in the values list was null before dropping the attribute, potentially causing data loss if other items in the list are not null.

#### Who is reviewing it? 
@clockard  @vinamartin  @jrnorth 

#### Any background context you want to provide?
Was found while working on a downstream project that uses DDF

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
