### PR TITLE
Narrow klv's tika dependencies to only what's necessary

### DIFF
--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -47,12 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers-standard-package</artifactId>
+            <artifactId>tika-parser-text-module</artifactId>
             <version>${tika.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Not only will this clearly indicate exactly which tika dependency is required for this module, it will prevent downstream clients of this library from having to bring in extra unnecessary dependencies.