### PR TITLE
[2.29.x] Fixes failed xlsx transforms due to incorrect xml beans version

### DIFF
--- a/features/utilities/src/main/feature/feature.xml
+++ b/features/utilities/src/main/feature/feature.xml
@@ -211,7 +211,7 @@
         <feature dependency="true">apache-commons</feature>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_5</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.saxon/9.9.1-6_1</bundle>
-        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlbeans/3.1.0_2</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlbeans/${xmlbeans.version}_1</bundle>
         <bundle>mvn:commons-io/commons-io/${commons-io.version}</bundle>
         <bundle>mvn:org.apache.commons/commons-math3/${commons-math3.version}</bundle>
         <bundle>mvn:org.apache.commons/commons-compress/${commons-compress.version}</bundle>


### PR DESCRIPTION
#### What does this PR do?
Xlsx tranformer was failing due to an missing/incorrect xmlbeans dependency.  The xmlbeans version was updated from 3.1.0 to 5.0.3 but the feature file containing the bundle version of xmlbeans was not updated accordingly.   

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 
@codice/build 

#### Ask 2 committers to review/merge the PR and tag them here.
@pklinef 
@derekwilhelm 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
