### PR TITLE
[2.29.x] Removed mime4j transitive dependency from abdera-extensions-geo to resolve CVEs

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -151,6 +151,12 @@
                 <groupId>org.apache.abdera</groupId>
                 <artifactId>abdera-extensions-geo</artifactId>
                 <version>${abdera.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.james</groupId>
+                        <artifactId>apache-mime4j-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>ddf.mime.core</groupId>

--- a/catalog/transformer/pom.xml
+++ b/catalog/transformer/pom.xml
@@ -63,11 +63,6 @@
                 <artifactId>abdera-extensions-opensearch</artifactId>
                 <version>${abdera.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.abdera</groupId>
-                <artifactId>abdera-extensions-geo</artifactId>
-                <version>${abdera.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <modules>


### PR DESCRIPTION
#### What does this PR do?
Removes mime4j 0.7.2 transitive dependency which causes CVE.

#### How should this be tested?
Run `mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@directories dependency-check:aggregate -B -pl '!distribution/docs, !platform/admin/modules/admin-modules-docs' -P '!itests'` on project and ensure that mime4j 0.7.2 does not show up in CVE list.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
