### PR TITLE
[2.29.x] Websocket updates

### DIFF
--- a/platform/security/servlet/security-servlet-web-socket-api/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
+++ b/platform/security/servlet/security-servlet-web-socket-api/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
@@ -61,6 +61,7 @@ public class SecureWebSocketServlet implements WebSocketCreator {
     return new SocketWrapper(executor, ws, sessionPlugins, servletUpgradeRequest.getSession());
   }
 
+  @org.eclipse.jetty.websocket.api.annotations.WebSocket
   public static class SocketWrapper {
 
     private final WebSocket ws;

--- a/platform/security/servlet/security-servlet-web-socket-api/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
+++ b/platform/security/servlet/security-servlet-web-socket-api/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
@@ -29,12 +29,12 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SecureWebSocketServlet extends WebSocketServlet {
+public class SecureWebSocketServlet implements WebSocketCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SecureWebSocketServlet.class);
 
@@ -51,15 +51,14 @@ public class SecureWebSocketServlet extends WebSocketServlet {
     this.sessionPlugins = sessionPlugins;
   }
 
-  @Override
   public void destroy() {
     executor.shutdown();
   }
 
   @Override
-  public void configure(WebSocketServletFactory factory) {
-    factory.setCreator(
-        (req, resp) -> new SocketWrapper(executor, ws, sessionPlugins, req.getSession()));
+  public Object createWebSocket(
+      ServletUpgradeRequest servletUpgradeRequest, ServletUpgradeResponse servletUpgradeResponse) {
+    return new SocketWrapper(executor, ws, sessionPlugins, servletUpgradeRequest.getSession());
   }
 
   @org.eclipse.jetty.websocket.api.annotations.WebSocket

--- a/platform/security/servlet/security-servlet-web-socket-api/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
+++ b/platform/security/servlet/security-servlet-web-socket-api/src/main/java/org/codice/ddf/security/servlet/web/socket/SecureWebSocketServlet.java
@@ -61,7 +61,6 @@ public class SecureWebSocketServlet implements WebSocketCreator {
     return new SocketWrapper(executor, ws, sessionPlugins, servletUpgradeRequest.getSession());
   }
 
-  @org.eclipse.jetty.websocket.api.annotations.WebSocket
   public static class SocketWrapper {
 
     private final WebSocket ws;


### PR DESCRIPTION
#### What does this PR do?

The move to pax web 8.0.24 updated websocket use and registration. Unlike other servlets there is no direct whiteboard registration for websockets. While there are a couple ways to register a websocket between the java servlet specification, jetty, and pax web this approach uses the Java Servlet annotation @WebServlet which works with all three. 
Pax web requires a more complicated setup for websockets through other approaches but by using this annotation and registering the Websocket bundles as WABs it correctly configures the Servlet registration/ Websocket upgrade. 


SecureWebsocketServlet has been changed to a websocketCreator for use with the new WABs that must be deployed for websocket integration. 

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->

#### Select relevant component teams: 
<!--
@codice/build 
@codice/continuous-integration 
@codice/core-apis 
@codice/data 
@codice/docs 
@codice/io 
@codice/ogc 
@codice/security 
@codice/solr 
@codice/test 
@codice/ui 
@codice/website 
-->

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below)
@ahoffer
@andrewkfiedler
@andrewzimmer
@AzGoalie
@bdthomson
@blen-desta
@brendan-hofmann
@brianfelix
@cassandrabailey293
@clockard
@coyotesqrl
@emmberk
@figliold
@garrettfreibott
@glenhein 
@gordocanchola 
@hayleynorton
@jlcsmith
@josephthweatt
@jrnorth
@lambeaux
@lamhuy
@leo-sakh
@mcalcote
@millerw8
@mojogitoverhere
@oconnormi
@paouelle
@pklinef
@ricklarsen - Documentation
@ryeats
@rymach
@rzwiefel
@shaundmorris
@smithjosh
@stustison
@vinamartin
@zta6
-->

#### How should this be tested?
1. Build ddf and install ddf-ui front and backend (with this PR: https://github.com/codice/ddf-ui/pull/1055) 
2. Open the network tab in your browser
4. Navigate to the search page localhost
5. Select the request for /search/catalog/ws/
6. Run a search and confirm that websockets are being used for searches (under the messages tab of the /search/catalog/ws/ request)
7. Disable websockets in the admin UI 
8. Access the search page in a new window and confirm that websockets are not being used for searches

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
