### PR TITLE
Bump to 2.31.0-SNAPSHOT and target JDK 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 
@@ -79,7 +79,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 
@@ -123,7 +123,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 
@@ -153,7 +153,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 
@@ -199,7 +199,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 
@@ -242,7 +242,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       next_dev_version: ${{ inputs.nextDevVersion }}
       skip_tests: ${{ inputs.skipTests }}
       test_run: ${{ inputs.testRun }}
-      jdk_version_map: '{"master":"17","2.29.x":"17","2.28.x":"11","2.27.x":"11","default":"11"}'
+      jdk_version_map: '{"master":"21","2.30.x":"17","2.29.x":"17","2.28.x":"11","2.27.x":"11","default":"11"}'
       artifact_path: 'distribution/ddf/target'
       resume_from: ${{ inputs.resumeFrom }}
       author_name: 'Codice Release Manager'

--- a/catalog/admin/catalog-admin-downloadmanager/pom.xml
+++ b/catalog/admin/catalog-admin-downloadmanager/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>catalog-admin</artifactId>
         <groupId>ddf.catalog.admin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-admin-downloadmanager</artifactId>

--- a/catalog/admin/catalog-admin-poller-service/pom.xml
+++ b/catalog/admin/catalog-admin-poller-service/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-admin</artifactId>
         <groupId>ddf.catalog.admin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Catalog :: Admin :: Poller Service</name>

--- a/catalog/admin/module/catalog-admin-module-layout/pom.xml
+++ b/catalog/admin/module/catalog-admin-module-layout/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-admin-module</artifactId>
         <groupId>ddf.catalog.admin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Catalog :: Admin :: Module :: Default Layout</name>

--- a/catalog/admin/module/catalog-admin-module-maplayers/pom.xml
+++ b/catalog/admin/module/catalog-admin-module-maplayers/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-admin-module</artifactId>
         <groupId>ddf.catalog.admin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Catalog :: Admin :: Module :: Map Layers</name>

--- a/catalog/admin/module/catalog-admin-module-sources/pom.xml
+++ b/catalog/admin/module/catalog-admin-module-sources/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-admin-module</artifactId>
         <groupId>ddf.catalog.admin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Catalog :: Admin :: Module :: Sources</name>

--- a/catalog/admin/module/pom.xml
+++ b/catalog/admin/module/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.admin</groupId>
         <artifactId>catalog-admin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-admin-module</artifactId>
     <packaging>pom</packaging>

--- a/catalog/admin/plugin/catalog-admin-plugin-sourceconfiguration/pom.xml
+++ b/catalog/admin/plugin/catalog-admin-plugin-sourceconfiguration/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-admin-plugin</artifactId>
         <groupId>ddf.catalog.admin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-admin-plugin-sourceconfiguration</artifactId>

--- a/catalog/admin/plugin/pom.xml
+++ b/catalog/admin/plugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.admin</groupId>
         <artifactId>catalog-admin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-admin-plugin</artifactId>
     <packaging>pom</packaging>

--- a/catalog/admin/pom.xml
+++ b/catalog/admin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.admin</groupId>
     <artifactId>catalog-admin</artifactId>

--- a/catalog/catalog-app/pom.xml
+++ b/catalog/catalog-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/common/catalog-common-geo-formatter/pom.xml
+++ b/catalog/common/catalog-common-geo-formatter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>common</artifactId>
         <groupId>ddf.catalog.common</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>geo-formatter</artifactId>
     <name>DDF :: Catalog :: Common :: Geo Formatter</name>

--- a/catalog/common/catalog-common-video-thumbnail-impl/pom.xml
+++ b/catalog/common/catalog-common-video-thumbnail-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>common</artifactId>
         <groupId>ddf.catalog.common</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>video-thumbnail-impl</artifactId>
     <name>DDF :: Catalog :: Common :: Video Thumbnail Impl</name>

--- a/catalog/common/catalog-common-video-thumbnail/pom.xml
+++ b/catalog/common/catalog-common-video-thumbnail/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>common</artifactId>
         <groupId>ddf.catalog.common</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>video-thumbnail</artifactId>
     <name>DDF :: Catalog :: Common :: Video Thumbnail</name>

--- a/catalog/common/pom.xml
+++ b/catalog/common/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.catalog.common</groupId>

--- a/catalog/confluence/catalog-confluence-common/pom.xml
+++ b/catalog/confluence/catalog-confluence-common/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>confluence</artifactId>
         <groupId>ddf.catalog.confluence</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/confluence/catalog-confluence-source/pom.xml
+++ b/catalog/confluence/catalog-confluence-source/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>confluence</artifactId>
         <groupId>ddf.catalog.confluence</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/confluence/pom.xml
+++ b/catalog/confluence/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog</artifactId>
         <groupId>ddf.catalog</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-actions/pom.xml
+++ b/catalog/core/catalog-core-actions/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-core-actions</artifactId>

--- a/catalog/core/catalog-core-api-impl/pom.xml
+++ b/catalog/core/catalog-core-api-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-api-impl</artifactId>
     <name>DDF :: Catalog :: Core :: API :: Impl</name>

--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-api</artifactId>
     <name>DDF :: Catalog :: Core :: API</name>

--- a/catalog/core/catalog-core-attachment-impl/pom.xml
+++ b/catalog/core/catalog-core-attachment-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-attachment-impl</artifactId>
     <name>DDF :: Catalog :: Core :: Attachment :: Impl</name>

--- a/catalog/core/catalog-core-attachment/pom.xml
+++ b/catalog/core/catalog-core-attachment/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-attachment</artifactId>
     <name>DDF :: Catalog :: Core :: Attachment</name>

--- a/catalog/core/catalog-core-attributeregistry/pom.xml
+++ b/catalog/core/catalog-core-attributeregistry/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-backupplugin/pom.xml
+++ b/catalog/core/catalog-core-backupplugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-core-backupplugin</artifactId>

--- a/catalog/core/catalog-core-camelcomponent/pom.xml
+++ b/catalog/core/catalog-core-camelcomponent/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-camelcomponent</artifactId>
     <name>DDF :: Catalog :: Core :: Camel Component</name>

--- a/catalog/core/catalog-core-commands/pom.xml
+++ b/catalog/core/catalog-core-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-commands</artifactId>
     <name>DDF :: Catalog :: Core :: Commands</name>

--- a/catalog/core/catalog-core-commons/pom.xml
+++ b/catalog/core/catalog-core-commons/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-commons</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/core/catalog-core-contentresourcereader/pom.xml
+++ b/catalog/core/catalog-core-contentresourcereader/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-defaultvalues/pom.xml
+++ b/catalog/core/catalog-core-defaultvalues/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-definitionparser/pom.xml
+++ b/catalog/core/catalog-core-definitionparser/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-directorymonitor/pom.xml
+++ b/catalog/core/catalog-core-directorymonitor/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-downloadaction/pom.xml
+++ b/catalog/core/catalog-core-downloadaction/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-core-downloadaction</artifactId>

--- a/catalog/core/catalog-core-eventcommands/pom.xml
+++ b/catalog/core/catalog-core-eventcommands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-eventcommands</artifactId>
     <name>DDF :: Catalog :: Core :: Event Commands</name>

--- a/catalog/core/catalog-core-impl/filter-proxy/pom.xml
+++ b/catalog/core/catalog-core-impl/filter-proxy/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>catalog-core-impl</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>filter-proxy</artifactId>
     <name>DDF :: Catalog :: Core :: Impl :: Filter Proxy</name>

--- a/catalog/core/catalog-core-impl/metacard-type-registry/pom.xml
+++ b/catalog/core/catalog-core-impl/metacard-type-registry/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>catalog-core-impl</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>metacard-type-registry</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/core/catalog-core-impl/pom.xml
+++ b/catalog/core/catalog-core-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-impl</artifactId>
     <name>DDF :: Catalog :: Core :: Impl</name>

--- a/catalog/core/catalog-core-impl/pubsub-tracker/pom.xml
+++ b/catalog/core/catalog-core-impl/pubsub-tracker/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>catalog-core-impl</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>ddf-pubsub-tracker</artifactId>
     <name>DDF :: Catalog :: Core :: Impl :: PubSub Tracker</name>

--- a/catalog/core/catalog-core-impl/pubsub/pom.xml
+++ b/catalog/core/catalog-core-impl/pubsub/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>catalog-core-impl</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>ddf-pubsub</artifactId>
     <name>DDF :: Catalog :: Core :: Impl :: PubSub</name>

--- a/catalog/core/catalog-core-injectattribute/pom.xml
+++ b/catalog/core/catalog-core-injectattribute/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-localstorageprovider/pom.xml
+++ b/catalog/core/catalog-core-localstorageprovider/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-metacardgroomerplugin/pom.xml
+++ b/catalog/core/catalog-core-metacardgroomerplugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-metacardgroomerplugin</artifactId>
     <name>DDF :: Catalog :: Core :: Metacard Groomer Plugin</name>

--- a/catalog/core/catalog-core-metacardtype/pom.xml
+++ b/catalog/core/catalog-core-metacardtype/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-metacardtype</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/core/catalog-core-metricsplugin/pom.xml
+++ b/catalog/core/catalog-core-metricsplugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-metricsplugin</artifactId>
     <name>DDF :: Catalog :: Core :: Metrics Plug-in</name>

--- a/catalog/core/catalog-core-requiredattributes/pom.xml
+++ b/catalog/core/catalog-core-requiredattributes/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-resourcesizeplugin/pom.xml
+++ b/catalog/core/catalog-core-resourcesizeplugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-resourcesizeplugin</artifactId>
     <name>DDF :: Catalog :: Core :: Metacard Resource Size PostQuery Plugin</name>

--- a/catalog/core/catalog-core-resourcestatusplugin/pom.xml
+++ b/catalog/core/catalog-core-resourcestatusplugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-resourcestatusplugin</artifactId>
     <name>DDF :: Catalog :: Plugin :: Metacard Resource Status PostQuery Plugin</name>

--- a/catalog/core/catalog-core-sourcemetricsplugin/pom.xml
+++ b/catalog/core/catalog-core-sourcemetricsplugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-sourcemetricsplugin</artifactId>
     <name>DDF :: Catalog :: Core :: Source Metrics Plugin</name>

--- a/catalog/core/catalog-core-standardframework/pom.xml
+++ b/catalog/core/catalog-core-standardframework/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-standardframework</artifactId>
     <name>DDF :: Catalog :: Core :: Standard Framework</name>

--- a/catalog/core/catalog-core-tagsfilterplugin/pom.xml
+++ b/catalog/core/catalog-core-tagsfilterplugin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-core-tagsfilterplugin</artifactId>

--- a/catalog/core/catalog-core-urlresourcereader/pom.xml
+++ b/catalog/core/catalog-core-urlresourcereader/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-core-urlresourcereader</artifactId>
     <name>DDF :: Catalog :: Core :: URL Resource Reader</name>

--- a/catalog/core/catalog-core-validator/pom.xml
+++ b/catalog/core/catalog-core-validator/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>core</artifactId>
         <groupId>ddf.catalog.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/core/catalog-core-versioning/pom.xml
