### PR TITLE
Fix flaky unit test [2.29.x]

### DIFF
--- a/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceInputStreamTest.java
+++ b/catalog/core/catalog-core-standardframework/src/test/java/ddf/catalog/resource/download/ReliableResourceInputStreamTest.java
@@ -149,11 +149,13 @@ public class ReliableResourceInputStreamTest {
 
   @Test
   public void testReadByteBufferBlocksUntilNewFbosBytesWritten() throws Exception {
+    when(downloadState.getDownloadState())
+        .thenReturn(DownloadManagerState.DownloadState.IN_PROGRESS);
     final ReliableResourceInputStream is =
         new ReliableResourceInputStream(
             fbos, countingFbos, downloadState, downloadIdentifier, resourceResponse);
     is.setCallableAndItsFuture(reliableResourceCallable, downloadFuture);
-    byte[] bytes = new String("Hello World").getBytes();
+    byte[] bytes = "Hello World".getBytes();
     countingFbos.write(bytes, 0, bytes.length);
     final byte[] buffer = new byte[50];
     int numBytesRead = is.read(buffer, 0, buffer.length);
@@ -163,33 +165,33 @@ public class ReliableResourceInputStreamTest {
     // to FileBackedOutputStream)
 
     Callable<Integer> callable =
-        new Callable<Integer>() {
-          @Override
-          public Integer call() {
-            int numBytesRead2 = 0;
-            try {
-              numBytesRead2 = is.read(buffer, 0, buffer.length);
-            } catch (IOException e) {
-              LOGGER.info("Failed to read bytes second time", e);
-            }
-            return numBytesRead2;
+        () -> {
+          int numBytesRead2 = 0;
+          try {
+            numBytesRead2 = is.read(buffer, 0, buffer.length);
+          } catch (IOException e) {
+            LOGGER.info("Failed to read bytes second time", e);
           }
+          return numBytesRead2;
         };
 
     ExecutorService executor = Executors.newCachedThreadPool();
     Future<Integer> future = executor.submit(callable);
 
-    // Write second string to FileBackedOutputStream - ReliableResourceInputStream's running
-    // read(byte[], off, len) method is in loop waiting for new bytes to be written and should
-    // detect this, read the new bytes and put them in the buffer
-    String secondString = "Hello a second time";
-    byte[] bytes2 = secondString.getBytes();
-    countingFbos.write(bytes2, 0, bytes2.length);
-    Integer bytesReadCount = future.get();
-    assertThat(bytesReadCount, is(bytes2.length));
-    assertThat(new String(buffer), containsString(secondString));
-
-    is.close();
+    try {
+      // Write second string to FileBackedOutputStream - ReliableResourceInputStream's running
+      // read(byte[], off, len) method is in loop waiting for new bytes to be written and should
+      // detect this, read the new bytes and put them in the buffer
+      String secondString = "Hello a second time";
+      byte[] bytes2 = secondString.getBytes();
+      countingFbos.write(bytes2, 0, bytes2.length);
+      Integer bytesReadCount = future.get();
+      assertThat(bytesReadCount, is(bytes2.length));
+      assertThat(new String(buffer), containsString(secondString));
+    } finally {
+      executor.shutdownNow();
+      is.close();
+    }
   }
 
   @Test(expected = NullPointerException.class)


### PR DESCRIPTION
#### What does this PR do?
This test is flaky because there is a race condition. If the extra thread calls the read method before the test writes the second string, then the read method will not wait for new bytes and will return -1 because the download state is COMPLETED. The test only passes when the timing works out such that the write happens before the extra thread calls the read method. Now, the test sets the download state to IN_PROGRESS, so the read method will correctly wait for new bytes if it is called before the write happens.

Will forward port this to master when this is approved and merged.

#### Who is reviewing it? 
@alexabird 
@jaymcnallie 

#### Select relevant component teams: 
@codice/test 

#### How should this be tested?
You can use the "run until failure" feature in IntelliJ to verify that you see the failure on the base branch, but not on this branch.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.