### PR TITLE
[2.29.x] Only specify garbage collection options when starting DDF

### DIFF
--- a/distribution/ddf-common/src/main/resources/bin/ddf
+++ b/distribution/ddf-common/src/main/resources/bin/ddf
@@ -16,6 +16,10 @@ PROPERTIES_FILE=$HOME_DIR/etc/custom.system.properties
 RESTART_FILE="$SCRIPTDIR/restart.jvm"
 GET=${SCRIPTDIR}/get_property
 
+# Defines java garbage collection logging options
+EXTRA_JAVA_OPTS="-Xlog:gc*=info:file=${HOME_DIR}/data/log/gc.log:time,uptime,level,tags:filecount=9,filesize=20m"
+export EXTRA_JAVA_OPTS
+
 # Return 0 (success/true) if a restart.jvm file was created to request a restart
 is_restarting() {
     local RC=1

--- a/distribution/ddf-common/src/main/resources/bin/ddf.bat
+++ b/distribution/ddf-common/src/main/resources/bin/ddf.bat
@@ -9,6 +9,9 @@ POPD
 
 SET GET_PROPERTY=%DIRNAME%get_property.bat
 
+REM Java garbage collection logging options
+SET EXTRA_JAVA_OPTS=-Xlog:gc*=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=9,filesize=20m
+
 REM Exit if JAVA_HOME or JRE_HOME is not set
 IF "%JAVA_HOME%" == "" IF "%JRE_HOME%" == ""  (
     ECHO JAVA_HOME nor JRE_HOME is set. Set JAVA_HOME or JRE_HOME to proceed - exiting.

--- a/distribution/ddf-common/src/main/resources/bin/setenv
+++ b/distribution/ddf-common/src/main/resources/bin/setenv
@@ -87,9 +87,6 @@ export DDF_ON_ERROR="bin/ddf_on_error.sh script "
 # Defines the special on-error Java options
 JAVA_ERROR_OPTS="-XX:OnOutOfMemoryError=\${DDF_ON_ERROR}%p -XX:OnError=\${DDF_ON_ERROR}%p"
 
-# Defines java garbage collection logging options
-GC_OPTS="-Xlog:gc*=info:file=${DDF_HOME}/data/log/gc.log:time,uptime,level,tags:filecount=9,filesize=20m"
-
 export KARAF_OPTS="-Dfile.encoding=UTF8"
 
-export JAVA_OPTS="-Xms2g -Xmx6g -XX:+UnlockDiagnosticVMOptions -Dddf.home=${DDF_HOME} -Dddf.home.perm=${DDF_HOME}/ -XX:+DisableAttachMechanism $JAVA_ERROR_OPTS $GC_OPTS --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.desktop/java.awt.font=ALL-UNNAMED"
+export JAVA_OPTS="-Xms2g -Xmx6g -XX:+UnlockDiagnosticVMOptions -Dddf.home=${DDF_HOME} -Dddf.home.perm=${DDF_HOME}/ -XX:+DisableAttachMechanism $JAVA_ERROR_OPTS --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.desktop/java.awt.font=ALL-UNNAMED"

--- a/distribution/ddf-common/src/main/resources/bin/setenv.bat
+++ b/distribution/ddf-common/src/main/resources/bin/setenv.bat
@@ -83,6 +83,5 @@ rem Defines the special on-error Java options
 rem set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR%%%p -XX:OnError=%DDF_ON_ERROR%%%p
 set JAVA_ERROR_OPTS=-XX:OnOutOfMemoryError=%DDF_ON_ERROR% -XX:OnError=%DDF_ON_ERROR%
 set KARAF_OPTS=-Dfile.encoding=UTF8
-rem Java garbage collection logging options
-set GC_OPTS=-Xlog:gc*=info:file=\"%DDF_HOME%data/log/gc.log\":time,uptime,level,tags:filecount=9,filesize=20m 
+
 set JAVA_OPTS=-Xms2g -Xmx6g -Dderby.system.home="%DDF_HOME%\data\derby" -Dderby.storage.fileSyncTransactionLog=true -Dfile.encoding=UTF8 -Dddf.home=%DDF_HOME% -Dddf.home.perm=%DDF_HOME_PERM% -XX:+DisableAttachMechanism %JAVA_ERROR_OPTS% %GC_OPTS%


### PR DESCRIPTION
#### What does this PR do?
Only specify garbage collection options when starting DDF

#### Who is reviewing it? 
@derekwilhelm 
@zkirksey 

#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith 
@glenhein 

#### How should this be tested?
Verify starting DDF has the GC options, while just accessing the karaf client does not

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