+++ b/catalog/core/catalog-core-versioning/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>core</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Core :: Versioning</name>

--- a/catalog/core/catalog-core-versioning/versioning-api/pom.xml
+++ b/catalog/core/catalog-core-versioning/versioning-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>catalog-core-versioning</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <packaging>bundle</packaging>

--- a/catalog/core/catalog-core-versioning/versioning-common/pom.xml
+++ b/catalog/core/catalog-core-versioning/versioning-common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog.core</groupId>
         <artifactId>catalog-core-versioning</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Core :: Versioning :: Common</name>

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.core</groupId>
     <artifactId>core</artifactId>

--- a/catalog/measure/catalog-measure-api/pom.xml
+++ b/catalog/measure/catalog-measure-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>measure</artifactId>
         <groupId>ddf.measure</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>measure-api</artifactId>
     <name>DDF :: Measure :: Measure API</name>

--- a/catalog/measure/pom.xml
+++ b/catalog/measure/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.measure</groupId>

--- a/catalog/opensearch/catalog-opensearch-api/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.opensearch</groupId>
         <artifactId>catalog-opensearch</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-opensearch-api</artifactId>
     <name>DDF :: Catalog :: OpenSearch :: API</name>

--- a/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.opensearch</groupId>
         <artifactId>catalog-opensearch</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-opensearch-endpoint</artifactId>
     <name>DDF :: Catalog :: OpenSearch :: Endpoint</name>

--- a/catalog/opensearch/catalog-opensearch-source/pom.xml
+++ b/catalog/opensearch/catalog-opensearch-source/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.opensearch</groupId>
         <artifactId>catalog-opensearch</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-opensearch-source</artifactId>
     <name>DDF :: Catalog :: OpenSearch :: Source</name>

--- a/catalog/opensearch/pom.xml
+++ b/catalog/opensearch/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-opensearch</artifactId>
     <groupId>ddf.catalog.opensearch</groupId>

--- a/catalog/plugin/catalog-plugin-checksum/pom.xml
+++ b/catalog/plugin/catalog-plugin-checksum/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-clientinfo/pom.xml
+++ b/catalog/plugin/catalog-plugin-clientinfo/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-content-uri/pom.xml
+++ b/catalog/plugin/catalog-plugin-content-uri/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-expirationdate/pom.xml
+++ b/catalog/plugin/catalog-plugin-expirationdate/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog.plugin</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Plugin :: Expiration Date</name>

--- a/catalog/plugin/catalog-plugin-facet-attribute-access/pom.xml
+++ b/catalog/plugin/catalog-plugin-facet-attribute-access/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-federation-replication/pom.xml
+++ b/catalog/plugin/catalog-plugin-federation-replication/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>plugin-federation-replication</artifactId>
     <name>DDF :: Catalog :: Plugin :: Federation :: Replication</name>

--- a/catalog/plugin/catalog-plugin-gazetteer/pom.xml
+++ b/catalog/plugin/catalog-plugin-gazetteer/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>plugin</artifactId>
     <groupId>ddf.catalog.plugin</groupId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-jpeg2000-thumbnail-converter/pom.xml
+++ b/catalog/plugin/catalog-plugin-jpeg2000-thumbnail-converter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.plugin</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>jpeg2000-thumbnail-converter</artifactId>
     <name>DDF :: Catalog :: Plugin :: Jpeg2000 :: Thumbnail :: Converter</name>

--- a/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacard-validation/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/catalog/plugin/catalog-plugin-metacardbackup-filestorage/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-filestorage/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-metacardbackup-s3storage/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-s3storage/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-metacardbackup-storage-api/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-storage-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-metacardbackup-storage-common/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardbackup-storage-common/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-metacardingest-network/pom.xml
+++ b/catalog/plugin/catalog-plugin-metacardingest-network/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-oauth/pom.xml
+++ b/catalog/plugin/catalog-plugin-oauth/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.plugin</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/catalog/plugin/catalog-plugin-pointofcontactupdate/pom.xml
+++ b/catalog/plugin/catalog-plugin-pointofcontactupdate/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/catalog-plugin-security-audit/pom.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/catalog/plugin/catalog-plugin-versioning/pom.xml
+++ b/catalog/plugin/catalog-plugin-versioning/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog.plugin</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Plugin :: Versioning</name>

--- a/catalog/plugin/catalog-plugin-videothumbnail/pom.xml
+++ b/catalog/plugin/catalog-plugin-videothumbnail/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>ddf.catalog.plugin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog</artifactId>
         <groupId>ddf.catalog</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.catalog.plugin</groupId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog</groupId>
     <artifactId>catalog</artifactId>

--- a/catalog/rest/catalog-rest-api/pom.xml
+++ b/catalog/rest/catalog-rest-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-rest-pom</artifactId>
         <groupId>ddf.catalog.rest</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-rest-api</artifactId>

--- a/catalog/rest/catalog-rest-endpoint/pom.xml
+++ b/catalog/rest/catalog-rest-endpoint/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.rest</groupId>
         <artifactId>catalog-rest-pom</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/catalog/rest/catalog-rest-impl/pom.xml
+++ b/catalog/rest/catalog-rest-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-rest-pom</artifactId>
         <groupId>ddf.catalog.rest</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-rest-impl</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/rest/catalog-rest-service-impl/pom.xml
+++ b/catalog/rest/catalog-rest-service-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-rest-pom</artifactId>
         <groupId>ddf.catalog.rest</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-rest-service-impl</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/rest/catalog-rest-service/pom.xml
+++ b/catalog/rest/catalog-rest-service/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog.rest</groupId>
         <artifactId>catalog-rest-pom</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-rest-service</artifactId>

--- a/catalog/rest/pom.xml
+++ b/catalog/rest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog</artifactId>
         <groupId>ddf.catalog</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-rest-pom</artifactId>
     <groupId>ddf.catalog.rest</groupId>

--- a/catalog/schematron/catalog-schematron-plugin/pom.xml
+++ b/catalog/schematron/catalog-schematron-plugin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>catalog-schematron-pom</artifactId>
         <groupId>ddf.catalog.schematron</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-schematron-plugin</artifactId>
     <name>DDF :: Catalog :: Schematron :: Plugin</name>

--- a/catalog/schematron/pom.xml
+++ b/catalog/schematron/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-schematron-pom</artifactId>
     <groupId>ddf.catalog.schematron</groupId>

--- a/catalog/security/catalog-security-filter/pom.xml
+++ b/catalog/security/catalog-security-filter/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-security-filter</artifactId>

--- a/catalog/security/catalog-security-logging/pom.xml
+++ b/catalog/security/catalog-security-logging/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-security-logging</artifactId>

--- a/catalog/security/catalog-security-metacardattributeplugin/pom.xml
+++ b/catalog/security/catalog-security-metacardattributeplugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/security/catalog-security-operationplugin/pom.xml
+++ b/catalog/security/catalog-security-operationplugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-security-operationplugin</artifactId>

--- a/catalog/security/catalog-security-plugin/pom.xml
+++ b/catalog/security/catalog-security-plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-security-plugin</artifactId>

--- a/catalog/security/catalog-security-pointofcontact-policyplugin/pom.xml
+++ b/catalog/security/catalog-security-pointofcontact-policyplugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/security/catalog-security-policyplugin/pom.xml
+++ b/catalog/security/catalog-security-policyplugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-security-policyplugin</artifactId>

--- a/catalog/security/catalog-security-resourceplugin/pom.xml
+++ b/catalog/security/catalog-security-resourceplugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>catalog-security-resourceplugin</artifactId>

--- a/catalog/security/catalog-security-xmlattributeplugin/pom.xml
+++ b/catalog/security/catalog-security-xmlattributeplugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-security-pom</artifactId>
         <groupId>ddf.catalog.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/security/pom.xml
+++ b/catalog/security/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog</artifactId>
         <groupId>ddf.catalog</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-security-pom</artifactId>
     <groupId>ddf.catalog.security</groupId>

--- a/catalog/solr/catalog-solr-app/pom.xml
+++ b/catalog/solr/catalog-solr-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.solr</groupId>
         <artifactId>catalog-solr</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-solr-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/solr/catalog-solr-cache/pom.xml
+++ b/catalog/solr/catalog-solr-cache/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-solr</artifactId>
         <groupId>ddf.catalog.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-solr-cache</artifactId>
     <name>DDF :: Catalog :: Solr :: Cache</name>

--- a/catalog/solr/catalog-solr-commands/pom.xml
+++ b/catalog/solr/catalog-solr-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-solr</artifactId>
         <groupId>ddf.catalog.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-solr-commands</artifactId>
     <name>DDF :: Catalog :: Solr :: Commands</name>

--- a/catalog/solr/catalog-solr-core/pom.xml
+++ b/catalog/solr/catalog-solr-core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-solr</artifactId>
         <groupId>ddf.catalog.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-solr-core</artifactId>
     <name>DDF :: Catalog :: Solr :: Core</name>

--- a/catalog/solr/catalog-solr-defaultmetacardtagscacheplugin/pom.xml
+++ b/catalog/solr/catalog-solr-defaultmetacardtagscacheplugin/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>catalog-solr</artifactId>
         <groupId>ddf.catalog.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-solr-defaultmetacardtagscacheplugin</artifactId>
     <name>DDF :: Catalog :: Solr :: Cache Put Plugin :: Default Metacard Tags</name>

--- a/catalog/solr/catalog-solr-offline-gazetteer/pom.xml
+++ b/catalog/solr/catalog-solr-offline-gazetteer/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>ddf.catalog.solr</groupId>
         <artifactId>catalog-solr</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-solr-offline-gazetteer</artifactId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>DDF :: Catalog :: Solr :: Offline Gazetteer</name>
 

--- a/catalog/solr/catalog-solr-provider/pom.xml
+++ b/catalog/solr/catalog-solr-provider/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-solr</artifactId>
         <groupId>ddf.catalog.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-solr-provider</artifactId>
     <name>DDF :: Catalog :: Solr :: Provider</name>

--- a/catalog/solr/catalog-solr-solrclient/pom.xml
+++ b/catalog/solr/catalog-solr-solrclient/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>catalog-solr</artifactId>
         <groupId>ddf.catalog.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/catalog/solr/pom.xml
+++ b/catalog/solr/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-solr</artifactId>
     <groupId>ddf.catalog.solr</groupId>

--- a/catalog/spatial/csw/pom.xml
+++ b/catalog/spatial/csw/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>spatial</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>csw</artifactId>
     <name>DDF :: Spatial :: CSW</name>

--- a/catalog/spatial/csw/spatial-csw-action/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-action/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>csw</artifactId>
     <groupId>org.codice.ddf.spatial</groupId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>spatial-csw-action</artifactId>

--- a/catalog/spatial/csw/spatial-csw-common/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>csw</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-csw-common</artifactId>
     <name>DDF :: Spatial :: CSW :: Common</name>

--- a/catalog/spatial/csw/spatial-csw-connectedsource/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-connectedsource/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>csw</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-csw-connectedsource</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/spatial/csw/spatial-csw-endpoint/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>csw</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-csw-endpoint</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/spatial/csw/spatial-csw-schema-bindings/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-schema-bindings/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>csw</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>spatial-csw-schema-bindings</artifactId>

