### PR TITLE
[2.29.x] Include spifly with jetty-extras

### DIFF
--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -66,6 +66,7 @@
                                 <descriptor>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/specs/${karaf.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.apache.karaf.decanter/apache-karaf-decanter/${decanter.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.ops4j.pax.web/pax-web-features/${pax.web.version}/xml/features</descriptor>
 

--- a/features/solr/src/main/feature/feature.xml
+++ b/features/solr/src/main/feature/feature.xml
@@ -19,7 +19,7 @@
     <repository>mvn:org.ops4j.pax.web/pax-web-features/${pax.web.version}/xml/features</repository>
 
     <feature name="solr-dependencies" version="${project.version}" >
-        <feature>pax-web-jetty</feature>
+        <feature>pax-web-jetty-extras</feature>
         <bundle>mvn:org.eclipse.jetty/jetty-client/${solr.jetty.version}</bundle>
         <bundle>mvn:org.eclipse.jetty/jetty-alpn-client/${solr.jetty.version}</bundle>
         <bundle>mvn:org.eclipse.jetty/jetty-alpn-java-client/${solr.jetty.version}</bundle>


### PR DESCRIPTION
#### What does this PR do?
The upgraded pax-web feature file is structured in a way that `spifly` and `asm` are no longer started with the `pax-web-core` or `pax-web-jetty`, instead 
#### Who is reviewing it? 
@stevenmalmgren 
@glenhein 
#### Select relevant component teams: 
@codice/build 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.
@jlcsmith 
@derekwilhelm 

#### How should this be tested?
<!--(List steps with links to updated documentation)-->

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
