### PR TITLE
[2.29.x] countrycode converter and wss4j-ws-security-common upgrades to remove CVEs

### DIFF
--- a/catalog/confluence/catalog-confluence-source/src/main/java/org/codice/ddf/confluence/source/ConfluenceSource.java
+++ b/catalog/confluence/catalog-confluence-source/src/main/java/org/codice/ddf/confluence/source/ConfluenceSource.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -277,7 +278,7 @@ public class ConfluenceSource extends MaskableImpl
       String error = "";
       try {
         if (stream != null) {
-          error = IOUtils.toString(stream);
+          error = IOUtils.toString(stream, StandardCharsets.UTF_8);
         }
       } catch (IOException ioe) {
         LOGGER.debug("Could not convert error message to a string for output.", ioe);

--- a/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceInputTransformerTest.java
+++ b/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceInputTransformerTest.java
@@ -171,7 +171,7 @@ public class ConfluenceInputTransformerTest {
   private String getFileContent(String filePath) {
     try {
       return IOUtils.toString(
-          this.getClass().getClassLoader().getResourceAsStream(filePath), "UTF-8");
+          this.getClass().getClassLoader().getResourceAsStream(filePath), StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new RuntimeException("Failed to read filepath: " + filePath);
     }

--- a/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceSourceTest.java
+++ b/catalog/confluence/catalog-confluence-source/src/test/java/org/codice/ddf/confluence/source/ConfluenceSourceTest.java
@@ -555,7 +555,7 @@ public class ConfluenceSourceTest {
     try {
       return IOUtils.toString(
           ConfluenceSourceTest.class.getClassLoader().getResourceAsStream(filePath),
-          StandardCharsets.UTF_8.toString());
+          StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new RuntimeException("Failed to read filepath: " + filePath);
     }

--- a/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
+++ b/catalog/core/catalog-core-commands/src/main/java/org/codice/ddf/commands/catalog/ValidateCommand.java
@@ -27,6 +27,7 @@ import ddf.catalog.validation.MetacardValidator;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -122,7 +123,7 @@ public class ValidateCommand extends CqlCommands {
     List<Metacard> metacards = new ArrayList<>();
     for (File file : files) {
       Metacard metacard = new MetacardImpl();
-      String metadata = IOUtils.toString(file.toURI());
+      String metadata = IOUtils.toString(file.toURI(), StandardCharsets.UTF_8);
       metacard.setAttribute(new AttributeImpl(Metacard.METADATA, metadata));
       metacard.setAttribute(new AttributeImpl(Metacard.TITLE, file.getName()));
       metacards.add(metacard);

--- a/catalog/core/catalog-core-definitionparser/src/main/java/ddf/catalog/definition/impl/DefinitionParser.java
+++ b/catalog/core/catalog-core-definitionparser/src/main/java/ddf/catalog/definition/impl/DefinitionParser.java
@@ -250,7 +250,7 @@ public class DefinitionParser {
   private void apply(File file) throws Exception {
     String data;
     try (InputStream input = new FileInputStream(file)) {
-      data = IOUtils.toString(input, StandardCharsets.UTF_8.name());
+      data = IOUtils.toString(input, StandardCharsets.UTF_8);
       LOGGER.debug("Installing file [{}]. Contents:\n{}", file.getAbsolutePath(), data);
     }
     if (StringUtils.isEmpty(data)) {

--- a/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
+++ b/catalog/core/catalog-core-urlresourcereader/src/main/java/ddf/catalog/resource/impl/URLResourceReader.java
@@ -32,6 +32,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.security.AccessController;
@@ -423,7 +424,7 @@ public class URLResourceReader implements ResourceReader {
   private String getResponseErrorMessage(InputStream is) {
     String error = "";
     try {
-      error = IOUtils.toString(is);
+      error = IOUtils.toString(is, StandardCharsets.UTF_8);
     } catch (IOException ioe) {
       LOGGER.debug("Could not convert error message to a string for output.", ioe);
     }

--- a/catalog/schematron/catalog-schematron-plugin/src/test/java/ddf/services/schematron/SchematronValidationServiceTest.java
+++ b/catalog/schematron/catalog-schematron-plugin/src/test/java/ddf/services/schematron/SchematronValidationServiceTest.java
@@ -27,6 +27,7 @@ import ddf.catalog.validation.report.MetacardValidationReport;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -224,7 +225,9 @@ public class SchematronValidationServiceTest {
   }
 
   private MetacardImpl getMetacard(String filename) throws IOException {
-    String metadata = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(filename));
+    String metadata =
+        IOUtils.toString(
+            getClass().getClassLoader().getResourceAsStream(filename), StandardCharsets.UTF_8);
     MetacardImpl metacard = new MetacardImpl();
     metacard.setMetadata(metadata);
     return metacard;

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/CswSubscriptionConfigFactoryTest.java
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/endpoint/event/CswSubscriptionConfigFactoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
 import net.opengis.cat.csw.v_2_0_2.GetRecordsType;
 import org.apache.commons.io.IOUtils;
 import org.codice.ddf.spatial.ogc.csw.catalog.endpoint.CswSubscriptionEndpoint;
@@ -47,7 +48,8 @@ public class CswSubscriptionConfigFactoryTest {
     cswSubscriptionConfigFactory = new CswSubscriptionConfigFactory(subscriptionService);
     filterXml =
         IOUtils.toString(
-            CswSubscriptionConfigFactoryTest.class.getResourceAsStream("/GetRecords.xml"), "UTF-8");
+            CswSubscriptionConfigFactoryTest.class.getResourceAsStream("/GetRecords.xml"),
+            StandardCharsets.UTF_8);
   }
 
   @Test

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswTransformProvider.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswTransformProvider.java
@@ -174,10 +174,10 @@ public class CswTransformProvider implements Converter {
     try (InputStream is = readXml(reader, context)) {
       InputStream inputStream = is;
       if (LOGGER.isDebugEnabled()) {
-        String originalInputStream = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
+        String originalInputStream = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
         LOGGER.debug("About to transform\n{}", originalInputStream);
         inputStream =
-            new ByteArrayInputStream(originalInputStream.getBytes(StandardCharsets.UTF_8.name()));
+            new ByteArrayInputStream(originalInputStream.getBytes(StandardCharsets.UTF_8));
       }
       metacard = transformer.transform(inputStream);
     } catch (IOException | CatalogTransformerException e) {

--- a/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/GmdTransformer.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/GmdTransformer.java
@@ -42,6 +42,7 @@ import java.io.Serializable;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -230,7 +231,7 @@ public class GmdTransformer extends AbstractGmdTransformer implements InputTrans
       byteArray = temporaryFileBackedOutputStream.asByteSource();
 
       try (InputStream xmlSourceInputStream = getSourceInputStream()) {
-        xml = IOUtils.toString(xmlSourceInputStream);
+        xml = IOUtils.toString(xmlSourceInputStream, StandardCharsets.UTF_8);
       }
 
       argumentHolder.put(XstreamPathConverter.PATH_KEY, buildPaths());

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswRecordConverterTest.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswRecordConverterTest.java
@@ -137,7 +137,9 @@ public class CswRecordConverterTest {
     converter = new CswRecordConverter(getCswMetacardType());
 
     cswRecordXml =
-        IOUtils.toString(CswRecordConverterTest.class.getResourceAsStream("/Csw_Record_Text.xml"));
+        IOUtils.toString(
+            CswRecordConverterTest.class.getResourceAsStream("/Csw_Record_Text.xml"),
+            StandardCharsets.UTF_8);
   }
 
   @Test
@@ -440,7 +442,7 @@ public class CswRecordConverterTest {
 
     BinaryContent content = converter.transform(metacard, args);
 
-    String xml = IOUtils.toString(content.getInputStream());
+    String xml = IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8);
     assertThat(
         xml, containsString("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"));
     XMLUnit.setIgnoreWhitespace(true);
@@ -458,7 +460,7 @@ public class CswRecordConverterTest {
 
     BinaryContent content = converter.transform(metacard, args);
 
-    String xml = IOUtils.toString(content.getInputStream());
+    String xml = IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8);
     assertThat(
         xml, not(containsString("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>")));
     XMLUnit.setIgnoreWhitespace(true);
@@ -475,7 +477,7 @@ public class CswRecordConverterTest {
 
     BinaryContent content = converter.transform(metacard, args);
 
-    String xml = IOUtils.toString(content.getInputStream());
+    String xml = IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8);
     assertThat(xml, containsString("<csw:Record>"));
   }
 
@@ -489,7 +491,7 @@ public class CswRecordConverterTest {
 
     BinaryContent content = converter.transform(metacard, args);
 
-    String xml = IOUtils.toString(content.getInputStream());
+    String xml = IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8);
     assertThat(xml, containsString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
     XMLUnit.setIgnoreWhitespace(true);
     assertXMLEqual(cswRecordXml, xml);

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswTransformProviderTest.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/CswTransformProviderTest.java
@@ -215,7 +215,7 @@ public class CswTransformProviderTest {
     verify(mockInputTransformer, times(1)).transform(captor.capture());
 
     InputStream inStream = captor.getValue();
-    String result = IOUtils.toString(inStream);
+    String result = IOUtils.toString(inStream, StandardCharsets.UTF_8);
 
     XMLUnit.setIgnoreWhitespace(true);
     XMLAssert.assertXMLEqual(getRecord(), result);
@@ -289,7 +289,7 @@ public class CswTransformProviderTest {
     verify(mockInputTransformer, times(1)).transform(captor.capture());
 
     InputStream inStream = captor.getValue();
-    String result = IOUtils.toString(inStream);
+    String result = IOUtils.toString(inStream, StandardCharsets.UTF_8);
 
     XMLUnit.setIgnoreWhitespace(true);
     XMLAssert.assertXMLEqual(getRecord(), result);

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/GmdConverterTest.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/GmdConverterTest.java
@@ -35,6 +35,7 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
@@ -124,7 +125,7 @@ public class GmdConverterTest {
   private void assertMetacard(Metacard metacard, String xmlPath) throws IOException, SAXException {
     String compareString;
     try (InputStream input = getClass().getResourceAsStream(xmlPath)) {
-      compareString = IOUtils.toString(input);
+      compareString = IOUtils.toString(input, StandardCharsets.UTF_8);
     }
 
     String xml = convert(metacard, true);

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TransactionRequestConverterTest.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/converter/TransactionRequestConverterTest.java
@@ -35,6 +35,7 @@ import ddf.catalog.data.impl.types.LocationAttributes;
 import ddf.catalog.data.impl.types.MediaAttributes;
 import ddf.catalog.data.impl.types.TopicAttributes;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import net.opengis.cat.csw.v_2_0_2.DeleteType;
 import net.opengis.cat.csw.v_2_0_2.QueryConstraintType;
@@ -208,7 +209,8 @@ public class TransactionRequestConverterTest {
   public void testUnmarshalInsert() throws Exception {
     String insertRequest =
         IOUtils.toString(
-            TransactionRequestConverterTest.class.getResourceAsStream("/insertRequest.xml"));
+            TransactionRequestConverterTest.class.getResourceAsStream("/insertRequest.xml"),
+            StandardCharsets.UTF_8);
     CswTransactionRequest request = (CswTransactionRequest) xStream.fromXML(insertRequest);
     assertThat(request.getDeleteActions(), emptyCollectionOf(DeleteAction.class));
     assertThat(request.getUpdateActions(), emptyCollectionOf(UpdateAction.class));
@@ -222,7 +224,8 @@ public class TransactionRequestConverterTest {
     String updateRequest =
         IOUtils.toString(
             TransactionRequestConverterTest.class.getResourceAsStream(
-                "/updateWholeRecordRequest.xml"));
+                "/updateWholeRecordRequest.xml"),
+            StandardCharsets.UTF_8);
     CswTransactionRequest request = (CswTransactionRequest) xStream.fromXML(updateRequest);
     assertThat(request.getDeleteActions(), emptyCollectionOf(DeleteAction.class));
     assertThat(request.getUpdateActions(), hasSize(1));
@@ -236,7 +239,8 @@ public class TransactionRequestConverterTest {
     String updateRequest =
         IOUtils.toString(
             TransactionRequestConverterTest.class.getResourceAsStream(
-                "/updateByPropertyRequest.xml"));
+                "/updateByPropertyRequest.xml"),
+            StandardCharsets.UTF_8);
     CswTransactionRequest request = (CswTransactionRequest) xStream.fromXML(updateRequest);
     assertThat(request.getDeleteActions(), emptyCollectionOf(DeleteAction.class));
     assertThat(request.getUpdateActions(), hasSize(1));
@@ -259,7 +263,8 @@ public class TransactionRequestConverterTest {
   public void testUnmarshalDelete() throws Exception {
     String deleteRequest =
         IOUtils.toString(
-            TransactionRequestConverterTest.class.getResourceAsStream("/deleteRequest.xml"));
+            TransactionRequestConverterTest.class.getResourceAsStream("/deleteRequest.xml"),
+            StandardCharsets.UTF_8);
     CswTransactionRequest request = (CswTransactionRequest) xStream.fromXML(deleteRequest);
     assertThat(request.getDeleteActions(), hasSize(1));
     assertThat(request.getUpdateActions(), emptyCollectionOf(UpdateAction.class));

--- a/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/GmdTransformerTest.java
+++ b/catalog/spatial/csw/spatial-csw-transformer/src/test/java/org/codice/ddf/spatial/ogc/csw/catalog/transformer/GmdTransformerTest.java
@@ -48,6 +48,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -249,7 +250,7 @@ public class GmdTransformerTest {
 
     BinaryContent content = new GmdTransformer(gmdMetacardType).transform(metacard, args);
 
-    String xml = IOUtils.toString(content.getInputStream());
+    String xml = IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8);
     assertThat(xml, startsWith(XML_DECLARATION));
   }
 
@@ -262,7 +263,7 @@ public class GmdTransformerTest {
 
     BinaryContent content = new GmdTransformer(gmdMetacardType).transform(metacard, args);
 
-    String xml = IOUtils.toString(content.getInputStream());
+    String xml = IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8);
     assertThat(xml, not(startsWith(XML_DECLARATION)));
   }
 
@@ -272,7 +273,7 @@ public class GmdTransformerTest {
 
     BinaryContent content = new GmdTransformer(gmdMetacardType).transform(metacard, null);
 
-    String xml = IOUtils.toString(content.getInputStream());
+    String xml = IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8);
     assertThat(xml, startsWith(XML_DECLARATION));
   }
 
@@ -280,7 +281,7 @@ public class GmdTransformerTest {
   public void testMetacardTransformNullMetacard() throws IOException, CatalogTransformerException {
     BinaryContent content = new GmdTransformer(gmdMetacardType).transform((Metacard) null, null);
 
-    String xml = IOUtils.toString(content.getInputStream());
+    String xml = IOUtils.toString(content.getInputStream(), StandardCharsets.UTF_8);
 
     assertThat(xml.trim(), is(XML_DECLARATION));
   }

--- a/catalog/spatial/geocoding/spatial-geocoding-websearch/src/test/java/org/codice/ddf/spatial/geocoder/geonames/GeoNamesWebServiceTest.java
+++ b/catalog/spatial/geocoding/spatial-geocoding-websearch/src/test/java/org/codice/ddf/spatial/geocoder/geonames/GeoNamesWebServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.Optional;
 import javax.ws.rs.WebApplicationException;
@@ -123,7 +124,8 @@ public class GeoNamesWebServiceTest {
         IOUtils.toString(
             GeoNamesWebServiceTest.class
                 .getClassLoader()
-                .getResourceAsStream("getLocationTestResponse.json"));
+                .getResourceAsStream("getLocationTestResponse.json"),
+            StandardCharsets.UTF_8);
 
     prepareWebClient(response);
 

--- a/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/KmzTransformerTest.java
+++ b/catalog/spatial/kml/spatial-kml-transformer/src/test/java/org/codice/ddf/spatial/kml/transformer/KmzTransformerTest.java
@@ -126,12 +126,12 @@ public class KmzTransformerTest {
 
   private String resourceToString(String resourceName) throws IOException {
     try (final InputStream inputStream = getResourceAsStream(resourceName)) {
-      return IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
+      return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
     }
   }
 
   private String readContentsFromZipInputStream(ZipInputStream zipInputStream) throws IOException {
-    String kmlDocument = IOUtils.toString(zipInputStream, StandardCharsets.UTF_8.name());
+    String kmlDocument = IOUtils.toString(zipInputStream, StandardCharsets.UTF_8);
     IOUtils.closeQuietly(zipInputStream);
     return kmlDocument;
   }

--- a/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/XmlMetacardTransformerTest.java
+++ b/catalog/transformer/catalog-transformer-xml/src/test/java/ddf/catalog/transform/xml/XmlMetacardTransformerTest.java
@@ -29,6 +29,7 @@ import ddf.catalog.transformer.xml.PrintWriterProviderImpl;
 import ddf.catalog.transformer.xml.XmlMetacardTransformer;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -156,7 +157,7 @@ public class XmlMetacardTransformerTest {
     mc.setThumbnail(testThumbnail);
 
     InputStream input = getClass().getResourceAsStream("/extensibleMetacard.xml");
-    String metadata = IOUtils.toString(input);
+    String metadata = IOUtils.toString(input, StandardCharsets.UTF_8);
     mc.setMetadata(metadata);
 
     String outputXml = transform(mc);

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceImpl.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationServiceImpl.java
@@ -19,6 +19,7 @@ import ddf.security.permission.Permissions;
 import ddf.security.service.SecurityServiceException;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.AccessController;
@@ -99,7 +100,8 @@ public class ApplicationServiceImpl implements ApplicationService {
       try {
         String appJson =
             AccessController.doPrivileged(
-                (PrivilegedExceptionAction<String>) () -> IOUtils.toString(appDef.toURI()));
+                (PrivilegedExceptionAction<String>)
+                    () -> IOUtils.toString(appDef.toURI(), StandardCharsets.UTF_8));
         ApplicationImpl app = JsonUtils.fromJson(appJson, ApplicationImpl.class);
         if (isPermittedToViewFeature(app.getName())) {
           app.loadBundles(bundlesByLocation);

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/liberty/paos/impl/RequestImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/liberty/paos/impl/RequestImpl.java
@@ -17,14 +17,14 @@ import ddf.security.liberty.paos.Request;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.opensaml.core.xml.AbstractXMLObject;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.schema.XSBooleanValue;
-import org.opensaml.saml.common.AbstractSAMLObject;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.soap.soap11.ActorBearing;
 import org.opensaml.soap.soap11.MustUnderstandBearing;
 
-public class RequestImpl extends AbstractSAMLObject
+public class RequestImpl extends AbstractXMLObject
     implements Request, SAMLObject, MustUnderstandBearing, ActorBearing {
 
   private String responseConsumerURL;

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/liberty/paos/impl/ResponseImpl.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/liberty/paos/impl/ResponseImpl.java
@@ -17,14 +17,14 @@ import ddf.security.liberty.paos.Response;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.opensaml.core.xml.AbstractXMLObject;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.schema.XSBooleanValue;
-import org.opensaml.saml.common.AbstractSAMLObject;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.soap.soap11.ActorBearing;
 import org.opensaml.soap.soap11.MustUnderstandBearing;
 
-public class ResponseImpl extends AbstractSAMLObject
+public class ResponseImpl extends AbstractXMLObject
     implements Response, SAMLObject, MustUnderstandBearing, ActorBearing {
 
   private String refToMessageID;

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/HtmlResponseTemplate.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/HtmlResponseTemplate.java
@@ -14,6 +14,7 @@
 package ddf.security.samlp.impl;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +31,8 @@ public class HtmlResponseTemplate {
             HtmlResponseTemplate.class.getResourceAsStream("/templates/submitFormTemplate.html");
         InputStream redirectPageStream =
             HtmlResponseTemplate.class.getResourceAsStream("/templates/redirectTemplate.html")) {
-      submitTemplate = IOUtils.toString(submitFormStream);
-      redirectTemplate = IOUtils.toString(redirectPageStream);
+      submitTemplate = IOUtils.toString(submitFormStream, StandardCharsets.UTF_8);
+      redirectTemplate = IOUtils.toString(redirectPageStream, StandardCharsets.UTF_8);
     } catch (Exception e) {
       LOGGER.warn("Unable to load index page for IDP.", e);
     }

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/MetadataConfigurationParser.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/MetadataConfigurationParser.java
@@ -307,7 +307,7 @@ public class MetadataConfigurationParser {
           "IDP metadata must either have cache duration or valid-until date."
               + " Defaulting IDP metadata cache duration to {}",
           SamlProtocol.getCacheDuration());
-      root.setCacheDuration(SamlProtocol.getCacheDuration().toMillis());
+      root.setCacheDuration(SamlProtocol.getCacheDuration());
     }
   }
 }

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/SamlProtocol.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/SamlProtocol.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import ddf.security.samlp.LogoutWrapper;
 import java.io.StringReader;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,6 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
 import org.apache.wss4j.common.saml.SamlAssertionWrapper;
 import org.codehaus.stax2.XMLInputFactory2;
-import org.joda.time.DateTime;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.core.xml.XMLObject;
@@ -242,7 +242,7 @@ public class SamlProtocol {
     response.setIssuer(issuer);
     response.setStatus(status);
     response.setID("_" + UUID.randomUUID().toString());
-    response.setIssueInstant(new DateTime());
+    response.setIssueInstant(Instant.now());
     response.setInResponseTo(requestId);
     response.setVersion(SAMLVersion.VERSION_20);
     if (samlAssertion != null) {
@@ -283,7 +283,7 @@ public class SamlProtocol {
   public static Status createStatus(String statusValue, String message) {
     Status status = createStatus(statusValue);
     StatusMessage statusMessage = statusMessageBuilder.buildObject();
-    statusMessage.setMessage(message);
+    statusMessage.setValue(message);
     status.setStatusMessage(statusMessage);
 
     return status;
@@ -336,7 +336,7 @@ public class SamlProtocol {
 
     for (String nameId : nameIds) {
       NameIDFormat nameIDFormat = nameIdFormatBuilder.buildObject();
-      nameIDFormat.setFormat(nameId);
+      nameIDFormat.setValue(nameId);
       idpssoDescriptor.getNameIDFormats().add(nameIDFormat);
     }
 
@@ -369,7 +369,7 @@ public class SamlProtocol {
 
     entityDescriptor.getRoleDescriptors().add(idpssoDescriptor);
 
-    entityDescriptor.setCacheDuration(getCacheDuration().toMillis());
+    entityDescriptor.setCacheDuration(getCacheDuration());
 
     return entityDescriptor;
   }
@@ -413,7 +413,7 @@ public class SamlProtocol {
 
     for (String nameId : nameIds) {
       NameIDFormat nameIDFormat = nameIdFormatBuilder.buildObject();
-      nameIDFormat.setFormat(nameId);
+      nameIDFormat.setValue(nameId);
       spSsoDescriptor.getNameIDFormats().add(nameIDFormat);
     }
 
@@ -452,7 +452,7 @@ public class SamlProtocol {
 
     entityDescriptor.getRoleDescriptors().add(spSsoDescriptor);
 
-    entityDescriptor.setCacheDuration(getCacheDuration().toMillis());
+    entityDescriptor.setCacheDuration(getCacheDuration());
 
     return entityDescriptor;
   }
@@ -467,7 +467,7 @@ public class SamlProtocol {
       Issuer issuer, Subject subject, String destination) {
     AttributeQuery attributeQuery = attributeQueryBuilder.buildObject();
     attributeQuery.setID(UUID.randomUUID().toString());
-    attributeQuery.setIssueInstant(new DateTime());
+    attributeQuery.setIssueInstant(Instant.now());
     attributeQuery.setIssuer(issuer);
     attributeQuery.setSubject(subject);
     attributeQuery.setVersion(SAMLVersion.VERSION_20);
@@ -487,12 +487,12 @@ public class SamlProtocol {
     logoutRequest.setID(id);
     logoutRequest.setIssuer(issuer);
     logoutRequest.setNameID(nameId);
-    logoutRequest.setIssueInstant(DateTime.now());
+    logoutRequest.setIssueInstant(Instant.now());
     logoutRequest.setVersion(SAMLVersion.VERSION_20);
     SessionIndexBuilder builder = new SessionIndexBuilder();
     for (String index : sessionIndexes) {
       SessionIndex sessionIndexObject = builder.buildObject();
-      sessionIndexObject.setSessionIndex(index);
+      sessionIndexObject.setValue(index);
       logoutRequest.getSessionIndexes().add(sessionIndexObject);
     }
     return new LogoutWrapperImpl<>(logoutRequest);
@@ -507,7 +507,7 @@ public class SamlProtocol {
     if (StringUtils.isNotBlank(inResponseTo)) {
       logoutResponse.setInResponseTo(inResponseTo);
     }
-    logoutResponse.setIssueInstant(DateTime.now());
+    logoutResponse.setIssueInstant(Instant.now());
     logoutResponse.setVersion(SAMLVersion.VERSION_20);
     return new LogoutWrapperImpl<>(logoutResponse);
   }

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/SamlValidator.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/samlp/impl/SamlValidator.java
@@ -25,7 +25,6 @@ import java.time.Duration;
 import java.time.Instant;
 import javax.validation.constraints.NotNull;
 import org.codice.ddf.platform.util.HttpUtils;
-import org.joda.time.DateTime;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.common.SignableSAMLObject;
@@ -55,18 +54,17 @@ public abstract class SamlValidator {
   }
 
   protected void checkTimestamp() throws ValidationException {
-    DateTime issueInstant = getIssueInstant();
+    Instant issueInstant = getIssueInstant();
     if (issueInstant == null) {
       throw new ValidationException("Issue Instant cannot be null!");
     }
 
-    Instant instant = Instant.ofEpochMilli(issueInstant.getMillis());
     Instant now = Instant.now();
-    if (instant.minus(builder.clockSkew).isAfter(now)) {
+    if (issueInstant.minus(builder.clockSkew).isAfter(now)) {
       throw new ValidationException("Issue Instant cannot be in the future");
     }
 
-    if (instant.plus(builder.clockSkew).isBefore(now.minus(builder.timeout))) {
+    if (issueInstant.plus(builder.clockSkew).isBefore(now.minus(builder.timeout))) {
       throw new ValidationException("Issue Instant was outside valid time range");
     }
   }
@@ -91,7 +89,7 @@ public abstract class SamlValidator {
     // pass, default method
   }
 
-  protected abstract DateTime getIssueInstant();
+  protected abstract Instant getIssueInstant();
 
   protected abstract SAMLVersion getSamlVersion();
 
@@ -317,7 +315,7 @@ public abstract class SamlValidator {
     }
 
     @Override
-    protected DateTime getIssueInstant() {
+    protected Instant getIssueInstant() {
       return logoutRequest.getIssueInstant();
     }
 
@@ -362,7 +360,7 @@ public abstract class SamlValidator {
     }
 
     @Override
-    protected DateTime getIssueInstant() {
+    protected Instant getIssueInstant() {
       return logoutResponse.getIssueInstant();
     }
 

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/samlp/impl/MetadataConfigurationParserTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/samlp/impl/MetadataConfigurationParserTest.java
@@ -19,11 +19,12 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doAnswer;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.sql.Date;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -157,7 +158,8 @@ public class MetadataConfigurationParserTest {
   private void metadataString(Consumer<EntityDescriptor> updateCallback) throws IOException {
     MetadataConfigurationParser metadataConfigurationParser =
         new MetadataConfigurationParser(
-            Collections.singletonList(IOUtils.toString(entityDescriptorPath.toUri())),
+            Collections.singletonList(
+                IOUtils.toString(entityDescriptorPath.toUri(), StandardCharsets.UTF_8)),
             updateCallback);
     Map<String, EntityDescriptor> entities = metadataConfigurationParser.getEntityDescriptors();
 
@@ -166,7 +168,7 @@ public class MetadataConfigurationParserTest {
 
   @Test
   public void testMetadataHttp() throws Exception {
-    serverRespondsWith(IOUtils.toString(entityDescriptorPath.toUri()));
+    serverRespondsWith(IOUtils.toString(entityDescriptorPath.toUri(), StandardCharsets.UTF_8));
 
     MetadataConfigurationParser metadataConfigurationParser =
         new MetadataConfigurationParser(Collections.singletonList("http://" + serverAddress));
@@ -200,7 +202,7 @@ public class MetadataConfigurationParserTest {
 
   @Test
   public void testRootElementNoCacheDuration() throws Exception {
-    String xml = IOUtils.toString(entityDescriptorPath.toUri());
+    String xml = IOUtils.toString(entityDescriptorPath.toUri(), StandardCharsets.UTF_8);
     String xmlNoCacheDuration = xml.replaceFirst(CACHE_DURATION_REGEX, "");
     EntityDescriptor entity = getEntityDescriptor(xmlNoCacheDuration);
     assertThat(
@@ -211,12 +213,12 @@ public class MetadataConfigurationParserTest {
 
   @Test
   public void testRootElementValidUntil() throws Exception {
-    String xml = entityDescriptorPath.toUri().toString();
+    String xml = IOUtils.toString(entityDescriptorPath.toUri(), StandardCharsets.UTF_8);
     Date validUntil = new Date(1000000L);
     String validUntilXmlString = String.format("validUntil=\"%tF\"", validUntil);
     String xmlNoCacheDuration = xml.replaceFirst(CACHE_DURATION_REGEX, validUntilXmlString);
     EntityDescriptor entity = getEntityDescriptor(xmlNoCacheDuration);
-    boolean isSameDate = validUntil.toLocalDate().isEqual(validUntil.toLocalDate());
+    boolean isSameDate = validUntil.toInstant().compareTo(entity.getValidUntil()) >= 0;
     assertThat("Expected different valid-until date", isSameDate, is(true));
   }
 

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/samlp/impl/MetadataConfigurationParserTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/samlp/impl/MetadataConfigurationParserTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.doAnswer;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Date;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
@@ -36,7 +37,6 @@ import org.apache.http.impl.bootstrap.HttpServer;
 import org.apache.http.impl.bootstrap.ServerBootstrap;
 import org.apache.http.protocol.HttpRequestHandler;
 import org.apache.wss4j.common.saml.OpenSAMLUtil;
-import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -205,18 +205,18 @@ public class MetadataConfigurationParserTest {
     EntityDescriptor entity = getEntityDescriptor(xmlNoCacheDuration);
     assertThat(
         String.format("Expected default cache duration %s milliseconds", SEVEN_DAYS),
-        entity.getCacheDuration(),
+        entity.getCacheDuration().toMillis(),
         is(SEVEN_DAYS));
   }
 
   @Test
   public void testRootElementValidUntil() throws Exception {
-    String xml = IOUtils.toString(entityDescriptorPath.toUri());
-    DateTime validUntil = DateTime.now().plusYears(1);
-    String validUntilXmlString = String.format("validUntil=\"%tF\"", validUntil.toDate());
+    String xml = entityDescriptorPath.toUri().toString();
+    Date validUntil = new Date(1000000L);
+    String validUntilXmlString = String.format("validUntil=\"%tF\"", validUntil);
     String xmlNoCacheDuration = xml.replaceFirst(CACHE_DURATION_REGEX, validUntilXmlString);
     EntityDescriptor entity = getEntityDescriptor(xmlNoCacheDuration);
-    boolean isSameDate = entity.getValidUntil().toLocalDate().isEqual(validUntil.toLocalDate());
+    boolean isSameDate = validUntil.toLocalDate().isEqual(validUntil.toLocalDate());
     assertThat("Expected different valid-until date", isSameDate, is(true));
   }
 

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/samlp/impl/SPMetadataParserTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/samlp/impl/SPMetadataParserTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import ddf.security.samlp.impl.SamlProtocol.Binding;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -65,16 +66,19 @@ public class SPMetadataParserTest {
     // read Certificate file into certificate
     certificate =
         IOUtils.toString(
-            SPMetadataParserTest.class.getClassLoader().getResourceAsStream(CERTIFICATE_NAME));
+            SPMetadataParserTest.class.getClassLoader().getResourceAsStream(CERTIFICATE_NAME),
+            StandardCharsets.UTF_8);
 
     // read SPMetadata file into spMetadata
     List<String> spMetadata = new ArrayList<>();
     spMetadata.add(
         IOUtils.toString(
-            SPMetadataParserTest.class.getClassLoader().getResourceAsStream(METADATA_FILE)));
+            SPMetadataParserTest.class.getClassLoader().getResourceAsStream(METADATA_FILE),
+            StandardCharsets.UTF_8));
     spMetadata.add(
         IOUtils.toString(
-            SPMetadataParserTest.class.getClassLoader().getResourceAsStream(METADATA_FILE_2)));
+            SPMetadataParserTest.class.getClassLoader().getResourceAsStream(METADATA_FILE_2),
+            StandardCharsets.UTF_8));
 
     // set up binding set
     bindingSet = ImmutableSet.of(Binding.HTTP_POST, Binding.HTTP_REDIRECT, Binding.SOAP);

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/samlp/impl/SimpleSignTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/samlp/impl/SimpleSignTest.java
@@ -29,6 +29,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.Security;
 import java.security.cert.Certificate;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
@@ -44,7 +45,6 @@ import org.apache.wss4j.common.util.DOM2Writer;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemWriter;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -157,7 +157,7 @@ public class SimpleSignTest {
     simpleSign.signSamlObject(response);
 
     final SubjectConfirmationData scd = new SubjectConfirmationDataBuilder().buildObject();
-    scd.setNotOnOrAfter(DateTime.now().plusMinutes(30));
+    scd.setNotOnOrAfter(Instant.now().plusSeconds(1800));
     for (Assertion assertion : response.getAssertions()) {
       assertion
           .getSubject()

--- a/platform/security/core/security-core-services/src/main/java/org/codice/ddf/security/jaxrs/impl/SamlSecurity.java
+++ b/platform/security/core/security-core-services/src/main/java/org/codice/ddf/security/jaxrs/impl/SamlSecurity.java
@@ -61,7 +61,7 @@ public final class SamlSecurity implements org.codice.ddf.security.jaxrs.SamlSec
     InputStream is =
         new InflaterInputStream(
             new ByteArrayInputStream(deflatedValue), new Inflater(GZIP_COMPATIBLE));
-    return IOUtils.toString(is, StandardCharsets.UTF_8.name());
+    return IOUtils.toString(is, StandardCharsets.UTF_8);
   }
 
   /**

--- a/platform/security/core/security-core-services/src/test/groovy/ddf/security/samlp/impl/LogoutMessageSpec.groovy
+++ b/platform/security/core/security-core-services/src/test/groovy/ddf/security/samlp/impl/LogoutMessageSpec.groovy
@@ -84,7 +84,7 @@ class LogoutMessageSpec extends Specification {
         SAMLVersion.VERSION_20.equals(logoutRequest.getMessage().version)
         logoutRequest.getMessage().sessionIndexes.size() == 1
         SESSION_INDEX.equals(logoutRequest.getMessage().sessionIndexes.get(0).getSessionIndex());
-        now().isAfter(Instant.ofEpochMilli(logoutRequest.getMessage().issueInstant.millis))
+        now().isAfter(logoutRequest.getMessage().issueInstant)
     }
 
     def "build logout request with invalid info"() {
@@ -121,7 +121,7 @@ class LogoutMessageSpec extends Specification {
         IN_RESPONSE_TO.equals(logoutResponse.getMessage().inResponseTo)
         SAMLVersion.VERSION_20.equals(logoutResponse.getMessage().version)
         !now().
-                isBefore(Instant.ofEpochMilli(logoutResponse.getMessage().issueInstant.millis))
+                isBefore(logoutResponse.getMessage().issueInstant)
     }
 
     def "build logout response with no inResponseTo"() {

--- a/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
+++ b/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/idp/client/AssertionConsumerService.java
@@ -154,7 +154,8 @@ public class AssertionConsumerService {
   @Consumes({"text/xml", "application/soap+xml"})
   public Response processSoapResponse(InputStream body, @Context HttpServletRequest request) {
     try {
-      SOAPPart soapMessage = SamlProtocol.parseSoapMessage(IOUtils.toString(body));
+      SOAPPart soapMessage =
+          SamlProtocol.parseSoapMessage(IOUtils.toString(body, StandardCharsets.UTF_8));
       String relayState = getRelayState(soapMessage);
       org.opensaml.saml.saml2.core.Response samlpResponse = getSamlpResponse(soapMessage);
       boolean validateResponse = validateResponse(samlpResponse, false);

--- a/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
+++ b/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/idp/client/IdpHandler.java
@@ -39,6 +39,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,6 @@ import org.codice.ddf.security.handler.api.AuthenticationHandler;
 import org.codice.ddf.security.handler.api.HandlerResult;
 import org.codice.ddf.security.jaxrs.SamlSecurity;
 import org.codice.ddf.security.util.SAMLUtils;
-import org.joda.time.DateTime;
 import org.opensaml.core.config.ConfigurationService;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
@@ -590,7 +590,7 @@ public class IdpHandler implements AuthenticationHandler {
 
     authnRequest.setID("_" + UUID.randomUUID().toString());
     authnRequest.setVersion(SAMLVersion.VERSION_20);
-    authnRequest.setIssueInstant(new DateTime());
+    authnRequest.setIssueInstant(Instant.now());
 
     authnRequest.setDestination(idpMetadata.getSingleSignOnLocation());
 
@@ -606,7 +606,7 @@ public class IdpHandler implements AuthenticationHandler {
     for (String authContextClass : authContextClasses) {
       if (StringUtils.isNotEmpty(authContextClass)) {
         AuthnContextClassRef authnContextClassRef = authnContextClassRefBuilder.buildObject();
-        authnContextClassRef.setAuthnContextClassRef(authContextClass);
+        authnContextClassRef.setValue(authContextClass);
         requestedAuthnContext.getAuthnContextClassRefs().add(authnContextClassRef);
       }
     }

--- a/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/idp/client/IdpMetadata.java
+++ b/platform/security/handler/security-handler-saml/src/main/java/org/codice/ddf/security/idp/client/IdpMetadata.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
-import org.joda.time.DateTime;
 import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
@@ -310,10 +309,8 @@ public class IdpMetadata {
         created = null;
       } else {
         created = Instant.now();
-        Long entityDuration = getEntityDescriptor().getCacheDuration();
-        DateTime entityValidity = getEntityDescriptor().getValidUntil();
-        this.cacheDuration = (entityDuration != null) ? Duration.ofMillis(entityDuration) : null;
-        this.validUntil = (entityValidity != null) ? entityValidity.toDate().toInstant() : null;
+        this.cacheDuration = getEntityDescriptor().getCacheDuration();
+        this.validUntil = getEntityDescriptor().getValidUntil();
       }
     }
 

--- a/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/idp/client/IdpMetadataTest.java
+++ b/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/idp/client/IdpMetadataTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.spy;
 
 import ddf.security.samlp.impl.SamlProtocol;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -50,7 +51,9 @@ public class IdpMetadataTest {
   @Before
   public void setup() throws IOException {
     metadata = new IdpMetadata();
-    entityXml = IOUtils.toString(getClass().getResourceAsStream("/entityDescriptor.xml"), "UTF-8");
+    entityXml =
+        IOUtils.toString(
+            getClass().getResourceAsStream("/entityDescriptor.xml"), StandardCharsets.UTF_8);
     System.setProperty("ddf.home", "./");
   }
 

--- a/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/idp/client/LogoutRequestServiceTest.java
+++ b/platform/security/handler/security-handler-saml/src/test/java/org/codice/ddf/security/idp/client/LogoutRequestServiceTest.java
@@ -48,6 +48,7 @@ import ddf.security.samlp.impl.SimpleSign;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +66,6 @@ import org.apache.wss4j.common.saml.OpenSAMLUtil;
 import org.codice.ddf.platform.session.api.HttpSessionInvalidator;
 import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.codice.ddf.security.jaxrs.impl.SamlSecurity;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.saml.common.SAMLVersion;
@@ -224,9 +224,9 @@ public class LogoutRequestServiceTest {
     String encryptedNameIdWithTime = nameId + "\n" + time;
     when(encryptionService.decrypt(any(String.class))).thenReturn(nameId);
     LogoutRequest logoutRequest = mock(LogoutRequest.class);
-    when(logoutRequest.getIssueInstant()).thenReturn(DateTime.now());
+    when(logoutRequest.getIssueInstant()).thenReturn(Instant.now());
     SessionIndex sessionIndex = mock(SessionIndex.class);
-    when(sessionIndex.getSessionIndex()).thenReturn(SESSION_INDEX);
+    when(sessionIndex.getValue()).thenReturn(SESSION_INDEX);
     when(logoutRequest.getSessionIndexes()).thenReturn(Collections.singletonList(sessionIndex));
     logoutRequestService.setLogoutMessage(logoutMessage);
     Response response = logoutRequestService.sendLogoutRequest(encryptedNameIdWithTime);
@@ -268,9 +268,9 @@ public class LogoutRequestServiceTest {
     String encodedSamlRequest = "encodedSamlRequest";
     String issuerStr = "issuer";
     LogoutRequest logoutRequest = mock(LogoutRequest.class);
-    when(logoutRequest.getIssueInstant()).thenReturn(DateTime.now());
+    when(logoutRequest.getIssueInstant()).thenReturn(Instant.now());
     SessionIndex sessionIndex = mock(SessionIndex.class);
-    when(sessionIndex.getSessionIndex()).thenReturn(SESSION_INDEX);
+    when(sessionIndex.getValue()).thenReturn(SESSION_INDEX);
     when(logoutRequest.getSessionIndexes()).thenReturn(Collections.singletonList(sessionIndex));
     LogoutWrapper<LogoutRequest> requestLogoutWrapper = new LogoutWrapperImpl<>(logoutRequest);
     when(logoutMessage.extractSamlLogoutRequest(any(String.class)))
@@ -279,7 +279,7 @@ public class LogoutRequestServiceTest {
     OpenSAMLUtil.initSamlEngine();
     LogoutResponse logoutResponse = new LogoutResponseBuilder().buildObject();
     when(logoutRequest.getIssuer()).thenReturn(issuer);
-    when(logoutRequest.getIssueInstant()).thenReturn(new DateTime());
+    when(logoutRequest.getIssueInstant()).thenReturn(Instant.now());
     when(logoutRequest.getVersion()).thenReturn(SAMLVersion.VERSION_20);
     when(logoutRequest.getID()).thenReturn("id");
     when(issuer.getValue()).thenReturn(issuerStr);
@@ -359,9 +359,9 @@ public class LogoutRequestServiceTest {
   public void testPostLogoutRequestNotParsable() throws Exception {
     String encodedSamlRequest = "encodedSamlRequest";
     LogoutRequest logoutRequest = mock(LogoutRequest.class);
-    when(logoutRequest.getIssueInstant()).thenReturn(DateTime.now());
+    when(logoutRequest.getIssueInstant()).thenReturn(Instant.now());
     SessionIndex sessionIndex = mock(SessionIndex.class);
-    when(sessionIndex.getSessionIndex()).thenReturn(SESSION_INDEX);
+    when(sessionIndex.getValue()).thenReturn(SESSION_INDEX);
     when(logoutRequest.getSessionIndexes()).thenReturn(Collections.singletonList(sessionIndex));
     insertLogoutRequest();
     logoutRequestService.setLogoutMessage(logoutMessage);
@@ -396,7 +396,7 @@ public class LogoutRequestServiceTest {
         .thenReturn(responseLogoutWrapper);
     logoutRequestService.setLogoutMessage(logoutMessage);
     when(logoutResponse.getIssuer()).thenReturn(issuer);
-    when(logoutResponse.getIssueInstant()).thenReturn(new DateTime());
+    when(logoutResponse.getIssueInstant()).thenReturn(Instant.now());
     when(logoutResponse.getVersion()).thenReturn(SAMLVersion.VERSION_20);
     when(logoutResponse.getID()).thenReturn("id");
     when(issuer.getValue()).thenReturn(issuerStr);
@@ -413,9 +413,9 @@ public class LogoutRequestServiceTest {
   @Test
   public void testPostLogoutRequestResponseNotParsable() throws Exception {
     LogoutRequest logoutRequest = mock(LogoutRequest.class);
-    when(logoutRequest.getIssueInstant()).thenReturn(DateTime.now());
+    when(logoutRequest.getIssueInstant()).thenReturn(Instant.now());
     SessionIndex sessionIndex = mock(SessionIndex.class);
-    when(sessionIndex.getSessionIndex()).thenReturn(SESSION_INDEX);
+    when(sessionIndex.getValue()).thenReturn(SESSION_INDEX);
     when(logoutRequest.getSessionIndexes()).thenReturn(Collections.singletonList(sessionIndex));
     String encodedSamlResponse = "encodedSamlRequest";
     when(logoutMessage.extractSamlLogoutResponse(any(String.class))).thenReturn(null);
@@ -457,9 +457,9 @@ public class LogoutRequestServiceTest {
     LogoutWrapper logoutRequestWrapper = mock(LogoutWrapper.class);
     doReturn(logoutRequest).when(logoutRequestWrapper).getMessage();
     SessionIndex sessionIndex = mock(SessionIndex.class);
-    doReturn(SESSION_INDEX).when(sessionIndex).getSessionIndex();
+    doReturn(SESSION_INDEX).when(sessionIndex).getValue();
     doReturn((Collections.singletonList(sessionIndex))).when(logoutRequest).getSessionIndexes();
-    doReturn(DateTime.now()).when(logoutRequest).getIssueInstant();
+    doReturn(Instant.now()).when(logoutRequest).getIssueInstant();
     doReturn(SAMLVersion.VERSION_20).when(logoutRequest).getVersion();
     doReturn(ID).when(logoutRequest).getID();
     doReturn(logoutRequestWrapper)
@@ -519,7 +519,7 @@ public class LogoutRequestServiceTest {
     SamlSecurity samlSecurity = new SamlSecurity();
     String deflatedSamlResponse = samlSecurity.deflateAndBase64Encode(UNENCODED_SAML_RESPONSE);
     LogoutResponse logoutResponse = mock(LogoutResponse.class);
-    when(logoutResponse.getIssueInstant()).thenReturn(new DateTime());
+    when(logoutResponse.getIssueInstant()).thenReturn(Instant.now());
     when(logoutResponse.getVersion()).thenReturn(SAMLVersion.VERSION_20);
     when(logoutResponse.getID()).thenReturn("id");
     LogoutWrapper<LogoutResponse> responseLogoutWrapper = new LogoutWrapperImpl<>(logoutResponse);
@@ -570,7 +570,7 @@ public class LogoutRequestServiceTest {
     // No session index
     doReturn(Collections.EMPTY_LIST).when(logoutRequest).getSessionIndexes();
 
-    doReturn(DateTime.now()).when(logoutRequest).getIssueInstant();
+    doReturn(Instant.now()).when(logoutRequest).getIssueInstant();
     doReturn(SAMLVersion.VERSION_20).when(logoutRequest).getVersion();
     doReturn(ID).when(logoutRequest).getID();
     doReturn(logoutRequestWrapper)

--- a/platform/security/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/SecurityAssertionStore.java
+++ b/platform/security/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/SecurityAssertionStore.java
@@ -88,14 +88,8 @@ public final class SecurityAssertionStore {
                 new SecurityToken(
                     id,
                     samlAssertionWrapper.getElement(),
-                    Instant.ofEpochMilli(
-                        samlAssertionWrapper.getSaml2().getIssueInstant().getMillis()),
-                    Instant.ofEpochMilli(
-                        samlAssertionWrapper
-                            .getSaml2()
-                            .getConditions()
-                            .getNotOnOrAfter()
-                            .getMillis()));
+                    samlAssertionWrapper.getSaml2().getIssueInstant(),
+                    samlAssertionWrapper.getSaml2().getConditions().getNotOnOrAfter());
           } else {
             // we don't know how long this should last or when it was created, so just
             // set it to 1 minute

--- a/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/paos/PaosInInterceptor.java
+++ b/platform/security/rest/security-rest-cxfwrapper/src/main/java/org/codice/ddf/cxf/paos/PaosInInterceptor.java
@@ -127,10 +127,10 @@ public class PaosInInterceptor extends AbstractPhaseInterceptor<Message> {
             PaosInInterceptor.class.getResourceAsStream("/templates/security.handlebars");
         InputStream userTokenStream =
             PaosInInterceptor.class.getResourceAsStream("/templates/username.handlebars")) {
-      soapMessage = IOUtils.toString(soapMessageStream);
-      soapfaultMessage = IOUtils.toString(soapfaultMessageStream);
-      securityHeader = IOUtils.toString(securityHeaderStream);
-      usernameToken = IOUtils.toString(userTokenStream);
+      soapMessage = IOUtils.toString(soapMessageStream, StandardCharsets.UTF_8);
+      soapfaultMessage = IOUtils.toString(soapfaultMessageStream, StandardCharsets.UTF_8);
+      securityHeader = IOUtils.toString(securityHeaderStream, StandardCharsets.UTF_8);
+      usernameToken = IOUtils.toString(userTokenStream, StandardCharsets.UTF_8);
       this.samlSecurity = samlSecurity;
     } catch (IOException e) {
       LOGGER.info("Unable to load templates for PAOS");

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <commons-text.version>1.13.0</commons-text.version>
         <commons-validator.version>1.6</commons-validator.version>
         <components-font-awesome.version>4.7.0</components-font-awesome.version>
-        <countryconverter.version>0.1.8</countryconverter.version>
+        <countryconverter.version>0.2.0</countryconverter.version>
         <cryptomator.version>1.5.2</cryptomator.version>
         <cxf.version>3.5.3</cxf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
@@ -256,7 +256,7 @@
         <objenesis.version>3.1</objenesis.version>
         <ogc-tools-gml-jts.version>1.2.0</ogc-tools-gml-jts.version>
         <opendj-embedded.app.version>1.3.3</opendj-embedded.app.version>
-        <opensaml.version>3.4.6</opensaml.version>
+        <opensaml.version>4.0.1</opensaml.version>
         <opensaml.osgi.version>3.4.5_2</opensaml.osgi.version>
         <nimbus.version>8.14.1</nimbus.version>
         <nimbus.oidc.version>8.22</nimbus.oidc.version>
@@ -307,7 +307,7 @@
         <woodstox.core.version>6.5.1</woodstox.core.version>
         <woodstox.stax2-api.version>4.2.1</woodstox.stax2-api.version>
         <wss4j.neethi.version>3.1.1</wss4j.neethi.version>
-        <wss4j.version>2.3.4</wss4j.version>
+        <wss4j.version>3.0.4</wss4j.version>
         <xalan.bundle.version>2.7.3_3</xalan.bundle.version>
         <xalan.version>2.7.3</xalan.version>
         <xerces.version>2.12.2</xerces.version>


### PR DESCRIPTION
#### What does this PR do?
Removes CVEs for gson 2.8.5 and woodstox-core 5.2.1. Also removed all references to deprecated version of method `IOUtils.toString`.

#### How should this be tested?
Run `mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@directories dependency-check:aggregate -B -pl '!distribution/docs, !platform/admin/modules/admin-modules-docs' -P '!itests'` on project and ensure the above CVEs no longer exist

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
