### PR TITLE
[2.29.x] Remove openjson dependency

### DIFF
--- a/features/utilities/pom.xml
+++ b/features/utilities/pom.xml
@@ -142,11 +142,6 @@
             <version>${zstd-jni.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.openjson</groupId>
-            <artifactId>openjson</artifactId>
-            <version>${openjson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>net.sf.jwordnet</groupId>
             <artifactId>jwnl</artifactId>
             <version>${jwnl.version}</version>

--- a/features/utilities/src/main/feature/feature.xml
+++ b/features/utilities/src/main/feature/feature.xml
@@ -190,7 +190,6 @@
         <feature prerequisite="true">wrap</feature>
         <feature>jackson</feature>
         <bundle>mvn:com.github.luben/zstd-jni/${zstd-jni.version}</bundle>
-        <bundle>mvn:com.github.openjson/openjson/${openjson.version}</bundle>
         <bundle>wrap:mvn:net.sf.jwordnet/jwnl/${jwnl.version}</bundle>
         <bundle>mvn:org.apache.tika/tika-core/${tika.version}</bundle>
         <bundle>mvn:org.apache.tika/tika-bundle-standard/${tika.version}</bundle>


### PR DESCRIPTION
#### What does this PR do?
Tika-parsers 2.4.0 no longer has the openjson runtime dependency (1.28.4 that we were previously using did) so that bundle can be removed from the feature and thus remove the related CVEs
ref: https://mvnrepository.com/artifact/org.apache.tika/tika-parsers/


#### Who is reviewing it? 
@glenhein @zkirksey @jlcsmith 

#### How should this be tested?
Start DDF and test Tika 
Run mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@directories dependency-check:aggregate -B -pl '!distribution/docs, !platform/admin/modules/admin-modules-docs' -P '!itests' on project and ensure that zookeeper does not show up in CVE list.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