--- a/catalog/spatial/csw/spatial-csw-source-common/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-source-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>csw</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-csw-source-common</artifactId>
     <packaging>jar</packaging>

--- a/catalog/spatial/csw/spatial-csw-source/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-source/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>csw</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-csw-source</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/spatial/csw/spatial-csw-transformer/pom.xml
+++ b/catalog/spatial/csw/spatial-csw-transformer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>csw</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>spatial-csw-transformer</artifactId>

--- a/catalog/spatial/geocoding/pom.xml
+++ b/catalog/spatial/geocoding/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>spatial</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>geocoding</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-api-impl/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-api-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-api-impl</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-api/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-api</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-create/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-create/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-create</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-endpoint/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-endpoint/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>geocoding</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/catalog/spatial/geocoding/spatial-geocoding-extract/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-extract/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-extract</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-feature/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-feature/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-feature</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-geocoder/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-geocoder/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-geocoder</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-offline-catalog/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-offline-catalog</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-offline-index/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-offline-index/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-offline-index</artifactId>

--- a/catalog/spatial/geocoding/spatial-geocoding-plugin/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-plugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-geocoding-plugin</artifactId>
     <name>DDF :: Spatial :: Geocoding :: Plugin</name>

--- a/catalog/spatial/geocoding/spatial-geocoding-websearch/pom.xml
+++ b/catalog/spatial/geocoding/spatial-geocoding-websearch/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>geocoding</artifactId>
         <groupId>org.codice.ddf.spatial</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-geocoding-websearch</artifactId>

--- a/catalog/spatial/kml/pom.xml
+++ b/catalog/spatial/kml/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>spatial</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-kml-pom</artifactId>
     <groupId>ddf.spatial.kml</groupId>

--- a/catalog/spatial/kml/spatial-kml-networklinkendpoint/pom.xml
+++ b/catalog/spatial/kml/spatial-kml-networklinkendpoint/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>spatial-kml-pom</artifactId>
         <groupId>ddf.spatial.kml</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spatial-kml-networklinkendpoint</artifactId>

--- a/catalog/spatial/kml/spatial-kml-transformer/pom.xml
+++ b/catalog/spatial/kml/spatial-kml-transformer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>spatial-kml-pom</artifactId>
         <groupId>ddf.spatial.kml</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-kml-transformer</artifactId>
     <name>DDF :: Spatial :: KML :: Transformer</name>

--- a/catalog/spatial/kml/spatial-kml-util/pom.xml
+++ b/catalog/spatial/kml/spatial-kml-util/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>spatial-kml-pom</artifactId>
         <groupId>ddf.spatial.kml</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/spatial/ogc/pom.xml
+++ b/catalog/spatial/ogc/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>spatial</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>ogc</artifactId>
     <name>DDF :: Spatial :: OGC</name>

--- a/catalog/spatial/ogc/spatial-ogc-api/pom.xml
+++ b/catalog/spatial/ogc/spatial-ogc-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>ogc</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-ogc-api</artifactId>
     <name>DDF :: Spatial :: OGC :: API</name>

--- a/catalog/spatial/ogc/spatial-ogc-common/pom.xml
+++ b/catalog/spatial/ogc/spatial-ogc-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>ogc</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-ogc-common</artifactId>
     <name>DDF :: Spatial :: OGC :: Common</name>

--- a/catalog/spatial/ogc/spatial-ogc-urlresourcereader/pom.xml
+++ b/catalog/spatial/ogc/spatial-ogc-urlresourcereader/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>ogc</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Spatial :: OGC :: URL Resource Reader</name>
     <artifactId>spatial-ogc-urlresourcereader</artifactId>

--- a/catalog/spatial/pom.xml
+++ b/catalog/spatial/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.ddf.spatial</groupId>
     <artifactId>spatial</artifactId>

--- a/catalog/spatial/spatial-app/pom.xml
+++ b/catalog/spatial/spatial-app/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>spatial</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/spatial/spatial-commands/pom.xml
+++ b/catalog/spatial/spatial-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>spatial</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-commands</artifactId>
     <name>DDF :: Spatial :: Commands</name>

--- a/catalog/spatial/wcs/pom.xml
+++ b/catalog/spatial/wcs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>spatial</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>wcs</artifactId>
     <packaging>pom</packaging>

--- a/catalog/spatial/wcs/spatial-wcs-common/pom.xml
+++ b/catalog/spatial/wcs/spatial-wcs-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wcs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wcs-common</artifactId>
     <name>DDF :: Spatial :: WCS :: Common</name>

--- a/catalog/spatial/wfs/1.1.0/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>wfs-v1.1.0</artifactId>
     <name>DDF :: Spatial :: WFS :: 1.1.0</name>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs-v1.1.0</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-v1_1_0-common</artifactId>
     <name>DDF :: Spatial :: WFS :: 1.1.0 :: Common</name>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-converter/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-converter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs-v1.1.0</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-v1_1_0-converter</artifactId>
     <name>DDF :: Spatial :: WFS :: 1.1.0 :: Converter</name>

--- a/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
+++ b/catalog/spatial/wfs/1.1.0/spatial-wfs-v1_1_0-source/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs-v1.1.0</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-v1_1_0-source</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/spatial/wfs/2.0.0/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>wfs-v2.0.0</artifactId>
     <name>DDF :: Spatial :: WFS :: 2.0.0</name>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-common/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs-v2.0.0</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-v2_0_0-common</artifactId>
     <name>DDF :: Spatial :: WFS :: 2.0.0 :: Common</name>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-connectedsource/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-connectedsource/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs-v2.0.0</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-v2_0_0-connectedsource</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-converter/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-converter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs-v2.0.0</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-v2_0_0-converter</artifactId>
     <name>DDF :: Spatial :: WFS :: 2.0.0 :: Converter</name>

--- a/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/pom.xml
+++ b/catalog/spatial/wfs/2.0.0/spatial-wfs-v2_0_0-source/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs-v2.0.0</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-v2_0_0-source</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/spatial/wfs/pom.xml
+++ b/catalog/spatial/wfs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>spatial</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>wfs</artifactId>
     <name>DDF :: Spatial :: WFS</name>

--- a/catalog/spatial/wfs/spatial-wfs-api/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-api</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/spatial/wfs/spatial-wfs-common/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-common</artifactId>
     <name>DDF :: Spatial :: WFS :: Common</name>

--- a/catalog/spatial/wfs/spatial-wfs-converter/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-converter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-converter</artifactId>
     <name>DDF :: Spatial :: WFS :: Converter</name>

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-api/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>spatial-wfs-featuretransformer-api</artifactId>

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-handlebars/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-handlebars/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>spatial-wfs-featuretransformer-handlebars</artifactId>

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer-xstream/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>wfs</artifactId>
     <groupId>org.codice.ddf.spatial</groupId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/spatial/wfs/spatial-wfs-featuretransformer/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-featuretransformer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>spatial-wfs-featuretransformer</artifactId>

--- a/catalog/spatial/wfs/spatial-wfs-mapper/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-mapper/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>spatial-wfs-mapper</artifactId>

--- a/catalog/spatial/wfs/spatial-wfs-metacardtype-registry-api/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-metacardtype-registry-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>spatial-wfs-metacardtype-registry-api</artifactId>

--- a/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-metacardtype-registry/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>spatial-wfs-metacardtype-registry</artifactId>

--- a/catalog/spatial/wfs/spatial-wfs-source/pom.xml
+++ b/catalog/spatial/wfs/spatial-wfs-source/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.ddf.spatial</groupId>
         <artifactId>wfs</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>spatial-wfs-source</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/transformer/catalog-transformer-attribute/pom.xml
+++ b/catalog/transformer/catalog-transformer-attribute/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>catalog-transformer-attribute</artifactId>

--- a/catalog/transformer/catalog-transformer-bootflag/pom.xml
+++ b/catalog/transformer/catalog-transformer-bootflag/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>transformer</artifactId>
         <groupId>ddf.catalog.transformer</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/transformer/catalog-transformer-common/pom.xml
+++ b/catalog/transformer/catalog-transformer-common/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>transformer</artifactId>
         <groupId>ddf.catalog.transformer</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/transformer/catalog-transformer-csv-common/pom.xml
+++ b/catalog/transformer/catalog-transformer-csv-common/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>transformer</artifactId>
         <groupId>ddf.catalog.transformer</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-transformer-csv-common</artifactId>
     <name>DDF :: Catalog :: Transformer :: Common :: CSV</name>

--- a/catalog/transformer/catalog-transformer-csv-queryresponse/pom.xml
+++ b/catalog/transformer/catalog-transformer-csv-queryresponse/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <packaging>bundle</packaging>
     <artifactId>csv-queryresponse-transformer</artifactId>

--- a/catalog/transformer/catalog-transformer-geojson-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-geojson-input/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geojson-input-transformer</artifactId>

--- a/catalog/transformer/catalog-transformer-geojson-metacard/pom.xml
+++ b/catalog/transformer/catalog-transformer-geojson-metacard/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>geojson-metacard-transformer</artifactId>

--- a/catalog/transformer/catalog-transformer-geojson-queryresponse/pom.xml
+++ b/catalog/transformer/catalog-transformer-geojson-queryresponse/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>geojson-queryresponse-transformer</artifactId>

--- a/catalog/transformer/catalog-transformer-html/pom.xml
+++ b/catalog/transformer/catalog-transformer-html/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>transformer</artifactId>
     <groupId>ddf.catalog.transformer</groupId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>DDF :: Catalog :: Transformer :: HTML</name>

--- a/catalog/transformer/catalog-transformer-metadata/pom.xml
+++ b/catalog/transformer/catalog-transformer-metadata/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>catalog-transformer-metadata</artifactId>

--- a/catalog/transformer/catalog-transformer-overlay/pom.xml
+++ b/catalog/transformer/catalog-transformer-overlay/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>transformer</artifactId>
         <groupId>ddf.catalog.transformer</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/transformer/catalog-transformer-pdf/pom.xml
+++ b/catalog/transformer/catalog-transformer-pdf/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Transformer :: PDF</name>

--- a/catalog/transformer/catalog-transformer-pptx/pom.xml
+++ b/catalog/transformer/catalog-transformer-pptx/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Transformer :: PPTX</name>

--- a/catalog/transformer/catalog-transformer-preview/pom.xml
+++ b/catalog/transformer/catalog-transformer-preview/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Transformer :: Preview</name>

--- a/catalog/transformer/catalog-transformer-propertyjson-metacard/pom.xml
+++ b/catalog/transformer/catalog-transformer-propertyjson-metacard/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Transformer :: Metacard :: PropertyJson</name>

--- a/catalog/transformer/catalog-transformer-resource/pom.xml
+++ b/catalog/transformer/catalog-transformer-resource/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>catalog-transformer-resource</artifactId>

--- a/catalog/transformer/catalog-transformer-rtf/pom.xml
+++ b/catalog/transformer/catalog-transformer-rtf/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>transformer</artifactId>
         <groupId>ddf.catalog.transformer</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/catalog/transformer/catalog-transformer-service-atom/pom.xml
