### PR TITLE
[2.29.x] Adds strict transport security header to responses

### DIFF
--- a/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ResponseFilter.java
+++ b/platform/platform-paxweb-jettyconfig/src/main/java/org/codice/ddf/pax/web/jetty/ResponseFilter.java
@@ -47,11 +47,16 @@ public class ResponseFilter implements HttpFilter {
   // Arbitrarily chose one week as a reasonable default. 604800 is one week in seconds.
   public static final String DEFAULT_CACHE_CONTROL_VALUE = "private, max-age=604800, immutable";
 
+  public static final String STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
+  public static final String STRICT_TRANSPORT_SECURITY_VALUE =
+      "max-age=31536000 ; includeSubDomains";
+
   private List<String> headers =
       Arrays.asList(
           X_XSS_PROTECTION + "=" + DEFAULT_XSS_PROTECTION_VALUE,
           X_FRAME_OPTIONS + "=" + DEFAULT_X_FRAME_OPTIONS_VALUE,
           X_CONTENT_SECURITY_POLICY + "=" + DEFAULT_CONTENT_SECURITY_POLICY,
+          STRICT_TRANSPORT_SECURITY + "=" + STRICT_TRANSPORT_SECURITY_VALUE,
           CACHE_CONTROL + "=" + DEFAULT_CACHE_CONTROL_VALUE);
 
   // Index paths (such as /search/catalog/ or /admin/) should never be cached


### PR DESCRIPTION
#### What does this PR do?
Adds the Strict-Transport-Security response header.  See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

Verified that the response header is showing up after this change when hitting the DDF REST endpoint:
![image](https://github.com/user-attachments/assets/147d22ba-e790-4140-a5cc-75a145b2e8a8)


#### Who is reviewing it? 
@derekwilhelm 
@alexabird 

#### Select relevant component teams: 
@codice/security 


#### Ask 2 committers to review/merge the PR and tag them here.
@derekwilhelm 
@alexabird 

#### How should this be tested?

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
