### PR TITLE
[2.29.x] Change deleted metacards to use known IDs

### DIFF
--- a/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
+++ b/catalog/core/catalog-core-metacardgroomerplugin/src/main/java/ddf/catalog/plugin/groomer/metacard/StandardMetacardGroomerPlugin.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.Date;
 import java.util.Map.Entry;
+import org.apache.commons.lang3.StringUtils;
 import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,8 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
   protected void applyCreatedOperationRules(
       CreateRequest createRequest, Metacard aMetacard, Date now) {
     LOGGER.debug("Applying standard rules on CreateRequest");
-    if ((aMetacard.getResourceURI() != null && !isCatalogResourceUri(aMetacard.getResourceURI()))
+    if ((isValidResourceUri(aMetacard.getResourceURI())
+            && !isCatalogResourceUri(aMetacard.getResourceURI()))
         || !uuidGenerator.validateUuid(aMetacard.getId())) {
       if (isPreferenceMetacard(aMetacard)) {
         String userId = (String) aMetacard.getAttribute(USER_ATTRIBUTE).getValue();
@@ -81,6 +83,10 @@ public class StandardMetacardGroomerPlugin extends AbstractMetacardGroomerPlugin
 
     aMetacard.setAttribute(new AttributeImpl(Core.METACARD_MODIFIED, now));
     logMetacardAttributeUpdate(aMetacard, Core.METACARD_MODIFIED, now);
+  }
+
+  private boolean isValidResourceUri(URI uri) {
+    return uri != null && StringUtils.isNotBlank(uri.toString());
   }
 
   private boolean isCatalogResourceUri(URI uri) {

--- a/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-standardframework/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -34,6 +34,8 @@
     <OCD name="Historian" id="ddf.catalog.history.Historian">
         <AD name="Enable Versioning" id="historyEnabled" type="Boolean" default="true"
             description="Enables versioning of both metacards and content."/>
+        <AD name="Use Known IDs for deleted metacards" id="useKnownIdForDeletes" type="Boolean" default="true"
+            description="Enables deleted metacards to use known UUID generation for their IDs"/>
     </OCD>
 
     <OCD name="Status Source Poller Runner" id="org.codice.ddf.catalog.sourcepoller.StatusSourcePollerRunner">


### PR DESCRIPTION
#### What does this PR do?

This PR changes how deleted metacard IDs are generated.  Since deleted metacards are meant to be singletons, the Historian has been changed to use a known ID (using the known ID function in the UuidGenerator api) for deleted metacards.  This ensures that the same ID is used for each and not allowing multiple deleted metacards to exist for the same metacard.  A configuration item was also added so that this capability could be turned off and the functionality returned to the way it has always been before if a deployment doesn't want to enable this capability.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 

@codice/data 


#### Ask 2 committers to review/merge the PR and tag them here.

@glenhein 
@jlcsmith


#### How should this be tested?
<!--(List steps with links to updated documentation)-->

1. Create a metacard of any type that is versioned
2. Delete the metacard and verify the deleted metacard is added to solr and note the metacard ID
3. Restore/revert the metacard and verify the original ID for the deleted data is used as expected
4. Delete the metacard again and verify the deleted metacard is added to solr
5. Check the ID for the latest deleted metacard and verify that it is the same ID that was used before

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