+++ b/catalog/transformer/catalog-transformer-service-atom/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>service-atom-transformer</artifactId>

--- a/catalog/transformer/catalog-transformer-service-xslt/pom.xml
+++ b/catalog/transformer/catalog-transformer-service-xslt/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>service-xslt-transformer</artifactId>

--- a/catalog/transformer/catalog-transformer-streaming-api/pom.xml
+++ b/catalog/transformer/catalog-transformer-streaming-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-transformer-streaming-api</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/transformer/catalog-transformer-streaming-impl/pom.xml
+++ b/catalog/transformer/catalog-transformer-streaming-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>catalog-transformer-streaming-impl</artifactId>

--- a/catalog/transformer/catalog-transformer-streaming-lib/pom.xml
+++ b/catalog/transformer/catalog-transformer-streaming-lib/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>catalog-transformer-streaming-lib</artifactId>

--- a/catalog/transformer/catalog-transformer-thumbnail/pom.xml
+++ b/catalog/transformer/catalog-transformer-thumbnail/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>catalog-transformer-thumbnail</artifactId>

--- a/catalog/transformer/catalog-transformer-tika-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-tika-input/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tika-input-transformer</artifactId>

--- a/catalog/transformer/catalog-transformer-video-input/pom.xml
+++ b/catalog/transformer/catalog-transformer-video-input/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>video-input-transformer</artifactId>

--- a/catalog/transformer/catalog-transformer-xlsx/pom.xml
+++ b/catalog/transformer/catalog-transformer-xlsx/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-transformer-xlsx</artifactId>

--- a/catalog/transformer/catalog-transformer-xml/pom.xml
+++ b/catalog/transformer/catalog-transformer-xml/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-transformer-xml</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/transformer/catalog-transformer-zip/pom.xml
+++ b/catalog/transformer/catalog-transformer-zip/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog.transformer</groupId>
         <artifactId>transformer</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-transformer-zip</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/transformer/pom.xml
+++ b/catalog/transformer/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.catalog.transformer</groupId>
     <artifactId>transformer</artifactId>

--- a/catalog/ui/pom.xml
+++ b/catalog/ui/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: UI</name>

--- a/catalog/ui/search-ui-app/pom.xml
+++ b/catalog/ui/search-ui-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.ui</groupId>
         <artifactId>catalog-ui</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: UI :: Search UI :: App</name>

--- a/catalog/ui/search-ui/pom.xml
+++ b/catalog/ui/search-ui/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog-ui</artifactId>
         <groupId>ddf.ui</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.ui.search</groupId>
     <artifactId>search-ui</artifactId>

--- a/catalog/ui/search-ui/search-redirect/pom.xml
+++ b/catalog/ui/search-ui/search-redirect/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>search-ui</artifactId>
         <groupId>ddf.ui.search</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/catalog/ui/search-ui/simple/pom.xml
+++ b/catalog/ui/search-ui/simple/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.ui.search</groupId>
         <artifactId>search-ui</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>simple</artifactId>
     <name>DDF :: UI :: Search UI :: Simple Search</name>

--- a/catalog/validator/catalog-validator-metacardduplication/pom.xml
+++ b/catalog/validator/catalog-validator-metacardduplication/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.ddf.validator</groupId>
         <artifactId>validator</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Validator :: Metacard Duplication</name>

--- a/catalog/validator/catalog-validator-metacardframecenter/pom.xml
+++ b/catalog/validator/catalog-validator-metacardframecenter/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.ddf.validator</groupId>
         <artifactId>validator</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Validator :: Metacard Frame Center</name>

--- a/catalog/validator/catalog-validator-metacardlocation/pom.xml
+++ b/catalog/validator/catalog-validator-metacardlocation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.ddf.validator</groupId>
         <artifactId>validator</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Catalog :: Validator :: Metacard Location</name>

--- a/catalog/validator/catalog-validator-metacardwkt/pom.xml
+++ b/catalog/validator/catalog-validator-metacardwkt/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>validator</artifactId>
         <groupId>org.codice.ddf.validator</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/validator/catalog-validator-unsupportedattributes/pom.xml
+++ b/catalog/validator/catalog-validator-unsupportedattributes/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>validator</artifactId>
     <groupId>org.codice.ddf.validator</groupId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/validator/catalog-validator-wkt/pom.xml
+++ b/catalog/validator/catalog-validator-wkt/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>validator</artifactId>
         <groupId>org.codice.ddf.validator</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/validator/pom.xml
+++ b/catalog/validator/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.catalog</groupId>
         <artifactId>catalog</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.ddf.validator</groupId>
     <artifactId>validator</artifactId>

--- a/distribution/console-branding/pom.xml
+++ b/distribution/console-branding/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>distribution</artifactId>
         <groupId>ddf</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>console-branding</artifactId>
     <groupId>ddf.distribution</groupId>

--- a/distribution/ddf-branding-plugin/pom.xml
+++ b/distribution/ddf-branding-plugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>distribution</artifactId>
         <groupId>ddf</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.distribution</groupId>
     <artifactId>ddf-branding-plugin</artifactId>

--- a/distribution/ddf-catalog/pom.xml
+++ b/distribution/ddf-catalog/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>distribution</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>ddf-catalog</artifactId>
     <groupId>org.codice.ddf</groupId>

--- a/distribution/ddf-common/pom.xml
+++ b/distribution/ddf-common/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>distribution</artifactId>
     <groupId>ddf</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
   </parent>
   <!--
 Provides the common/shared resources used by the DDF core, standard, and enterprise distributions.

--- a/distribution/ddf/pom.xml
+++ b/distribution/ddf/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kernel</artifactId>
         <groupId>org.codice.ddf</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
         <relativePath>../kernel/pom.xml</relativePath>
     </parent>
     <!--

--- a/distribution/docker/ddf-docker/pom.xml
+++ b/distribution/docker/ddf-docker/pom.xml
@@ -25,8 +25,8 @@
     <name>DDF :: Distribution :: Docker :: DDF</name>
 
     <properties>
-        <!-- Set the version of the codice/ddf-base docker image to build on top of here -->
-        <docker.ddf.base.version>3.0</docker.ddf.base.version>
+        <!-- JDK 21 base; pinned by digest for reproducibility. Bump in lockstep with codice/docker-ddf-base releases. -->
+        <docker.ddf.base.version>4.0@sha256:005cfb947b79fa15695c099707b268b4e267f0138eb2fb1d65b374ec8b31d84e</docker.ddf.base.version>
     </properties>
 
     <dependencies>

--- a/distribution/docker/ddf-docker/pom.xml
+++ b/distribution/docker/ddf-docker/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.distribution</groupId>
         <artifactId>docker</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>ddf-docker</artifactId>
     <groupId>ddf.distribution.docker</groupId>

--- a/distribution/docker/pom.xml
+++ b/distribution/docker/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>distribution</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>docker</artifactId>
     <groupId>ddf.distribution</groupId>

--- a/distribution/docker/solr-docker/pom.xml
+++ b/distribution/docker/solr-docker/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.distribution</groupId>
         <artifactId>docker</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>solr-docker</artifactId>
     <groupId>ddf.distribution.docker</groupId>

--- a/distribution/docker/solrcloud/pom.xml
+++ b/distribution/docker/solrcloud/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.distribution</groupId>
         <artifactId>docker</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>ddf-solrcloud</artifactId>
     <groupId>ddf.distribution.docker</groupId>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>distribution</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>docs</artifactId>
     <name>DDF DOCS</name>

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>distribution</artifactId>
         <groupId>ddf</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <!--
     Packages the DDF configured Karaf.

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>distribution</artifactId>
     <packaging>pom</packaging>

--- a/distribution/software-list/pom.xml
+++ b/distribution/software-list/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>distribution</artifactId>
         <groupId>ddf</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>software-list</artifactId>
     <groupId>ddf.distribution</groupId>

--- a/distribution/solr-distro/pom.xml
+++ b/distribution/solr-distro/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>distribution</artifactId>
         <groupId>ddf</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Distribution :: Solr Distro</name>

--- a/distribution/test/example-bundle/pom.xml
+++ b/distribution/test/example-bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>test</artifactId>
         <groupId>ddf.test</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>example-bundle</artifactId>

--- a/distribution/test/features-xml/pom.xml
+++ b/distribution/test/features-xml/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>test</artifactId>
         <groupId>ddf.test</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>features-xml</artifactId>
     <packaging>pom</packaging>

--- a/distribution/test/itests/pom.xml
+++ b/distribution/test/itests/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.test</groupId>
         <artifactId>test</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.test.itests</groupId>
     <artifactId>itests</artifactId>

--- a/distribution/test/itests/test-itests-common/pom.xml
+++ b/distribution/test/itests/test-itests-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.test.itests</groupId>
         <artifactId>itests</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-common</artifactId>
     <name>DDF :: Integration Test :: Common</name>

--- a/distribution/test/itests/test-itests-ddf-core/pom.xml
+++ b/distribution/test/itests/test-itests-ddf-core/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>itests</artifactId>
         <groupId>ddf.test.itests</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/distribution/test/itests/test-itests-ddf/pom.xml
+++ b/distribution/test/itests/test-itests-ddf/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.test.itests</groupId>
         <artifactId>itests</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-ddf</artifactId>
     <name>DDF :: Integration :: Test</name>

--- a/distribution/test/itests/test-itests-dependencies-app/pom.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>itests</artifactId>
         <groupId>ddf.test.itests</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-dependencies-app</artifactId>
     <name>DDF :: Integration :: Test Dependencies App</name>

--- a/distribution/test/itests/test-itests-kernel/pom.xml
+++ b/distribution/test/itests/test-itests-kernel/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>itests</artifactId>
         <groupId>ddf.test.itests</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Integration Test :: Kernel</name>
     <artifactId>test-itests-kernel</artifactId>

--- a/distribution/test/performance/jmeter/catalog-transformer-xml/pom.xml
+++ b/distribution/test/performance/jmeter/catalog-transformer-xml/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.test.performance.jmeter</groupId>
         <artifactId>jmeter</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>ddf-test-performance-jmeter-catalog-transformer-xml</artifactId>
     <name>DDF :: Test :: Performance :: JMeter :: Catalog XML Transformer</name>

--- a/distribution/test/performance/jmeter/csw/pom.xml
+++ b/distribution/test/performance/jmeter/csw/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.test.performance.jmeter</groupId>
         <artifactId>jmeter</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>ddf-test-performance-jmeter-csw</artifactId>
     <name>DDF :: Test :: Performance :: JMeter :: CSW</name>

--- a/distribution/test/performance/jmeter/pom.xml
+++ b/distribution/test/performance/jmeter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.test.performance</groupId>
         <artifactId>performance</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.test.performance.jmeter</groupId>
     <artifactId>jmeter</artifactId>

--- a/distribution/test/performance/pom.xml
+++ b/distribution/test/performance/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.test</groupId>
         <artifactId>test</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.test.performance</groupId>
     <artifactId>performance</artifactId>

