### PR TITLE
[2.29.x] Set processing details when WFS sorting is disabled

### DIFF
--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/src/main/java/org/codice/ddf/spatial/ogc/wfs/v110/catalog/source/WfsSource.java
@@ -859,8 +859,7 @@ public class WfsSource extends AbstractWfsSource {
           if (areAnyFiltersSet(filter)) {
             wfsQuery.setFilter(filter);
           }
-          if (!this.disableSorting
-              && query.getSortBy() != null
+          if (query.getSortBy() != null
               && query.getSortBy().getPropertyName() != null
               && query.getSortBy().getPropertyName().getPropertyName() != null) {
             setSortBy(query.getSortBy(), filterDelegateEntry.getKey(), wfsQuery, details);

--- a/catalog/transformer/catalog-transformer-overlay/src/main/java/ddf/catalog/transformer/OverlayActionProvider.java
+++ b/catalog/transformer/catalog-transformer-overlay/src/main/java/ddf/catalog/transformer/OverlayActionProvider.java
@@ -26,6 +26,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.locationtech.jts.geom.Geometry;
@@ -110,8 +111,11 @@ public class OverlayActionProvider implements ActionProvider {
   private boolean canHandleMetacard(Metacard metacard) {
     final String wkt = metacard.getLocation();
     try {
-      final Geometry geometry = GeometryUtils.parseGeometry(wkt);
-      return GeometryUtils.canHandleGeometry(geometry) && hasOverlay.test(metacard);
+      if (StringUtils.isNotEmpty(wkt)) {
+        final Geometry geometry = GeometryUtils.parseGeometry(wkt);
+        return GeometryUtils.canHandleGeometry(geometry) && hasOverlay.test(metacard);
+      }
+      return false;
     } catch (CatalogTransformerException e) {
       LOGGER.debug("Cannot parse this metacard's geometry [wkt = {}]", wkt, e);
       return false;


### PR DESCRIPTION
#### What does this PR do?
Forward ports a missing line from this [PR](https://github.com/codice/ddf/pull/6751/files#diff-9d159d4abec701db1c9737de8745bf74ee320e17d84d8b638942c2ac47a9e736) which sets processing details when a WFS source has sorting disabled.

Also, the OverlayActionProvider was throwing an NPE when a metacard didn't have a WKT. I added a check for this.

#### Who is reviewing it? 
@glenhein 
@alexabird 

#### Ask 2 committers to review/merge the PR and tag them here.
@glenhein 
@alexabird 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
