### PR TITLE
Fix 2.29.x branch build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,8 +94,12 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'maven-latest', jdk: 'jdk21', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                    // the itests module and its children need to be built to run the core tests, since
+                    // that module is skipped in the full build and the core tests depend on those
+                    // artifacts
                     sh '''
                         unset JAVA_TOOL_OPTIONS
+                        mvn install -B -pl $ITESTS -amd -DskipTests $DISABLE_DOWNLOAD_PROGRESS_OPTS
                         mvn install -B -pl $ITCORE -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS
                     '''
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,12 @@ pipeline {
 
         // The incremental build will be triggered only for PRs. It will build the differences between the PR and the target branch
         stage('Incremental Build') {
+            when {
+                allOf {
+                    expression { env.CHANGE_ID != null }
+                    expression { env.CHANGE_TARGET != null }
+                }
+            }
             options {
                 timeout(time: 3, unit: 'HOURS')
             }
@@ -83,13 +89,6 @@ pipeline {
         }
 
         stage('DDF Core Tests Only Build') {
-            // temporary change to test this stage in a PR
-            when {
-                allOf {
-                    expression { env.CHANGE_ID != null }
-                    expression { env.CHANGE_TARGET != null }
-                }
-            }
             options {
                 timeout(time: 1, unit: 'HOURS')
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,12 +56,6 @@ pipeline {
 
         // The incremental build will be triggered only for PRs. It will build the differences between the PR and the target branch
         stage('Incremental Build') {
-            when {
-                allOf {
-                    expression { env.CHANGE_ID != null }
-                    expression { env.CHANGE_TARGET != null }
-                }
-            }
             options {
                 timeout(time: 3, unit: 'HOURS')
             }
@@ -89,6 +83,13 @@ pipeline {
         }
 
         stage('DDF Core Tests Only Build') {
+            // temporary change to test this stage in a PR
+            when {
+                allOf {
+                    expression { env.CHANGE_ID != null }
+                    expression { env.CHANGE_TARGET != null }
+                }
+            }
             options {
                 timeout(time: 1, unit: 'HOURS')
             }


### PR DESCRIPTION
The 2.29.x branch (not PR) Jenkins job has been failing for a long time due to the core tests stage failing. This is an attempt to get the job working again so we can enable nightly builds on the branch and deploy up-to-date snapshots.