--- a/distribution/test/pom.xml
+++ b/distribution/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>distribution</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.test</groupId>

--- a/distribution/test/test-input-transformer-stubs/pom.xml
+++ b/distribution/test/test-input-transformer-stubs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>test</artifactId>
         <groupId>ddf.test</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-input-transformer-stubs</artifactId>
     <name>DDF :: Test :: Input Transformer Stubs</name>

--- a/distribution/test/test-metacard-validator/pom.xml
+++ b/distribution/test/test-metacard-validator/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>test</artifactId>
         <groupId>ddf.test</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/test/test-rest-endpoint/pom.xml
+++ b/distribution/test/test-rest-endpoint/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>test</artifactId>
         <groupId>ddf.test</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Test :: REST Endpoint</name>

--- a/distribution/test/test-storageplugins/pom.xml
+++ b/distribution/test/test-storageplugins/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>test</artifactId>
         <groupId>ddf.test</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-storageplugins</artifactId>
     <name>DDF :: SDK :: Plugin :: Sample Storage Plugins</name>

--- a/features/admin/pom.xml
+++ b/features/admin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Features :: Admin</name>

--- a/features/apps/pom.xml
+++ b/features/apps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Features :: Apps</name>
     <artifactId>apps</artifactId>

--- a/features/branding/pom.xml
+++ b/features/branding/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Features :: Branding</name>
     <artifactId>branding</artifactId>

--- a/features/camel-karaf/pom.xml
+++ b/features/camel-karaf/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Features :: Camel Karaf</name>

--- a/features/install-profiles/pom.xml
+++ b/features/install-profiles/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Features :: Install Profiles</name>

--- a/features/kernel/pom.xml
+++ b/features/kernel/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Features :: Kernel</name>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>ddf</artifactId>
         <groupId>ddf</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF Features</name>
     <groupId>ddf.features</groupId>

--- a/features/security/pom.xml
+++ b/features/security/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Features :: Security</name>

--- a/features/solr/pom.xml
+++ b/features/solr/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Features :: Solr</name>
     <artifactId>solr</artifactId>

--- a/features/test-utilities/pom.xml
+++ b/features/test-utilities/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Features :: Test Utils</name>
 

--- a/features/utilities/pom.xml
+++ b/features/utilities/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>ddf.features</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Features :: Utilities</name>

--- a/gitsetup/pom.xml
+++ b/gitsetup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <groupId>ddf</groupId>

--- a/libs/activities/pom.xml
+++ b/libs/activities/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice.ddf</groupId>

--- a/libs/alerts/pom.xml
+++ b/libs/alerts/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice.ddf</groupId>

--- a/libs/checksum/pom.xml
+++ b/libs/checksum/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice.ddf</groupId>

--- a/libs/common-system/pom.xml
+++ b/libs/common-system/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>common-system</artifactId>
     <name>DDF :: Common System</name>

--- a/libs/geospatial/pom.xml
+++ b/libs/geospatial/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>lib</artifactId>
         <groupId>ddf.lib</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.ddf</groupId>
     <artifactId>geospatial</artifactId>

--- a/libs/gson-support/pom.xml
+++ b/libs/gson-support/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gson-support</artifactId>

--- a/libs/httpproxy/pom.xml
+++ b/libs/httpproxy/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.httpproxy</groupId>
     <artifactId>httpproxy-pom</artifactId>

--- a/libs/httpproxy/proxy-camel-route/pom.xml
+++ b/libs/httpproxy/proxy-camel-route/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>httpproxy-pom</artifactId>
         <groupId>org.codice.httpproxy</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>proxy-camel-route</artifactId>
     <name>Codice :: HttpProxy :: ProxyCamelRoute</name>

--- a/libs/httpproxy/proxy-camel-servlet/pom.xml
+++ b/libs/httpproxy/proxy-camel-servlet/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>httpproxy-pom</artifactId>
         <groupId>org.codice.httpproxy</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>proxy-camel-servlet</artifactId>
     <name>Codice :: HttpProxy :: ProxyCamelServlet</name>

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>lib</artifactId>
         <groupId>ddf.lib</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/mpeg-transport-stream/pom.xml
+++ b/libs/mpeg-transport-stream/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>lib</artifactId>
         <groupId>ddf.lib</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/notifications/pom.xml
+++ b/libs/notifications/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice.ddf</groupId>

--- a/libs/platform-configuration-impl/pom.xml
+++ b/libs/platform-configuration-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.ddf</groupId>
     <artifactId>platform-configuration-impl</artifactId>

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.lib</groupId>
     <artifactId>lib</artifactId>

--- a/libs/test-common/pom.xml
+++ b/libs/test-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-common</artifactId>

--- a/libs/tlmatcher/pom.xml
+++ b/libs/tlmatcher/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.lib</groupId>
         <artifactId>lib</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tlmatcher</artifactId>

--- a/platform/action/core/platform-action-core-api/pom.xml
+++ b/platform/action/core/platform-action-core-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>action-core-pom</artifactId>
         <groupId>ddf.action.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>action-core-api</artifactId>
     <packaging>bundle</packaging>

--- a/platform/action/core/platform-action-core-impl/pom.xml
+++ b/platform/action/core/platform-action-core-impl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>action-core-pom</artifactId>
         <groupId>ddf.action.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>action-core-impl</artifactId>
     <packaging>bundle</packaging>

--- a/platform/action/core/pom.xml
+++ b/platform/action/core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>action</artifactId>
         <groupId>ddf.action</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>action-core-pom</artifactId>
     <groupId>ddf.action.core</groupId>

--- a/platform/action/pom.xml
+++ b/platform/action/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.action</groupId>

--- a/platform/admin/admin-configuration-configupdater/pom.xml
+++ b/platform/admin/admin-configuration-configupdater/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>platform-admin</artifactId>
         <groupId>ddf.admin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Admin :: Configuration Updater</name>

--- a/platform/admin/configurator/admin-configurator-actions-api/pom.xml
+++ b/platform/admin/configurator/admin-configurator-actions-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.admin</groupId>
         <artifactId>configurator</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>admin-configurator-actions-api</artifactId>

--- a/platform/admin/configurator/admin-configurator-api/pom.xml
+++ b/platform/admin/configurator/admin-configurator-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.admin</groupId>
         <artifactId>configurator</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>admin-configurator-api</artifactId>

--- a/platform/admin/configurator/admin-configurator-impl/pom.xml
+++ b/platform/admin/configurator/admin-configurator-impl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.admin</groupId>
         <artifactId>configurator</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>admin-configurator-impl</artifactId>

--- a/platform/admin/configurator/pom.xml
+++ b/platform/admin/configurator/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.admin</groupId>
         <artifactId>platform-admin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>configurator</artifactId>

--- a/platform/admin/core/admin-core-api/pom.xml
+++ b/platform/admin/core/admin-core-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-core</artifactId>
         <groupId>ddf.admin.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>admin-core-api</artifactId>
     <modelVersion>4.0.0</modelVersion>

--- a/platform/admin/core/admin-core-appservice/pom.xml
+++ b/platform/admin/core/admin-core-appservice/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>admin-core</artifactId>
         <groupId>ddf.admin.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>admin-core-appservice</artifactId>
     <name>DDF :: Admin :: Core :: Application Service</name>

--- a/platform/admin/core/admin-core-configpidplugin/pom.xml
+++ b/platform/admin/core/admin-core-configpidplugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-core</artifactId>
         <groupId>ddf.admin.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>admin-core-configplugin</artifactId>

--- a/platform/admin/core/admin-core-configpolicy/pom.xml
+++ b/platform/admin/core/admin-core-configpolicy/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-core</artifactId>
         <groupId>ddf.admin.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Admin :: Core :: Config Policy</name>
     <artifactId>admin-core-configpolicy</artifactId>

--- a/platform/admin/core/admin-core-impl/pom.xml
+++ b/platform/admin/core/admin-core-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-core</artifactId>
         <groupId>ddf.admin.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Admin :: Core :: Impl</name>

--- a/platform/admin/core/admin-core-insecuredefaults/pom.xml
+++ b/platform/admin/core/admin-core-insecuredefaults/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>admin-core</artifactId>
         <groupId>ddf.admin.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>admin-core-insecuredefaults</artifactId>
     <name>DDF :: Admin :: Core :: Insecure Defaults</name>

--- a/platform/admin/core/admin-core-jolokia/pom.xml
+++ b/platform/admin/core/admin-core-jolokia/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>admin-core</artifactId>
         <groupId>ddf.admin.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>admin-core-jolokia</artifactId>
     <name>DDF :: Admin :: Core :: Jolokia</name>

--- a/platform/admin/core/admin-core-logviewer/pom.xml
+++ b/platform/admin/core/admin-core-logviewer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-core</artifactId>
         <groupId>ddf.admin.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Admin :: LogViewer</name>
     <groupId>ddf.admin.core</groupId>

--- a/platform/admin/core/pom.xml
+++ b/platform/admin/core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.admin</groupId>
         <artifactId>platform-admin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.admin.core</groupId>
     <artifactId>admin-core</artifactId>

--- a/platform/admin/modules/admin-metrics-ui/pom.xml
+++ b/platform/admin/modules/admin-metrics-ui/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>admin-modules</artifactId>
         <groupId>ddf.admin.modules</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>admin-metrics-ui</artifactId>

--- a/platform/admin/modules/admin-modules-application/pom.xml
+++ b/platform/admin/modules/admin-modules-application/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-modules</artifactId>
         <groupId>ddf.admin.modules</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Admin :: Modules :: Applications</name>

--- a/platform/admin/modules/admin-modules-configuration/pom.xml
+++ b/platform/admin/modules/admin-modules-configuration/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-modules</artifactId>
         <groupId>ddf.admin.modules</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Admin :: Modules :: Configuration</name>

--- a/platform/admin/modules/admin-modules-docs/pom.xml
+++ b/platform/admin/modules/admin-modules-docs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>admin-modules</artifactId>
         <groupId>ddf.admin.modules</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Admin :: Modules :: Documentation UI</name>
     <artifactId>admin-docs-ui</artifactId>

--- a/platform/admin/modules/admin-modules-installer/pom.xml
+++ b/platform/admin/modules/admin-modules-installer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-modules</artifactId>
         <groupId>ddf.admin.modules</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Admin :: Modules :: Installer</name>
     <modelVersion>4.0.0</modelVersion>

--- a/platform/admin/modules/admin-security-certificate-ui/pom.xml
+++ b/platform/admin/modules/admin-security-certificate-ui/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>admin-modules</artifactId>
         <groupId>ddf.admin.modules</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Admin :: Modules :: Security Certificate UI</name>

--- a/platform/admin/modules/pom.xml
+++ b/platform/admin/modules/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.admin</groupId>
         <artifactId>platform-admin</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.admin.modules</groupId>
     <artifactId>admin-modules</artifactId>

--- a/platform/admin/pom.xml
+++ b/platform/admin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF Admin</name>

--- a/platform/admin/ui/pom.xml
+++ b/platform/admin/ui/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-admin</artifactId>
         <groupId>ddf.admin</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Admin :: UI</name>
     <modelVersion>4.0.0</modelVersion>

