### PR TITLE
[2.29.x] Fix solr image to allow startup as solr user

### DIFF
--- a/distribution/docker/solr-docker/src/main/docker/Dockerfile
+++ b/distribution/docker/solr-docker/src/main/docker/Dockerfile
@@ -22,9 +22,11 @@ COPY --from=prep /prep/solr/conf/* /seed/
 COPY maven/createCore.sh /usr/local/bin/create-ddf-core
 RUN chmod 755 /usr/local/bin/create-ddf-core
 RUN chown -R solr:solr /seed
-USER solr
 
 # Add ddf-solr entrypoint
 COPY maven/docker-ddf-solr-entrypoint.sh /usr/local/bin/docker-ddf-solr-entrypoint
+RUN chmod 755 /usr/local/bin/docker-ddf-solr-entrypoint
+
+USER solr
 ENTRYPOINT ["/usr/local/bin/docker-ddf-solr-entrypoint"]
 CMD ["solr-foreground"]


### PR DESCRIPTION
#### What does this PR do?
Copies and sets the entrypoint script permissions to 755 so that the image can be started by the solr user

#### Who is reviewing it? 
@lavoywj 
@jrnorth 

#### Select relevant component teams: 
@codice/solr 

#### Ask 2 committers to review/merge the PR and tag them here.

@clockard
@pklinef


#### How should this be tested?
<!--(List steps with links to updated documentation)-->
Start the image as-is and verify that the container starts and solr is running as the solr user

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes: #____

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
