### PR TITLE
Make Jetty max HTTP request header size configurable

### DIFF
--- a/platform/platform-paxweb-jettyconfig/src/main/resources/jetty.xml
+++ b/platform/platform-paxweb-jettyconfig/src/main/resources/jetty.xml
@@ -34,6 +34,12 @@
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+        <Set name="requestHeaderSize">
+            <Env name="JETTY_MAX_HTTP_REQUEST_HEADER_SIZE" default="8192"/>
+        </Set>
+    </New>
+
     <Call name="setSessionIdManager">
         <Arg>
             <New class="org.codice.ddf.security.session.AttributeSharingHashSessionIdManager">
@@ -105,8 +111,5 @@
             </Set>
         </New>
     </Set>
-
-
-
 
 </Configure>


### PR DESCRIPTION
#### What does this PR do?
Makes Jetty's maximum HTTP request header size configurable via the `JETTY_MAX_HTTP_REQUEST_HEADER_SIZE` environment variable.

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.