--- a/platform/branding-api/pom.xml
+++ b/platform/branding-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.platform</groupId>
     <artifactId>branding-api</artifactId>

--- a/platform/branding-registry-impl/pom.xml
+++ b/platform/branding-registry-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>branding-registry-impl</artifactId>
     <name>DDF :: Platform :: Branding Registry Impl</name>

--- a/platform/country-converter/platform-country-converter-api/pom.xml
+++ b/platform/country-converter/platform-country-converter-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>country-converter</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Platform :: Country :: Converter :: API</name>
     <modelVersion>4.0.0</modelVersion>

--- a/platform/country-converter/platform-country-converter-local/pom.xml
+++ b/platform/country-converter/platform-country-converter-local/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>country-converter</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Platform :: Country :: Converter :: Local</name>
     <groupId>ddf.platform.country</groupId>

--- a/platform/country-converter/pom.xml
+++ b/platform/country-converter/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Platform :: Country :: Converter</name>
     <modelVersion>4.0.0</modelVersion>

--- a/platform/email/platform-email-api/pom.xml
+++ b/platform/email/platform-email-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>email</artifactId>
         <groupId>ddf.platform.email</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>platform-email-api</artifactId>

--- a/platform/email/platform-email-impl/pom.xml
+++ b/platform/email/platform-email-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>email</artifactId>
         <groupId>ddf.platform.email</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>platform-email-impl</artifactId>

--- a/platform/email/pom.xml
+++ b/platform/email/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.platform.email</groupId>

--- a/platform/error/platform-error-api/pom.xml
+++ b/platform/error/platform-error-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>error</artifactId>
         <groupId>ddf.platform.error</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>platform-error-api</artifactId>

--- a/platform/error/platform-error-impl/pom.xml
+++ b/platform/error/platform-error-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>error</artifactId>
         <groupId>ddf.platform.error</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>platform-error-impl</artifactId>

--- a/platform/error/platform-error-servlet/pom.xml
+++ b/platform/error/platform-error-servlet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>error</artifactId>
         <groupId>ddf.platform.error</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>platform-error-servlet</artifactId>

--- a/platform/error/pom.xml
+++ b/platform/error/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.platform.error</groupId>

--- a/platform/http-filter-api/pom.xml
+++ b/platform/http-filter-api/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>ddf.platform</groupId>
     <artifactId>platform</artifactId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/platform/io/platform-io-impl/pom.xml
+++ b/platform/io/platform-io-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>io</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/platform/io/platform-io-internal-api/pom.xml
+++ b/platform/io/platform-io-internal-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>io</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/platform/io/pom.xml
+++ b/platform/io/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/landing-page/pom.xml
+++ b/platform/landing-page/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>landing-page</artifactId>
     <name>DDF :: Platform :: Landing Page</name>

--- a/platform/metrics/metrics-prometheus-endpoint/pom.xml
+++ b/platform/metrics/metrics-prometheus-endpoint/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>ddf.metrics</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.ddf.metrics</groupId>
     <artifactId>metrics-prometheus-endpoint</artifactId>

--- a/platform/metrics/metrics-servlet-filter/pom.xml
+++ b/platform/metrics/metrics-servlet-filter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>ddf.metrics</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.metrics</groupId>

--- a/platform/metrics/metrics-system-reporter/pom.xml
+++ b/platform/metrics/metrics-system-reporter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>ddf.metrics</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.ddf.metrics</groupId>
     <artifactId>metrics-system-reporter</artifactId>

--- a/platform/metrics/micrometer-bundle/pom.xml
+++ b/platform/metrics/micrometer-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>ddf.metrics</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.metrics</groupId>

--- a/platform/metrics/micrometer-prometheus-bundle/pom.xml
+++ b/platform/metrics/micrometer-prometheus-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>ddf.metrics</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.metrics</groupId>

--- a/platform/metrics/opentelemetry-api-bundle/pom.xml
+++ b/platform/metrics/opentelemetry-api-bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>ddf.metrics</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.ddf.metrics</groupId>

--- a/platform/metrics/pom.xml
+++ b/platform/metrics/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.metrics</groupId>
     <artifactId>metrics</artifactId>

--- a/platform/mime/core/platform-mime-core-api/pom.xml
+++ b/platform/mime/core/platform-mime-core-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>mime-core-pom</artifactId>
         <groupId>ddf.mime.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>mime-core-api</artifactId>
     <name>DDF :: MIME :: Core :: MIME API</name>

--- a/platform/mime/core/platform-mime-core-configurableresolver/pom.xml
+++ b/platform/mime/core/platform-mime-core-configurableresolver/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>mime-core-pom</artifactId>
         <groupId>ddf.mime.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>mime-core-configurableresolver</artifactId>
     <name>DDF :: MIME :: Core :: ConfigurableResolver</name>

--- a/platform/mime/core/platform-mime-core-impl/pom.xml
+++ b/platform/mime/core/platform-mime-core-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>mime-core-pom</artifactId>
         <groupId>ddf.mime.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>mime-core-impl</artifactId>
     <name>DDF :: MIME :: Core :: MIME Implementation</name>

--- a/platform/mime/core/pom.xml
+++ b/platform/mime/core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>mime</artifactId>
         <groupId>ddf.mime</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>mime-core-pom</artifactId>
     <groupId>ddf.mime.core</groupId>

--- a/platform/mime/pom.xml
+++ b/platform/mime/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.mime</groupId>
     <artifactId>mime</artifactId>

--- a/platform/mime/tika/platform-mime-tika-resolver/pom.xml
+++ b/platform/mime/tika/platform-mime-tika-resolver/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>mime-tika-pom</artifactId>
         <groupId>ddf.mime.tika</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>mime-tika-resolver</artifactId>
     <name>DDF :: MIME :: Tika :: Tika MIME Resolver</name>

--- a/platform/mime/tika/pom.xml
+++ b/platform/mime/tika/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>mime</artifactId>
         <groupId>ddf.mime</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>mime-tika-pom</artifactId>
     <groupId>ddf.mime.tika</groupId>

--- a/platform/osgi/bootflag-api/pom.xml
+++ b/platform/osgi/bootflag-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>osgi</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/osgi/platform-osgi-conditions/pom.xml
+++ b/platform/osgi/platform-osgi-conditions/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>osgi</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/platform/osgi/platform-osgi-condpermadmin/pom.xml
+++ b/platform/osgi/platform-osgi-condpermadmin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>osgi</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/platform/osgi/platform-osgi-configadmin/pom.xml
+++ b/platform/osgi/platform-osgi-configadmin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>osgi</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/platform/osgi/platform-osgi-internal-api/pom.xml
+++ b/platform/osgi/platform-osgi-internal-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>osgi</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/platform/osgi/pom.xml
+++ b/platform/osgi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/platform/parser/api/pom.xml
+++ b/platform/parser/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>parser</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>platform-parser-api</artifactId>
     <name>DDF :: Platform :: Parser :: API</name>

--- a/platform/parser/pom.xml
+++ b/platform/parser/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>parser</artifactId>
     <name>DDF :: Platform :: Parser</name>

--- a/platform/parser/xml/pom.xml
+++ b/platform/parser/xml/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>parser</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>platform-parser-xml</artifactId>
     <name>DDF :: Platform :: Parser :: XML</name>

--- a/platform/persistence/platform-persistence-commands/pom.xml
+++ b/platform/persistence/platform-persistence-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.persistence.core</groupId>
     <artifactId>persistence-core-commands</artifactId>

--- a/platform/persistence/platform-persistence-core-api/pom.xml
+++ b/platform/persistence/platform-persistence-core-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.persistence.core</groupId>
     <artifactId>persistence-core-api</artifactId>

--- a/platform/persistence/platform-persistence-core-attributes-impl/pom.xml
+++ b/platform/persistence/platform-persistence-core-attributes-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.persistence.core</groupId>
     <artifactId>persistence-core-attributes-impl</artifactId>

--- a/platform/persistence/platform-persistence-core-impl/pom.xml
+++ b/platform/persistence/platform-persistence-core-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.persistence</groupId>
         <artifactId>persistence</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.persistence.core</groupId>
     <artifactId>persistence-core-impl</artifactId>

--- a/platform/persistence/platform-persistence-core-listeners/pom.xml
+++ b/platform/persistence/platform-persistence-core-listeners/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>persistence</artifactId>
         <groupId>ddf.persistence</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.persistence.core</groupId>
     <artifactId>persistence-core-listeners</artifactId>

--- a/platform/persistence/pom.xml
+++ b/platform/persistence/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.persistence</groupId>
     <artifactId>persistence</artifactId>

--- a/platform/platform-api/pom.xml
+++ b/platform/platform-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/platform-commands/pom.xml
+++ b/platform/platform-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>platform-commands</artifactId>
     <name>DDF :: Platform :: Commands</name>

--- a/platform/platform-configuration-endpoint/pom.xml
+++ b/platform/platform-configuration-endpoint/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>platform-configuration-endpoint</artifactId>

--- a/platform/platform-configuration-service/pom.xml
+++ b/platform/platform-configuration-service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/platform-configuration/pom.xml
+++ b/platform/platform-configuration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>platform-configuration</artifactId>
     <name>DDF :: Platform :: Configuration</name>

--- a/platform/platform-logging/pom.xml
+++ b/platform/platform-logging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>platform-logging</artifactId>
     <name>DDF :: Platform :: Logging</name>

--- a/platform/platform-paxweb-jettyconfig/pom.xml
+++ b/platform/platform-paxweb-jettyconfig/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>platform-paxweb-jettyconfig</artifactId>

--- a/platform/platform-scheduler/pom.xml
+++ b/platform/platform-scheduler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>platform-scheduler</artifactId>
     <name>DDF :: Platform :: Scheduler</name>

--- a/platform/platform-session-invalidator-api/pom.xml
+++ b/platform/platform-session-invalidator-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>platform-session-invalidator-api</artifactId>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.platform</groupId>
     <artifactId>platform</artifactId>

--- a/platform/preferences/pom.xml
+++ b/platform/preferences/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.platform</groupId>
     <artifactId>preferences</artifactId>

--- a/platform/preferences/preferences-api/pom.xml
+++ b/platform/preferences/preferences-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>preferences</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>preferences-api</artifactId>
     <name>DDF :: Preferences :: API</name>

--- a/platform/preferences/preferences-impl/pom.xml
+++ b/platform/preferences/preferences-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>preferences</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>preferences-impl</artifactId>
     <name>DDF :: Preferences :: Impl</name>

--- a/platform/resource-bundle-locator/pom.xml
+++ b/platform/resource-bundle-locator/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>ddf.platform</groupId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
   </parent>
 
   <name>DDF :: Platform :: Resource Bundle Locator</name>

--- a/platform/security-filter-api/pom.xml
+++ b/platform/security-filter-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <!-- probably should get moved into platform-security-core-api or such but there's not only apis in there-->

--- a/platform/security/certificate/pom.xml
+++ b/platform/security/certificate/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.security.certificate</groupId>

