### PR TITLE
[2.29.x] Remove unnecessary catalog dependencies

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -375,29 +375,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>org.ops4j.pax.web</groupId>
-            <artifactId>pax-web-spi</artifactId>
-            <version>${pax.web.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.core</artifactId>
-            <version>${osgi.enterprise.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.cmpn</artifactId>
-            <version>${osgi.compendium.version}</version>
-        </dependency>
-    </dependencies>
     <modules>
         <module>measure</module>
         <module>common</module>

--- a/platform/landing-page/pom.xml
+++ b/platform/landing-page/pom.xml
@@ -93,6 +93,17 @@
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.web</groupId>
+            <artifactId>pax-web-spi</artifactId>
+            <version>${pax.web.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
* `pax-web-spi` is only needed in `platform/landing-page` - Its blueprint registers a service with interface `org.ops4j.pax.web.service.whiteboard.ResourceMapping` and instantiates `org.ops4j.pax.web.extender.whiteboard.runtime.DefaultResourceMapping`
* `osgi.core` and `osgi.cmpn` are already declared in the submodules they are required