### PR TITLE
Make solr field/schema resolvers respect the tokenized field of attributes

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/ddf/catalog/data/impl/types/CoreAttributes.java
@@ -206,7 +206,7 @@ public class CoreAttributes implements Core, MetacardType {
             METACARD_TAGS,
             true /* indexed */,
             true /* stored */,
-            false /* tokenized */,
+            true /* tokenized */,
             true /* multivalued */,
             BasicTypes.STRING_TYPE));
     descriptors.add(

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/DynamicSchemaResolver.java
@@ -178,9 +178,6 @@ public class DynamicSchemaResolver {
       textSortCharacterLimit = 127;
     }
     fieldsCache.add(Metacard.ID + SchemaFields.TEXT_SUFFIX);
-    fieldsCache.add(Metacard.ID + SchemaFields.TEXT_SUFFIX + SchemaFields.TOKENIZED);
-    fieldsCache.add(
-        Metacard.ID + SchemaFields.TEXT_SUFFIX + SchemaFields.TOKENIZED + SchemaFields.HAS_CASE);
 
     fieldsCache.add(SchemaFields.METACARD_TYPE_FIELD_NAME);
     fieldsCache.add(SchemaFields.METACARD_TYPE_OBJECT_FIELD_NAME);
@@ -273,10 +270,10 @@ public class DynamicSchemaResolver {
           if (AttributeFormat.XML.equals(format)
               && solrInputDocument.getFieldValue(
                       formatIndexName + getSpecialIndexSuffix(AttributeFormat.STRING))
-                  == null) {
+                  == null
+              && ad.isTokenized()) {
             List<String> parsedTexts = parseTextFrom(attributeValues);
-
-            // parsedTexts => *_txt_tokenized
+            // parsedTexts => *_txt_tokenized - only if attribute is tokenized
             String specialStringIndexName =
                 ad.getName()
                     + getFieldSuffix(AttributeFormat.STRING)
@@ -294,12 +291,14 @@ public class DynamicSchemaResolver {
             solrInputDocument.addField(
                 ad.getName() + getFieldSuffix(AttributeFormat.STRING), truncatedValues);
 
-            // *_txt_tokenized
-            solrInputDocument.addField(
-                ad.getName()
-                    + getFieldSuffix(AttributeFormat.STRING)
-                    + getSpecialIndexSuffix(AttributeFormat.STRING),
-                attributeValues);
+            // *_txt_tokenized - only if attribute is tokenized
+            if (ad.isTokenized()) {
+              solrInputDocument.addField(
+                  ad.getName()
+                      + getFieldSuffix(AttributeFormat.STRING)
+                      + getSpecialIndexSuffix(AttributeFormat.STRING),
+                  attributeValues);
+            }
           } else if (AttributeFormat.OBJECT.equals(format)) {
             ByteArrayOutputStream byteArrayOS = new ByteArrayOutputStream();
             List<Serializable> byteArrays = new ArrayList<>();
@@ -594,13 +593,12 @@ public class DynamicSchemaResolver {
       Map<String, Serializable> enabledFeatures) {
 
     final String fieldSuffix = getFieldSuffix(format);
-    String fieldName =
-        propertyName
-            + fieldSuffix
-            + (isSearchedAsExactValue ? "" : getSpecialIndexSuffix(format, enabledFeatures));
+    String baseName = propertyName + fieldSuffix;
+    String extendedName =
+        baseName + (isSearchedAsExactValue ? "" : getSpecialIndexSuffix(format, enabledFeatures));
 
-    if (fieldsCache.contains(fieldName)) {
-      return fieldName;
+    if (fieldsCache.contains(extendedName)) {
+      return extendedName;
     }
 
     switch (format) {
@@ -613,13 +611,14 @@ public class DynamicSchemaResolver {
       default:
         break;
     }
-
+    // if we have the base name in the cache but not the extended name assume the extended doesn't
+    // exist otherwise fallback to the old convention
+    String bestGuess = fieldsCache.contains(baseName) ? baseName : extendedName;
     LOGGER.debug(
         "Could not find exact schema field name for [{}], attempting to search with [{}]",
         propertyName,
-        fieldName);
-
-    return fieldName;
+        bestGuess);
+    return bestGuess;
   }
 
   private String getFieldSuffix(AttributeFormat format) {
@@ -658,8 +657,11 @@ public class DynamicSchemaResolver {
         && mappedPropertyName.endsWith(SchemaFields.PHONETICS)) {
       return mappedPropertyName;
     }
-    // TODO We can check if this field really does exist
-    return mappedPropertyName + SchemaFields.HAS_CASE;
+    String potentialField = mappedPropertyName + SchemaFields.HAS_CASE;
+    if (fieldsCache.contains(potentialField)) {
+      return potentialField;
+    }
+    return fieldsCache.contains(mappedPropertyName) ? mappedPropertyName : potentialField;
   }
 
   private String getSpecialIndexSuffix(AttributeFormat format) {
@@ -705,6 +707,18 @@ public class DynamicSchemaResolver {
     AttributeFormat format = descriptor.getType().getAttributeFormat();
 
     fieldsCache.add(descriptor.getName() + schemaFields.getFieldSuffix(format));
+
+    if (format.equals(AttributeFormat.GEOMETRY)) {
+      fieldsCache.add(
+          descriptor.getName()
+              + schemaFields.getFieldSuffix(format)
+              + getSpecialIndexSuffix(format));
+      return;
+    }
+
+    if (!descriptor.isTokenized()) {
+      return;
+    }
 
     if (!getSpecialIndexSuffix(format).equals("")) {
       fieldsCache.add(
@@ -892,9 +906,7 @@ public class DynamicSchemaResolver {
               .collect(Collectors.toList());
     }
 
-    return fields.stream()
-        .map(field -> field + SchemaFields.TEXT_SUFFIX)
-        .collect(Collectors.toSet());
+    return new HashSet<>(fields);
   }
 
   private Set<String> getAnyGeoFields() {

--- a/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
+++ b/catalog/solr/catalog-solr-core/src/main/java/ddf/catalog/source/solr/SolrFilterDelegate.java
@@ -313,19 +313,14 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
   private String wildcardSolrQuery(
       String searchPhrase, String propertyName, boolean isCaseSensitive, boolean isExact) {
     String solrQuery;
-    String tokenized = resolver.getSpecialIndexSuffix(AttributeFormat.STRING, enabledFeatures);
     if (Metacard.ANY_TEXT.equals(propertyName)) {
       solrQuery =
           resolver
               .anyTextFields()
               .map(
-                  field -> {
-                    if (!isExact) {
-                      return field + tokenized;
-                    } else {
-                      return field;
-                    }
-                  })
+                  field ->
+                      resolver.getField(
+                          field, AttributeFormat.STRING, isExact, Collections.emptyMap()))
               .map(
                   textField -> {
                     if (isCaseSensitive && !isExact) {
@@ -337,10 +332,7 @@ public class SolrFilterDelegate extends FilterDelegate<SolrQuery> {
               .map(field -> field + ":" + searchPhrase)
               .collect(Collectors.joining(" "));
     } else {
-      String field = getMappedPropertyName(propertyName, AttributeFormat.STRING, true);
-      if (!isExact) {
-        field += tokenized;
-      }
+      String field = getMappedPropertyName(propertyName, AttributeFormat.STRING, isExact);
       if (isCaseSensitive && !isExact) {
         field = resolver.getCaseSensitiveField(field, enabledFeatures);
       }

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/DynamicSchemaResolverTest.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/DynamicSchemaResolverTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -54,7 +55,7 @@ import org.mockito.ArgumentCaptor;
 
 public class DynamicSchemaResolverTest {
 
-  private static final int INITIAL_FIELDS_CACHE_COUNT = 5;
+  private static final int INITIAL_FIELDS_CACHE_COUNT = 3;
 
   private static final ObjectMapper METACARD_TYPE_MAPPER =
       MetacardTypeMapperFactory.newObjectMapper();
@@ -180,7 +181,7 @@ public class DynamicSchemaResolverTest {
     // Perform Test
     List<String> fields = resolver.anyTextFields().collect(Collectors.toList());
     Truth.assertThat(fields)
-        .containsExactly("metadata_txt", "title_txt", "description_txt", "ext.extracted.text_txt");
+        .containsExactly("metadata", "title", "description", "ext.extracted.text");
   }
 
   @Test
@@ -300,5 +301,203 @@ public class DynamicSchemaResolverTest {
     assertThat(
         dynamicSchemaResolver.getField("unknown", AttributeFormat.STRING, true, enabledFeatures),
         is("unknown_txt"));
+  }
+
+  @Test
+  public void testAddFieldsWithXmlAttributeNotTokenized() throws Exception {
+    // Setup - XML attribute that is NOT tokenized
+    String metacardTypeName = "test";
+    Set<AttributeDescriptor> attributeDescriptors = new HashSet<>(1);
+    String attributeName = "metadata";
+    boolean indexed = true;
+    boolean stored = true;
+    boolean tokenized = false;
+    boolean multiValued = false;
+
+    attributeDescriptors.add(
+        new TestAttributeDescriptorImpl(
+            attributeName,
+            attributeName,
+            indexed,
+            stored,
+            tokenized,
+            multiValued,
+            BasicTypes.XML_TYPE));
+
+    Attribute mockAttribute = mock(Attribute.class);
+    when(mockAttribute.getValue()).thenReturn("<root>test</root>");
+    when(mockAttribute.getValues()).thenReturn(Collections.singletonList("<root>test</root>"));
+
+    Metacard mockMetacard = mock(Metacard.class, RETURNS_DEEP_STUBS);
+    when(mockMetacard.getMetacardType().getName()).thenReturn(metacardTypeName);
+    when(mockMetacard.getMetacardType().getAttributeDescriptors()).thenReturn(attributeDescriptors);
+    when(mockMetacard.getAttribute(attributeName)).thenReturn(mockAttribute);
+
+    SolrInputDocument solrInputDocument = new SolrInputDocument();
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver();
+
+    // Perform Test
+    resolver.addFields(mockMetacard, solrInputDocument);
+
+    // Verify - tokenized=false means the special string index should NOT be populated
+    assertThat(solrInputDocument.getFieldValue("metadata_txt_tokenized"), is(nullValue()));
+  }
+
+  @Test
+  public void testAddFieldsWithXmlAttributeTokenized() throws Exception {
+    // Setup - XML attribute that IS tokenized
+    String metacardTypeName = "test";
+    Set<AttributeDescriptor> attributeDescriptors = new HashSet<>(1);
+    String attributeName = "metadata";
+    boolean indexed = true;
+    boolean stored = true;
+    boolean tokenized = true;
+    boolean multiValued = false;
+
+    attributeDescriptors.add(
+        new TestAttributeDescriptorImpl(
+            attributeName,
+            attributeName,
+            indexed,
+            stored,
+            tokenized,
+            multiValued,
+            BasicTypes.XML_TYPE));
+
+    Attribute mockAttribute = mock(Attribute.class);
+    when(mockAttribute.getValue()).thenReturn("<root>test</root>");
+    when(mockAttribute.getValues()).thenReturn(Collections.singletonList("<root>test</root>"));
+
+    Metacard mockMetacard = mock(Metacard.class, RETURNS_DEEP_STUBS);
+    when(mockMetacard.getMetacardType().getName()).thenReturn(metacardTypeName);
+    when(mockMetacard.getMetacardType().getAttributeDescriptors()).thenReturn(attributeDescriptors);
+    when(mockMetacard.getAttribute(attributeName)).thenReturn(mockAttribute);
+
+    SolrInputDocument solrInputDocument = new SolrInputDocument();
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver();
+
+    // Perform Test
+    resolver.addFields(mockMetacard, solrInputDocument);
+
+    // Verify - tokenized=true means the special string index SHOULD be populated
+    assertThat(solrInputDocument.getFieldValue("metadata_txt_tokenized"), notNullValue());
+  }
+
+  @Test
+  public void testAddFieldsWithStringAttributeNotTokenizedAddsTxtNotTokenizedField()
+      throws Exception {
+    // Setup - STRING attribute that is NOT tokenized
+    String metacardTypeName = "test";
+    Set<AttributeDescriptor> attributeDescriptors = new HashSet<>(1);
+    String attributeName = "title";
+    boolean indexed = true;
+    boolean stored = true;
+    boolean tokenized = false;
+    boolean multiValued = false;
+
+    attributeDescriptors.add(
+        new TestAttributeDescriptorImpl(
+            attributeName,
+            attributeName,
+            indexed,
+            stored,
+            tokenized,
+            multiValued,
+            BasicTypes.STRING_TYPE));
+
+    Attribute mockAttribute = mock(Attribute.class);
+    when(mockAttribute.getValue()).thenReturn("test value");
+    when(mockAttribute.getValues()).thenReturn(Collections.singletonList("test value"));
+
+    Metacard mockMetacard = mock(Metacard.class, RETURNS_DEEP_STUBS);
+    when(mockMetacard.getMetacardType().getName()).thenReturn(metacardTypeName);
+    when(mockMetacard.getMetacardType().getAttributeDescriptors()).thenReturn(attributeDescriptors);
+    when(mockMetacard.getAttribute(attributeName)).thenReturn(mockAttribute);
+
+    SolrInputDocument solrInputDocument = new SolrInputDocument();
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver();
+
+    // Perform Test
+    resolver.addFields(mockMetacard, solrInputDocument);
+
+    // Verify - tokenized=false means the tokenized field should NOT be populated
+    assertThat(solrInputDocument.getFieldValue("title_txt"), is("test value"));
+    assertThat(solrInputDocument.getFieldValue("title_txt_tokenized"), is(nullValue()));
+  }
+
+  @Test
+  public void testAddFieldsWithStringAttributeTokenizedAddsBothTxtAndTokenizedField()
+      throws Exception {
+    // Setup - STRING attribute that IS tokenized
+    String metacardTypeName = "test";
+    Set<AttributeDescriptor> attributeDescriptors = new HashSet<>(1);
+    String attributeName = "title";
+    boolean indexed = true;
+    boolean stored = true;
+    boolean tokenized = true;
+    boolean multiValued = false;
+
+    attributeDescriptors.add(
+        new TestAttributeDescriptorImpl(
+            attributeName,
+            attributeName,
+            indexed,
+            stored,
+            tokenized,
+            multiValued,
+            BasicTypes.STRING_TYPE));
+
+    Attribute mockAttribute = mock(Attribute.class);
+    when(mockAttribute.getValue()).thenReturn("test value");
+    when(mockAttribute.getValues()).thenReturn(Collections.singletonList("test value"));
+
+    Metacard mockMetacard = mock(Metacard.class, RETURNS_DEEP_STUBS);
+    when(mockMetacard.getMetacardType().getName()).thenReturn(metacardTypeName);
+    when(mockMetacard.getMetacardType().getAttributeDescriptors()).thenReturn(attributeDescriptors);
+    when(mockMetacard.getAttribute(attributeName)).thenReturn(mockAttribute);
+
+    SolrInputDocument solrInputDocument = new SolrInputDocument();
+    DynamicSchemaResolver resolver = new DynamicSchemaResolver();
+
+    // Perform Test
+    resolver.addFields(mockMetacard, solrInputDocument);
+
+    // Verify - tokenized=true means both fields SHOULD be populated
+    assertThat(solrInputDocument.getFieldValue("title_txt"), is("test value"));
+    assertThat(solrInputDocument.getFieldValue("title_txt_tokenized"), is("test value"));
+  }
+
+  @Test
+  public void testGetFieldNumericalFallsBackToRequestedSuffix() {
+    // When no numerical field exists in cache, should fall back to the requested suffix
+    assertThat(
+        dynamicSchemaResolver.getField(
+            "unknown", AttributeFormat.INTEGER, false, Collections.emptyMap()),
+        is("unknown_int"));
+    assertThat(
+        dynamicSchemaResolver.getField(
+            "unknown", AttributeFormat.LONG, false, Collections.emptyMap()),
+        is("unknown_lng"));
+    assertThat(
+        dynamicSchemaResolver.getField(
+            "unknown", AttributeFormat.DOUBLE, false, Collections.emptyMap()),
+        is("unknown_dbl"));
+    assertThat(
+        dynamicSchemaResolver.getField(
+            "unknown", AttributeFormat.FLOAT, false, Collections.emptyMap()),
+        is("unknown_flt"));
+    assertThat(
+        dynamicSchemaResolver.getField(
+            "unknown", AttributeFormat.SHORT, false, Collections.emptyMap()),
+        is("unknown_shr"));
+  }
+
+  @Test
+  public void testGetFieldXmlReturnsTextPathSuffix() {
+    // XML format should use TEXT_PATH (_tpt) suffix
+    assertThat(
+        dynamicSchemaResolver.getField(
+            "metadata", AttributeFormat.XML, false, Collections.emptyMap()),
+        is("metadata_xml_tpt"));
   }
 }

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/SolrFilterDelegateTest.java
@@ -232,7 +232,9 @@ public class SolrFilterDelegateTest {
         .thenReturn(SchemaFields.TOKENIZED);
     when(mockResolver.getCaseSensitiveField("testProperty_txt_tokenized", Collections.emptyMap()))
         .thenReturn("testProperty_txt_tokenized_tokenized");
-
+    when(mockResolver.getField(
+            "testProperty", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("testProperty_txt_tokenized");
     // when searching for like reserved characters
     SolrQuery likeQuery =
         toTest.propertyIsLike("testProperty", "+ - && || ! ( ) { } [ ] ^ \" ~ : \\*?", true);
@@ -445,6 +447,13 @@ public class SolrFilterDelegateTest {
         .thenReturn(Collections.singletonList("metadata_txt").stream());
     when(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .thenReturn(SchemaFields.TOKENIZED);
+    when(mockResolver.getField(
+            "metadata_txt", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("metadata_txt_tokenized");
+    when(mockResolver.getField("metadata", AttributeFormat.STRING, true, Collections.emptyMap()))
+        .thenReturn("metadata_txt");
+    when(mockResolver.getField("metadata", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("metadata_txt_tokenized");
 
     String searchPhrase = "abc-123*";
     String expectedQuery = "(" + TOKENIZED_METADATA_FIELD + ":(abc\\-123*))";
@@ -486,6 +495,13 @@ public class SolrFilterDelegateTest {
         .thenReturn(Collections.singletonList("metadata_txt").stream());
     when(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .thenReturn(SchemaFields.TOKENIZED);
+    when(mockResolver.getField(
+            "metadata_txt", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("metadata_txt_tokenized");
+    when(mockResolver.getField("metadata", AttributeFormat.STRING, true, Collections.emptyMap()))
+        .thenReturn("metadata_txt");
+    when(mockResolver.getField("metadata", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("metadata_txt_tokenized");
 
     String searchPhrase = "title*";
     String expectedQuery = "(" + TOKENIZED_METADATA_FIELD + ":(title*))";
@@ -502,6 +518,13 @@ public class SolrFilterDelegateTest {
         .thenReturn(Collections.singletonList("metadata_txt").stream());
     when(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .thenReturn(SchemaFields.TOKENIZED);
+    when(mockResolver.getField(
+            "metadata_txt", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("metadata_txt_tokenized");
+    when(mockResolver.getField("metadata", AttributeFormat.STRING, true, Collections.emptyMap()))
+        .thenReturn("metadata_txt");
+    when(mockResolver.getField("metadata", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("metadata_txt_tokenized");
 
     String searchPhrase = "abc 123*";
     String expectedQuery = "(" + TOKENIZED_METADATA_FIELD + ":(abc 123*))";
@@ -519,6 +542,13 @@ public class SolrFilterDelegateTest {
         .thenReturn(SchemaFields.TOKENIZED);
     when(mockResolver.getCaseSensitiveField("metadata_txt_tokenized", Collections.emptyMap()))
         .thenReturn("metadata_txt_tokenized_has_case");
+    when(mockResolver.getField(
+            "metadata_txt", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("metadata_txt_tokenized");
+    when(mockResolver.getField("metadata", AttributeFormat.STRING, true, Collections.emptyMap()))
+        .thenReturn("metadata_txt");
+    when(mockResolver.getField("metadata", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("metadata_txt_tokenized");
 
     String searchPhrase = "abc-123*";
     String expectedQuery =
@@ -688,6 +718,8 @@ public class SolrFilterDelegateTest {
   public void testPropertyIsInProximityTo() {
     when(mockResolver.getField("title", AttributeFormat.STRING, true, Collections.emptyMap()))
         .thenReturn("title_txt");
+    when(mockResolver.getField("title", AttributeFormat.STRING, false, Collections.emptyMap()))
+        .thenReturn("title_txt_tokenized");
     when(mockResolver.getSpecialIndexSuffix(AttributeFormat.STRING, Collections.emptyMap()))
         .thenReturn(SchemaFields.TOKENIZED);
 

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderQuery.java
@@ -206,7 +206,7 @@ public class SolrProviderQuery {
 
     create(list, provider);
 
-    Filter txtFilter = getFilterBuilder().attribute("id").like().text("*");
+    Filter txtFilter = getFilterBuilder().attribute(Metacard.ANY_TEXT).like().text("*");
 
     QueryImpl query = new QueryImpl(txtFilter);
 

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSpatial.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderSpatial.java
@@ -119,7 +119,7 @@ public class SolrProviderSpatial {
     // CREATE
     create(list, provider);
 
-    Filter filter = getFilterBuilder().attribute(Metacard.ID).is().like().text("*");
+    Filter filter = getFilterBuilder().attribute(Metacard.ANY_TEXT).is().like().text("*");
     SourceResponse sourceResponse = provider.query(new QueryRequestImpl(new QueryImpl(filter)));
     assertEquals("Failed to find all records.", 3, sourceResponse.getResults().size());
 

--- a/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderTestUtil.java
+++ b/catalog/solr/catalog-solr-core/src/test/java/ddf/catalog/source/solr/provider/SolrProviderTestUtil.java
@@ -81,7 +81,7 @@ public class SolrProviderTestUtil {
 
     QueryImpl query;
     SourceResponse sourceResponse;
-    query = new QueryImpl(filterBuilder.attribute(Metacard.ID).is().like().text("*"));
+    query = new QueryImpl(filterBuilder.attribute(Metacard.ANY_TEXT).is().like().text("*"));
     query.setPageSize(ALL_RESULTS);
     sourceResponse = provider.query(new QueryRequestImpl(query));
 
@@ -180,15 +180,15 @@ public class SolrProviderTestUtil {
     descriptors.add(
         new AttributeDescriptorImpl(Metacard.ID, true, true, true, false, BasicTypes.STRING_TYPE));
     descriptors.add(
-        new AttributeDescriptorImpl(doubleField, true, true, true, false, BasicTypes.DOUBLE_TYPE));
+        new AttributeDescriptorImpl(doubleField, true, true, false, false, BasicTypes.DOUBLE_TYPE));
     descriptors.add(
-        new AttributeDescriptorImpl(floatField, true, true, true, false, BasicTypes.FLOAT_TYPE));
+        new AttributeDescriptorImpl(floatField, true, true, false, false, BasicTypes.FLOAT_TYPE));
     descriptors.add(
-        new AttributeDescriptorImpl(intField, true, true, true, false, BasicTypes.INTEGER_TYPE));
+        new AttributeDescriptorImpl(intField, true, true, false, false, BasicTypes.INTEGER_TYPE));
     descriptors.add(
-        new AttributeDescriptorImpl(longField, true, true, true, false, BasicTypes.LONG_TYPE));
+        new AttributeDescriptorImpl(longField, true, true, false, false, BasicTypes.LONG_TYPE));
     descriptors.add(
-        new AttributeDescriptorImpl(shortField, true, true, true, false, BasicTypes.SHORT_TYPE));
+        new AttributeDescriptorImpl(shortField, true, true, false, false, BasicTypes.SHORT_TYPE));
     return descriptors;
   }
 

--- a/platform/solr/solr-query/src/main/java/org/codice/solr/query/SchemaField.java
+++ b/platform/solr/solr-query/src/main/java/org/codice/solr/query/SchemaField.java
@@ -19,7 +19,7 @@ public class SchemaField {
 
   private String name;
 
-  private String suffix;
+  private String specialSuffix;
 
   private String type;
 
@@ -36,12 +36,12 @@ public class SchemaField {
     this.name = name;
   }
 
-  public String getSuffix() {
-    return suffix;
+  public String getSpecialSuffix() {
+    return specialSuffix;
   }
 
-  public void setSuffix(String suffix) {
-    this.suffix = suffix;
+  public void setSpecialSuffix(String specialSuffix) {
+    this.specialSuffix = specialSuffix;
   }
 
   public String getType() {

--- a/platform/solr/solr-query/src/main/java/org/codice/solr/query/SchemaFieldResolver.java
+++ b/platform/solr/solr-query/src/main/java/org/codice/solr/query/SchemaFieldResolver.java
@@ -132,7 +132,7 @@ public class SchemaFieldResolver {
     return FORMAT_TO_SUFFIX_MAP.get(attributeFormat);
   }
 
-  public SchemaField getSchemaField(String propertyName, boolean isSearchedAsExactValue) {
+  public SchemaField getSchemaField(String propertyName) {
     SchemaField schemaField = null;
     LukeRequest luke = new LukeRequest();
     LukeResponse rsp;
@@ -152,13 +152,13 @@ public class SchemaFieldResolver {
             String fieldType = entry.getValue().getType();
             int index = StringUtils.lastIndexOfAny(entry.getKey(), FORMAT_SUFFIXES);
             String suffix = entry.getKey().substring(index);
-            if (!isSearchedAsExactValue) {
-              suffix = getSpecialIndexSuffix(suffix);
-              fieldType += suffix;
-            }
-            LOGGER.debug("field {} has type {}", entry.getKey(), fieldType);
             schemaField = new SchemaField(entry.getKey(), fieldType);
-            schemaField.setSuffix(suffix);
+            String specialSuffix = getSpecialIndexSuffix(suffix);
+            // Only add special suffix if the resulting field actually exists in the schema
+            String potentialFieldName = propertyName + suffix + specialSuffix;
+            if (fieldsInfo.containsKey(potentialFieldName)) {
+              schemaField.setSpecialSuffix(specialSuffix);
+            }
             return schemaField;
           }
         }
@@ -185,6 +185,6 @@ public class SchemaFieldResolver {
       return SchemaFieldResolver.TEXT_PATH;
     }
 
-    return "";
+    return null;
   }
 }

--- a/platform/solr/solr-query/src/main/java/org/codice/solr/query/SolrQueryFilterVisitor.java
+++ b/platform/solr/solr-query/src/main/java/org/codice/solr/query/SolrQueryFilterVisitor.java
@@ -199,8 +199,6 @@ public class SolrQueryFilterVisitor extends DefaultFilterVisitor {
 
     String pattern = normalizePattern(filter.getLiteral(), wildcard, singleChar, escapeChar);
 
-    String mappedPropertyName = getMappedPropertyName(propertyName);
-
     String searchPhrase = escapeSpecialCharacters(pattern);
 
     boolean isAnyText = Metacard.ANY_TEXT.equals(propertyName);
@@ -208,8 +206,15 @@ public class SolrQueryFilterVisitor extends DefaultFilterVisitor {
     if (isAnyText && SOLR_WILDCARD_CHAR.equals(searchPhrase)) {
       return new SolrQuery("*:*");
     }
+    String solrPropertyName;
+    SchemaField schemaField = getSchemaField(propertyName);
+    if (schemaField != null && schemaField.getSpecialSuffix() != null) {
+      solrPropertyName = schemaField.getName() + schemaField.getSpecialSuffix();
+    } else {
+      solrPropertyName = getMappedPropertyName(propertyName, AttributeFormat.STRING, true);
+    }
 
-    return new SolrQuery(mappedPropertyName + SchemaFieldResolver.TOKENIZED + ":" + searchPhrase);
+    return new SolrQuery(solrPropertyName + ":" + searchPhrase);
   }
 
   @SuppressWarnings("java:S127")
@@ -262,18 +267,7 @@ public class SolrQueryFilterVisitor extends DefaultFilterVisitor {
     // will have the suffix and the variations on the property name, e.g., for propertyName="user"
     // fieldsInfo will have keys for "user_txt", "user_txt_tokenized", and
     // "user_txt_tokenized_has_case"
-    SchemaField schemaField;
-    String cacheKey = solrCoreName + "." + propertyName;
-    if (schemaFieldsCache.containsKey(cacheKey)) {
-      LOGGER.debug("Getting SchemaField for propertyName {} from cache", propertyName);
-      schemaField = schemaFieldsCache.get(cacheKey);
-    } else {
-      LOGGER.debug("Using SchemaFieldResolver for propertyName {}", propertyName);
-      schemaField = schemaFieldResolver.getSchemaField(propertyName, true);
-      if (schemaField != null) {
-        schemaFieldsCache.put(cacheKey, schemaField);
-      }
-    }
+    SchemaField schemaField = getSchemaField(propertyName);
 
     if (schemaField != null) {
       mappedPropertyName = schemaField.getName();
@@ -289,6 +283,22 @@ public class SolrQueryFilterVisitor extends DefaultFilterVisitor {
     }
 
     return mappedPropertyName;
+  }
+
+  SchemaField getSchemaField(String propertyName) {
+    SchemaField schemaField;
+    String cacheKey = solrCoreName + "." + propertyName;
+    if (schemaFieldsCache.containsKey(cacheKey)) {
+      LOGGER.debug("Getting SchemaField for propertyName {} from cache", propertyName);
+      schemaField = schemaFieldsCache.get(cacheKey);
+    } else {
+      LOGGER.debug("Using SchemaFieldResolver for propertyName {}", propertyName);
+      schemaField = schemaFieldResolver.getSchemaField(propertyName);
+      if (schemaField != null) {
+        schemaFieldsCache.put(cacheKey, schemaField);
+      }
+    }
+    return schemaField;
   }
 
   private String getMappedPropertyName(

--- a/platform/solr/solr-query/src/test/java/org/codice/solr/query/SolrQueryFilterVisitorTest.java
+++ b/platform/solr/solr-query/src/test/java/org/codice/solr/query/SolrQueryFilterVisitorTest.java
@@ -29,6 +29,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.common.util.NamedList;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.Or;
+import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
 import org.junit.Before;
 import org.junit.Test;
@@ -129,15 +130,14 @@ public class SolrQueryFilterVisitorTest {
   public void testUnsupportedQuery() throws Exception {
     Filter filter = ECQL.toFilter("property LIKE 'val*'");
     SolrQuery solrQuery = (SolrQuery) filter.accept(solrVisitor, null);
-    assertThat(solrQuery.getQuery().trim(), equalTo("property_txt_tokenized:val*"));
+    assertThat(solrQuery.getQuery().trim(), equalTo("property_txt:val*"));
   }
 
   @Test
   public void testGetMappedPropertyNameCache() {
     SchemaFieldResolver mockResolver = mock(SchemaFieldResolver.class);
     SchemaField schema = new SchemaField("testField_int", "tint");
-    schema.setSuffix("_int");
-    when(mockResolver.getSchemaField("testField", true)).thenReturn(schema);
+    when(mockResolver.getSchemaField("testField")).thenReturn(schema);
     solrVisitor = new SolrQueryFilterVisitor("alerts", mockResolver);
 
     String propertyName = solrVisitor.getMappedPropertyName("testField");
@@ -145,7 +145,7 @@ public class SolrQueryFilterVisitorTest {
 
     propertyName = solrVisitor.getMappedPropertyName("testField");
     assertThat(propertyName, is("testField_int"));
-    verify(mockResolver, times(1)).getSchemaField("testField", true);
+    verify(mockResolver, times(1)).getSchemaField("testField");
   }
 
   @Test
@@ -153,7 +153,7 @@ public class SolrQueryFilterVisitorTest {
     SchemaFieldResolver mockResolver = mock(SchemaFieldResolver.class);
 
     // returning null simulates no entry in SOLR to query schema for "testField"
-    when(mockResolver.getSchemaField("testField2", true)).thenReturn(null);
+    when(mockResolver.getSchemaField("testField2")).thenReturn(null);
     when(mockResolver.getFieldSuffix(AttributeFormat.STRING)).thenReturn("_txt");
     solrVisitor = new SolrQueryFilterVisitor("alerts", mockResolver);
 
@@ -162,12 +162,46 @@ public class SolrQueryFilterVisitorTest {
 
     // simulates an entry in SOLR to query schema for "testField"
     SchemaField schema = new SchemaField("testField2_int", "tint");
-    schema.setSuffix("_int");
 
-    when(mockResolver.getSchemaField("testField2", true)).thenReturn(schema);
+    when(mockResolver.getSchemaField("testField2")).thenReturn(schema);
     propertyName = solrVisitor.getMappedPropertyName("testField2");
     assertThat(propertyName, is("testField2_int"));
 
-    verify(mockResolver, times(2)).getSchemaField("testField2", true);
+    verify(mockResolver, times(2)).getSchemaField("testField2");
+  }
+
+  @Test
+  public void testGetMappedPropertyName() {
+    SchemaFieldResolver mockResolver = mock(SchemaFieldResolver.class);
+    SchemaField schema = new SchemaField("metadata_txt", "string");
+    when(mockResolver.getSchemaField("metadata")).thenReturn(schema);
+    solrVisitor = new SolrQueryFilterVisitor("alert", mockResolver);
+    String propertyName = solrVisitor.getMappedPropertyName("metadata");
+    assertThat(propertyName, is("metadata_txt"));
+    verify(mockResolver, times(1)).getSchemaField("metadata");
+  }
+
+  @Test
+  public void testPropertyIsLikeWithSpecialSuffix() throws CQLException {
+    SchemaFieldResolver mockResolver = mock(SchemaFieldResolver.class);
+    SchemaField schema = new SchemaField("metadata2_txt", "string");
+    schema.setSpecialSuffix(SchemaFieldResolver.TOKENIZED);
+    when(mockResolver.getSchemaField("metadata2")).thenReturn(schema);
+    solrVisitor = new SolrQueryFilterVisitor("alert", mockResolver);
+    Filter filter = ECQL.toFilter("metadata2 LIKE 'val*'");
+    SolrQuery solrQuery = (SolrQuery) filter.accept(solrVisitor, null);
+    assertThat(solrQuery.getQuery().trim(), equalTo("metadata2_txt_tokenized:val*"));
+  }
+
+  @Test
+  public void testPropertyIsLikeWithoutSpecialSuffix() throws CQLException {
+    SchemaFieldResolver mockResolver = mock(SchemaFieldResolver.class);
+    SchemaField schema = new SchemaField("metadata3_txt", "string");
+    when(mockResolver.getSchemaField("metadata3")).thenReturn(schema);
+    when(mockResolver.getFieldSuffix(AttributeFormat.STRING)).thenReturn("_txt");
+    solrVisitor = new SolrQueryFilterVisitor("alert", mockResolver);
+    Filter filter = ECQL.toFilter("metadata3 LIKE 'val*'");
+    SolrQuery solrQuery = (SolrQuery) filter.accept(solrVisitor, null);
+    assertThat(solrQuery.getQuery().trim(), equalTo("metadata3_txt:val*"));
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Updates the solr resolvers to respect the tokenized field of attribute definitions instead of assuming all text fields are tokenized.
Also makes metacard-tags tokenized.

One question I still have is why wildcard id queries don't work in the testing framework. By default the solr schema does have id defined as tokenized but that's not how the attribute is defined. It should work either way but it wasn't in the tests which is why I had to switch them to anyText filters.

#### Who is reviewing it? 
@jaymcnallie 
@jrnorth 


#### Any background context you want to provide?
The default ddf solr schema uses primarily dynamic field definitions. These definitions determine how solr stores/handles the data and completely disregards the MetacardType definitions of attributes when it comes to fields like indexed and tokenized. If a downstream project wants to define their fields explicitly for better data handling the resolvers assumption of all string fields being tokenized breaks down and causes issues.


#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