--- a/platform/security/certificate/security-certificate-generator/pom.xml
+++ b/platform/security/certificate/security-certificate-generator/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>certificate</artifactId>
         <groupId>ddf.security.certificate</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Certificate :: Generator</name>

--- a/platform/security/certificate/security-certificate-keystoreeditor/pom.xml
+++ b/platform/security/certificate/security-certificate-keystoreeditor/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>certificate</artifactId>
         <groupId>ddf.security.certificate</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Certificate :: Keystore Editor</name>

--- a/platform/security/certificate/security-crl-generator/pom.xml
+++ b/platform/security/certificate/security-crl-generator/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.security.certificate</groupId>
         <artifactId>certificate</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Certificate Revocation List Generator</name>

--- a/platform/security/certificate/security-ocsp-checker/pom.xml
+++ b/platform/security/certificate/security-ocsp-checker/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.security.certificate</groupId>
         <artifactId>certificate</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/claims/pom.xml
+++ b/platform/security/claims/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>claims</artifactId>
     <groupId>ddf.security.claims</groupId>

--- a/platform/security/claims/security-claims-attributequery/pom.xml
+++ b/platform/security/claims/security-claims-attributequery/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>claims</artifactId>
         <groupId>ddf.security.claims</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/claims/security-claims-attributequerycommon/pom.xml
+++ b/platform/security/claims/security-claims-attributequerycommon/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>claims</artifactId>
         <groupId>ddf.security.claims</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/claims/security-claims-certificate/pom.xml
+++ b/platform/security/claims/security-claims-certificate/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>claims</artifactId>
         <groupId>ddf.security.claims</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/claims/security-claims-ldap/pom.xml
+++ b/platform/security/claims/security-claims-ldap/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>claims</artifactId>
         <groupId>ddf.security.claims</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-claims-ldap</artifactId>
     <name>DDF :: Security :: Claims :: LDAP</name>

--- a/platform/security/claims/security-claims-property/pom.xml
+++ b/platform/security/claims/security-claims-property/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>claims</artifactId>
         <groupId>ddf.security.claims</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-claims-property</artifactId>

--- a/platform/security/command/pom.xml
+++ b/platform/security/command/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.security.command</groupId>

--- a/platform/security/command/security-command-listener/pom.xml
+++ b/platform/security/command/security-command-listener/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>command</artifactId>
         <groupId>ddf.security.command</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Command :: Listener</name>

--- a/platform/security/command/security-command-sessionmanager/pom.xml
+++ b/platform/security/command/security-command-sessionmanager/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>ddf.security.command</groupId>
         <artifactId>command</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <name>DDF :: Security :: Command :: Session Manager</name>

--- a/platform/security/core/pom.xml
+++ b/platform/security/core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-core-pom</artifactId>
     <groupId>ddf.security.core</groupId>

--- a/platform/security/core/security-core-impl/pom.xml
+++ b/platform/security/core/security-core-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.security.core</groupId>
         <artifactId>security-core-pom</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-core-impl</artifactId>
     <name>DDF :: Security :: Core :: Implementation</name>

--- a/platform/security/core/security-core-services/pom.xml
+++ b/platform/security/core/security-core-services/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>security-core-pom</artifactId>
         <groupId>ddf.security.core</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/encryption/platform-security-encryption-api/pom.xml
+++ b/platform/security/encryption/platform-security-encryption-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>security-encryption-pom</artifactId>
         <groupId>ddf.security.encryption</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-encryption-api</artifactId>
     <name>DDF :: Security :: Encryption :: API</name>

--- a/platform/security/encryption/platform-security-encryption-commands/pom.xml
+++ b/platform/security/encryption/platform-security-encryption-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>security-encryption-pom</artifactId>
         <groupId>ddf.security.encryption</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-encryption-commands</artifactId>
     <name>DDF :: Security :: Encryption :: Commands</name>

--- a/platform/security/encryption/platform-security-encryption-crypter/pom.xml
+++ b/platform/security/encryption/platform-security-encryption-crypter/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>security-encryption-pom</artifactId>
     <groupId>ddf.security.encryption</groupId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>

--- a/platform/security/encryption/platform-security-encryption-impl/pom.xml
+++ b/platform/security/encryption/platform-security-encryption-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>security-encryption-pom</artifactId>
         <groupId>ddf.security.encryption</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-encryption-impl</artifactId>
     <name>DDF :: Security :: Encryption :: Implementation</name>

--- a/platform/security/encryption/pom.xml
+++ b/platform/security/encryption/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-encryption-pom</artifactId>
     <groupId>ddf.security.encryption</groupId>

--- a/platform/security/expansion/pom.xml
+++ b/platform/security/expansion/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-expansion-pom</artifactId>
     <groupId>ddf.security.expansion</groupId>

--- a/platform/security/expansion/security-expansion-api/pom.xml
+++ b/platform/security/expansion/security-expansion-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>security-expansion-pom</artifactId>
         <groupId>ddf.security.expansion</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-expansion-api</artifactId>
     <name>DDF :: Security :: Expansion :: API</name>

--- a/platform/security/expansion/security-expansion-commands/pom.xml
+++ b/platform/security/expansion/security-expansion-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>security-expansion-pom</artifactId>
         <groupId>ddf.security.expansion</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-expansion-commands</artifactId>
     <name>DDF :: Security :: Expansion :: Commands</name>

--- a/platform/security/expansion/security-expansion-impl/pom.xml
+++ b/platform/security/expansion/security-expansion-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>security-expansion-pom</artifactId>
         <groupId>ddf.security.expansion</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-expansion-impl</artifactId>
     <name>DDF :: Security :: Expansion :: Implementation</name>

--- a/platform/security/expansion/security-expansion-metacardattr-map/pom.xml
+++ b/platform/security/expansion/security-expansion-metacardattr-map/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-expansion-pom</artifactId>
         <groupId>ddf.security.expansion</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-expansion-metacardattr-map</artifactId>

--- a/platform/security/expansion/security-expansion-userattr-map/pom.xml
+++ b/platform/security/expansion/security-expansion-userattr-map/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-expansion-pom</artifactId>
         <groupId>ddf.security.expansion</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-expansion-userattr-map</artifactId>

--- a/platform/security/filter/pom.xml
+++ b/platform/security/filter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.security.filter</groupId>
     <artifactId>filter</artifactId>

--- a/platform/security/filter/security-filter-authorization/pom.xml
+++ b/platform/security/filter/security-filter-authorization/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>filter</artifactId>
         <groupId>ddf.security.filter</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Filter :: Authorization</name>

--- a/platform/security/filter/security-filter-csrf/pom.xml
+++ b/platform/security/filter/security-filter-csrf/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.security.filter</groupId>
         <artifactId>filter</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/filter/security-filter-login/pom.xml
+++ b/platform/security/filter/security-filter-login/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>filter</artifactId>
         <groupId>ddf.security.filter</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Filter :: Login</name>

--- a/platform/security/filter/security-filter-web-sso/pom.xml
+++ b/platform/security/filter/security-filter-web-sso/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>filter</artifactId>
         <groupId>ddf.security.filter</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Filter :: Web-SSO</name>

--- a/platform/security/handler/pom.xml
+++ b/platform/security/handler/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.security.handler</groupId>
     <artifactId>handler</artifactId>

--- a/platform/security/handler/security-handler-api/pom.xml
+++ b/platform/security/handler/security-handler-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>handler</artifactId>
         <groupId>ddf.security.handler</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Handler :: API</name>

--- a/platform/security/handler/security-handler-basic/pom.xml
+++ b/platform/security/handler/security-handler-basic/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>handler</artifactId>
         <groupId>ddf.security.handler</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Handler :: Basic</name>

--- a/platform/security/handler/security-handler-impl/pom.xml
+++ b/platform/security/handler/security-handler-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>handler</artifactId>
         <groupId>ddf.security.handler</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/handler/security-handler-oauth/pom.xml
+++ b/platform/security/handler/security-handler-oauth/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>handler</artifactId>
         <groupId>ddf.security.handler</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/handler/security-handler-oidc/pom.xml
+++ b/platform/security/handler/security-handler-oidc/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>handler</artifactId>
         <groupId>ddf.security.handler</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/handler/security-handler-pki/pom.xml
+++ b/platform/security/handler/security-handler-pki/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>handler</artifactId>
         <groupId>ddf.security.handler</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Handler :: PKI</name>

--- a/platform/security/handler/security-handler-saml/pom.xml
+++ b/platform/security/handler/security-handler-saml/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>handler</artifactId>
         <groupId>ddf.security.handler</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Handler :: SAML</name>

--- a/platform/security/interceptor/pom.xml
+++ b/platform/security/interceptor/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.security.interceptor</groupId>

--- a/platform/security/interceptor/security-interceptor-guest-wrapper/pom.xml
+++ b/platform/security/interceptor/security-interceptor-guest-wrapper/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>interceptor</artifactId>
         <groupId>ddf.security.interceptor</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-interceptor-guest-wrapper</artifactId>

--- a/platform/security/interceptor/security-interceptor-guest/pom.xml
+++ b/platform/security/interceptor/security-interceptor-guest/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>interceptor</artifactId>
         <groupId>ddf.security.interceptor</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-interceptor-guest</artifactId>

--- a/platform/security/interceptor/security-interceptor-logger/pom.xml
+++ b/platform/security/interceptor/security-interceptor-logger/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>interceptor</artifactId>
         <groupId>ddf.security.interceptor</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/log-sanitizer/pom.xml
+++ b/platform/security/log-sanitizer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>log-sanitizer</artifactId>
     <name>DDF :: Security :: Log Sanitizer</name>

--- a/platform/security/pdp/pom.xml
+++ b/platform/security/pdp/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-pdp-pom</artifactId>
     <groupId>ddf.security.pdp</groupId>

--- a/platform/security/pdp/security-pdp-authzrealm/pom.xml
+++ b/platform/security/pdp/security-pdp-authzrealm/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-pdp-pom</artifactId>
         <groupId>ddf.security.pdp</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-pdp-authzrealm</artifactId>

--- a/platform/security/pep/pom.xml
+++ b/platform/security/pep/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-pep-pom</artifactId>
     <groupId>ddf.security.pep</groupId>

--- a/platform/security/pep/security-pep-interceptor/pom.xml
+++ b/platform/security/pep/security-pep-interceptor/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.security.pep</groupId>
         <artifactId>security-pep-pom</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-pep-interceptor</artifactId>
     <name>DDF :: Security :: PEP :: Interceptor</name>

--- a/platform/security/platform-security-core-api/pom.xml
+++ b/platform/security/platform-security-core-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.security.core</groupId>
     <artifactId>security-core-api</artifactId>

--- a/platform/security/policy/pom.xml
+++ b/platform/security/policy/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF Security Policy</name>

--- a/platform/security/policy/security-policy-api/pom.xml
+++ b/platform/security/policy/security-policy-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-policy</artifactId>
         <groupId>ddf.security.policy</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Policy :: API</name>

--- a/platform/security/policy/security-policy-context/pom.xml
+++ b/platform/security/policy/security-policy-context/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-policy</artifactId>
         <groupId>ddf.security.policy</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: Policy :: Context Manager</name>

--- a/platform/security/pom.xml
+++ b/platform/security/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.platform.security</groupId>
     <artifactId>platform-security</artifactId>

--- a/platform/security/realm/pom.xml
+++ b/platform/security/realm/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/realm/security-realm-guest/pom.xml
+++ b/platform/security/realm/security-realm-guest/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>realm</artifactId>
         <groupId>ddf.security.realm</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/realm/security-realm-oidc/pom.xml
+++ b/platform/security/realm/security-realm-oidc/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>realm</artifactId>
         <groupId>ddf.security.realm</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/realm/security-realm-pki/pom.xml
+++ b/platform/security/realm/security-realm-pki/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>realm</artifactId>
         <groupId>ddf.security.realm</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/platform/security/realm/security-realm-saml/pom.xml
+++ b/platform/security/realm/security-realm-saml/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.security.realm</groupId>
         <artifactId>realm</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-realm-saml</artifactId>
     <packaging>bundle</packaging>

--- a/platform/security/realm/security-realm-userpass/pom.xml
+++ b/platform/security/realm/security-realm-userpass/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>realm</artifactId>
         <groupId>ddf.security.realm</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/rest/pom.xml
+++ b/platform/security/rest/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-rest</artifactId>

--- a/platform/security/rest/security-rest-clientapi/pom.xml
+++ b/platform/security/rest/security-rest-clientapi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-rest</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/rest/security-rest-cxfwrapper/pom.xml
+++ b/platform/security/rest/security-rest-cxfwrapper/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>security-rest</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-rest-cxfwrapper</artifactId>

--- a/platform/security/saml/pom.xml
+++ b/platform/security/saml/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/security/saml/saml-assertion-validator-impl/pom.xml
+++ b/platform/security/saml/saml-assertion-validator-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>saml</artifactId>
         <groupId>ddf.security.saml</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saml-assertion-validator-impl</artifactId>

--- a/platform/security/saml/saml-assertion-validator/pom.xml
+++ b/platform/security/saml/saml-assertion-validator/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>saml</artifactId>
         <groupId>ddf.security.saml</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>saml-assertion-validator</artifactId>

--- a/platform/security/secure-boot/pom.xml
+++ b/platform/security/secure-boot/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>secure-boot</artifactId>

--- a/platform/security/security-jaas-ldap/pom.xml
+++ b/platform/security/security-jaas-ldap/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.security.jaas</groupId>
     <artifactId>security-jaas-ldap</artifactId>

--- a/platform/security/security-oidc-bundle/pom.xml
+++ b/platform/security/security-oidc-bundle/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Security :: OIDC :: Bundle</name>

--- a/platform/security/security-saml-util/pom.xml
+++ b/platform/security/security-saml-util/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.security</groupId>
     <artifactId>security-saml-util</artifactId>

--- a/platform/security/security-token-storage/pom.xml
+++ b/platform/security/security-token-storage/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/security-token-storage/token-storage-api/pom.xml
+++ b/platform/security/security-token-storage/token-storage-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.security.storage</groupId>
         <artifactId>security-token-storage</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>token-storage-api</artifactId>

--- a/platform/security/security-token-storage/token-storage-impl/pom.xml
+++ b/platform/security/security-token-storage/token-storage-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>ddf.security.storage</groupId>
         <artifactId>security-token-storage</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/servlet/pom.xml
+++ b/platform/security/servlet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-security</artifactId>
         <groupId>ddf.platform.security</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf.security.servlet</groupId>

--- a/platform/security/servlet/security-servlet-default-logout/pom.xml
+++ b/platform/security/servlet/security-servlet-default-logout/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.security.servlet</groupId>
         <artifactId>security-servlet</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/servlet/security-servlet-logout-api/pom.xml
+++ b/platform/security/servlet/security-servlet-logout-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.security.servlet</groupId>
         <artifactId>security-servlet</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/servlet/security-servlet-logout-endpoint/pom.xml
+++ b/platform/security/servlet/security-servlet-logout-endpoint/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>ddf.security.servlet</groupId>
         <artifactId>security-servlet</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/servlet/security-servlet-logout/pom.xml
+++ b/platform/security/servlet/security-servlet-logout/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-servlet</artifactId>
         <groupId>ddf.security.servlet</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-servlet-logout</artifactId>

--- a/platform/security/servlet/security-servlet-session-expiry/pom.xml
+++ b/platform/security/servlet/security-servlet-session-expiry/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-servlet</artifactId>
         <groupId>ddf.security.servlet</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-servlet-session-expiry</artifactId>

--- a/platform/security/servlet/security-servlet-web-socket-api/pom.xml
+++ b/platform/security/servlet/security-servlet-web-socket-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-servlet</artifactId>
         <groupId>ddf.security.servlet</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-servlet-web-socket-api</artifactId>

--- a/platform/security/servlet/security-servlet-whoami/pom.xml
+++ b/platform/security/servlet/security-servlet-whoami/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>security-servlet</artifactId>
         <groupId>ddf.security.servlet</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>security-servlet-whoami</artifactId>

--- a/platform/security/session-management-api/pom.xml
+++ b/platform/security/session-management-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/security/session-management-impl/pom.xml
+++ b/platform/security/session-management-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.security</groupId>
         <artifactId>platform-security</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/platform/solr/pom.xml
+++ b/platform/solr/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.platform.solr</groupId>
     <artifactId>platform-solr</artifactId>

--- a/platform/solr/solr-appender/pom.xml
+++ b/platform/solr/solr-appender/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform-solr</artifactId>
         <groupId>ddf.platform.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/solr/solr-dependencies/pom.xml
+++ b/platform/solr/solr-dependencies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-solr</artifactId>
         <groupId>ddf.platform.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>solr-dependencies</artifactId>
     <name>DDF :: Platform :: Solr :: Dependencies</name>

--- a/platform/solr/solr-factory-impl/pom.xml
+++ b/platform/solr/solr-factory-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-solr</artifactId>
         <groupId>ddf.platform.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>solr-factory-impl</artifactId>
     <name>DDF :: Platform :: Solr :: Factory Impl</name>

--- a/platform/solr/solr-factory/pom.xml
+++ b/platform/solr/solr-factory/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform-solr</artifactId>
         <groupId>ddf.platform.solr</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>solr-factory</artifactId>
     <name>DDF :: Platform :: Solr :: Factory</name>

--- a/platform/solr/solr-query/pom.xml
+++ b/platform/solr/solr-query/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.solr</groupId>
         <artifactId>platform-solr</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>solr-query</artifactId>
     <name>DDF :: Platform :: Solr :: Query</name>

--- a/platform/solr/solr-schema/pom.xml
+++ b/platform/solr/solr-schema/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.solr</groupId>
         <artifactId>platform-solr</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>solr-schema</artifactId>
     <name>DDF :: Platform :: Solr :: Schema</name>

--- a/platform/sync-installer/pom.xml
+++ b/platform/sync-installer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <name>DDF :: Platform :: Sync Installer</name>
     <artifactId>sync-installer</artifactId>

--- a/platform/sync-installer/sync-installer-api/pom.xml
+++ b/platform/sync-installer/sync-installer-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>sync-installer</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>sync-installer-api</artifactId>

--- a/platform/sync-installer/sync-installer-impl/pom.xml
+++ b/platform/sync-installer/sync-installer-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>sync-installer</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>sync-installer-impl</artifactId>

--- a/platform/usng4j/platform-usng4j-api/pom.xml
+++ b/platform/usng4j/platform-usng4j-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>usng4j</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/usng4j/platform-usng4j-impl/pom.xml
+++ b/platform/usng4j/platform-usng4j-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>usng4j</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform/usng4j/pom.xml
+++ b/platform/usng4j/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>ddf.platform</groupId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DDF :: Platform :: USNG4J</name>

--- a/platform/util/platform-util-uuidgenerator/pom.xml
+++ b/platform/util/platform-util-uuidgenerator/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.util</groupId>
         <artifactId>util</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>uuidgenerator</artifactId>
     <name>DDF :: Platform :: Util :: UUID Generator</name>

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-api/pom.xml
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.util</groupId>
         <artifactId>uuidgenerator</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>util-uuidgenerator-api</artifactId>
     <name>DDF :: Platform :: Util :: UUID Generator API</name>

--- a/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/pom.xml
+++ b/platform/util/platform-util-uuidgenerator/util-uuidgenerator-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.util</groupId>
         <artifactId>uuidgenerator</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <artifactId>util-uuidgenerator-impl</artifactId>
     <name>DDF :: Platform :: Util :: UUID Generator Impl</name>

--- a/platform/util/platform-util/pom.xml
+++ b/platform/util/platform-util/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform.util</groupId>
         <artifactId>util</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>platform-util</artifactId>

--- a/platform/util/pom.xml
+++ b/platform/util/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.platform</groupId>
         <artifactId>platform</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
     <groupId>ddf.platform.util</groupId>
     <artifactId>util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ddf</groupId>
     <artifactId>ddf</artifactId>
-    <version>2.30.2-SNAPSHOT</version>
+    <version>2.31.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DDF Reactor</name>
     <description>Distributed Data Framework (DDF) Parent</description>
@@ -49,8 +49,8 @@
         <version>1.0.13</version>
     </parent>
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!--  default URL properties -->
         <ddf.scm.connection.url />
         <snapshots.repository.url />

--- a/thirdparty/eclipse-emf/pom.xml
+++ b/thirdparty/eclipse-emf/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.thirdparty</groupId>
         <artifactId>thirdparty</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>eclipse-emf</artifactId>

--- a/thirdparty/pom.xml
+++ b/thirdparty/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <groupId>ddf.thirdparty</groupId>

--- a/thirdparty/restito/pom.xml
+++ b/thirdparty/restito/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.thirdparty</groupId>
         <artifactId>thirdparty</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>restito</artifactId>

--- a/thirdparty/tika/pom.xml
+++ b/thirdparty/tika/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>ddf.thirdparty</groupId>
         <artifactId>thirdparty</artifactId>
-        <version>2.30.2-SNAPSHOT</version>
+        <version>2.31.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tika</artifactId>


### PR DESCRIPTION
## Summary
- Bumps `maven.compiler.source/target` from 17 to 21
- Bumps every module from `2.30.2-SNAPSHOT` to `2.31.0-SNAPSHOT` via `mvn versions:set -DprocessAllModules`
- Updates `.github/workflows/ci.yml` to set up JDK 21
- Updates `.github/workflows/release.yml` `jdk_version_map` so `master` releases on JDK 21 and adds `2.30.x` → JDK 17 (the maintenance branch was cut from current master before this bump)

The `2.30.x` branch is the maintenance line for the JDK 17 train; bug fixes targeted at JDK 17 consumers should land there.

Karaf 4.4.10 and CXF 3.6.10 are unchanged. Both are officially "JDK 17" in their support matrices but in practice work on JDK 21 against this codebase.

## Test plan
- [x] `mvn install -DskipTests` builds clean on JDK 21 locally
- [x] `mvn install -P '!itests'` (full unit test suite) passes on JDK 21 locally
- [x] Karaf-container itests pass on JDK 21 locally
- [x] CI green on this PR